### PR TITLE
Pas de rattachement d'un prescripteur à une nouvelle organisation

### DIFF
--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -91,19 +91,20 @@ class PrescriberForm(FullnameFormMixin, SignupForm):
         else:
             organization = self.organization
 
-            if organization:
-                if organization.has_members:
-                    organization.new_signup_warning_email_to_existing_members(user).send()
-                else:
-                    # for existing organization with no member
+        if organization:
+            if organization.has_members:
+                organization.new_signup_warning_email_to_existing_members(user).send()
+            else:
+                # for *existing* organization with no member
+                if not self.new_organization:
                     organization.organization_with_no_member_email(user).send()
 
-                membership = PrescriberMembership()
-                membership.user = user
-                membership.organization = organization
-                # The first member becomes an admin.
-                membership.is_admin = membership.organization.members.count() == 0
-                membership.save()
+            membership = PrescriberMembership()
+            membership.user = user
+            membership.organization = organization
+            # The first member becomes an admin.
+            membership.is_admin = membership.organization.members.count() == 0
+            membership.save()
 
         return user
 

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -497,7 +497,7 @@ class PrescriberSignupTest(TestCase):
         # Check email has been sent to support (validation/refusal of authorisation needed)
         self.assertEqual(len(mail.outbox), 2)
         subject = mail.outbox[0].subject
-        self.assertIn("Première inscription à une organisation", subject)
+        self.assertIn("Première inscription à une organisation existante", subject)
         subject = mail.outbox[1].subject
         self.assertIn("Confirmer l'adresse email pour la Plateforme de l'inclusion", subject)
 


### PR DESCRIPTION
Le rattachement d'un prescripteur à une nouvelle organisation (pas en base) lors de la souscription:
* n'est pas correctement implémenté (pas de membership)
* envoie un mail inutile (ajout à une orga sans membres)

+ Fix des tests correspondants 