### PR TITLE
Une embauche reportée doit permettre un nouveau diagnostic

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -301,7 +301,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         when processing an application, False otherwise.
         """
         return (
-            self.state.is_processing
+            (self.state.is_processing or self.state.is_postponed)
             and self.to_siae.is_subject_to_eligibility_rules
             and not self.job_seeker.has_valid_eligibility_diagnosis
         )

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -115,7 +115,7 @@
                         {% blocktrans with date=eligibility_diagnosis.expires_at|date %}
                             Ce diagnostic est expiré depuis le {{ date }}.
                         {% endblocktrans %}
-                        {% if job_application.state.is_processing %}
+                        {% if job_application.state.is_processing or job_application.state.is_postponed %}
                             {% trans "Pour embaucher ce candidat, réalisez un nouveau diagnostic d'éligibilité afin d'évaluer sa situation actuelle." %}
                         {% endif %}
                     </p>
@@ -229,37 +229,10 @@
         <hr>
 
         {% if job_application.eligibility_diagnosis_by_siae_required %}
-                {% if eligibility_diagnosis and eligibility_diagnosis.has_expired %}
-                    <p>
-                        <a href="{% url 'apply:eligibility' job_application_id=job_application %}"
-                           class="btn btn-secondary btn-block">
-                                {% trans "Réaliser un nouveau diagnostic" %}
-                            {% include "includes/icon.html" with icon="arrow-right" %}
-                        </a>
-                    </p>
-
-                    <p>
-                        <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
-                           class="btn btn-outline-danger btn-block">
-                            {% trans "Je ne veux pas l'embaucher" %}
-                            {% include "includes/icon.html" with icon="arrow-right" %}
-                        </a>
-                    </p>
-
-                {% else %}
-
-                    <p>
-                        <a href="{% url 'apply:eligibility' job_application_id=job_application %}"
-                           class="btn btn-secondary btn-block">
-                                {% trans "Valider les critères d'éligibilité" %}
-                            {% include "includes/icon.html" with icon="arrow-right" %}
-                        </a>
-                    </p>
-
-                {% endif %}
-
+            <p>
+                {% include "eligibility/includes/new_diagnosis_button.html" %}
+            </p>
         {% else %}
-
             <p>
                 <a href="{% url 'apply:accept' job_application_id=job_application.id %}"
                    class="btn btn-outline-success btn-block">
@@ -276,23 +249,7 @@
                 </a>
             </p>
 
-            <p>
-                <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
-                   class="btn btn-outline-danger btn-block">
-                    {% trans "Je ne veux pas l'embaucher" %}
-                    {% include "includes/icon.html" with icon="arrow-right" %}
-                </a>
-            </p>
-
         {% endif %}
-
-    {% endif %}
-
-    {# Possible next steps when the state is postponed ------------------------------------------------------ #}
-
-    {% if job_application.state.is_postponed %}
-
-        <hr>
 
         <p>
             <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
@@ -302,10 +259,32 @@
             </a>
         </p>
 
+    {% endif %}
+
+    {# Possible next steps when the state is postponed ------------------------------------------------------ #}
+
+    {% if job_application.state.is_postponed %}
+
+        <hr>
+
+        {% if job_application.eligibility_diagnosis_by_siae_required %}
+            <p>
+                {% include "eligibility/includes/new_diagnosis_button.html" %}
+            </p>
+        {% else %}
+            <p>
+                <a href="{% url 'apply:accept' job_application_id=job_application.id %}"
+                   class="btn btn-outline-success btn-block">
+                    {% trans "Je l'embauche" %}
+                    {% include "includes/icon.html" with icon="arrow-right" %}
+                </a>
+            </p>
+        {% endif %}
+
         <p>
-            <a href="{% url 'apply:accept' job_application_id=job_application.id %}"
-               class="btn btn-outline-success btn-block">
-                {% trans "Je l'embauche" %}
+            <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
+               class="btn btn-outline-danger btn-block">
+                {% trans "Je ne veux pas l'embaucher" %}
                 {% include "includes/icon.html" with icon="arrow-right" %}
             </a>
         </p>

--- a/itou/templates/eligibility/includes/new_diagnosis_button.html
+++ b/itou/templates/eligibility/includes/new_diagnosis_button.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+<a href="{% url 'apply:eligibility' job_application_id=job_application %}"
+   class="btn btn-secondary btn-block">
+    {% if eligibility_diagnosis and eligibility_diagnosis.has_expired %}
+        {% trans "Réaliser un nouveau diagnostic" %}
+    {% else %}
+        {% trans "Valider les critères d'éligibilité" %}
+    {% endif %}
+    {% include "includes/icon.html" with icon="arrow-right" %}
+</a>

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -233,7 +233,11 @@ def eligibility(request, job_application_id, template_name="apply/process_eligib
     """
 
     queryset = JobApplication.objects.siae_member_required(request.user)
-    job_application = get_object_or_404(queryset, id=job_application_id, state=JobApplicationWorkflow.STATE_PROCESSING)
+    job_application = get_object_or_404(
+        queryset,
+        id=job_application_id,
+        state__in=[JobApplicationWorkflow.STATE_PROCESSING, JobApplicationWorkflow.STATE_POSTPONED],
+    )
 
     if not job_application.to_siae.is_subject_to_eligibility_rules:
         raise Http404()


### PR DESCRIPTION
Actuellement, une embauche qui a été reportée (étiquette "Embauche pour plus tard") ne permet que l'acceptation ou le refus de la candidature.

Or, si le diagnostic qui a été réalisé n'est plus valide (il date de plus de six mois), l'employeur devrait être en mesure de réaliser un nouveau diagnostic avant l'embauche.

Cette PR permet également le refus d'une candidature qui est en cours de traitement (`STATE_PROCESSING`), avant la validation des critères d'éligibilité.