### PR TITLE
Admin : nouveau calcul des coordonnées géographiques

### DIFF
--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -123,10 +123,18 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
         return queryset
 
     def save_model(self, request, obj, form, change):
-        if not obj.pk:
+
+        if not change:
             obj.created_by = request.user
-        if not obj.geocoding_score and obj.address_on_one_line:
-            obj.set_coords(obj.address_on_one_line, post_code=obj.post_code)
+            if not obj.geocoding_score and obj.address_on_one_line:
+                # Set geocoding.
+                obj.set_coords(obj.address_on_one_line, post_code=obj.post_code)
+
+        if change and obj.address_on_one_line:
+            old_obj = self.model.objects.get(id=obj.id)
+            if obj.address_on_one_line != old_obj.address_on_one_line:
+                # Refresh geocoding.
+                obj.set_coords(obj.address_on_one_line, post_code=obj.post_code)
 
         super().save_model(request, obj, form, change)
 


### PR DESCRIPTION
Dans les interfaces `SiaeAdmin` et `PrescriberOrganizationAdmin`, si on modifie un objet et qu'on détecte un changement d'adresse, alors on recalcule les coordonnées géographiques.