### PR TITLE
Un candidat ou un prescripteur peut filtrer ses candidatures.

### DIFF
--- a/itou/templates/apply/includes/job_applications_filters.html
+++ b/itou/templates/apply/includes/job_applications_filters.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+{% load bootstrap4 %}
+
+<ul class="list-group list-group-horizontal mt-sm-5 mb-sm-0">
+    <li class="list-group-item border-0 pl-0">
+        <button class="btn btn-secondary" type="button" data-toggle="modal" data-target="#filtersModal">
+          {% trans "Filtres" %}
+        </button>
+    </li>
+    {% for filter in filters %}
+        <li class="list-group-item border-0 pl-0 pt-3">
+            <span class="badge badge-light align-middle">{{ filter.label }} : {{ filter.value }}</span>
+        </li>
+    {% endfor %}
+</ul>
+
+<div class="modal fade" id="filtersModal" tabindex="-1" role="dialog" aria-labelledby="filtersModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <form method="get" action="">
+                <div class="modal-header">
+                    <h4 class="modal-title">{% trans "Filtres" %}</h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="{% trans 'Fermer' %}">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <h5>{% trans "Date de candidature" %}</h5>
+                    {% bootstrap_field filters_form.start_date form_group_class="form_group m-3" %}
+                    {% bootstrap_field filters_form.end_date form_group_class="form_group m-3" %}
+
+                    <h5>{% trans "Statut" %}</h5>
+                      {% for choice in filters_form.states %}
+                      <div class="form-check form-check-inline dropdown-item">
+                          <input id="{{ choice.id_for_label }}" class="form-check-input" name="{{ choice.data.name }}" type="checkbox" value="{{ choice.data.value }}" {% if choice.data.selected %}checked=""{% endif %}>
+                          <label for="{{ choice.id_for_label }}" class="form-check-label">{{ choice.choice_label }}</label>
+                      </div>
+                      {% endfor %}
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Fermer" %}</button>
+                    <button type="submit" class="btn btn-primary">{% trans "Appliquer" %}</button>
+                </div>
+            </form>
+        </div> <!-- .modal-content -->
+    </div> <!-- .modal-dialog -->
+</div> <!-- .modal -->

--- a/itou/templates/apply/list_for_job_seeker.html
+++ b/itou/templates/apply/list_for_job_seeker.html
@@ -7,6 +7,8 @@
 
     <h1>{% trans "Candidatures envoyées" %}</h1>
 
+    {% include "apply/includes/job_applications_filters.html" with filters=filters filters_form=filters_form %}
+
     {% if not job_applications_page %}
         <h2 class="font-weight-normal text-muted">
             {% trans "Aucune candidature pour le moment." %}
@@ -31,4 +33,10 @@
 
     {% include "includes/pagination.html" with page=job_applications_page %}
 
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <!-- Needed to use the Datepicker JS widget. -->
+    {{ filters_form.media }}
 {% endblock %}

--- a/itou/templates/apply/list_for_prescriber.html
+++ b/itou/templates/apply/list_for_prescriber.html
@@ -7,6 +7,8 @@
 
     <h1>{% trans "Suivi des candidatures" %}</h1>
 
+    {% include "apply/includes/job_applications_filters.html" with filters=filters filters_form=filters_form %}
+
     {% if not job_applications_page %}
         <h2 class="font-weight-normal text-muted">
             {% trans "Aucune candidature pour le moment." %}
@@ -31,4 +33,10 @@
 
     {% include "includes/pagination.html" with page=job_applications_page %}
 
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <!-- Needed to use the Datepicker JS widget. -->
+    {{ filters_form.media }}
 {% endblock %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -7,20 +7,9 @@
 {% block content %}
 
     <h1>{% trans "Candidatures reçues" %}</h1>
-
     <h2 class="text-muted">{{ siae.display_name }}</h2>
-        <ul class="list-group list-group-horizontal mt-sm-5 mb-sm-0">
-            <li class="list-group-item border-0 pl-0">
-                <button class="btn btn-secondary" type="button" data-toggle="modal" data-target="#itouModal">
-                  {% trans "Filtres" %}
-                </button>
-            </li>
-            {% for filter in filters %}
-                <li class="list-group-item border-0 pl-0 pt-3">
-                    <span class="badge badge-light align-middle">{{ filter.label }} : {{ filter.value }}</span>
-                </li>
-            {% endfor %}
-        </ul>
+
+    {% include "apply/includes/job_applications_filters.html" with filters=filters filters_form=filters_form %}
 
     {% if not job_applications_page %}
         <h2 class="font-weight-normal text-muted mt-4">
@@ -49,40 +38,6 @@
     {% include "includes/pagination.html" with page=job_applications_page %}
 
 {% endblock %}
-
-
-{% block modal_content %}
-    <form method="get" action="">
-        {{ block.super }}
-    </form>
-{% endblock modal_content %}
-
-{% block modal_title %}
-    <h4 class="modal-title">{% trans "Filtres" %}</h4>
-    <button type="button" class="close" data-dismiss="modal" aria-label="{% trans 'Fermer' %}">
-        <span aria-hidden="true">&times;</span>
-    </button>
-{% endblock modal_title %}
-
-{% block modal_body %}
-    <h5>{% trans "Date de candidature" %}</h5>
-    {% bootstrap_field filters_form.start_date form_group_class="form_group m-3" %}
-    {% bootstrap_field filters_form.end_date form_group_class="form_group m-3" %}
-
-    <h5>{% trans "Statut" %}</h5>
-      {% for choice in filters_form.states %}
-      <div class="form-check form-check-inline dropdown-item">
-          <input id="{{ choice.id_for_label }}" class="form-check-input" name="{{ choice.data.name }}" type="checkbox" value="{{ choice.data.value }}" {% if choice.data.selected %}checked=""{% endif %}>
-          <label for="{{ choice.id_for_label }}" class="form-check-label">{{ choice.choice_label }}</label>
-      </div>
-      {% endfor %}
-{% endblock %}
-
-{% block modal_footer %}
-    <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Fermer" %}</button>
-    <button type="submit" class="btn btn-primary">{% trans "Appliquer" %}</button>
-{% endblock %}
-
 
 {% block script %}
     {{ block.super }}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -174,26 +174,6 @@
 
     </div>
 
-    {% block modal %}
-    <div class="modal fade" id="itouModal" tabindex="-1" role="dialog" aria-labelledby="itouModalLabel" aria-hidden="true">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                {% block modal_content %}
-                    <div class="modal-header">
-                    {% block modal_title %}{% endblock modal_title %}
-                    </div>
-                    <div class="modal-body">
-                        {% block modal_body %}{% endblock modal_body %}
-                    </div>
-                    <div class="modal-footer">
-                        {% block modal_footer %}{% endblock modal_footer %}
-                    </div>
-                {% endblock modal_content %}
-            </div> <!-- .modal-content -->
-        </div> <!-- .modal-dialog -->
-    </div> <!-- .modal -->
-    {% endblock modal %}
-
     <script src="{% static "vendor/jquery-3.4.1/jquery.min.js" %}"></script>
     <script src="{% static "vendor/jquery-ui-1.12.1/jquery-ui.min.js" %}"></script>
     <script src="{% static "vendor/bootstrap-4.3.1/popper.min.js" %}"></script>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -210,3 +210,46 @@ class FilterJobApplicationsForm(forms.Form):
             )
             end_date = timezone.make_aware(end_date)
         return end_date
+
+    def get_qs_filters(self):
+        """
+        Get filters to be applied to a query set.
+        """
+        filters = {}
+        data = self.cleaned_data
+
+        if data.get("states"):
+            filters["state__in"] = data.get("states")
+        if data.get("start_date"):
+            filters["created_at__gte"] = data.get("start_date")
+        if data.get("end_date"):
+            filters["created_at__lte"] = data.get("end_date")
+
+        return filters
+
+    def humanize_filters(self):
+        """
+        Return active filters to be displayed in a template.
+        """
+        start_date = self.cleaned_data.get("start_date")
+        end_date = self.cleaned_data.get("end_date")
+        states = self.cleaned_data.get("states")
+        active_filters = []
+
+        if start_date:
+            label = FilterJobApplicationsForm.base_fields.get("start_date").label
+            active_filters.append([label, start_date])
+
+        if end_date:
+            label = FilterJobApplicationsForm.base_fields.get("end_date").label
+            active_filters.append([label, end_date])
+
+        if states:
+            values = [
+                str(JobApplicationWorkflow.states[state].title) for state in states
+            ]
+            value = ", ".join(values)
+            label = _("Statuts") if (len(values) > 1) else _("Statut")
+            active_filters.append([label, value])
+
+        return [{"label": f[0], "value": f[1]} for f in active_filters]

--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -23,15 +23,25 @@ class ProcessListTest(TestCase):
                 to_siae=siae, state=state, created_at=creation_date
             )
 
-        siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
-        self.base_url = reverse("apply:list_for_siae")
+        # SIAE view
+        self.siae_user = job_application.to_siae.members.first()
+        self.siae_base_url = reverse("apply:list_for_siae")
+
+        # Candidate view
+        self.job_seeker = job_application.job_seeker
+        self.job_seeker_base_url = reverse("apply:list_for_job_seeker")
+
+        # Create one more SIAE and one more application
+        # so that a job seeker has 2 applications in his dashboard.
+        siae = SiaeWithMembershipFactory()
+        job_application = JobApplicationFactory(job_seeker=self.job_seeker, to_siae=siae)
 
     def test_list_for_siae_view(self):
         """
         Provide a list of job applications sent to a specific SIAE.
         """
-        response = self.client.get(self.base_url)
+        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        response = self.client.get(self.siae_base_url)
 
         # Count job applications used by the template
         total_applications = len(response.context["job_applications_page"].object_list)
@@ -44,8 +54,9 @@ class ProcessListTest(TestCase):
         Provide a list of job applications sent to a specific SIAE.
         Results are filtered by a user-selected state.
         """
+        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
         query = f"states={JobApplicationWorkflow.initial_state}"
-        url = f"{self.base_url}?{query}"
+        url = f"{self.siae_base_url}?{query}"
         response = self.client.get(url)
 
         # Count job applications used by the template
@@ -60,6 +71,7 @@ class ProcessListTest(TestCase):
         Provide a list of job applications sent to a specific SIAE.
         Results are filtered by user-selected states.
         """
+        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
         job_application_states = [
             f"states={state.name}"
             for i, state in enumerate(JobApplicationWorkflow.states)
@@ -67,7 +79,7 @@ class ProcessListTest(TestCase):
         ]
         job_application_states = "&".join(job_application_states)
 
-        url = f"{self.base_url}?{job_application_states}"
+        url = f"{self.siae_base_url}?{job_application_states}"
         response = self.client.get(url)
 
         total_applications = len(response.context["job_applications_page"].object_list)
@@ -79,6 +91,7 @@ class ProcessListTest(TestCase):
         Provide a list of job applications sent to a specific SIAE.
         Results are filtered by user-selected dates.
         """
+        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
         total_expected = 3
         date_format = DatePickerField().DATE_FORMAT
         job_applications = JobApplication.objects.order_by("created_at")
@@ -90,7 +103,7 @@ class ProcessListTest(TestCase):
             date_format
         )
         query = urlencode({"start_date": start_date, "end_date": end_date})
-        url = f"{self.base_url}?{query}"
+        url = f"{self.siae_base_url}?{query}"
         response = self.client.get(url)
 
         # Count job applications used by the template
@@ -106,7 +119,8 @@ class ProcessListTest(TestCase):
         in the HTTP query if they are not filled in by the user.
         Make sure the template loads all available job applications if fields are empty.
         """
-        url = f"{self.base_url}?start_date=&end_date="
+        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        url = f"{self.siae_base_url}?start_date=&end_date="
         response = self.client.get(url)
 
         # Count job applications used by the template
@@ -115,3 +129,38 @@ class ProcessListTest(TestCase):
         # Result page should only contain job applications which dates
         # match the date range selected by the user.
         self.assertEqual(total_applications, len(JobApplicationWorkflow.states))
+
+
+    ############################################################
+    ################## Job seeker view #########################
+    ############################################################
+    def test_list_for_job_seeker_view(self):
+        """
+        Provide a list of job applications sent by a job seeker.
+        """
+        self.client.login(username=self.job_seeker.email, password=DEFAULT_PASSWORD)
+        response = self.client.get(self.job_seeker_base_url)
+
+        # Count job applications used by the template
+        total_applications = len(response.context["job_applications_page"].object_list)
+
+        # Result page should contain all SIAE's job applications.
+        self.assertEqual(total_applications, self.job_seeker.job_applications.count())
+
+
+    def test_list_for_job_seeker_view__filtered_by_state(self):
+        """
+        Provide a list of job applications sent by a job seeker
+        and filtered by a state.
+        """
+        self.client.login(username=self.job_seeker.email, password=DEFAULT_PASSWORD)
+        query = f"states={JobApplicationWorkflow.initial_state}"
+        url = f"{self.job_seeker_base_url}?{query}"
+        response = self.client.get(url)
+
+        # Count job applications used by the template
+        total_applications = len(response.context["job_applications_page"].object_list)
+
+        # Result page should only contain job applications which status
+        # matches the one selected by the user.
+        self.assertEqual(total_applications, 1)

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -2,13 +2,11 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.decorators import user_passes_test
 from django.shortcuts import get_object_or_404, render
-from django.utils.translation import gettext_lazy as _
 
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae
 from itou.utils.pagination import pager
 from itou.www.apply.forms import FilterJobApplicationsForm
-from itou.job_applications.models import JobApplicationWorkflow
 
 
 @login_required
@@ -17,20 +15,15 @@ def list_for_job_seeker(request, template_name="apply/list_for_job_seeker.html")
     """
     List of applications for a job seeker.
     """
+    filters_form = FilterJobApplicationsForm(request.GET or None)
+    filters = None
+    job_applications = request.user.job_applications
 
-    job_applications_query = request.user.job_applications
-    filters_form = FilterJobApplicationsForm()
-    filters = request.GET
+    if filters_form.is_valid():
+        job_applications = job_applications.filter(**filters_form.get_qs_filters())
+        filters = filters_form.humanize_filters()
 
-    if filters:
-        filters_form = FilterJobApplicationsForm(data=filters)
-        if filters_form.is_valid():
-            job_applications_query = _add_filters_to_query(
-                query=job_applications_query, data=filters_form.cleaned_data
-            )
-        filters = _humanize_filters(filters_form.cleaned_data)
-
-    job_applications = job_applications_query.select_related(
+    job_applications = job_applications.select_related(
         "job_seeker",
         "sender",
         "sender_siae",
@@ -64,21 +57,18 @@ def list_for_prescriber(request, template_name="apply/list_for_prescriber.html")
 
     if prescriber_organization:
         # Show all applications organization-wide.
-        job_applications_query = prescriber_organization.jobapplication_set.all()
+        job_applications = prescriber_organization.jobapplication_set
     else:
-        job_applications_query = request.user.job_applications_sent.all()
+        job_applications = request.user.job_applications_sent
 
-    filters_form = FilterJobApplicationsForm()
-    filters = request.GET
-    if filters:
-        filters_form = FilterJobApplicationsForm(data=filters)
-        if filters_form.is_valid():
-            job_applications_query = _add_filters_to_query(
-                query=job_applications_query, data=filters_form.cleaned_data
-            )
-        filters = _humanize_filters(filters_form.cleaned_data)
+    filters_form = FilterJobApplicationsForm(request.GET or None)
+    filters = None
 
-    job_applications = job_applications_query.select_related(
+    if filters_form.is_valid():
+        job_applications = job_applications.filter(**filters_form.get_qs_filters())
+        filters = filters_form.humanize_filters()
+
+    job_applications = job_applications.select_related(
         "job_seeker",
         "sender",
         "sender_siae",
@@ -107,19 +97,15 @@ def list_for_siae(request, template_name="apply/list_for_siae.html"):
     pk = request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY]
     queryset = Siae.active_objects.member_required(request.user)
     siae = get_object_or_404(queryset, pk=pk)
-    job_applications_query = siae.job_applications_received
-    filters_form = FilterJobApplicationsForm()
-    filters = request.GET
+    job_applications = siae.job_applications_received
+    filters_form = FilterJobApplicationsForm(request.GET or None)
+    filters = None
 
-    if filters:
-        filters_form = FilterJobApplicationsForm(data=filters)
-        if filters_form.is_valid():
-            job_applications_query = _add_filters_to_query(
-                query=job_applications_query, data=filters_form.cleaned_data
-            )
-        filters = _humanize_filters(filters_form.cleaned_data)
+    if filters_form.is_valid():
+        job_applications = job_applications.filter(**filters_form.get_qs_filters())
+        filters = filters_form.humanize_filters()
 
-    job_applications = job_applications_query.select_related(
+    job_applications = job_applications.select_related(
         "job_seeker",
         "sender",
         "sender_siae",
@@ -137,56 +123,3 @@ def list_for_siae(request, template_name="apply/list_for_siae.html"):
         "filters": filters,
     }
     return render(request, template_name, context)
-
-
-##########################################################################
-######## Functions for internal-use only, not linked to a path. ##########
-##########################################################################
-
-
-def _add_filters_to_query(data, query):
-    """
-    Add filters coming from a form to a query.
-    """
-
-    # Active filters
-    states = data.get("states")
-    start_date = data.get("start_date")
-    end_date = data.get("end_date")
-
-    if states:
-        query = query.filter(state__in=states)
-
-    if start_date:
-        query = query.filter(created_at__gte=start_date)
-
-    if end_date:
-        query = query.filter(created_at__lte=end_date)
-
-    return query
-
-
-def _humanize_filters(filters):
-    """
-    Return active filters to be displayed in a template.
-    """
-    start_date = filters.get("start_date")
-    end_date = filters.get("end_date")
-    states = filters.get("states")
-    active_filters = []
-
-    if start_date:
-        label = FilterJobApplicationsForm.base_fields.get("start_date").label
-        active_filters.append([label, start_date])
-
-    if end_date:
-        label = FilterJobApplicationsForm.base_fields.get("end_date").label
-        active_filters.append([label, end_date])
-
-    if states:
-        values = [str(JobApplicationWorkflow.states[state].title) for state in states]
-        value = ", ".join(values)
-        label = _("Statuts") if (len(values) > 1) else _("Statut")
-        active_filters.append([label, value])
-
-    return [{"label": f[0], "value": f[1]} for f in active_filters]

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -64,11 +64,21 @@ def list_for_prescriber(request, template_name="apply/list_for_prescriber.html")
 
     if prescriber_organization:
         # Show all applications organization-wide.
-        job_applications = prescriber_organization.jobapplication_set.all()
+        job_applications_query = prescriber_organization.jobapplication_set.all()
     else:
-        job_applications = request.user.job_applications_sent.all()
+        job_applications_query = request.user.job_applications_sent.all()
 
-    job_applications = job_applications.select_related(
+    filters_form = FilterJobApplicationsForm()
+    filters = request.GET
+    if filters:
+        filters_form = FilterJobApplicationsForm(data=filters)
+        if filters_form.is_valid():
+            job_applications_query = _add_filters_to_query(
+                query=job_applications_query, data=filters_form.cleaned_data
+            )
+        filters = _humanize_filters(filters_form.cleaned_data)
+
+    job_applications = job_applications_query.select_related(
         "job_seeker",
         "sender",
         "sender_siae",
@@ -80,7 +90,11 @@ def list_for_prescriber(request, template_name="apply/list_for_prescriber.html")
         job_applications, request.GET.get("page"), items_per_page=10
     )
 
-    context = {"job_applications_page": job_applications_page}
+    context = {
+        "job_applications_page": job_applications_page,
+        "filters_form": filters_form,
+        "filters": filters,
+    }
     return render(request, template_name, context)
 
 

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -18,7 +18,19 @@ def list_for_job_seeker(request, template_name="apply/list_for_job_seeker.html")
     List of applications for a job seeker.
     """
 
-    job_applications = request.user.job_applications.select_related(
+    job_applications_query = request.user.job_applications
+    filters_form = FilterJobApplicationsForm()
+    filters = request.GET
+
+    if filters:
+        filters_form = FilterJobApplicationsForm(data=filters)
+        if filters_form.is_valid():
+            job_applications_query = _add_filters_to_query(
+                query=job_applications_query, data=filters_form.cleaned_data
+            )
+        filters = _humanize_filters(filters_form.cleaned_data)
+
+    job_applications = job_applications_query.select_related(
         "job_seeker",
         "sender",
         "sender_siae",
@@ -29,7 +41,11 @@ def list_for_job_seeker(request, template_name="apply/list_for_job_seeker.html")
         job_applications, request.GET.get("page"), items_per_page=10
     )
 
-    context = {"job_applications_page": job_applications_page}
+    context = {
+        "job_applications_page": job_applications_page,
+        "filters_form": filters_form,
+        "filters": filters,
+    }
     return render(request, template_name, context)
 
 


### PR DESCRIPTION
Filtres ajoutés aux tableaux de bord Prescripteur et Candidat : 
- date de création
- statut

Cette PR supprime également le bloc `modal` du gabarit `base` : il n'était utilisé que pour les filtres mais cette solution n'était pas la plus optimale.