### PR TITLE
Attempt to fix random 403 errors on stats page

### DIFF
--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import render
 from django.utils import timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import cache_page
-from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.csrf import csrf_exempt
 
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
@@ -22,7 +22,7 @@ DATA_UNAVAILABLE_BY_DEPARTMENT_ERROR_MESSAGE = _("donnée non disponible par dé
 
 
 @cache_page(60 * 60 * 2)
-@csrf_protect
+@csrf_exempt
 def stats(request, template_name="stats/stats.html"):
     data = {}
 

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import render
 from django.utils import timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import cache_page
+from django.views.decorators.csrf import csrf_protect
 
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
@@ -21,6 +22,7 @@ DATA_UNAVAILABLE_BY_DEPARTMENT_ERROR_MESSAGE = _("donnée non disponible par dé
 
 
 @cache_page(60 * 60 * 2)
+@csrf_protect
 def stats(request, template_name="stats/stats.html"):
     data = {}
 


### PR DESCRIPTION
Initial bug report from Pierre : https://itou-inclusion.slack.com/archives/CQ6D0QPPZ/p1585820853006600

403 CSRF errors happen randomly in production when
trying to load stats page for a specific department.
I could not reproduce in local nor in staging, but my guess
is that the department selector form CSRF token being
cached in the general stats page is the culprit.
This is an attempt to fix cache vs csrf as found here
https://docs.djangoproject.com/en/3.0/ref/csrf/#caching
I have good hope this fixes things in production, at least
it does not cause any issue in local dev.

![image](https://user-images.githubusercontent.com/10533583/78249007-4cf31f80-74f6-11ea-8a31-9f13ae42fd44.png)

Si ça ne suffit pas alors ce sera carrément un `@csrf_exempt` vu que cette form n'est pas sensible (read only - ne change pas de data en db)