### PR TITLE
Mise à jour du tableau de bord Prescripteur Habilités

### DIFF
--- a/itou/templates/apply/includes/list_card_body.html
+++ b/itou/templates/apply/includes/list_card_body.html
@@ -35,7 +35,7 @@
                         <b>{{ job_application.sender_prescriber_organization.display_name }}</b>
                         {% if job_application.sender_prescriber_organization.is_authorized %}
                             <br>
-                            <span class="badge badge-warning">{% trans "Prescripteur habilité par le Préfet" %}</span>
+                            <span class="badge badge-warning">{% trans "Prescripteur habilité" %}</span>
                         {% endif %}
                     {% endif %}
                 {% endif %}

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -131,7 +131,7 @@
                 {% trans "Structure :" %}
                 <b>{{ job_application.sender_prescriber_organization.display_name }}</b>
                 {% if job_application.sender_prescriber_organization.is_authorized %}
-                    <span class="badge badge-warning">{% trans "Prescripteur habilité par le Préfet" %}</span>
+                    <span class="badge badge-warning">{% trans "Prescripteur habilité" %}</span>
                 {% endif %}
             </li>
         {% endif %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -146,8 +146,8 @@
                                 {% trans "Collaborateurs" %}
                             </a>
                         </p>
-                        <hr>
                         {% if current_prescriber_organization.is_authorized %}
+                            <hr>
                             <p class="card-text">
                                 {% include "includes/icon.html" with icon="award" %}
                                 <span>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -44,8 +44,19 @@
     <h1>
         {% trans "Tableau de bord" %}
         {% if current_siae %} - <span class="text-muted">{{ current_siae.display_name }}</span>{% endif %}
-        {% if current_prescriber_organization %} - <span class="text-muted">{{ current_prescriber_organization.display_name }}</span>{% endif %}
+        {% if current_prescriber_organization %} -
+            <span class="text-muted">{{ current_prescriber_organization.display_name }}</span>
+            {% if current_prescriber_organization.is_authorized %}
+                {% include "includes/icon.html" with icon="award" class="h1 align-middle" size=30 %}
+            {% endif %}
+        {% endif %}
     </h1>
+
+    {% if current_prescriber_organization and current_prescriber_organization.is_authorized %}
+        <p class="text-muted">
+            <span class="badge badge-warning">{% trans "Prescripteur habilité" %}</span>
+        </p>
+    {% endif %}
 
     <div class="card-deck mt-3">
 
@@ -135,6 +146,17 @@
                                 {% trans "Collaborateurs" %}
                             </a>
                         </p>
+                        <hr>
+                        {% if current_prescriber_organization.is_authorized %}
+                            <p class="card-text">
+                                {% include "includes/icon.html" with icon="award" %}
+                                <span>
+                                    {% blocktrans with name=current_prescriber_organization.display_name %}
+                                        {{ name }} est une organisation habilitée. Vous pouvez réaliser le <a href="https://app.gitbook.com/@itou/s/doc-inclusion-beta-gouv-fr/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique#diagnostic_de_reference" target="_blank">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
+                                    {% endblocktrans %}
+                                </span>
+                            </p>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -170,7 +170,7 @@
             {% trans "<b>Prescripteur habilité</b> : prescripteur appartenant à une organisation." %}
         </li>
         <li>
-            {% trans "<b>Organisation</b> : organisation habilitée par le préfet." %}
+            {% trans "<b>Organisation</b> : organisation habilitée." %}
         </li>
         <li>
             {% trans "<b>Organisation inscrite</b> : organisation ayant au moins un compte créé sur la plateforme." %}


### PR DESCRIPTION
Le tableau de bord des prescripteurs montre désormais si l'organisation est habilitée ou pas.

![image](https://user-images.githubusercontent.com/6150920/80495589-6908a600-8968-11ea-9868-62506e7e2573.png)
