### PR TITLE
Fix pre-commit-hook dans le Makefile du projet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ style:
 setup_git_pre_commit_hook:
 	touch .git/hooks/pre-commit
 	chmod +x .git/hooks/pre-commit
-	echo "\
+	echo -e "\
 	docker exec -t itou_django black --line-length 119 itou\n\
 	docker exec -t itou_django isort --recursive itou\n\
 	" > .git/hooks/pre-commit


### PR DESCRIPTION
Le pre-commit hook génère un fichier qui contient des `\n` au lieu de sauts de lignes *(comportement par défaut de `echo`)*.﻿
