### PR TITLE
Modification de l'affichage du nom des organisations

### DIFF
--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -138,7 +138,7 @@ class PrescriberOrganization(AddressMixin):  # Do not forget the mixin!
 
     @property
     def display_name(self):
-        return self.name.title()
+        return self.name.capitalize()
 
     @property
     def has_members(self):

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -180,7 +180,7 @@ class Siae(AddressMixin):  # Do not forget the mixin!
     def display_name(self):
         if self.brand:
             return self.brand
-        return self.name.title()
+        return self.name.capitalize()
 
     @property
     def has_members(self):


### PR DESCRIPTION
Actuellement nous mettons en majuscule la première lettre de **chaque** mot présent dans le nom d'une organisation. Or cela pose quelques soucis d'ordre marketing. Par exemple, on n'écrit pas "Pôle Emploi" mais "Pole emploi". 
Cette PR propose de ne mettre en majuscules que le premier mot.

Il faut également mettre à jour le nom des organisations Pôle emploi pour ajouter l'accent circonflexe actuellement manquant.

```
from itou.prescribers.models import PrescriberOrganization

orgs = PrescriberOrganization.objects.filter(name__icontains="POLE EMPLOI")

for org in orgs:
    org.name = org.name.replace("POLE EMPLOI", "Pôle emploi")
    org.save()
```