### PR TITLE
Ajout de la possibilité de rechercher par ID dans l'admin

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -52,10 +52,10 @@ class IsValidFilter(admin.SimpleListFilter):
 
 @admin.register(models.Approval)
 class ApprovalAdmin(admin.ModelAdmin):
-    list_display = ("id", "number", "user", "start_at", "end_at", "is_valid", "created_at")
-    search_fields = ("number", "user__first_name", "user__last_name", "user__email")
+    list_display = ("pk", "number", "user", "start_at", "end_at", "is_valid", "created_at")
+    search_fields = ("pk", "number", "user__first_name", "user__last_name", "user__email")
     list_filter = (IsValidFilter,)
-    list_display_links = ("id", "number")
+    list_display_links = ("pk", "number")
     raw_id_fields = ("user", "created_by")
     readonly_fields = ("created_at", "created_by")
     date_hierarchy = "start_at"
@@ -107,7 +107,7 @@ class ApprovalAdmin(admin.ModelAdmin):
 @admin.register(models.PoleEmploiApproval)
 class PoleEmploiApprovalAdmin(admin.ModelAdmin):
     list_display = (
-        "id",
+        "pk",
         "pole_emploi_id",
         "number",
         "first_name",
@@ -118,7 +118,7 @@ class PoleEmploiApprovalAdmin(admin.ModelAdmin):
         "end_at",
         "is_valid",
     )
-    search_fields = ("pole_emploi_id", "number", "first_name", "last_name", "birth_name")
+    search_fields = ("pk", "pole_emploi_id", "number", "first_name", "last_name", "birth_name")
     list_filter = (IsValidFilter,)
     date_hierarchy = "birthdate"
 

--- a/itou/eligibility/admin.py
+++ b/itou/eligibility/admin.py
@@ -12,8 +12,8 @@ class AdministrativeCriteriaInline(admin.TabularInline):
 
 @admin.register(models.EligibilityDiagnosis)
 class EligibilityDiagnosisAdmin(admin.ModelAdmin):
-    list_display = ("id", "job_seeker", "author", "author_kind", "created_at")
-    list_display_links = ("id", "job_seeker")
+    list_display = ("pk", "job_seeker", "author", "author_kind", "created_at")
+    list_display_links = ("pk", "job_seeker")
     list_filter = ("author_kind",)
     raw_id_fields = ("job_seeker", "author", "author_siae", "author_prescriber_organization")
     readonly_fields = ("created_at", "updated_at")
@@ -23,8 +23,8 @@ class EligibilityDiagnosisAdmin(admin.ModelAdmin):
 
 @admin.register(models.AdministrativeCriteria)
 class AdministrativeCriteriaAdmin(admin.ModelAdmin):
-    list_display = ("id", "name", "level", "ui_rank", "created_at")
-    list_display_links = ("id", "name")
+    list_display = ("pk", "name", "level", "ui_rank", "created_at")
+    list_display_links = ("pk", "name")
     list_filter = ("level",)
     raw_id_fields = ("created_by",)
     readonly_fields = ("created_at",)

--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -41,7 +41,7 @@ class ApprovalNumberSentByEmailFilter(admin.SimpleListFilter):
 class JobApplicationAdmin(admin.ModelAdmin):
     actions = ("bulk_send_approval_by_email",)
     date_hierarchy = "created_at"
-    list_display = ("id", "state", "sender_kind", "created_at")
+    list_display = ("pk", "state", "sender_kind", "created_at")
     raw_id_fields = ("job_seeker", "sender", "sender_siae", "sender_prescriber_organization", "to_siae", "approval")
     exclude = ("selected_jobs",)
     list_filter = (
@@ -54,7 +54,7 @@ class JobApplicationAdmin(admin.ModelAdmin):
     )
     readonly_fields = ("created_at", "updated_at", "approval_number_delivered_by")
     inlines = (JobsInline, TransitionLogInline)
-    search_fields = ("to_siae__siret", "job_seeker__email")
+    search_fields = ("pk", "to_siae__siret", "job_seeker__email")
 
     def bulk_send_approval_by_email(self, request, queryset):
         queryset = queryset.exclude(approval=None).filter(approval_number_sent_by_email=False)

--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -95,8 +95,8 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
         ),
     )
     inlines = (MembersInline,)
-    list_display = ("id", "name", "post_code", "city", "department", "member_count")
-    list_display_links = ("id", "name")
+    list_display = ("pk", "name", "post_code", "city", "department", "member_count")
+    list_display_links = ("pk", "name")
     list_filter = (AuthorizationValidationRequired, HasMembersFilter, "is_authorized", "kind", "department")
     raw_id_fields = ("created_by",)
     readonly_fields = (
@@ -110,7 +110,7 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
         "authorization_updated_at",
         "authorization_updated_by",
     )
-    search_fields = ("siret", "name", "code_safir_pole_emploi")
+    search_fields = ("pk", "siret", "name", "code_safir_pole_emploi")
 
     def member_count(self, obj):
         return obj._member_count

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -35,7 +35,7 @@ class SiaeHasMembersFilter(admin.SimpleListFilter):
 
 @admin.register(models.Siae)
 class SiaeAdmin(admin.ModelAdmin):
-    list_display = ("id", "siret", "kind", "name", "department", "geocoding_score", "member_count")
+    list_display = ("pk", "siret", "kind", "name", "department", "geocoding_score", "member_count")
     list_filter = (SiaeHasMembersFilter, "kind", "block_job_applications", "source", "department")
     raw_id_fields = ("created_by",)
     readonly_fields = ("created_by", "created_at", "updated_at", "job_applications_blocked_at")
@@ -78,7 +78,7 @@ class SiaeAdmin(admin.ModelAdmin):
             },
         ),
     )
-    search_fields = ("id", "siret", "name")
+    search_fields = ("pk", "siret", "name")
     inlines = (MembersInline, JobsInline)
 
     def member_count(self, obj):

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -65,7 +65,7 @@ class ItouUserAdmin(UserAdmin):
 
     inlines = UserAdmin.inlines + [SiaeMembershipInline, PrescriberMembershipInline]
     list_display = (
-        "id",
+        "pk",
         "email",
         "first_name",
         "last_name",
@@ -75,10 +75,11 @@ class ItouUserAdmin(UserAdmin):
         "has_verified_email",
         "last_login",
     )
-    list_display_links = ("id", "email")
+    list_display_links = ("pk", "email")
     list_filter = UserAdmin.list_filter + (KindFilter,)
     ordering = ("-id",)
     raw_id_fields = ("created_by",)
+    search_fields = UserAdmin.search_fields + ("pk",)
 
     fieldsets = UserAdmin.fieldsets + (
         (
@@ -136,7 +137,7 @@ class ItouUserAdmin(UserAdmin):
             qs = qs.exclude(is_superuser=True)
         if request.resolver_match.view_name.endswith("changelist"):
             has_verified_email = EmailAddress.objects.filter(email=OuterRef("email"), verified=True)
-            is_peamu = SocialAccount.objects.filter(user_id=OuterRef("id"), provider="peamu")
+            is_peamu = SocialAccount.objects.filter(user_id=OuterRef("pk"), provider="peamu")
             qs = qs.annotate(_has_verified_email=Exists(has_verified_email))
             qs = qs.annotate(_is_peamu=Exists(is_peamu))
         return qs


### PR DESCRIPTION
Ajout de la possibilité de rechercher par ID dans l'admin pour :

- `Approval`
- `PoleEmploiApproval`
- `PrescriberOrganization`
- `Siae`
- `User`

+ `pk` VS `id`