### PR TITLE
Modification d'affichage du terme "SIAE"

### DIFF
--- a/itou/templates/admin/approvals/manually_add_approval.html
+++ b/itou/templates/admin/approvals/manually_add_approval.html
@@ -71,7 +71,7 @@
 
 <h2>
     <a href="{% url "admin:siaes_siae_change" job_application.to_siae.id %}" target="_blank">
-        {% trans "SIAE" %}
+        {% trans "Employeur solidaire" %}
     </a>
 </h2>
 <ul>

--- a/itou/templates/apply/email/accept_trigger_approval_body.txt
+++ b/itou/templates/apply/email/accept_trigger_approval_body.txt
@@ -12,7 +12,7 @@ Informations pour l'obtention d'un numéro d'agrément.
 - Email : {{ job_application.job_seeker.email }}{% endif %}
 - Date de naissance : {{ job_application.job_seeker.birthdate|date:"d/m/Y" }}
 
-{% trans "*SIAE* :" %}
+{% trans "*Employeur solidaire* :" %}
 
 - Siret : {{ job_application.to_siae.siret }}
 - Nom : {{ job_application.to_siae.display_name }}

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -114,7 +114,7 @@
 
         {% if job_application.sender_siae %}
             <li>
-                {% trans "SIAE :" %}
+                {% trans "Employeur solidaire :" %}
                 <b>{{ job_application.sender_siae.display_name }}</b>
             </li>
         {% endif %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -131,7 +131,7 @@
 
         {% if user.is_siae_staff %}
             <div class="card">
-                <h5 class="card-header">{% trans "SIAE" %}</h5>
+                <h5 class="card-header">{% trans "Employeur solidaire" %}</h5>
                 <div class="card-body">
                     <p class="card-text">
                         {% include "includes/icon.html" with icon="box" %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -110,7 +110,7 @@
         {% if user.is_authenticated %}
         <div class="layout-section layout-section-white border-bottom">
             <nav class="nav">
-                <a class="nav-link" href="/">{% trans "Rechercher une SIAE" %}</a>
+                <a class="nav-link" href="/">{% trans "Rechercher un employeur solidaire" %}</a>
                 <a class="nav-link" href="{% url 'dashboard:index' %}">{% trans "Tableau de bord" %}</a>
             </nav>
         </div>

--- a/itou/templates/siaes/edit_siae.html
+++ b/itou/templates/siaes/edit_siae.html
@@ -2,11 +2,11 @@
 {% load i18n %}
 {% load bootstrap4 %}
 
-{% block title %}{% trans "Modifier les coordonnées de votre SIAE" %}{{ block.super }}{% endblock %}
+{% block title %}{% trans "Modifier les coordonnées de votre structure" %}{{ block.super }}{% endblock %}
 
 {% block content %}
 
-<h1>{% trans "Modifier les coordonnées de votre SIAE" %}</h1>
+<h1>{% trans "Modifier les coordonnées de votre structure" %}</h1>
 
 <h2 class="text-muted">
     {{ siae.display_name }}
@@ -15,7 +15,7 @@
 </h2>
 
 <div class="alert alert-info" role="alert">
-    {% blocktrans %}Si vous devez modifier le nom de votre SIAE, <a href="mailto:{{ ITOU_EMAIL_CONTACT }}">contactez-nous</a>.{% endblocktrans %}
+    {% blocktrans %}Si vous devez modifier le nom de votre structure, <a href="mailto:{{ ITOU_EMAIL_CONTACT }}">contactez-nous</a>.{% endblocktrans %}
 </div>
 
 <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/templates/signup/signup_siae.html
+++ b/itou/templates/signup/signup_siae.html
@@ -2,12 +2,12 @@
 {% load bootstrap4 %}
 {% load i18n %}
 
-{% block title %}{% trans "SIAE - Inscription" %}{{ block.super }}{% endblock %}
+{% block title %}{% trans "Employeur solidaire - Inscription" %}{{ block.super }}{% endblock %}
 
 
 {% block content %}
 <h1>
-    {% trans "SIAE" %}
+    {% trans "Employeur solidaire" %}
     <small class="text-muted">{% trans "Inscription" %}</small>
 </h1>
 

--- a/itou/www/prescribers_views/forms.py
+++ b/itou/www/prescribers_views/forms.py
@@ -60,6 +60,6 @@ class EditPrescriberOrganizationForm(forms.ModelForm):
         fields = ["name", "phone", "email", "website", "description"]
         help_texts = {
             "phone": _("Par exemple 0610203040"),
-            "description": _("Texte de présentation de votre SIAE."),
+            "description": _("Texte de présentation de votre structure."),
             "website": _("Votre site web doit commencer par http:// ou https://"),
         }

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -57,7 +57,7 @@ class CreateSiaeForm(forms.ModelForm):
                 "Si ce champ est renseigné, il sera utilisé en tant que nom sur la fiche."
             ),
             "department": TEST_DEPARTMENTS_HELP_TEXT,
-            "description": _("Texte de présentation de votre SIAE."),
+            "description": _("Texte de présentation de votre structure."),
             "phone": _("Par exemple 0610203040"),
             "siret": _(
                 "Saisissez 14 chiffres. "
@@ -127,7 +127,7 @@ class EditSiaeForm(forms.ModelForm):
                 "Si ce champ est renseigné, il sera utilisé en tant que nom sur la fiche."
             ),
             "department": TEST_DEPARTMENTS_HELP_TEXT,
-            "description": _("Texte de présentation de votre SIAE."),
+            "description": _("Texte de présentation de votre structure."),
             "phone": _("Par exemple 0610203040"),
             "website": _("Votre site web doit commencer par http:// ou https://"),
         }

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -94,7 +94,7 @@ class PrescriberSignupForm(FullnameFormMixin, SignupForm):
 class SiaeSignupForm(FullnameFormMixin, SignupForm):
 
     siret = forms.CharField(
-        label=_("Numéro SIRET de votre SIAE"),
+        label=_("Numéro SIRET de votre structure"),
         max_length=14,
         validators=[validate_siret],
         required=True,


### PR DESCRIPTION
Remplacement de "SIAE" par "Employeur solidaire" ou "votre structure" sur le site. 
Cependant, les termes utilisés dans l'admin restent les mêmes.