### PR TITLE
Modification de l'affichage du nom des organisations

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -425,10 +425,13 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     @property
     def email_new_for_siae(self):
         to = self.get_siae_recipents_email_list()
+        bcc = []
+        if self.is_sent_by_proxy:
+            bcc.append(self.sender.email)
         context = {"job_application": self}
         subject = "apply/email/new_for_siae_subject.txt"
         body = "apply/email/new_for_siae_body.txt"
-        return get_email_message(to, context, subject, body)
+        return get_email_message(to, context, subject, body, bcc=bcc)
 
     @property
     def email_accept(self):

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -202,6 +202,10 @@ class JobApplicationEmailTest(TestCase):
         self.assertIn(job_application.to_siae.members.first().email, email.to)
         self.assertEqual(len(email.to), 1)
 
+        # BCC.
+        self.assertIn(job_application.sender.email, email.bcc)
+        self.assertEqual(len(email.bcc), 1)
+
         # Body.
         self.assertIn(job_application.job_seeker.first_name, email.body)
         self.assertIn(job_application.job_seeker.last_name, email.body)

--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -138,7 +138,7 @@ class PrescriberOrganization(AddressMixin):  # Do not forget the mixin!
 
     @property
     def display_name(self):
-        return self.name.title()
+        return self.name.capitalize()
 
     @property
     def has_members(self):

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -180,7 +180,7 @@ class Siae(AddressMixin):  # Do not forget the mixin!
     def display_name(self):
         if self.brand:
             return self.brand
-        return self.name.title()
+        return self.name.capitalize()
 
     @property
     def has_members(self):


### PR DESCRIPTION
Actuellement nous mettons en majuscule la première lettre de **chaque** mot présent dans le nom d'une organisation. Or cela pose quelques soucis d'ordre marketing. Par exemple, on n'écrit pas "Pôle Emploi" mais "Pole emploi". 
Cette PR propose de ne mettre en majuscules que le premier mot.

Il faut également mettre à jour le nom des organisations Pôle emploi pour ajouter l'accent circonflexe actuellement manquant.

```
from itou.prescribers.models import PrescriberOrganization

orgs = PrescriberOrganization.objects.filter(name__icontains="POLE EMPLOI")

for org in orgs:
    org.name = org.name.replace("POLE EMPLOI", "Pôle emploi")
    org.save()
```