### PR TITLE
Adresse obligatoire lors de l'acceptation d'une candidature

### DIFF
--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -6,25 +6,39 @@
 
     {{ block.super }}
 
-    <form method="post" action="" class="js-prevent-multiple-submit">
+
+    <div class="alert alert-info" role="alert">
+        {% trans "Confirmez votre choix en renseignant quelques informations supplémentaires." %}
+    </div>
+
+    <form method="post" action="" class="js-prevent-multiple-submit mt-5">
 
         {% csrf_token %}
 
-        {% if form_pe_status %}
+        {% if form_address or form_pe_status %}
+            <h3>{% trans "Candidat" %}</h3>
+        {% endif %}
 
+        {% if form_pe_status %}
             <div class="alert alert-warning" role="alert">
                 {% trans "Pour obtenir un PASS IAE dans les meilleurs délais, assurez-vous de l'exactitude de la date de naissance et du statut Pôle emploi du candidat." %}
             </div>
 
             {% bootstrap_form form_pe_status %}
-
         {% endif %}
 
-        <div class="alert alert-warning" role="alert">
-            {% trans "Confirmez votre choix." %}
+        {% if form_user_address %}
+            <div class="mt-5">
+                {% bootstrap_form form_user_address %}
+            </div>
+        {% endif %}
+
+        <div class="mt-5">
+            <h3>{% trans "Embauche" %}</h3>
+
+            {% bootstrap_form form_accept %}
         </div>
 
-        {% bootstrap_form form_accept %}
 
         {% buttons %}
             <a class="btn btn-secondary" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">{% trans "Annuler" %}</a>

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -27,6 +27,10 @@
             <li>{% trans "Téléphone :" %} <a href="tel:{{ job_application.job_seeker.phone }}">{{ job_application.job_seeker.phone|format_phone }}</a></li>
         {% endif %}
 
+        {% if job_application.job_seeker.address_on_one_line %}
+            <li>{% trans "Adresse" %} : <b>{{ job_application.job_seeker.address_on_one_line }}</b></li>
+        {% endif %}
+
         {% if job_application.selected_jobs.exists %}
             <li>
                 {% trans "Métier(s) recherché(s) :" %}

--- a/itou/users/factories.py
+++ b/itou/users/factories.py
@@ -5,6 +5,7 @@ import factory
 import factory.fuzzy
 
 from itou.users import models
+from itou.utils.address.departments import DEPARTMENTS
 
 
 DEFAULT_PASSWORD = "p4ssw0rd"
@@ -28,6 +29,13 @@ class UserFactory(factory.django.DjangoModelFactory):
 class JobSeekerFactory(UserFactory):
     is_job_seeker = True
     pole_emploi_id = factory.fuzzy.FuzzyText(length=8, chars=string.digits)
+
+
+class JobSeekerWithAddressFactory(JobSeekerFactory):
+    address_line_1 = factory.Faker("street_address", locale="fr_FR")
+    department = factory.fuzzy.FuzzyChoice(DEPARTMENTS.keys())
+    post_code = factory.Faker("postalcode")
+    city = factory.Faker("city", locale="fr_FR")
 
 
 class PrescriberFactory(UserFactory):

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -246,6 +246,22 @@ class JobSeekerPoleEmploiStatusForm(forms.ModelForm):
         )
 
 
+class UserAddressForm(AddressFormMixin, forms.ModelForm):
+    """
+    Add job seeker address in the job application process.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for field in ["address_line_1", "post_code", "city_name"]:
+            self.fields[field].required = True
+
+    class Meta:
+        model = get_user_model()
+        fields = ["address_line_1", "address_line_2", "post_code", "city_name", "city"]
+
+
 class FilterJobApplicationsForm(forms.Form):
     """
     Allow users to filter job applications based on specific fields.

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -11,7 +11,7 @@ from django.views.decorators.http import require_http_methods
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.utils.perms.user import get_user_info
-from itou.www.apply.forms import AcceptForm, AnswerForm, JobSeekerPoleEmploiStatusForm, RefusalForm
+from itou.www.apply.forms import AcceptForm, AnswerForm, JobSeekerPoleEmploiStatusForm, RefusalForm, UserAddressForm
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm, ConfirmEligibilityForm
 
 
@@ -146,9 +146,14 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
     # Ask the SIAE to verify the job seeker's Pôle emploi status.
     # This will ensure a smooth Approval delivery.
     form_pe_status = None
+    form_user_address = None
+
     if job_application.to_siae.is_subject_to_eligibility_rules:
         form_pe_status = JobSeekerPoleEmploiStatusForm(instance=job_application.job_seeker, data=request.POST or None)
         forms.append(form_pe_status)
+
+        form_user_address = UserAddressForm(instance=job_application.job_seeker, data=request.POST or None)
+        forms.append(form_user_address)
 
     form_accept = AcceptForm(instance=job_application, data=request.POST or None)
     forms.append(form_accept)
@@ -157,6 +162,9 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
 
         if form_pe_status:
             form_pe_status.save()
+
+        if form_user_address:
+            form_user_address.save()
 
         job_application = form_accept.save()
         job_application.accept(user=request.user)
@@ -189,6 +197,7 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
     context = {
         "approvals_wrapper": job_application.job_seeker.approvals_wrapper,
         "form_accept": form_accept,
+        "form_user_address": form_user_address,
         "form_pe_status": form_pe_status,
         "job_application": job_application,
     }


### PR DESCRIPTION
Si une structure est soumise aux règles de éligibilité, elle doit renseigner l'adresse du candidat lorsqu'elle accepte sa candidature.

Cette adresse s'affiche également sur la page récapitulative d'une candidature.

La page d'acceptation d'une candidature commençant à être assez longue, j'ai modifié quelques éléments pour la rendre plus lisible.

![adresse_1](https://user-images.githubusercontent.com/6150920/80609655-a63c6900-8a38-11ea-88a6-db4d8947acfd.png)

![adresse_2](https://user-images.githubusercontent.com/6150920/80609670-ab011d00-8a38-11ea-9453-60d2542587a9.png)
