### PR TITLE
Ajout des formulaires d'opinion Typeform dans certains emails

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -356,6 +356,11 @@ ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY = "current_prescriber_organization"
 ITOU_SESSION_CURRENT_SIAE_KEY = "current_siae"
 ITOU_SESSION_JOB_APPLICATION_KEY = "job_application"
 
+# Typeform survey links to include in some emails
+ITOU_EMAIL_APPROVAL_SURVEY_LINK = "https://startupsbeta.typeform.com/to/au9d8P"
+ITOU_EMAIL_PRESCRIBER_NEW_HIRING_LINK = "https://startupsbeta.typeform.com/to/X40eJC"
+
+
 # Some external libraries, as PDF Shift, need access to static files
 # but they can't access them when working locally.
 # Use the staging domain name when this case arises.

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -451,7 +451,8 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         bcc = []
         if self.is_sent_by_proxy:
             bcc.append(self.sender.email)
-        context = {"job_application": self}
+        context = {"job_application": self,
+                   "survey_link": settings.ITOU_EMAIL_PRESCRIBER_NEW_HIRING_LINK, }
         subject = "apply/email/accept_subject.txt"
         body = "apply/email/accept_body.txt"
         return get_email_message(to, context, subject, body, bcc=bcc)
@@ -497,7 +498,8 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         if not self.approval:
             raise RuntimeError(_("No approval found for this job application."))
         to = [accepted_by.email]
-        context = {"job_application": self}
+        context = {"job_application": self, 
+                   "survey_link": settings.ITOU_EMAIL_APPROVAL_SURVEY_LINK, }
         subject = "apply/email/approval_number_subject.txt"
         body = "apply/email/approval_number_body.txt"
         return get_email_message(to, context, subject, body)

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -451,8 +451,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         bcc = []
         if self.is_sent_by_proxy:
             bcc.append(self.sender.email)
-        context = {"job_application": self,
-                   "survey_link": settings.ITOU_EMAIL_PRESCRIBER_NEW_HIRING_LINK, }
+        context = {"job_application": self, "survey_link": settings.ITOU_EMAIL_PRESCRIBER_NEW_HIRING_LINK}
         subject = "apply/email/accept_subject.txt"
         body = "apply/email/accept_body.txt"
         return get_email_message(to, context, subject, body, bcc=bcc)
@@ -498,8 +497,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         if not self.approval:
             raise RuntimeError(_("No approval found for this job application."))
         to = [accepted_by.email]
-        context = {"job_application": self, 
-                   "survey_link": settings.ITOU_EMAIL_APPROVAL_SURVEY_LINK, }
+        context = {"job_application": self, "survey_link": settings.ITOU_EMAIL_APPROVAL_SURVEY_LINK}
         subject = "apply/email/approval_number_subject.txt"
         body = "apply/email/approval_number_body.txt"
         return get_email_message(to, context, subject, body)

--- a/itou/templates/apply/email/accept_body.txt
+++ b/itou/templates/apply/email/accept_body.txt
@@ -8,14 +8,6 @@
 La candidature de {{ job_seeker_full_name }} envoyée par {{ sender_full_name }} a été acceptée par {{ to_siae }}.
 {% endblocktrans %}
 
-{% blocktrans %}
-La Plateforme de l’inclusion a-t-elle permis que votre candidat(e) soit embauché(e) plus rapidement ?
-{% endblocktrans %}
-
-{% blocktrans %}
-Je donne mon avis en cliquant sur ce lien: {{ survey_link }}
-{% endblocktrans %}
-
 {% else %}
 
 {% blocktrans with to_siae=job_application.to_siae.display_name %}
@@ -29,5 +21,13 @@ Votre candidature a été acceptée par {{ to_siae }}.
 
 {{ job_application.answer }}
 {% endif %}
+
+{% blocktrans %}
+La Plateforme de l’inclusion a-t-elle permis que votre candidat(e) soit embauché(e) plus rapidement ?
+{% endblocktrans %}
+
+{% blocktrans %}
+Donnez votre avis en cliquant sur ce lien: {{ survey_link }}
+{% endblocktrans %}
 
 {% endblock body %}

--- a/itou/templates/apply/email/accept_body.txt
+++ b/itou/templates/apply/email/accept_body.txt
@@ -13,7 +13,7 @@ La Plateforme de l’inclusion a-t-elle permis que votre candidat(e) soit embauc
 {% endblocktrans %}
 
 {% blocktrans %}
-Je donne mon avis en cliquant sur ce lien: 
+Je donne mon avis en cliquant sur ce lien: {{ survey_link }}
 {% endblocktrans %}
 
 {% else %}

--- a/itou/templates/apply/email/accept_body.txt
+++ b/itou/templates/apply/email/accept_body.txt
@@ -8,6 +8,14 @@
 La candidature de {{ job_seeker_full_name }} envoyée par {{ sender_full_name }} a été acceptée par {{ to_siae }}.
 {% endblocktrans %}
 
+{% blocktrans %}
+La Plateforme de l’inclusion a-t-elle permis que votre candidat(e) soit embauché(e) plus rapidement ?
+{% endblocktrans %}
+
+{% blocktrans %}
+Je donne mon avis en cliquant sur ce lien: 
+{% endblocktrans %}
+
 {% else %}
 
 {% blocktrans with to_siae=job_application.to_siae.display_name %}

--- a/itou/templates/apply/email/accept_subject.txt
+++ b/itou/templates/apply/email/accept_subject.txt
@@ -1,5 +1,5 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% load i18n %}
 {% block subject %}
-{% blocktrans %}Candidature acceptée{% endblocktrans %}
+{% blocktrans %}Candidature acceptée et votre avis sur la Plateforme de l'inclusion{% endblocktrans %}
 {% endblock %}

--- a/itou/templates/apply/email/approval_number_body.txt
+++ b/itou/templates/apply/email/approval_number_body.txt
@@ -32,7 +32,7 @@ Veuillez trouver ci-après les caractéristiques du PASS IAE,{% endblocktrans %}
 {% trans "La plateforme de l’inclusion vous a-t-elle permis d’embaucher plus rapidement ?" %}
 
 {% blocktrans %}
-Je donne mon avis en cliquant sur ce lien: {{ survey_link }}
+Donnez votre avis en cliquant sur ce lien: {{ survey_link }}
 {% endblocktrans %}
 
 {% endblock body %}

--- a/itou/templates/apply/email/approval_number_body.txt
+++ b/itou/templates/apply/email/approval_number_body.txt
@@ -29,4 +29,10 @@ Veuillez trouver ci-après les caractéristiques du PASS IAE,{% endblocktrans %}
 {% trans "Votre contact :" %}
 {{ itou_email_contact }}
 
+{% trans "La plateforme de l’inclusion vous a-t-elle permis d’embaucher plus rapidement ?" %}
+
+{% blocktrans %}
+Je donne mon avis en cliquant sur ce lien: {{ survey_link }}
+{% endblocktrans %}
+
 {% endblock body %}

--- a/itou/templates/apply/email/approval_number_subject.txt
+++ b/itou/templates/apply/email/approval_number_subject.txt
@@ -1,5 +1,5 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% load i18n %}
 {% block subject %}
-{% blocktrans with job_seeker_full_name=job_application.job_seeker.get_full_name %}Délivrance d'un PASS IAE pour {{ job_seeker_full_name }}{% endblocktrans %}
+{% blocktrans with job_seeker_full_name=job_application.job_seeker.get_full_name %}Délivrance d'un PASS IAE pour {{ job_seeker_full_name }} et votre avis sur la Plateforme de l'inclusion{% endblocktrans %}
 {% endblock %}


### PR DESCRIPTION
Les liens vers les formulaires Typeform sont ajoutés aux emails de:
* délivrance d'un PASS IAE
* confirmation d'embauche pour un prescripteur
