### PR TITLE
Bouton "Télécharger l'attestation"

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -313,6 +313,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     def can_download_approval_as_pdf(self):
         return (
             self.state.is_accepted
+            and not self.can_be_cancelled
             and self.to_siae.is_subject_to_eligibility_rules
             and self.approval
             and self.approval.is_valid


### PR DESCRIPTION
Le bouton permettant de télécharger l'attestation d'un PASS IAE ne s'affiche plus si la candidature peut être annulée.