### PR TITLE
Ajout d'un contrôle sur la date de naissance

### DIFF
--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+import datetime
 from unittest import mock
 
 from django.conf import settings
@@ -259,11 +259,15 @@ class UtilsValidatorsTest(TestCase):
         validate_pole_emploi_id("1234567E")
 
     def test_validate_birthdate(self):
-        current_date = datetime.now().date()
-        self.assertRaises(ValidationError, validate_birthdate, current_date + timedelta(days=1))
-        self.assertRaises(ValidationError, validate_birthdate, current_date + timedelta(days=365))
+        # Min.
+        self.assertRaises(ValidationError, validate_birthdate, datetime.date(1899, 12, 31))
+        validate_birthdate(datetime.date(1900, 1, 1))
+        # Max.
+        current_date = datetime.datetime.now().date()
+        self.assertRaises(ValidationError, validate_birthdate, current_date + datetime.timedelta(days=1))
+        self.assertRaises(ValidationError, validate_birthdate, current_date + datetime.timedelta(days=365))
         self.assertRaises(ValidationError, validate_birthdate, current_date)
-        validate_birthdate(current_date - timedelta(days=3600))
+        validate_birthdate(current_date - datetime.timedelta(days=3600))
 
 
 class UtilsTemplateTagsTestCase(TestCase):
@@ -450,7 +454,7 @@ class SiaeSignupTokenGeneratorTest(TestCase):
         """
         siae = Siae.objects.create(email="test@example.com")
         siae_reload = Siae.objects.get(email="test@example.com")
-        p0 = MockedSiaeSignupTokenGenerator(datetime.now())
+        p0 = MockedSiaeSignupTokenGenerator(datetime.datetime.now())
         tk1 = p0.make_token(siae)
         tk2 = p0.make_token(siae_reload)
         self.assertEqual(tk1, tk2)
@@ -462,9 +466,13 @@ class SiaeSignupTokenGeneratorTest(TestCase):
         siae = Siae.objects.create()
         p0 = SiaeSignupTokenGenerator()
         tk1 = p0.make_token(siae)
-        p1 = MockedSiaeSignupTokenGenerator(datetime.now() + timedelta(seconds=(SIAE_SIGNUP_MAGIC_LINK_TIMEOUT - 1)))
+        p1 = MockedSiaeSignupTokenGenerator(
+            datetime.datetime.now() + datetime.timedelta(seconds=(SIAE_SIGNUP_MAGIC_LINK_TIMEOUT - 1))
+        )
         self.assertIs(p1.check_token(siae, tk1), True)
-        p2 = MockedSiaeSignupTokenGenerator(datetime.now() + timedelta(seconds=(SIAE_SIGNUP_MAGIC_LINK_TIMEOUT + 1)))
+        p2 = MockedSiaeSignupTokenGenerator(
+            datetime.datetime.now() + datetime.timedelta(seconds=(SIAE_SIGNUP_MAGIC_LINK_TIMEOUT + 1))
+        )
         self.assertIs(p2.check_token(siae, tk1), False)
 
     def test_check_token_with_nonexistent_token_and_user(self):

--- a/itou/utils/validators.py
+++ b/itou/utils/validators.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.utils import timezone
@@ -33,6 +35,16 @@ def validate_pole_emploi_id(pole_emploi_id):
         )
 
 
+def get_min_birthdate():
+    return datetime.date(1900, 1, 1)
+
+
+def get_max_birthdate():
+    return timezone.now().date()
+
+
 def validate_birthdate(birthdate):
-    if birthdate >= timezone.now().date():
-        raise ValidationError(_("Cette date de naissance n'est pas valide (date future)"))
+    if birthdate < get_min_birthdate():
+        raise ValidationError(_("La date de naissance doit être postérieure à 1900."))
+    if birthdate >= get_max_birthdate():
+        raise ValidationError(_("Cette date de naissance n'est pas valide (date future)."))

--- a/itou/utils/widgets.py
+++ b/itou/utils/widgets.py
@@ -1,9 +1,10 @@
 """
 Specific widgets used in forms.
 """
-
 from bootstrap_datepicker_plus import DatePickerInput
 from django.utils.translation import gettext_lazy
+
+from itou.utils.validators import get_max_birthdate, get_min_birthdate
 
 
 class DatePickerField(DatePickerInput):
@@ -47,3 +48,13 @@ class DatePickerField(DatePickerInput):
     def __init__(self, options={}):
         options = {**self.OPTIONS, **options}
         super().__init__(options=options)
+
+    @classmethod
+    def max_birthdate(cls):
+        # http://eonasdan.github.io/bootstrap-datetimepicker/Options/#minmaxdate
+        # Takes a moment.js format string.
+        return get_max_birthdate().strftime("%d/%m/%Y")
+
+    @classmethod
+    def min_birthdate(cls):
+        return get_min_birthdate().strftime("%d/%m/%Y")

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -43,7 +43,13 @@ class CheckJobSeekerInfoForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["birthdate"].required = True
-        self.fields["birthdate"].widget = DatePickerField({"viewMode": "years"})
+        self.fields["birthdate"].widget = DatePickerField(
+            {
+                "viewMode": "years",
+                "minDate": DatePickerField.min_birthdate(),
+                "maxDate": DatePickerField.max_birthdate(),
+            }
+        )
         self.fields["birthdate"].input_formats = [DatePickerField.DATE_FORMAT]
 
     class Meta:
@@ -72,7 +78,13 @@ class CreateJobSeekerForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
 
         # Birth date
         self.fields["birthdate"].required = True
-        self.fields["birthdate"].widget = DatePickerField({"viewMode": "years"})
+        self.fields["birthdate"].widget = DatePickerField(
+            {
+                "viewMode": "years",
+                "minDate": DatePickerField.min_birthdate(),
+                "maxDate": DatePickerField.max_birthdate(),
+            }
+        )
         self.fields["birthdate"].input_formats = [DatePickerField.DATE_FORMAT]
 
     class Meta:

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -22,7 +22,13 @@ class EditUserInfoForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
         else:
             self.fields["phone"].required = True
             self.fields["birthdate"].required = True
-            self.fields["birthdate"].widget = DatePickerField({"viewMode": "years"})
+            self.fields["birthdate"].widget = DatePickerField(
+                {
+                    "viewMode": "years",
+                    "minDate": DatePickerField.min_birthdate(),
+                    "maxDate": DatePickerField.max_birthdate(),
+                }
+            )
             self.fields["birthdate"].input_formats = [DatePickerField.DATE_FORMAT]
 
     class Meta:


### PR DESCRIPTION
La date de naissance doit être postérieure à 1900.

Ajout de bornes dans la sélection des années du _datepicker_.