### PR TITLE
Modification de l'affichage de l'agrément sur une candidature

### DIFF
--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -39,16 +39,6 @@
                     {% trans "PASS IAE en cours de délivrance." %}
                 {% endif %}
             </div>
-
-        {% else %}
-            {% if approvals_wrapper.latest_approval %}
-                <div class="alert border">
-                    {# Hide approval number while the job application hasn't been accepted. #}
-                    {% trans "Agrément existant" %}
-                    <br>
-                    {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
-                </div>
-            {% endif %}
         {% endif %}
 
     {% endif %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6150920/80130381-c41d5000-8598-11ea-82b7-fd0bc501bc9c.png)

Bug : l'agrément s'affiche après la rétractation d'une candidature si le demandeur d'emploi a un agrément encore valide.

Proposition : ne l'afficher **que** si la candidature a été acceptée.

Pour reproduire le bug, considérons qu'un DE a deux candidatures acceptées et un agrément. L'une des deux est annulée. L'agrément s'affiche encore, mais sans le numéro.

Or l'employeur s'attend à ce que l'agrément ait été supprimé après la rétractation. Il ne devrait donc plus voir la section "Agrément existant".