### PR TITLE
Message d'erreur difficile à interpréter lors de l'inscription d'un PH

### DIFF
--- a/itou/templates/apply/submit_step_eligibility.html
+++ b/itou/templates/apply/submit_step_eligibility.html
@@ -6,7 +6,7 @@
     {{ block.super }}
 
     <div class="alert alert-warning" role="alert">
-        {% blocktrans %}La prescription d'un parcours IAE implique la réalisation préalable d'un diagnostic socio-professionnel permettant d'identifier les raisons, tenant compte <a href="#criteres_administratifs">des critères administratifs</a> et des freins sociaux, pour lesquelles la personne relève d'un parcours d'insertion par l'IAE. Ce diagnostic devra reprendre a minima les éléments présents dans <a href="#diagnostic_de_reference">le diagnostic de référence</a>{% endblocktrans %}
+        {% blocktrans %}La prescription d'un parcours IAE implique la réalisation préalable d'un diagnostic socio-professionnel permettant d'identifier les raisons, tenant compte <a href="#criteres_administratifs">des critères administratifs</a> et des freins sociaux, pour lesquels la personne relève d'un parcours d'insertion par l'IAE. Ce diagnostic devra reprendre a minima les éléments présents dans <a href="#diagnostic_de_reference">le diagnostic de référence</a>{% endblocktrans %}
     </div>
 
     <hr>

--- a/itou/templates/signup/signup_prescriber_authorized.html
+++ b/itou/templates/signup/signup_prescriber_authorized.html
@@ -30,10 +30,10 @@
 
     <nav>
         <div class="nav nav-tabs" id="form-tab" role="tablist">
-            <a class="nav-item nav-link active" id="form-org-tab" data-toggle="tab" href="#form-org" role="tab" aria-controls="nav-home" aria-selected="true">
+            <a class="nav-item nav-link active" id="form-org-tab" data-toggle="tab" href="#form-org" role="tab" aria-controls="nav-home" aria-selected="true" onClick="$('#id_unregistered_organization').val('');">
                 {% trans "Votre organisation" %}
             </a>
-            <a class="nav-item nav-link" id="form-code-tab" data-toggle="tab" href="#form-code" role="tab" aria-controls="form-code" aria-selected="false">
+            <a class="nav-item nav-link" id="form-code-tab" data-toggle="tab" href="#form-code" role="tab" aria-controls="form-code" aria-selected="false" onClick="$('#id_authorized_organization_id').val('');$('#id_authorized_organization').val('');">
                 {% trans "Vous ne trouvez pas votre organisation ?" %}
             </a>
         </div>

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -189,6 +189,9 @@ class AuthorizedPrescriberForm(PrescriberForm):
         unregistered_organization = self.cleaned_data["unregistered_organization"]
         authorized_organization_id = self.cleaned_data["authorized_organization_id"]
 
+        if not (unregistered_organization or authorized_organization_id):
+            raise ValidationError(gettext_lazy("Vous devez choisir une organisation"))
+        
         if (unregistered_organization and authorized_organization_id) or not (
             unregistered_organization or authorized_organization_id
         ):

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -191,7 +191,7 @@ class AuthorizedPrescriberForm(PrescriberForm):
 
         if not (unregistered_organization or authorized_organization_id):
             raise ValidationError(gettext_lazy("Vous devez choisir une organisation"))
-        
+
         if (unregistered_organization and authorized_organization_id) or not (
             unregistered_organization or authorized_organization_id
         ):


### PR DESCRIPTION
###Modifié: 
Le libellé d'un des messages d'erreur du formulaire de saisie pouvait mener à une incompréhension.

###Ajouté: 
Le fait de changer de tab invalide la saisie de l'autre tab