### PR TITLE
Fix stats page (job_applications_having_authorized_prescriber query)

### DIFF
--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -344,9 +344,9 @@ def get_hiring_delays(hirings):
         )
         # We ignore hirings whose events are in the wrong chronological order.
         .filter(
-            logs__timestamp__gte=F('created_at'),
-            job_seeker__approvals__created_at__gte=F('logs__timestamp'),
-            job_seeker__approvals__start_at__gte=F('job_seeker__approvals__created_at'),
+            logs__timestamp__gte=F("created_at"),
+            job_seeker__approvals__created_at__gte=F("logs__timestamp"),
+            job_seeker__approvals__start_at__gte=F("job_seeker__approvals__created_at"),
         )
     )
 
@@ -454,7 +454,10 @@ def _get_donut_chart_data(
     between various donut charts (DNRY).
     """
     job_applications_having_authorized_prescriber = (
-        job_applications.filter(sender_prescriber_organization__is_authorized=True)
+        job_applications.filter(
+            job_seeker__eligibility_diagnoses__author_kind=prescriber_kind
+        )
+        .filter(sender_prescriber_organization__is_authorized=True)
         .distinct()
         .count()
     )


### PR DESCRIPTION
The underlying query for this sum was lacking a filter
to exclude some edge cases like
JobApplication: ef6bfa6e-20fe-4522-a79b-536865fd91ee
JobApplication: 188fce6b-ce42-4e12-a8ee-2ff617cd4c3c
which have
sender_prescriber_organization__is_authorized=True
but
job_seeker__eligibility_diagnoses__author_kind <> 'prescriber'
Apparently this kind of job_application does exist, which means
that the diagnose can be made by some non-prescriber entity
despite the fact that the application's sender is a prescriber.