### PR TITLE
Upgrade to PostgreSQL 12 and fix restore script

### DIFF
--- a/docker/dev/postgres/Dockerfile
+++ b/docker/dev/postgres/Dockerfile
@@ -1,4 +1,5 @@
-FROM mdillon/postgis:11
+# https://registry.hub.docker.com/r/postgis/postgis
+FROM postgis/postgis:12-master
 
 COPY ./docker/dev/postgres/maintenance /usr/local/bin/maintenance
 

--- a/docker/dev/postgres/maintenance/backup
+++ b/docker/dev/postgres/maintenance/backup
@@ -21,12 +21,10 @@ export PGUSER="${ITOU_POSTGRES_USER}"
 export PGPASSWORD="${ITOU_POSTGRES_PASSWORD}"
 export PGDATABASE="${ITOU_POSTGRES_DATABASE_NAME}"
 
-backup_filename="${BACKUP_FILE_PREFIX}_$(date +'%Y_%m_%dT%H_%M_%S').sql.gz"
-pg_dump | gzip > "${BACKUP_DIR_PATH}/${backup_filename}"
-
+backup_filename="${BACKUP_FILE_PREFIX}_custom_format_$(date +'%Y_%m_%dT%H_%M_%S').dump"
 # https://www.postgresql.org/docs/11/app-pgdump.html
-# Make a second dump in a custom-format archive suitable for input into pg_restore.
+# Dump in custom-format archive suitable for input into pg_restore.
 # This format is compressed by default.
-pg_dump --format=c > "${BACKUP_DIR_PATH}/${BACKUP_FILE_PREFIX}_custom_format_$(date +'%Y_%m_%dT%H_%M_%S').dump"
+pg_dump --format=c > "${BACKUP_DIR_PATH}/${backup_filename}"
 
 message_success "'${ITOU_POSTGRES_DATABASE_NAME}' database backup '${backup_filename}' has been created and placed in '${BACKUP_DIR_PATH}'."

--- a/docker/dev/postgres/maintenance/restore
+++ b/docker/dev/postgres/maintenance/restore
@@ -43,6 +43,6 @@ message_info "Creating a new database..."
 createdb --owner="${ITOU_POSTGRES_USER}"
 
 message_info "Applying the backup to the new database..."
-gunzip -c "${backup_filename}" | psql "${ITOU_POSTGRES_DATABASE_NAME}"
+pg_restore --dbname="${ITOU_POSTGRES_DATABASE_NAME}" --format=c --clean --no-owner --verbose "${backup_filename}"
 
 message_success "The '${ITOU_POSTGRES_DATABASE_NAME}' database has been restored from the '${backup_filename}' backup."


### PR DESCRIPTION
Upgrade de version majeure de postgres de 11 vers 12.

Pour éviter des une migration de données [un peu relou](https://github.com/docker-library/postgres/issues/682#issuecomment-587104091) il vaut mieux supprimer les volumes et les recréer : 

```shell
docker system prune -f

docker-compose -f docker-compose-dev.yml build --no-cache postgres

docker-compose -f docker-compose-dev.yml down --volumes

docker-compose -f docker-compose-dev.yml up
```