### PR TITLE
Petit mot en trop dans la description du DELD

### DIFF
--- a/itou/eligibility/data/administrative_criteria.json
+++ b/itou/eligibility/data/administrative_criteria.json
@@ -109,7 +109,7 @@
     "fields": {
       "level": "2",
       "name": "DELD (12-24 mois)",
-      "desc": "Demandeur d'emploi de très longue durée (inscrit à Pôle emploi)",
+      "desc": "Demandeur d'emploi de longue durée (inscrit à Pôle emploi)",
       "written_proof": "Attestation Pôle emploi",
       "written_proof_url": "",
       "ui_rank": 5,


### PR DESCRIPTION
Demandeur d'emploi de longue durée (inscrit à Pôle emploi)

(et pas **très** longue durée)

donnée modifiée sur la DB de prod