### PR TITLE
Opacité du bouton de recherche

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -287,6 +287,11 @@ a.disabled button:hover, button.disabled:hover {
     border-color: inherit;
 }
 
+/* Overrides opacity for disabled button (search cities) */
+.js-search-button {
+    opacity: 100% !important;
+}
+
 /* Old browsers.
 --------------------------------------------------------------------------- */
 


### PR DESCRIPTION
En cas de non-completion du champ de recherche, le bouton est `disabled` mais son apparence reste normale﻿
