### PR TITLE
Un diagnostic a une durée de vie limitée

### DIFF
--- a/itou/eligibility/admin.py
+++ b/itou/eligibility/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
+from django.utils.translation import gettext as _
+from django.utils.formats import date_format
 from itou.eligibility import models
 
 
@@ -12,13 +14,26 @@ class AdministrativeCriteriaInline(admin.TabularInline):
 
 @admin.register(models.EligibilityDiagnosis)
 class EligibilityDiagnosisAdmin(admin.ModelAdmin):
-    list_display = ("pk", "job_seeker", "author", "author_kind", "created_at")
+    list_display = ("pk", "job_seeker", "author", "author_kind", "created_at", "has_expired")
     list_display_links = ("pk", "job_seeker")
     list_filter = ("author_kind",)
     raw_id_fields = ("job_seeker", "author", "author_siae", "author_prescriber_organization")
-    readonly_fields = ("created_at", "updated_at")
+    readonly_fields = ("created_at", "updated_at", "expires_at", "has_expired")
     search_fields = ("job_seeker__email", "author__email")
     inlines = (AdministrativeCriteriaInline,)
+
+    def has_expired(self, obj):
+        value = _("Non")
+        if obj.has_expired:
+            value = _("Oui")
+        return value
+
+    has_expired.short_description = _("Expiré")
+
+    def expires_at(self, obj):
+        return date_format(obj.expires_at)
+
+    expires_at.short_description = _("Date d'expiration")
 
 
 @admin.register(models.AdministrativeCriteria)

--- a/itou/eligibility/factories.py
+++ b/itou/eligibility/factories.py
@@ -1,4 +1,6 @@
 import factory
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
 
 from itou.eligibility import models
 from itou.users.factories import JobSeekerFactory, PrescriberFactory
@@ -13,6 +15,13 @@ class EligibilityDiagnosisFactory(factory.django.DjangoModelFactory):
     job_seeker = factory.SubFactory(JobSeekerFactory)
     author = factory.SubFactory(PrescriberFactory)
     author_kind = models.EligibilityDiagnosis.AUTHOR_KIND_PRESCRIBER
+
+
+class ExpiredEligibilityDiagnosisFactory(EligibilityDiagnosisFactory):
+
+    created_at = factory.LazyAttribute(
+        lambda self: timezone.now() - relativedelta(months=models.EligibilityDiagnosis.EXPIRATION_DELAY_MONTHS, days=1)
+    )
 
 
 class AdministrativeCriteriaFactory(factory.django.DjangoModelFactory):

--- a/itou/eligibility/models.py
+++ b/itou/eligibility/models.py
@@ -1,5 +1,6 @@
 import logging
 
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
@@ -25,6 +26,8 @@ class EligibilityDiagnosis(models.Model):
         (AUTHOR_KIND_PRESCRIBER, _("Prescripteur")),
         (AUTHOR_KIND_SIAE_STAFF, _("Employeur (SIAE)")),
     )
+
+    EXPIRATION_DELAY_MONTHS = 6
 
     job_seeker = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -71,6 +74,14 @@ class EligibilityDiagnosis(models.Model):
 
     def __str__(self):
         return str(self.id)
+
+    @property
+    def expires_at(self):
+        return self.created_at + relativedelta(months=self.EXPIRATION_DELAY_MONTHS)
+
+    @property
+    def has_expired(self):
+        return timezone.now() > self.expires_at
 
     def save(self, *args, **kwargs):
         self.updated_at = timezone.now()

--- a/itou/eligibility/tests.py
+++ b/itou/eligibility/tests.py
@@ -1,5 +1,7 @@
+from dateutil.relativedelta import relativedelta
 from django.test import TestCase
 
+from itou.eligibility.factories import EligibilityDiagnosisFactory, ExpiredEligibilityDiagnosisFactory
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.prescribers.factories import AuthorizedPrescriberOrganizationWithMembershipFactory
 from itou.siaes.factories import SiaeWithMembershipFactory
@@ -9,7 +11,6 @@ from itou.utils.perms.user import KIND_PRESCRIBER, KIND_SIAE_STAFF, UserInfo
 
 class EligibilityDiagnosisModelTest(TestCase):
     def test_create_diagnosis(self):
-
         job_seeker = JobSeekerFactory()
         siae = SiaeWithMembershipFactory()
         user = siae.members.first()
@@ -60,6 +61,13 @@ class EligibilityDiagnosisModelTest(TestCase):
         self.assertIn(criteria1, administrative_criteria)
         self.assertIn(criteria2, administrative_criteria)
         self.assertIn(criteria3, administrative_criteria)
+
+    def test_has_expired(self):
+        diagnosis = EligibilityDiagnosisFactory()
+        self.assertFalse(diagnosis.has_expired)
+
+        self.diagnosis = ExpiredEligibilityDiagnosisFactory()
+        self.assertTrue(self.diagnosis.has_expired)
 
 
 class AdministrativeCriteriaModelTest(TestCase):

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -303,7 +303,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         return (
             self.state.is_processing
             and self.to_siae.is_subject_to_eligibility_rules
-            and not self.job_seeker.has_eligibility_diagnosis
+            and not self.job_seeker.has_valid_eligibility_diagnosis
         )
 
     @property

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -35,13 +35,13 @@ class JobApplicationModelTest(TestCase):
         job_application = JobApplicationFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING, to_siae__kind=Siae.KIND_GEIQ
         )
-        self.assertFalse(job_application.job_seeker.has_eligibility_diagnosis)
+        self.assertFalse(job_application.job_seeker.has_valid_eligibility_diagnosis)
         self.assertFalse(job_application.eligibility_diagnosis_by_siae_required)
 
         job_application = JobApplicationFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING, to_siae__kind=Siae.KIND_EI
         )
-        self.assertFalse(job_application.job_seeker.has_eligibility_diagnosis)
+        self.assertFalse(job_application.job_seeker.has_valid_eligibility_diagnosis)
         self.assertTrue(job_application.eligibility_diagnosis_by_siae_required)
 
     def test_accepted_by(self):

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -64,8 +64,6 @@
 
     {% if job_application.to_siae.is_subject_to_eligibility_rules %}
 
-        {% with job_application.job_seeker.get_eligibility_diagnosis as eligibility_diagnosis %}
-
             {% if eligibility_diagnosis %}
 
                 <hr>
@@ -114,7 +112,12 @@
 
                 {% if eligibility_diagnosis.has_expired %}
                     <p class="text-danger">
-                        {% trans "Ce diagnostic est expiré depuis le " %} {{ eligibility_diagnosis.expires_at|date }}.
+                        {% blocktrans with date=eligibility_diagnosis.expires_at|date %}
+                            Ce diagnostic est expiré depuis le {{ date }}.
+                        {% endblocktrans %}
+                        {% if job_application.state.is_processing %}
+                            {% trans "Pour embaucher ce candidat, réalisez un nouveau diagnostic d'éligibilité afin d'évaluer sa situation actuelle." %}
+                        {% endif %}
                     </p>
                 {% else %}
                     <p>
@@ -133,8 +136,6 @@
                 </p>
 
             {% endif %}
-
-        {% endwith %}
 
     {% endif %}
 
@@ -228,14 +229,34 @@
         <hr>
 
         {% if job_application.eligibility_diagnosis_by_siae_required %}
+                {% if eligibility_diagnosis and eligibility_diagnosis.has_expired %}
+                    <p>
+                        <a href="{% url 'apply:eligibility' job_application_id=job_application %}"
+                           class="btn btn-secondary btn-block">
+                                {% trans "Réaliser un nouveau diagnostic" %}
+                            {% include "includes/icon.html" with icon="arrow-right" %}
+                        </a>
+                    </p>
 
-            <p>
-                <a href="{% url 'apply:eligibility' job_application_id=job_application %}"
-                   class="btn btn-secondary btn-block">
-                    {% trans "Valider les critères d'éligibilité" %}
-                    {% include "includes/icon.html" with icon="arrow-right" %}
-                </a>
-            </p>
+                    <p>
+                        <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
+                           class="btn btn-outline-danger btn-block">
+                            {% trans "Je ne veux pas l'embaucher" %}
+                            {% include "includes/icon.html" with icon="arrow-right" %}
+                        </a>
+                    </p>
+
+                {% else %}
+
+                    <p>
+                        <a href="{% url 'apply:eligibility' job_application_id=job_application %}"
+                           class="btn btn-secondary btn-block">
+                                {% trans "Valider les critères d'éligibilité" %}
+                            {% include "includes/icon.html" with icon="arrow-right" %}
+                        </a>
+                    </p>
+
+                {% endif %}
 
         {% else %}
 

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -69,9 +69,14 @@
             {% if eligibility_diagnosis %}
 
                 <hr>
-                <h3 class="font-weight-normal text-muted">{% trans "Critères d'éligibilité" %}</h3>
+                <h3 class="font-weight-normal text-muted d-flex">
+                    {% trans "Critères d'éligibilité" %}
+                    {% if eligibility_diagnosis.has_expired %}
+                        <span class="badge badge-danger ml-3">{% trans "Expirés" %}</span>
+                    {% endif %}
+                </h3>
                 <p>
-                    {% trans "Validés par :" %}
+                    {% trans "Validés par" %}
                     <b>{{ eligibility_diagnosis.author.get_full_name }}</b>
                     {% if eligibility_diagnosis.author_siae %}
                         ({{ eligibility_diagnosis.author_siae.display_name }})
@@ -80,7 +85,7 @@
                         ({{ eligibility_diagnosis.author_prescriber_organization.display_name }})
                     {% endif %}
                     {% trans "le" %}
-                    <b>{{ eligibility_diagnosis.created_at|date:"d/m/Y" }}</b>
+                    <b>{{ eligibility_diagnosis.created_at|date:"d/m/Y" }}</b>.
                 </p>
 
                 {% with eligibility_diagnosis.administrative_criteria.all as administrative_criteria %}
@@ -107,14 +112,24 @@
                     {% endif %}
                 {% endwith %}
 
-                {% elif approvals_wrapper.latest_approval and approvals_wrapper.latest_approval.is_valid and not approvals_wrapper.latest_approval.originates_from_itou %}
+                {% if eligibility_diagnosis.has_expired %}
+                    <p class="text-danger">
+                        {% trans "Ce diagnostic est expiré depuis le " %} {{ eligibility_diagnosis.expires_at|date }}.
+                    </p>
+                {% else %}
+                    <p>
+                        {% trans "Ce diagnostic expire le " %} {{ eligibility_diagnosis.expires_at|date }}.
+                    </p>
+                {% endif %}
+
+            {% elif approvals_wrapper.latest_approval and approvals_wrapper.latest_approval.is_valid and not approvals_wrapper.latest_approval.originates_from_itou %}
 
                 {# The existence of a valid `PoleEmploiApproval` implies that #}
                 {# a diagnosis has been made outside of Itou. #}
                 <hr>
                 <h3 class="font-weight-normal text-muted">{% trans "Critères d'éligibilité" %}</h3>
                 <p>
-                    {% trans "Validés par :" %} <b>{% trans "Pôle emploi" %}</b>
+                    {% trans "Validés par" %} <b>{% trans "Pôle emploi" %}</b>.
                 </p>
 
             {% endif %}
@@ -231,7 +246,7 @@
                     {% include "includes/icon.html" with icon="arrow-right" %}
                 </a>
             </p>
-            
+
             <p>
                 <a href="{% url 'apply:postpone' job_application_id=job_application.id %}"
                    class="btn btn-outline-success btn-block">

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -102,12 +102,13 @@ class User(AbstractUser, AddressMixin):
     @property
     def has_eligibility_diagnosis(self):
         """
-        Returns True if a diagnosis exists, False otherwise.
+        Returns True if an ongoing diagnosis exists, False otherwise.
         """
         if not self.is_job_seeker:
             return False
         if self.eligibility_diagnoses.exists():
-            return True
+            if not self.eligibility_diagnoses.latest("-created_at").has_expired:
+                return True
         # The existence of a valid `PoleEmploiApproval` implies that a diagnosis
         # has been made outside of Itou.
         latest_approval = self.approvals_wrapper.latest_approval

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -107,7 +107,7 @@ class User(AbstractUser, AddressMixin):
         if not self.is_job_seeker:
             return False
         if self.eligibility_diagnoses.exists():
-            if not self.eligibility_diagnoses.latest("-created_at").has_expired:
+            if not self.eligibility_diagnoses.latest("created_at").has_expired:
                 return True
         # The existence of a valid `PoleEmploiApproval` implies that a diagnosis
         # has been made outside of Itou.
@@ -119,7 +119,7 @@ class User(AbstractUser, AddressMixin):
             return None
         return self.eligibility_diagnoses.select_related(
             "author", "author_siae", "author_prescriber_organization"
-        ).latest("-created_at")
+        ).latest("created_at")
 
     @cached_property
     def is_peamu(self):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -100,19 +100,23 @@ class User(AbstractUser, AddressMixin):
         return ApprovalsWrapper(self)
 
     @property
-    def has_eligibility_diagnosis(self):
+    def has_valid_eligibility_diagnosis(self):
         """
         Returns True if an ongoing diagnosis exists, False otherwise.
         """
         if not self.is_job_seeker:
             return False
-        if self.eligibility_diagnoses.exists():
+        if self.has_eligibility_diagnoses:
             if not self.eligibility_diagnoses.latest("created_at").has_expired:
                 return True
         # The existence of a valid `PoleEmploiApproval` implies that a diagnosis
         # has been made outside of Itou.
         latest_approval = self.approvals_wrapper.latest_approval
         return latest_approval and latest_approval.is_valid and not latest_approval.originates_from_itou
+
+    @cached_property
+    def has_eligibility_diagnoses(self):
+        return self.eligibility_diagnoses.exists()
 
     def get_eligibility_diagnosis(self):
         if not self.is_job_seeker:

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from itou.approvals.factories import PoleEmploiApprovalFactory
-from itou.eligibility.factories import EligibilityDiagnosisFactory
+from itou.eligibility.factories import EligibilityDiagnosisFactory, ExpiredEligibilityDiagnosisFactory
 from itou.users.factories import JobSeekerFactory, PrescriberFactory
 
 
@@ -67,6 +67,11 @@ class ModelTest(TestCase):
         PoleEmploiApprovalFactory(
             pole_emploi_id=job_seeker.pole_emploi_id, birthdate=job_seeker.birthdate, start_at=start_at, end_at=end_at
         )
+        self.assertFalse(job_seeker.has_eligibility_diagnosis)
+
+        # Has an expired diagnosis
+        job_seeker = JobSeekerFactory()
+        ExpiredEligibilityDiagnosisFactory(job_seeker=job_seeker)
         self.assertFalse(job_seeker.has_eligibility_diagnosis)
 
     def test_clean_pole_emploi_fields(self):

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -44,21 +44,21 @@ class ModelTest(TestCase):
         with self.assertRaises(ValidationError):
             User.create_job_seeker_by_proxy(proxy_user, **user_data)
 
-    def test_has_eligibility_diagnosis(self):
+    def test_has_valid_eligibility_diagnosis(self):
 
         # No diagnosis.
         job_seeker = JobSeekerFactory()
-        self.assertFalse(job_seeker.has_eligibility_diagnosis)
+        self.assertFalse(job_seeker.has_valid_eligibility_diagnosis)
 
         # Has Itou diagnosis.
         job_seeker = JobSeekerFactory()
         EligibilityDiagnosisFactory(job_seeker=job_seeker)
-        self.assertTrue(job_seeker.has_eligibility_diagnosis)
+        self.assertTrue(job_seeker.has_valid_eligibility_diagnosis)
 
         # Has valid Pôle emploi diagnosis.
         job_seeker = JobSeekerFactory()
         PoleEmploiApprovalFactory(pole_emploi_id=job_seeker.pole_emploi_id, birthdate=job_seeker.birthdate)
-        self.assertTrue(job_seeker.has_eligibility_diagnosis)
+        self.assertTrue(job_seeker.has_valid_eligibility_diagnosis)
 
         # Has expired Pôle emploi diagnosis.
         job_seeker = JobSeekerFactory()
@@ -67,12 +67,12 @@ class ModelTest(TestCase):
         PoleEmploiApprovalFactory(
             pole_emploi_id=job_seeker.pole_emploi_id, birthdate=job_seeker.birthdate, start_at=start_at, end_at=end_at
         )
-        self.assertFalse(job_seeker.has_eligibility_diagnosis)
+        self.assertFalse(job_seeker.has_valid_eligibility_diagnosis)
 
         # Has an expired diagnosis
         job_seeker = JobSeekerFactory()
         ExpiredEligibilityDiagnosisFactory(job_seeker=job_seeker)
-        self.assertFalse(job_seeker.has_eligibility_diagnosis)
+        self.assertFalse(job_seeker.has_valid_eligibility_diagnosis)
 
     def test_clean_pole_emploi_fields(self):
 

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -291,12 +291,18 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.get(next_url)
         self.assertEqual(response.status_code, 200)
 
-        self.assertFalse(new_job_seeker.has_eligibility_diagnosis)
+        self.assertFalse(new_job_seeker.has_valid_eligibility_diagnosis)
 
         response = self.client.post(next_url)
         self.assertEqual(response.status_code, 302)
 
-        self.assertTrue(new_job_seeker.has_eligibility_diagnosis)
+        # In order to avoid calling the database too often, `has_eligibility_diagnoses`
+        # is a cached property.
+        # Delete the attribute to refresh it.
+        # See https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.functional.cached_property
+        delattr(new_job_seeker, "has_eligibility_diagnoses")
+
+        self.assertTrue(new_job_seeker.has_valid_eligibility_diagnosis)
 
         next_url = reverse("apply:step_application", kwargs={"siae_pk": siae.pk})
         self.assertEqual(response.url, next_url)
@@ -472,7 +478,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.post(next_url)
         self.assertEqual(response.status_code, 302)
 
-        self.assertFalse(new_job_seeker.has_eligibility_diagnosis)
+        self.assertFalse(new_job_seeker.has_valid_eligibility_diagnosis)
 
         next_url = reverse("apply:step_application", kwargs={"siae_pk": siae.pk})
         self.assertEqual(response.url, next_url)

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -44,7 +44,7 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
     cancellation_days = JobApplication.CANCELLATION_DAYS_AFTER_HIRING_STARTED
 
     eligibility_diagnosis = None
-    if job_application.job_seeker.eligibility_diagnoses.exists():
+    if job_application.job_seeker.has_eligibility_diagnoses:
         eligibility_diagnosis = job_application.job_seeker.get_eligibility_diagnosis()
 
     context = {

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -43,9 +43,14 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
     transition_logs = job_application.logs.select_related("user").all().order_by("timestamp")
     cancellation_days = JobApplication.CANCELLATION_DAYS_AFTER_HIRING_STARTED
 
+    eligibility_diagnosis = None
+    if job_application.job_seeker.eligibility_diagnoses.exists():
+        eligibility_diagnosis = job_application.job_seeker.get_eligibility_diagnosis()
+
     context = {
         "approvals_wrapper": job_application.job_seeker.approvals_wrapper,
         "cancellation_days": cancellation_days,
+        "eligibility_diagnosis": eligibility_diagnosis,
         "job_application": job_application,
         "transition_logs": transition_logs,
     }

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -247,7 +247,7 @@ def step_eligibility(request, siae_pk, template_name="apply/submit_step_eligibil
         # Only "authorized prescribers" can perform an eligibility diagnosis.
         not user_info.is_authorized_prescriber
         # Eligibility diagnosis already performed.
-        or job_seeker.has_eligibility_diagnosis
+        or job_seeker.has_valid_eligibility_diagnosis
     )
     if skip:
         return HttpResponseRedirect(next_url)


### PR DESCRIPTION
Un diagnostic est désormais valable six mois après sa création. Si un employeur veut embaucher une personne après l'expiration du diagnostic, il doit en réaliser un nouveau.

![image](https://user-images.githubusercontent.com/6150920/87409656-8cd1a480-c5c5-11ea-9fd4-6ee4d37251bc.png)

![image](https://user-images.githubusercontent.com/6150920/88038857-14c82900-cb47-11ea-9f6e-bcfd34131bc2.png)

