### PR TITLE
FIX - Problème d'email à l'inscription des prescripteurs

### DIFF
--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -57,8 +57,8 @@ class PrescriberForm(FullnameFormMixin, SignupForm):
     def clean_email(self):
         # Must check if already exists
         email = self.cleaned_data["email"]
-        if User.email_already_exists(email):
-            raise ValidationError(gettext_lazy("Cette adresse email est déjà enregitrée"))
+        if get_user_model().email_already_exists(email):
+            raise ValidationError(gettext_lazy("Cette adresse email est déjà enregistrée"))
         return email
 
     def clean_secret_code(self):

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -10,8 +10,8 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _, gettext_lazy
 
 from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
-from itou.users.models import User
 from itou.siaes.models import Siae, SiaeMembership
+from itou.users.models import User
 from itou.utils.tokens import siae_signup_token_generator
 from itou.utils.validators import validate_siret
 
@@ -118,12 +118,9 @@ class PoleEmploiPrescriberForm(PrescriberForm):
 
     def clean_email(self):
         email = super().clean_email()
+
         if not email.endswith("@pole-emploi.fr"):
             raise ValidationError(gettext_lazy("L'adresse e-mail doit être une adresse Pôle emploi"))
-
-        # Must check if already exists
-        if User.email_already_exists(email):
-            raise ValidationError(gettext_lazy("Cette adresse email est déjà enregitrée"))
 
         return email
 

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -10,6 +10,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _, gettext_lazy
 
 from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
+from itou.users.models import User
 from itou.siaes.models import Siae, SiaeMembership
 from itou.utils.tokens import siae_signup_token_generator
 from itou.utils.validators import validate_siret
@@ -52,6 +53,13 @@ class PrescriberForm(FullnameFormMixin, SignupForm):
         super().__init__(*args, **kwargs)
         self.organization = None
         self.new_organization = None
+
+    def clean_email(self):
+        # Must check if already exists
+        email = self.cleaned_data["email"]
+        if User.email_already_exists(email):
+            raise ValidationError(gettext_lazy("Cette adresse email est déjà enregitrée"))
+        return email
 
     def clean_secret_code(self):
         """
@@ -109,9 +117,14 @@ class PoleEmploiPrescriberForm(PrescriberForm):
     safir_code = forms.CharField(max_length=5, label=gettext_lazy("Code SAFIR"))
 
     def clean_email(self):
-        email = self.cleaned_data["email"]
+        email = super().clean_email()
         if not email.endswith("@pole-emploi.fr"):
             raise ValidationError(gettext_lazy("L'adresse e-mail doit être une adresse Pôle emploi"))
+
+        # Must check if already exists
+        if User.email_already_exists(email):
+            raise ValidationError(gettext_lazy("Cette adresse email est déjà enregitrée"))
+
         return email
 
     def clean_safir_code(self):

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -412,9 +412,9 @@ class PrescriberSignupTest(TestCase):
 
         # User validation via email tested in `test_prescriber_signup_without_code_nor_organization`
 
-        # Check bugfix on prescriber signup (email already exists)
+        # Check prescriber signup (email already exists)
         response = self.client.post(url, data=post_data)
-        self.assertFormError(response, "form", "email", "Cette adresse email est déjà enregitrée")
+        self.assertFormError(response, "form", "email", "Cette adresse email est déjà enregistrée")
 
     def test_authorized_prescriber_with_organization(self):
         url = reverse("signup:prescriber_authorized")

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -412,6 +412,10 @@ class PrescriberSignupTest(TestCase):
 
         # User validation via email tested in `test_prescriber_signup_without_code_nor_organization`
 
+        # Check bugfix on prescriber signup (email already exists)
+        response = self.client.post(url, data=post_data)
+        self.assertFormError(response, "form", "email", "Cette adresse email est déjà enregitrée")
+
     def test_authorized_prescriber_with_organization(self):
         url = reverse("signup:prescriber_authorized")
         response = self.client.get(url)


### PR DESCRIPTION
L'e-mail des prescripteurs (tous types) n'est pas correctement testé pour les doublons dans le formulaire d'inscription.