### PR TITLE
FIX: import des fichiers JS dans les résultats de recherche

### DIFF
--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -138,7 +138,7 @@
 {% endblock %}
 
 {% block script %}
-    {{ super }}
+    {{ block.super }}
     <script type="text/javascript">
         // Related to the search results map experiment.
         $( "#mapPoll button" ).click(function() {


### PR DESCRIPTION
Les scripts JS (block `script`) du template `base.html` ne sont pas importés:
* plus d'autocomplétion dans la page des résultats de recherche
