### PR TITLE
Use ManifestStaticFilesStorage instead of CachedStaticFilesStorage

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -183,7 +183,7 @@ STATIC_ROOT = os.path.join(APPS_DIR, "static_collected")
 
 STATIC_URL = "/static/"
 
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.CachedStaticFilesStorage"
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 
 STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.FileSystemFinder",

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -3,7 +3,7 @@ import logging
 from .base import *  # noqa
 
 
-# `CachedStaticFilesStorage` (used in base settings) requires `collectstatic` to be run.
+# `ManifestStaticFilesStorage` (used in base settings) requires `collectstatic` to be run.
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
 # Prevent calls to external APIs.


### PR DESCRIPTION
CachedStaticFilesStorage is deprecated.

Refs :

- https://docs.djangoproject.com/en/3.0/ref/contrib/staticfiles/#cachedstaticfilesstorage
- https://docs.djangoproject.com/en/3.0/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage