### PR TITLE
Silence `Invalid HTTP_HOST header` errors

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -219,11 +219,21 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "handlers": {"console": {"class": "logging.StreamHandler"}},
+    "handlers": {
+        "console": {"class": "logging.StreamHandler"},
+        "null": {"class": "logging.NullHandler"},
+    },
     "loggers": {
         "django": {
             "handlers": ["console"],
             "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
+        },
+        # Silence `Invalid HTTP_HOST header` errors.
+        # This should be done at the HTTP server level when possible.
+        # https://docs.djangoproject.com/en/3.0/topics/logging/#django-security
+        "django.security.DisallowedHost": {
+            "handlers": ["null"],
+            "propagate": False,
         },
         "itou": {
             "handlers": ["console"],


### PR DESCRIPTION
Normalement c'est un truc que je fais au niveau de Nginx :

```
    if ($http_host != inclusion.beta.gouv.fr) {
        return 444;
    }
```

Mais là chez Clever je ne suis pas certain qu'on puisse le faire… Du coup je propose de mettre ces alertes sous silence au niveau de l'applicatif. Votre avis ?