### PR TITLE
Fix bug in invitations

### DIFF
--- a/itou/www/invitations_views/forms.py
+++ b/itou/www/invitations_views/forms.py
@@ -114,8 +114,8 @@ class PrescriberWithOrgInvitationFormSet(forms.BaseModelFormSet):
         See https://docs.djangoproject.com/en/3.0/topics/forms/modelforms/#changing-the-queryset
         """
         super().__init__(*args, **kwargs)
-        self.forms[0].empty_permitted = False
         self.queryset = PrescriberWithOrgInvitation.objects.none()
+        self.forms[0].empty_permitted = False
 
 
 """
@@ -184,8 +184,8 @@ class SiaeStaffInvitationFormSet(forms.BaseModelFormSet):
         See https://docs.djangoproject.com/en/3.0/topics/forms/modelforms/#changing-the-queryset
         """
         super().__init__(*args, **kwargs)
-        self.forms[0].empty_permitted = False
         self.queryset = SiaeStaffInvitation.objects.none()
+        self.forms[0].empty_permitted = False
 
 
 """


### PR DESCRIPTION
La correction que j'ai apportée au système des invitations lundi a généré un autre bug assez improbable.
Le formulaire d'invitation permet la modification d'invitations et non plus simplement leur création ! Cette PR permet de revenir au fonctionnement initial dans lequel seul l'envoi d'invitations est possible. 