### PR TITLE
Feedback habilitations prescripteurs

### DIFF
--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -193,6 +193,18 @@ class PrescriberOrganization(AddressMixin):  # Do not forget the mixin!
         body = "prescribers/email/refused_prescriber_organization_email_body.txt"
         return get_email_message(to, context, subject, body)
 
+    def must_validate_prescriber_organization_email(self):
+        """
+        Send an email to the support:
+        signup of a new prescriber organization, with unregistered/unchecked org
+        => prescriber organization authorization must be validated
+        """
+        to = [settings.ITOU_EMAIL_CONTACT]
+        context = {"organization": self}
+        subject = "prescribers/email/must_validate_prescriber_organization_email_subject.txt"
+        body = "prescribers/email/must_validate_prescriber_organization_email_body.txt"
+        return get_email_message(to, context, subject, body)
+
 
 class PrescriberMembership(models.Model):
     """Intermediary model between `User` and `PrescriberOrganization`."""

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -130,7 +130,7 @@
                                 {% trans "Modifier votre organisation" %}
                             </a>
                         </p>
-                        {% if user_is_prescriber_org_admin %}
+                        {% if user_is_prescriber_org_admin and not prescriber_org_is_kind_pe %}
                             <p class="card-text">
                                 {% include "includes/icon.html" with icon="user-plus" %}
                                 <i>{% trans "Inviter des utilisateurs" %}</i>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -130,7 +130,7 @@
                                 {% trans "Modifier votre organisation" %}
                             </a>
                         </p>
-                        {% if user_is_prescriber_org_admin and not prescriber_org_is_kind_pe %}
+                        {% if user_is_prescriber_org_admin and prescriber_is_orienter %}
                             <p class="card-text">
                                 {% include "includes/icon.html" with icon="user-plus" %}
                                 <i>{% trans "Inviter des utilisateurs" %}</i>

--- a/itou/templates/prescribers/email/must_validate_prescriber_organization_email_body.txt
+++ b/itou/templates/prescribers/email/must_validate_prescriber_organization_email_body.txt
@@ -1,0 +1,14 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% load format_filters %}
+{% load i18n %}
+{% block body %}
+
+{% trans "Une nouvelle organisation de prescripteur a été créée. L'habilitation de cette structure est à vérifier." %}
+
+{% trans "*Structure* :" %}
+
+- {% trans "Nom" %} : {{ organization.display_name }}
+- {% trans "ID" %} : {{ organization.id }}
+
+
+{% endblock body %}

--- a/itou/templates/prescribers/email/must_validate_prescriber_organization_email_subject.txt
+++ b/itou/templates/prescribers/email/must_validate_prescriber_organization_email_subject.txt
@@ -1,0 +1,5 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% load i18n %}
+{% block subject %}
+{% blocktrans %}Vérification de l'habilitation d'une nouvelle organisation{% endblocktrans %}
+{% endblock %}

--- a/itou/www/autocomplete/views.py
+++ b/itou/www/autocomplete/views.py
@@ -62,8 +62,8 @@ def prescriber_authorized_organizations_autocomplete(request):
     organizations = (
         [
             {"value": org.name, "id": org.id}
-            for org in PrescriberOrganization.objects.exclude(is_authorized=False)
-            .exclude(kind=PrescriberOrganization.Kind.PE)
+            for org in PrescriberOrganization.objects.exclude(kind=PrescriberOrganization.Kind.PE)
+            .filter(authorization_status=PrescriberOrganization.AuthorizationStatus.VALIDATED)
             .autocomplete(term, limit=20)
         ]
         if term

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -40,7 +40,9 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                 prescriber.authorization_status == PrescriberOrganization.AuthorizationStatus.NOT_SET
             )
             # This is to hide the "secret code", except for orienter orgs
-            prescriber_is_orienter = prescriber.authorization_status == PrescriberOrganization.AuthorizationStatus.NOT_REQUIRED
+            prescriber_is_orienter = (
+                prescriber.authorization_status == PrescriberOrganization.AuthorizationStatus.NOT_REQUIRED
+            )
 
     context = {
         "job_applications_counter": job_applications_counter,

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -19,6 +19,7 @@ from itou.www.dashboard.forms import EditUserInfoForm
 def dashboard(request, template_name="dashboard/dashboard.html"):
     job_applications_counter = 0
     prescriber_authorization_status_not_set = None
+    prescriber_org_is_kind_pe = False
 
     if request.user.is_siae_staff:
         pk = request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY]
@@ -38,10 +39,14 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
             prescriber_authorization_status_not_set = (
                 prescriber.authorization_status == PrescriberOrganization.AuthorizationStatus.NOT_SET
             )
+            # This is useful to hide the "secret code" for PE orgs which may be confusing:
+            # PE prescriber signup / link can only be made via SAFIR code
+            prescriber_org_is_kind_pe = prescriber.kind == PrescriberOrganization.Kind.PE
 
     context = {
         "job_applications_counter": job_applications_counter,
         "prescriber_authorization_status_not_set": prescriber_authorization_status_not_set,
+        "prescriber_org_is_kind_pe": prescriber_org_is_kind_pe,
     }
 
     return render(request, template_name, context)

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -19,7 +19,7 @@ from itou.www.dashboard.forms import EditUserInfoForm
 def dashboard(request, template_name="dashboard/dashboard.html"):
     job_applications_counter = 0
     prescriber_authorization_status_not_set = None
-    prescriber_org_is_kind_pe = False
+    prescriber_is_orienter = False
 
     if request.user.is_siae_staff:
         pk = request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY]
@@ -39,14 +39,13 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
             prescriber_authorization_status_not_set = (
                 prescriber.authorization_status == PrescriberOrganization.AuthorizationStatus.NOT_SET
             )
-            # This is useful to hide the "secret code" for PE orgs which may be confusing:
-            # PE prescriber signup / link can only be made via SAFIR code
-            prescriber_org_is_kind_pe = prescriber.kind == PrescriberOrganization.Kind.PE
+            # This is to hide the "secret code", except for orienter orgs
+            prescriber_is_orienter = prescriber.authorization_status == PrescriberOrganization.AuthorizationStatus.NOT_REQUIRED
 
     context = {
         "job_applications_counter": job_applications_counter,
         "prescriber_authorization_status_not_set": prescriber_authorization_status_not_set,
-        "prescriber_org_is_kind_pe": prescriber_org_is_kind_pe,
+        "prescriber_is_orienter": prescriber_is_orienter,
     }
 
     return render(request, template_name, context)

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -279,7 +279,7 @@ class SelectSiaeForm(forms.Form):
 
 class SiaeSignupForm(FullnameFormMixin, SignupForm):
     """
-    Second of two forms of siae signup process.aussi le code d'invitation qui apparaît dans le dashboard après le rattachement du premier membre d'une orga en attente de vérification d'habilitation. Le code d'invitation n'est plus nécessaire, car pour se rattacher à une structure ayant déjà un membre il suffit de la sélectionner dans le menu déroulant
+    Second of two forms of siae signup process.
     This is the final form where the signup actually happens
     on the siae identified by the first form.
     """

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -80,6 +80,7 @@ class PrescriberForm(FullnameFormMixin, SignupForm):
             self.new_organization.created_by = user
             self.new_organization.save()
             organization = self.new_organization
+            organization.must_validate_prescriber_organization_email().send()
         else:
             organization = self.organization
 
@@ -278,7 +279,7 @@ class SelectSiaeForm(forms.Form):
 
 class SiaeSignupForm(FullnameFormMixin, SignupForm):
     """
-    Second of two forms of siae signup process.
+    Second of two forms of siae signup process.aussi le code d'invitation qui apparaît dans le dashboard après le rattachement du premier membre d'une orga en attente de vérification d'habilitation. Le code d'invitation n'est plus nécessaire, car pour se rattacher à une structure ayant déjà un membre il suffit de la sélectionner dans le menu déroulant
     This is the final form where the signup actually happens
     on the siae identified by the first form.
     """

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -498,6 +498,11 @@ class PrescriberSignupTest(TestCase):
         self.assertIsNone(new_org.authorization_updated_by)
         self.assertEqual(new_org.created_by, user)
 
+        # Check email has been sent to support (validation/refusal of authorisation needed)
+        self.assertEqual(len(mail.outbox), 2)
+        subject = mail.outbox[0].subject
+        self.assertIn("Vérification de l'habilitation d'une nouvelle organisation", subject)
+
     def test_prescriber_signup_without_code_nor_organization(self):
         """
         Prescriber signup (orienter) without code nor organization.


### PR DESCRIPTION
- Added notification email to support when there is a new prescriber org auth validation to be done
- Do not display code except for orienter (simpler)
- Updated dashboard for PE prescriber: hide the secret code (useless with SAFIR)
- Better filter for prescriber org autocomplete
