### PR TITLE
Résolution d'un bug relatif au système d'invitations

### DIFF
--- a/itou/www/invitations_views/forms.py
+++ b/itou/www/invitations_views/forms.py
@@ -114,6 +114,7 @@ class PrescriberWithOrgInvitationFormSet(forms.BaseModelFormSet):
         See https://docs.djangoproject.com/en/3.0/topics/forms/modelforms/#changing-the-queryset
         """
         super().__init__(*args, **kwargs)
+        self.forms[0].empty_permitted = False
         self.queryset = PrescriberWithOrgInvitation.objects.none()
 
 
@@ -183,6 +184,7 @@ class SiaeStaffInvitationFormSet(forms.BaseModelFormSet):
         See https://docs.djangoproject.com/en/3.0/topics/forms/modelforms/#changing-the-queryset
         """
         super().__init__(*args, **kwargs)
+        self.forms[0].empty_permitted = False
         self.queryset = SiaeStaffInvitation.objects.none()
 
 


### PR DESCRIPTION
Actuellement, lorsqu'un utilisateur envoie un formulaire d'invitation vide [ce dernier est considéré comme valide](https://stackoverflow.com/a/16878132/3086625). Cela génère des erreurs qui remontent souvent dans Sentry.
Cette PR supprime cette possibilité, rendant le formulaire invalide s'il est vide.