### PR TITLE
Rendre plus visible les résultats de recherche

### DIFF
--- a/itou/templates/home/home.html
+++ b/itou/templates/home/home.html
@@ -12,7 +12,7 @@
 
             <h2 class="text-center my-5 text-light">{% trans "Prenez contact avec un employeur solidaire" %}</h3>
 
-            <form method="get" action="{% url 'search:siaes' %}">
+            <form method="get" action="{% url 'search:siaes_results' %}">
                 {% include "search/includes/siaes_search_form.html" with form=siae_search_form %}
             </form>
 

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -148,12 +148,12 @@
                     <a class="nav-link{% if request.path == '/dashboard/' %} active{% endif %}" href="{% url 'dashboard:index' %}">{% trans "Tableau de bord" %}</a>
                 {% endif %}
 
-                <a class="nav-link{% if request.path == '/' or request.path == '/search/employers' %} active{% endif %}" href="/">{% trans "Rechercher des employeurs" %}</a>
+                <a class="nav-link{% if request.path == '/' or '/search/employers' in request.path %} active{% endif %}" href="/">{% trans "Rechercher des employeurs" %}</a>
 
                 {% if user.is_authenticated %}
                     {# Do not confuse unlogged users with a prescriber search, especially jobseekers  #}
                     {# who may be unfamiliar with the prescriber concept. #}
-                    <a class="nav-link{% if request.path == '/search/prescribers' %} active{% endif %}" href="{% url 'search:prescribers' %}">{% trans "Rechercher des prescripteurs" %}</a>
+                    <a class="nav-link{% if '/search/prescribers' in request.path %} active{% endif %}" href="{% url 'search:prescribers_home' %}">{% trans "Rechercher des prescripteurs" %}</a>
                 {% endif %}
 
                 <a class="nav-link" href="https://forum.inclusion.beta.gouv.fr" rel="noopener" target="_blank">{% trans "Forum" %} {% include "includes/icon.html" with icon="external-link" %}</a>

--- a/itou/templates/search/prescribers_search_home.html
+++ b/itou/templates/search/prescribers_search_home.html
@@ -1,0 +1,24 @@
+{% extends "layout/content.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Rechercher des prescripteurs" %}{{ block.super }}{% endblock %}
+
+{% block pre_content %}
+
+    <section class="layout-section layout-banner-container">
+
+        <div class="layout-content">
+
+            <h2 class="text-center my-5 text-light">{% trans "Rechercher des prescripteurs" %}</h2>
+
+            <form method="get" action="{% url 'search:prescribers_results' %}" class="d-block mb-5">
+                {% include "search/includes/prescribers_search_form.html" with form=form %}
+            </form>
+
+        </div>
+
+        <div class="layout-banner layout-banner-work-office"></div>
+
+    </section>
+
+{% endblock %}

--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -8,82 +8,64 @@
     {{ block.super }}
 {% endblock %}
 
-{% block pre_content %}
-
-    <section class="layout-section layout-banner-container">
-
-        <div class="layout-content">
-
-            <h2 class="text-center my-5 text-light">{% trans "Rechercher des prescripteurs" %}</h2>
-
-            <form method="get" action="" class="d-block mb-5">
-                {% include "search/includes/prescribers_search_form.html" with form=form %}
-            </form>
-
-        </div>
-
-        <div class="layout-banner layout-banner-work-office"></div>
-
-    </section>
-
-{% endblock %}
-
 {% block content %}
 
-    {% if request.GET %}
+    <h2>{% trans "Rechercher des prescripteurs" %}</h2>
 
-        <h3>
-            {% trans "Prescripteurs" %}
-            {% if request.GET.city_name and request.GET.distance %}
-                {% with request.GET.city_name as city and request.GET.distance as distance %}
-                    {% blocktrans %}à <b>{{ distance }} Km</b> autour de <b>{{ city }}</b>{% endblocktrans %}
-                {% endwith %}
-            {% endif %}
-        </h3>
+    <form method="get" action="" class="d-block mb-5">
+        {% include "search/includes/prescribers_search_form.html" with form=form %}
+    </form>
 
-        {% if not prescriber_orgs_page %}
-
-            <h4 class="font-weight-normal text-muted">
-                {% trans "Aucun résultat." %}
-            </h4>
-
-        {% else %}
-
-            <h4 class="font-weight-normal text-muted">
-                {% with prescriber_orgs_page.number as current_page and prescriber_orgs_page.paginator.num_pages as total_pages %}
-                    {% blocktrans count counter=prescriber_orgs_page.paginator.count %}
-                        <b>1</b> résultat
-                    {% plural %}
-                        <b>{{ counter }}</b> résultats
-                    {% endblocktrans %}
-                    {% if prescriber_orgs_page.paginator.num_pages > 1 %}
-                        {% blocktrans %}- Page <b>{{ current_page }}</b>/{{ total_pages }}{% endblocktrans %}
-                    {% endif %}
-                {% endwith %}
-            </h4>
-
-            {% for prescriber_org in prescriber_orgs_page %}
-                <div class="card d-block my-4">
-                    <div class="card-body">
-                        <h5 class="card-title">
-                            <a href="{{ prescriber_org.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                                {{ prescriber_org.name }}
-                            </a>
-                        </h5>
-                        <h6 class="card-subtitle mb-2 text-muted">{{ prescriber_org.address_on_one_line }}</h6>
-                        <p class="card-text">
-                            {% blocktrans with distance=prescriber_org.distance.km|floatformat:1 %}
-                                <span class="badge badge-dark">{{ distance }} Km</span>
-                                de votre lieu de recherche
-                            {% endblocktrans %}
-                        </p>
-                    </div>
-                </div>
-            {% endfor %}
-
-            {% include "includes/pagination.html" with page=prescriber_orgs_page %}
-
+    <h3>
+        {% trans "Prescripteurs" %}
+        {% if request.GET.city_name and request.GET.distance %}
+            {% with request.GET.city_name as city and request.GET.distance as distance %}
+                {% blocktrans %}à <b>{{ distance }} Km</b> autour de <b>{{ city }}</b>{% endblocktrans %}
+            {% endwith %}
         {% endif %}
+    </h3>
+
+    {% if not prescriber_orgs_page %}
+
+        <h4 class="font-weight-normal text-muted">
+            {% trans "Aucun résultat." %}
+        </h4>
+
+    {% else %}
+
+        <h4 class="font-weight-normal text-muted">
+            {% with prescriber_orgs_page.number as current_page and prescriber_orgs_page.paginator.num_pages as total_pages %}
+                {% blocktrans count counter=prescriber_orgs_page.paginator.count %}
+                    <b>1</b> résultat
+                {% plural %}
+                    <b>{{ counter }}</b> résultats
+                {% endblocktrans %}
+                {% if prescriber_orgs_page.paginator.num_pages > 1 %}
+                    {% blocktrans %}- Page <b>{{ current_page }}</b>/{{ total_pages }}{% endblocktrans %}
+                {% endif %}
+            {% endwith %}
+        </h4>
+
+        {% for prescriber_org in prescriber_orgs_page %}
+            <div class="card d-block my-4">
+                <div class="card-body">
+                    <h5 class="card-title">
+                        <a href="{{ prescriber_org.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                            {{ prescriber_org.name }}
+                        </a>
+                    </h5>
+                    <h6 class="card-subtitle mb-2 text-muted">{{ prescriber_org.address_on_one_line }}</h6>
+                    <p class="card-text">
+                        {% blocktrans with distance=prescriber_org.distance.km|floatformat:1 %}
+                            <span class="badge badge-dark">{{ distance }} Km</span>
+                            de votre lieu de recherche
+                        {% endblocktrans %}
+                    </p>
+                </div>
+            </div>
+        {% endfor %}
+
+        {% include "includes/pagination.html" with page=prescriber_orgs_page %}
 
     {% endif %}
 

--- a/itou/templates/search/siaes_search_home.html
+++ b/itou/templates/search/siaes_search_home.html
@@ -1,0 +1,24 @@
+{% extends "layout/content.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Rechercher des employeurs solidaires" %}{{ block.super }}{% endblock %}
+
+{% block pre_content %}
+
+    <section class="layout-section layout-banner-container">
+
+        <div class="layout-content">
+
+            <h2 class="text-center my-5 text-light">{% trans "Rechercher des employeurs solidaires" %}</h2>
+
+            <form method="get" action="{% url 'search:siaes_results' %}" class="d-block mb-5">
+                {% include "search/includes/siaes_search_form.html" with form=form %}
+            </form>
+
+        </div>
+
+        <div class="layout-banner layout-banner-work-labour"></div>
+
+    </section>
+
+{% endblock %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -8,128 +8,98 @@
     {{ block.super }}
 {% endblock %}
 
-{% block pre_content %}
-
-    <section class="layout-section layout-banner-container">
-
-        <div class="layout-content">
-
-            <h2 class="text-center my-5 text-light">{% trans "Rechercher des employeurs solidaires" %}</h2>
-
-            <form method="get" action="" class="d-block mb-5">
-                {% include "search/includes/siaes_search_form.html" with form=form %}
-            </form>
-
-        </div>
-
-        <div class="layout-banner layout-banner-work-labour"></div>
-
-    </section>
-
-{% endblock %}
-
 {% block content %}
 
-    {% if request.GET %}
+    <h2>{% trans "Rechercher des employeurs solidaires" %}</h2>
 
-        <h3>
-            {% with request.GET.city_name as city and request.GET.distance as distance %}
-                {% blocktrans %}Employeurs solidaires à <b>{{ distance }} Km</b> autour de <b>{{ city }}</b>{% endblocktrans %}
+    <form method="get" action="" class="d-block mb-5">
+        {% include "search/includes/siaes_search_form.html" with form=form %}
+    </form>
+
+    <h3>
+        {% with request.GET.city_name as city and request.GET.distance as distance %}
+            {% blocktrans %}Employeurs solidaires à <b>{{ distance }} Km</b> autour de <b>{{ city }}</b>{% endblocktrans %}
+        {% endwith %}
+    </h3>
+
+    {% if not siaes_page %}
+
+        <h4 class="font-weight-normal text-muted">
+            {% trans "Aucun résultat." %}
+        </h4>
+
+    {% else %}
+
+        <h4 class="font-weight-normal text-muted">
+            {% with siaes_page.number as current_page and siaes_page.paginator.num_pages as total_pages %}
+                {% blocktrans count counter=siaes_page.paginator.count %}
+                    <b>1</b> résultat
+                {% plural %}
+                    <b>{{ counter }}</b> résultats
+                {% endblocktrans %}
+                {% if siaes_page.paginator.num_pages > 1 %}
+                    {% blocktrans %}- Page <b>{{ current_page }}</b>/{{ total_pages }}{% endblocktrans %}
+                {% endif %}
             {% endwith %}
-        </h3>
+        </h4>
 
-        {% if not siaes_page %}
-
-            <h4 class="font-weight-normal text-muted">
-                {% trans "Aucun résultat." %}
-            </h4>
-
-        {% else %}
-
-            <h4 class="font-weight-normal text-muted">
-                {% with siaes_page.number as current_page and siaes_page.paginator.num_pages as total_pages %}
-                    {% blocktrans count counter=siaes_page.paginator.count %}
-                        <b>1</b> résultat
-                    {% plural %}
-                        <b>{{ counter }}</b> résultats
-                    {% endblocktrans %}
-                    {% if siaes_page.paginator.num_pages > 1 %}
-                        {% blocktrans %}- Page <b>{{ current_page }}</b>/{{ total_pages }}{% endblocktrans %}
+        {% for siae in siaes_page %}
+            <div class="card d-block my-4">
+                <div class="card-body">
+                    <h5 class="card-title">
+                        <b><abbr title="{{ siae.get_kind_display }}">{{ siae.kind }}</abbr></b>
+                        -
+                        <a href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                            {{ siae.display_name }}
+                        </a>
+                        {# Display non-user-edited name too. #}
+                        {% if siae.brand %}<small class="text-muted">({{ siae.name|title }})</small>{% endif %}
+                    </h5>
+                    <h6 class="card-subtitle mb-2 text-muted">{{ siae.address_on_one_line }}</h6>
+                    <p class="card-text">
+                        {% blocktrans with distance=siae.distance.km|floatformat:1 %}
+                            <span class="badge badge-dark">{{ distance }} Km</span>
+                            de votre lieu de recherche
+                        {% endblocktrans %}
+                    </p>
+                    {% if siae.job_description_through.exists and not siae.block_job_applications %}
+                        <h6 class="border-bottom border-gray pb-2">{% trans "Métiers proposés" %}</h6>
+                        <ul class="mb-0">
+                        {% for job in siae.job_description_through.all %}
+                            <li>
+                                <a href="{{ job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}">
+                                    {{ job.display_name }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                        </ul>
                     {% endif %}
-                {% endwith %}
-            </h4>
+                </div>
 
-            {% for siae in siaes_page %}
-                <div class="card d-block my-4">
-                    <div class="card-body">
-                        <h5 class="card-title">
-                            <b><abbr title="{{ siae.get_kind_display }}">{{ siae.kind }}</abbr></b>
-                            -
-                            <a href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                                {{ siae.display_name }}
-                            </a>
-                            {# Display non-user-edited name too. #}
-                            {% if siae.brand %}<small class="text-muted">({{ siae.name|title }})</small>{% endif %}
-                        </h5>
-                        <h6 class="card-subtitle mb-2 text-muted">{{ siae.address_on_one_line }}</h6>
-                        <p class="card-text">
-                            {% blocktrans with distance=siae.distance.km|floatformat:1 %}
-                                <span class="badge badge-dark">{{ distance }} Km</span>
-                                de votre lieu de recherche
-                            {% endblocktrans %}
-                        </p>
-                        {% if siae.job_description_through.exists and not siae.block_job_applications %}
-                            <h6 class="border-bottom border-gray pb-2">{% trans "Métiers proposés" %}</h6>
-                            <ul class="mb-0">
-                            {% for job in siae.job_description_through.all %}
-                                <li>
-                                    <a href="{{ job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}">
-                                        {{ job.display_name }}
-                                    </a>
-                                </li>
-                            {% endfor %}
-                            </ul>
-                        {% endif %}
-                    </div>
-
-                    <div class="card-footer">
-                        {% if not siae.num_active_members %}
-                            <a class="btn btn-sm btn-outline-secondary disabled" href="">
-                                {% include "includes/icon.html" with icon="message-square" %} {% trans "Postuler" %}
-                            </a>
-                            <small>{% trans "Cet employeur n'a pas encore créé son compte sur la plateforme." %}</small>
-                        {% elif siae.block_job_applications %}
-                            <a class="btn btn-sm btn-outline-secondary disabled" href="">
-                                {% include "includes/icon.html" with icon="message-square" %} {% trans "Postuler" %}
-                            </a>
-                            <small>{% trans "Cet employeur n'accepte plus de candidatures pour le moment" %}</small>
-                        {% else %}
-                            <a class="btn btn-sm btn-outline-primary" href="{% url 'apply:start' siae_pk=siae.pk %}">
-                                {% include "includes/icon.html" with icon="message-square" %} {% trans "Postuler" %}
-                            </a>
-                        {% endif %}
-
-                    </div>
+                <div class="card-footer">
+                    {% if not siae.num_active_members %}
+                        <a class="btn btn-sm btn-outline-secondary disabled" href="">
+                            {% include "includes/icon.html" with icon="message-square" %} {% trans "Postuler" %}
+                        </a>
+                        <small>{% trans "Cet employeur n'a pas encore créé son compte sur la plateforme." %}</small>
+                    {% elif siae.block_job_applications %}
+                        <a class="btn btn-sm btn-outline-secondary disabled" href="">
+                            {% include "includes/icon.html" with icon="message-square" %} {% trans "Postuler" %}
+                        </a>
+                        <small>{% trans "Cet employeur n'accepte plus de candidatures pour le moment" %}</small>
+                    {% else %}
+                        <a class="btn btn-sm btn-outline-primary" href="{% url 'apply:start' siae_pk=siae.pk %}">
+                            {% include "includes/icon.html" with icon="message-square" %} {% trans "Postuler" %}
+                        </a>
+                    {% endif %}
 
                 </div>
-            {% endfor %}
 
-            {% include "includes/pagination.html" with page=siaes_page %}
+            </div>
+        {% endfor %}
 
-        {% endif %}
+        {% include "includes/pagination.html" with page=siaes_page %}
 
     {% endif %}
 
-{% endblock %}
-
-{% block script %}
-    {{ block.super }}
-    <script type="text/javascript">
-        // Related to the search results map experiment.
-        $( "#mapPoll button" ).click(function() {
-            $( "#mapPoll .buttonsContainer" ).fadeOut(function() {
-                $("#mapPoll").append("<div class='col-sm text-center'>Merci !</div>");
-            });
-        });
-    </script>
 {% endblock %}

--- a/itou/www/search/urls.py
+++ b/itou/www/search/urls.py
@@ -7,6 +7,8 @@ from itou.www.search import views
 app_name = "search"
 
 urlpatterns = [
-    path("employers", views.search_siaes, name="siaes"),
-    path("prescribers", views.search_prescribers, name="prescribers"),
+    path("employers", views.search_siaes_home, name="siaes_home"),
+    path("employers/results", views.search_siaes_results, name="siaes_results"),
+    path("prescribers", views.search_prescribers_home, name="prescribers_home"),
+    path("prescribers/results", views.search_prescribers_results, name="prescribers_results"),
 ]

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -8,7 +8,16 @@ from itou.utils.pagination import pager
 from itou.www.search.forms import PrescriberSearchForm, SiaeSearchForm
 
 
-def search_siaes(request, template_name="search/siaes_search_results.html"):
+def search_siaes_home(request, template_name="search/siaes_search_home.html"):
+    """
+    The search home page has a different design from the results page.
+    """
+    form = SiaeSearchForm()
+    context = {"form": form}
+    return render(request, template_name, context)
+
+
+def search_siaes_results(request, template_name="search/siaes_search_results.html"):
 
     form = SiaeSearchForm(data=request.GET or None)
     siaes_page = None
@@ -35,7 +44,17 @@ def search_siaes(request, template_name="search/siaes_search_results.html"):
 
 
 @login_required
-def search_prescribers(request, template_name="search/prescribers_search_results.html"):
+def search_prescribers_home(request, template_name="search/prescribers_search_home.html"):
+    """
+    The search home page has a different design from the results page.
+    """
+    form = PrescriberSearchForm()
+    context = {"form": form}
+    return render(request, template_name, context)
+
+
+@login_required
+def search_prescribers_results(request, template_name="search/prescribers_search_results.html"):
 
     form = PrescriberSearchForm(data=request.GET or None)
     prescriber_orgs_page = None


### PR DESCRIPTION
La liste de résultats des employeurs solidaires n'est pas assez visible à cause du gros bandeau.

On implémente une séparation de la recherche (SIAE et prescripteurs) en deux parties avec :

- une home + bandeau
- les résultats sans bandeau