### PR TITLE
Correction dans le processus de recettes jetables

### DIFF
--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -67,7 +67,7 @@ jobs:
   create:
     runs-on: ubuntu-latest
     needs: delete
-    if: always()
+    if: contains( github.event.pull_request.labels.*.name, 'review-app')
 
     steps:
     - name: 📥 Checkout to the PR branch


### PR DESCRIPTION
Une recette jetable devrait être créée uniquement quand le label "review-app" est présent dans la PR.