### PR TITLE
Export des PASS IAE vers un fichier Excel

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -14,6 +14,8 @@ ROOT_DIR = os.path.abspath(os.path.join(CURRENT_DIR, "../.."))
 
 APPS_DIR = os.path.abspath(os.path.join(ROOT_DIR, "itou"))
 
+EXPORT_DIR = f"{ROOT_DIR}/exports"
+
 # General.
 # ------------------------------------------------------------------------------
 

--- a/exports/readme.md
+++ b/exports/readme.md
@@ -1,0 +1,1 @@
+This folder contains export files (approvals,...) created via manage.py commands.

--- a/itou/approvals/management/commands/export_approvals.py
+++ b/itou/approvals/management/commands/export_approvals.py
@@ -1,0 +1,44 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from itou.utils.exports.export_approvals import export_approvals
+
+
+class Command(BaseCommand):
+
+    help = "Export the content of the approvals from the database into a xlsx file or an output stream."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--format",
+            dest="export_format",
+            required=False,
+            action="store",
+            help="Choose between 'stream' and 'file' export type",
+        )
+
+    def set_logger(self, verbosity):
+        """
+        Set logger level based on the verbosity option.
+        """
+        handler = logging.StreamHandler(self.stdout)
+
+        self.logger = logging.getLogger(__name__)
+        self.logger.propagate = False
+        self.logger.addHandler(handler)
+
+        self.logger.setLevel(logging.INFO)
+        if verbosity > 1:
+            self.logger.setLevel(logging.DEBUG)
+
+    def handle(self, export_format, **options):
+        chosen_format = export_format or "file"
+        self.set_logger(options.get("verbosity"))
+        self.logger.info(f"Exporting approvals (export to '{export_format}')")
+
+        result = export_approvals(chosen_format)
+
+        if chosen_format == "stream":
+            self.stdout.write(result)
+        else:
+            self.logger.info(f"Done! Approvals export file written to: '{result}'")

--- a/itou/approvals/management/commands/export_approvals.py
+++ b/itou/approvals/management/commands/export_approvals.py
@@ -1,21 +1,22 @@
 import logging
 
 from django.core.management.base import BaseCommand
+
 from itou.utils.exports.export_approvals import export_approvals
 
 
 class Command(BaseCommand):
+    """
+    Export all valid approvals (PASS IAE, not Pole emploi) to an Excel file.
+
+    This file is:
+    * named 'export_pass_iae_MMDDYYY_HHMINSEC.xslx' (datetime of export)
+    * put in the 'exports' folder
+
+    There is no optional argument at the moment.
+    """
 
     help = "Export the content of the approvals from the database into a xlsx file or an output stream."
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "--format",
-            dest="export_format",
-            required=False,
-            action="store",
-            help="Choose between 'stream' and 'file' export type",
-        )
 
     def set_logger(self, verbosity):
         """
@@ -31,14 +32,11 @@ class Command(BaseCommand):
         if verbosity > 1:
             self.logger.setLevel(logging.DEBUG)
 
-    def handle(self, export_format, **options):
-        chosen_format = export_format or "file"
+    def handle(self, **options):
+
         self.set_logger(options.get("verbosity"))
-        self.logger.info(f"Exporting approvals (export to '{export_format}')")
+        self.logger.info(f"Exporting approvals")
 
-        result = export_approvals(chosen_format)
+        result = export_approvals()
 
-        if chosen_format == "stream":
-            self.stdout.write(result)
-        else:
-            self.logger.info(f"Done! Approvals export file written to: '{result}'")
+        self.logger.info(f"Done!\nApprovals / PASS IAE export file written to: '{result}'")

--- a/itou/templates/admin/approvals/change_list.html
+++ b/itou/templates/admin/approvals/change_list.html
@@ -1,0 +1,9 @@
+{% extends 'admin/change_list.html' %}
+{% load i18n %}
+
+{% block object-tools-items %}
+    {{ block.super }}
+    <li>
+        <a href="export_approvals">{% trans "Exporter les PASS IAE (EXCEL)" %}</a>
+    </li>
+{% endblock %}

--- a/itou/utils/exports/export_approvals.py
+++ b/itou/utils/exports/export_approvals.py
@@ -43,7 +43,7 @@ def _approval_line(approval):
     ]
 
 
-def export_approvals(export_format=None):
+def export_approvals(export_format="file"):
     """
     Main entry point. Currently used by admin site and an admin command (`itou/approvals/management/commands/export_approvals.py`)
 
@@ -55,8 +55,6 @@ def export_approvals(export_format=None):
         * a path for `file`
         * a pair with filename and object for `stream`
     """
-    export_format = "file" if not export_format else export_format
-
     assert export_format in EXPORT_FORMATS, f"Unknown export format '{export_format}'"
 
     wb = Workbook()

--- a/itou/utils/exports/export_approvals.py
+++ b/itou/utils/exports/export_approvals.py
@@ -78,7 +78,7 @@ def export_approvals(export_format="file"):
             ws.column_dimensions[get_column_letter(j)].width = max_width[j]
 
     suffix = current_dt.strftime("%d%m%Y_%H%M%S")
-    filename = f"export_pass_iae_{suffix}.xslx"
+    filename = f"export_pass_iae_{suffix}.xlsx"
 
     if export_format == "file":
         path = f"{EXPORT_DIR}/{filename}"

--- a/itou/utils/exports/export_approvals.py
+++ b/itou/utils/exports/export_approvals.py
@@ -1,0 +1,75 @@
+import datetime
+import os
+
+from openpyxl import Workbook
+from openpyxl.utils import get_column_letter
+from openpyxl.writer.excel import save_virtual_workbook
+
+from django.conf import settings
+
+
+from itou.approvals.models import Approval
+
+EXPORT_DIR = f"{settings.ROOT_DIR}/exports"
+
+FIELDS = [
+    "id_pole_emploi",
+    "nom",
+    "prenom",
+    "date_naissance",
+    "numero_pass_iae",
+    "date_debut_pass_iae",
+    "date_fin_pass_iae",
+    "code_postal",
+    "code_postal_employeur",
+]
+DATE_FMT = "%d-%m-%Y"
+EXPORT_FORMATS = ["stream", "file"]
+
+
+def _approval_line(approval):
+    assert approval
+    return [
+        approval.user.pole_emploi_id,
+        approval.user.first_name,
+        approval.user.last_name,
+        approval.user.birthdate.strftime(DATE_FMT),
+        approval.number,
+        approval.start_at.strftime(DATE_FMT),
+        approval.end_at.strftime(DATE_FMT),
+        approval.user.post_code,
+        approval.jobapplication_set.latest("created_at").to_siae.post_code,
+    ]
+
+
+def export_approvals(export_format=None):
+    export_format = "file" if not export_format else export_format
+
+    assert export_format in EXPORT_FORMATS, f"Unknown export format '{export_format}'"
+
+    wb = Workbook()
+    ws = wb.active
+
+    current_dt = datetime.datetime.now()
+    ws.title = "Export PASS SIAE " + current_dt.strftime(DATE_FMT)
+
+    data = [FIELDS]
+
+    for approval in Approval.objects.all():
+        data.append(_approval_line(approval))
+
+    max_width = [0] * (len(FIELDS) + 1)
+
+    for i, row in enumerate(data, 1):
+        for j, cell_value in enumerate(row, 1):
+            max_width[j] = max(max_width[j], len(cell_value))
+            ws.cell(i, j).value = cell_value
+            ws.column_dimensions[get_column_letter(j)].width = max_width[j]
+
+    if export_format == "file":
+        suffix = current_dt.strftime("%d%m%Y_%H%M%S")
+        path = f"{EXPORT_DIR}/export_pass_iae_{suffix}.xslx"
+        wb.save(path)
+        return path
+    elif export_format == "stream":
+        return save_virtual_workbook(wb)

--- a/itou/utils/exports/export_approvals.py
+++ b/itou/utils/exports/export_approvals.py
@@ -23,6 +23,8 @@ FIELDS = [
     "date_fin_pass_iae",
     "code_postal",
     "code_postal_employeur",
+    "numero_siret",
+    "raison_sociale"
 ]
 DATE_FMT = "%d-%m-%Y"
 EXPORT_FORMATS = ["stream", "file"]
@@ -30,6 +32,7 @@ EXPORT_FORMATS = ["stream", "file"]
 
 def _approval_line(approval):
     assert approval
+    siae  = approval.jobapplication_set.latest("created_at").to_siae
     return [
         approval.user.pole_emploi_id,
         approval.user.first_name,
@@ -39,7 +42,9 @@ def _approval_line(approval):
         approval.start_at.strftime(DATE_FMT),
         approval.end_at.strftime(DATE_FMT),
         approval.user.post_code,
-        approval.jobapplication_set.latest("created_at").to_siae.post_code,
+        siae.post_code,
+        siae.siret,
+        siae.name,
     ]
 
 

--- a/itou/utils/exports/export_approvals.py
+++ b/itou/utils/exports/export_approvals.py
@@ -11,8 +11,6 @@ from itou.approvals.models import Approval
 # XLS export of currently valid approvals
 # Currently used by admin site and admin command (export_approvals)
 
-EXPORT_DIR = f"{settings.ROOT_DIR}/exports"
-
 FIELDS = [
     "id_pole_emploi",
     "nom",
@@ -24,7 +22,7 @@ FIELDS = [
     "code_postal",
     "code_postal_employeur",
     "numero_siret",
-    "raison_sociale"
+    "raison_sociale",
 ]
 DATE_FMT = "%d-%m-%Y"
 EXPORT_FORMATS = ["stream", "file"]
@@ -32,7 +30,7 @@ EXPORT_FORMATS = ["stream", "file"]
 
 def _approval_line(approval):
     assert approval
-    siae  = approval.jobapplication_set.latest("created_at").to_siae
+    siae = approval.jobapplication_set.latest("created_at").to_siae
     return [
         approval.user.pole_emploi_id,
         approval.user.first_name,
@@ -86,7 +84,7 @@ def export_approvals(export_format="file"):
     filename = f"export_pass_iae_{suffix}.xlsx"
 
     if export_format == "file":
-        path = f"{EXPORT_DIR}/{filename}"
+        path = f"{settings.EXPORT_DIR}/{filename}"
         wb.save(path)
         return path
     elif export_format == "stream":


### PR DESCRIPTION
# Export des PASS IAE (Excel)

Permet d'exporter les PASS IAE en cours de validité vers un fichier Excel (format xlsx).

Peut-etre utilisé via:
- une commande d'admin Django: `manage.py export_approvals`
- le site d'admin (bouton dans la partie `objecttools`)


![export-pass-ia-button](https://user-images.githubusercontent.com/147232/82427838-eae08080-9a89-11ea-8eb0-0df9290764f5.png)
