### PR TITLE
vgrange/send_more_context_to_sentry

### DIFF
--- a/config/settings/_sentry.py
+++ b/config/settings/_sentry.py
@@ -1,0 +1,43 @@
+import os
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import ignore_logger
+
+def strip_sentry_sensitive_data(event, hint):
+    """
+    Be very cautious about not raising any exception in this method,
+    because when this happens, the initial 500 error
+    never reaches the sentry servers... and it could take
+    months before we realize a real error was silenced.
+    Also, you cannot use the debugger here.
+    """
+    if "user" in event:
+        # Unfortunately this does not work for the IP address
+        # which keeps appearing. ¯\_(ツ)_/¯
+        keys_to_delete_if_present = ["email", "username", "ip_address"]
+        for key in keys_to_delete_if_present:
+            if key in event["user"]:
+                del event["user"][key]
+        # Identify clearly users who have not logged in.
+        if "id" not in event["user"]:
+            event["user"]["id"] = "anonymous"
+    return event
+
+
+def sentry_init(dsn):
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[DjangoIntegration()],
+        # Associate users (ID+email+username+IP) to errors.
+        # https://docs.sentry.io/platforms/python/django/
+        send_default_pii=True,
+        # Filter out sensitive email and username.
+        # Unfortunately ip_address cannot be filtered out.
+        # https://docs.sentry.io/error-reporting/configuration/filtering/?platform=python
+        before_send=strip_sentry_sensitive_data,
+        # The alternative solution
+        # https://docs.sentry.io/enriching-error-data/additional-data/?platform=python#capturing-the-user
+        # only ever works here (without access to `request.user`)
+        # and is silently ignored when used in `context_processors.py` to get access to `request.user`.
+    )
+    ignore_logger("django.security.DisallowedHost")

--- a/config/settings/demo.py
+++ b/config/settings/demo.py
@@ -1,10 +1,6 @@
-from .base import *  # noqa
+from .base import *
+from ._sentry import sentry_init
 
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
-from sentry_sdk.integrations.logging import ignore_logger
-
-ITOU_FQDN = "demo.inclusion.beta.gouv.fr"
 ALLOWED_HOSTS = ["127.0.0.1", ".cleverapps.io", ITOU_FQDN]
 
 DATABASES = {
@@ -20,13 +16,12 @@ DATABASES = {
 
 ITOU_ENVIRONMENT = "DEMO"
 ITOU_PROTOCOL = "https"
+ITOU_FQDN = "demo.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact+demo@inclusion.beta.gouv.fr"
 DEFAULT_FROM_EMAIL = "noreply+demo@inclusion.beta.gouv.fr"
 
-sentry_sdk.init(dsn=os.environ["SENTRY_DSN_DEMO"], integrations=[DjangoIntegration()])
-ignore_logger("django.security.DisallowedHost")
+sentry_init(dsn=os.environ["SENTRY_DSN_DEMO"])
 
-ITOU_ENVIRONMENT = "DEMO"
 ASP_ITOU_PREFIX = "XXXXX"
 
 # Override allauth DefaultAccountAdapter: provides custom context to email templates

--- a/config/settings/dev.py.template
+++ b/config/settings/dev.py.template
@@ -1,6 +1,6 @@
-from .base import *  # noqa
+from .base import *
 
-DEBUG = os.environ.get("DJANGO_DEBUG", True)  # noqa: F405
+DEBUG = os.environ.get("DJANGO_DEBUG", True)  # noqa F405
 
 ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1", "192.168.0.1"]
 

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -1,9 +1,5 @@
-from .base import *  # noqa
-
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
-from sentry_sdk.integrations.logging import ignore_logger
-
+from .base import *
+from ._sentry import sentry_init
 
 ALLOWED_HOSTS = ["itou-prod.cleverapps.io", "inclusion.beta.gouv.fr"]
 
@@ -24,5 +20,4 @@ ITOU_FQDN = "inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact@inclusion.beta.gouv.fr"
 DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"
 
-sentry_sdk.init(dsn=os.environ["SENTRY_DSN_PROD"], integrations=[DjangoIntegration()])
-ignore_logger("django.security.DisallowedHost")
+sentry_init(dsn=os.environ["SENTRY_DSN_PROD"])

--- a/config/settings/review_apps.py
+++ b/config/settings/review_apps.py
@@ -1,8 +1,5 @@
-from .base import *  # noqa
-
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
-from sentry_sdk.integrations.logging import ignore_logger
+from .base import *
+from ._sentry import sentry_init
 
 ALLOWED_HOSTS = ["127.0.0.1", ".cleverapps.io"]
 
@@ -23,7 +20,6 @@ ITOU_FQDN = os.environ.get("DEPLOY_URL", "staging.inclusion.beta.gouv.fr")
 ITOU_EMAIL_CONTACT = "contact+staging@inclusion.beta.gouv.fr"
 DEFAULT_FROM_EMAIL = "noreply+staging@inclusion.beta.gouv.fr"
 
-SHOW_TEST_ACCOUNTS_BANNER = True
+sentry_init(dsn=os.environ["SENTRY_DSN_STAGING"])
 
-sentry_sdk.init(dsn=os.environ["SENTRY_DSN_STAGING"], integrations=[DjangoIntegration()])
-ignore_logger("django.security.DisallowedHost")
+SHOW_TEST_ACCOUNTS_BANNER = True

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -1,8 +1,5 @@
-from .base import *  # noqa
-
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
-from sentry_sdk.integrations.logging import ignore_logger
+from .base import *
+from ._sentry import sentry_init
 
 ALLOWED_HOSTS = ["127.0.0.1", "staging.inclusion.beta.gouv.fr"]
 
@@ -23,7 +20,6 @@ ITOU_FQDN = "staging.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact+staging@inclusion.beta.gouv.fr"
 DEFAULT_FROM_EMAIL = "noreply+staging@inclusion.beta.gouv.fr"
 
-sentry_sdk.init(dsn=os.environ["SENTRY_DSN_STAGING"], integrations=[DjangoIntegration()])
-ignore_logger("django.security.DisallowedHost")
+sentry_init(dsn=os.environ["SENTRY_DSN_STAGING"])
 
 ASP_ITOU_PREFIX = "YYYYY"

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -1,6 +1,6 @@
 import logging
 
-from .base import *  # noqa
+from .base import *
 
 
 # `ManifestStaticFilesStorage` (used in base settings) requires `collectstatic` to be run.

--- a/itou/external_data/apps.py
+++ b/itou/external_data/apps.py
@@ -15,4 +15,4 @@ class ExternalDataConfig(AppConfig):
         When the app is loaded:
         import / activate registration to allauth login signals
         """
-        import itou.external_data.signals  # noqa: F401
+        import itou.external_data.signals  # noqa F401

--- a/itou/siaes/migrations/0029_auto_20200821_1616.py
+++ b/itou/siaes/migrations/0029_auto_20200821_1616.py
@@ -30,4 +30,5 @@ class Migration(migrations.Migration):
         ("siaes", "0028_auto_20200821_1616"),
     ]
 
+    # Forward migration was deactivated on purpose.
     operations = [migrations.RunPython(migrations.RunPython.noop, migrations.RunPython.noop)]

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -48,11 +48,13 @@ def get_current_organization_and_perms(request):
         "user_is_siae_admin": user_is_siae_admin,
         "user_siae_set": user_siae_set,
     }
+
     context.update(
         get_matomo_context(
             user=request.user, prescriber_organization=prescriber_organization, user_is_siae_admin=user_is_siae_admin
         )
     )
+
     return context
 
 


### PR DESCRIPTION
J'ai finalement utilisé l'option `send_default_pii=True` qui envoit l'ID + email + username + adresse IP de l'utilisateur sans qu'on puisse controler plus finement (j'aurai bien enlevé l'IP...).

Du coup malheureusement on aura pas plus de contexte, donc par exemple on connait le user siae mais on ne saura pas sur laquelle de ses structures il travaillait au moment de l'erreur :-(

J'aurai de loin préféré utiliser [https://docs.sentry.io/enriching-error-data/additional-data/?platform=python#capturing-the-user](ceci) dans le `context_processors.py` pour pouvoir envoyer exactement ce qu'on voulait. Malheureusement tous mes essais étaient silencieusement ignorés.

FTR j'ai pu faire mes tests directement en local dev pour itérer rapidemment sans devoir redéployer la review-app à chaque fois.

Voici ce que ça donne au final. Si l'issue a plusieurs events, attention à bien regarder chaque event car chacun a potentiellement un user différent.

![image](https://user-images.githubusercontent.com/10533583/90768002-c0a39680-e2f6-11ea-806a-d09c4fef634e.png)

![image](https://user-images.githubusercontent.com/10533583/90768278-242dc400-e2f7-11ea-9552-006b5ac9adf9.png)

