### PR TITLE
Ajout d'un bouton "Voir la carte"

### DIFF
--- a/itou/static/js/matomo.js
+++ b/itou/static/js/matomo.js
@@ -6,7 +6,7 @@ $(document).ready(() => {
        <a href="#" class="matomo-event" data-matomo-category="MyCategory"
        data-matomo-action="MyAction" data-matomo-option="MyOption" >
     ********************************************************************/
-    $("a.matomo-event").on("click", function() {
+    $(".matomo-event").on("click", function() {
         var category = $(this).data("matomo-category");
         var action = $(this).data("matomo-action");
         var option = $(this).data("matomo-option");

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -34,10 +34,25 @@
                 <div class="modal-dialog modal-dialog-centered" role="document">
                     <div class="modal-content">
                         <div class="modal-body p-4">
-                            <h5 class="modal-title" id="mapModalLabel">En cours de conception 💡</h5>
-                            <p class="py-2">Nous réfléchissons à afficher les résultats sur une carte.
-                            Un peu de patience, c'est peut-être pour bientôt...</p>
-                            <button type="button" class="btn btn-primary w-100 w-sm-auto" data-dismiss="modal" aria-label="Close">Fermer</button>
+                            <h5 class="modal-title text-center" id="mapModalLabel">En cours de conception 💡</h5>
+                            <p class="pt-2">Nous réfléchissons à afficher les résultats sur une carte.
+                            Votez pour nous donner votre avis !</p>
+                            <div id="mapPoll">
+                                <div class="row buttonsContainer">
+                                    <div class="col-sm pr-sm-2">
+                                        <button type="button" class="btn btn-outline-primary w-100">
+                                            <span class="h4">👍</span> <span class="d-block">Je veux voir</span> la carte !
+                                        </button>
+                                    </div>
+                                    <div class="col-sm pl-sm-2">
+                                        <button type="button" class="btn btn-outline-primary w-100">
+                                            <span class="h4">👎</span> <span class="d-block">La carte ne</span> m'intéresse pas.
+                                        </button>
+                                    </div>
+                                </div>
+
+                            </div>
+                            <button type="button" class="btn btn-primary w-100 mt-3 mb-2" data-dismiss="modal" aria-label="Close">Fermer</button>
                         </div>
                     </div>
                 </div>
@@ -122,4 +137,16 @@
 
     {% endif %}
 
+{% endblock %}
+
+{% block script %}
+    {{ super }}
+    <script type="text/javascript">
+        // Related to the search results map experiment.
+        $( "#mapPoll button" ).click(function() {
+            $( "#mapPoll .buttonsContainer" ).fadeOut(function() {
+                $("#mapPoll").append("<div class='col-sm text-center'>Merci !</div>");
+            });
+        });
+    </script>
 {% endblock %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -17,7 +17,17 @@
         </h1>
 
         {% if siaes_page %}
-            <button type="button" class="btn btn-success my-3 m-sm-0 mb-sm-2" data-toggle="modal" data-target="#mapModal">{% include "includes/icon.html" with icon="map-pin" %} Voir la carte</button>
+            <button
+                type="button"
+                class="btn btn-success my-3 m-sm-0 mb-sm-2 matomo-event"
+                data-toggle="modal"
+                data-target="#mapModal"
+                data-matomo-category="experimentation"
+                data-matomo-action="clic"
+                data-matomo-option="carte-recherche"
+                >
+                    {% include "includes/icon.html" with icon="map-pin" %} Voir la carte
+            </button>
 
             <!-- Modal to test that a map is really needed by users -->
             <div class="modal fade" id="mapModal" tabindex="-1" role="dialog" aria-labelledby="mapModal" aria-hidden="true">

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -9,11 +9,34 @@
         {% include "search/includes/siaes_search_form.html" with form=form %}
     </form>
 
-    <h1 class="font-weight-normal">
-        {% with request.GET.city_name as city and request.GET.distance as distance %}
-            {% blocktrans %}Employeurs solidaires à <b>{{ distance }} Km</b> autour de <b>{{ city }}</b>{% endblocktrans %}
-        {% endwith %}
-    </h1>
+    <div class="d-flex flex-column flex-sm-row justify-content-sm-between align-items-sm-center">
+        <h1 class="font-weight-normal">
+            {% with request.GET.city_name as city and request.GET.distance as distance %}
+                {% blocktrans %}Employeurs solidaires à <b>{{ distance }} Km</b> autour de <b>{{ city }}</b>{% endblocktrans %}
+            {% endwith %}
+        </h1>
+
+        {% if siaes_page %}
+            <button type="button" class="btn btn-success my-3 m-sm-0 mb-sm-2" data-toggle="modal" data-target="#mapModal">{% include "includes/icon.html" with icon="map-pin" %} Voir la carte</button>
+
+            <!-- Modal to test that a map is really needed by users -->
+            <div class="modal fade" id="mapModal" tabindex="-1" role="dialog" aria-labelledby="mapModal" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered" role="document">
+                    <div class="modal-content">
+                        <div class="modal-body p-4">
+                            <h5 class="modal-title" id="mapModalLabel">En cours de conception 💡</h5>
+                            <p class="py-2">Nous réfléchissons à afficher les résultats sur une carte.
+                            Un peu de patience, c'est peut-être pour bientôt...</p>
+                            <button type="button" class="btn btn-primary w-100 w-sm-auto" data-dismiss="modal" aria-label="Close">Fermer</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- Modal end -->
+        {% endif %}
+
+    </div>
+
 
     {% if not siaes_page %}
 

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-    <form method="get" action="" class="d-block mb-3">
+    <form method="get" action="" class="d-block mb-3" style="margin: -1rem;">
         {% include "search/includes/siaes_search_form.html" with form=form %}
     </form>
 


### PR DESCRIPTION
Testons si les utilisateurs aimeraient voir les résultats de recherche sur une carte !

Le bouton ne s'affiche que s'il y a des résultats.

![image](https://user-images.githubusercontent.com/6150920/81715293-58802180-9478-11ea-95b9-ec27769f835f.png)

![image](https://user-images.githubusercontent.com/6150920/81823891-1ff24d80-9535-11ea-9ac6-d78a22a8b4fc.png)

![image](https://user-images.githubusercontent.com/6150920/81823974-38626800-9535-11ea-8335-96dc35fec7f0.png)

:information_source: Cette PR est liée à une expérimentation. [Lire la documentation à ce sujet](https://app.gitbook.com/@itou/s/equipe-itou/analyses-dusage-sur-matomo/mesurer-lattractivite-dune-nouvelle-fonctionnalite) ou [consulter la liste des événements](https://app.gitbook.com/@itou/s/equipe-itou/developpeurs/matomo/evenements).