### PR TITLE
Fixed organization name disappearing in search form

### DIFF
--- a/itou/static/js/city_autocomplete_field.js
+++ b/itou/static/js/city_autocomplete_field.js
@@ -19,7 +19,6 @@ $(document).ready(() => {
       minLength: 1,
       source: citySearchInput.data('autocomplete-source-url'),
       autoFocus: true,
-      created: clearInput(),
       // Make a selection on focus.
       focus: (event, ui) => {
         searchButton.prop("disabled", true)


### PR DESCRIPTION
When submitting organization search form, all inputs of the form in the results page are filled, except the name.
