### PR TITLE
Fix bug async en fin d'import

### DIFF
--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -8,7 +8,6 @@ from django.utils.dateparse import parse_datetime
 
 from itou.external_data.models import ExternalDataImport, JobSeekerExternalData
 
-from concurrent.futures import ProcessPoolExecutor
 
 # PE Connect API data retrieval tools
 
@@ -255,10 +254,13 @@ def _store_user_data(user, status, data):
 # * logs will be truncated (per thread writing, will not work simply with async)
 #
 
-# executor = ProcessPoolExecutor(max_workers=2)
-
 
 def async_import_user_data(user, token):
+    """
+    Using a new event loop because we're on main thread
+    Loops have a default executor but we can eventually provide on (ProcessPoolExecutor)
+    This would allow tuning the number of workers for this task for all the app.
+    """
     loop = asyncio.new_event_loop()
     loop.run_in_executor(None, import_user_data, user, token)
 

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -255,11 +255,11 @@ def async_import_user_data(user, token):
     """
     Asynchronous update of user data:
 
-    This part of the app have to be processed asynchronously:
+    This part of the app has to be processed asynchronously:
         - many (blocking) HTTP requests are made sequentially in order to fetch data from PE,
           rising up the total execution time to more than 5s in some cases,
         - it is triggered from a synchronous signal receiver (see `signals.py`),
-        - it's mostly "fire & forget" and able to log any issue in it's own context.
+        - it's mostly "fire & forget" and able to log any issue in its own context.
 
     "What happens in a loop stays in the loop":
 

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -254,8 +254,8 @@ def _store_user_data(user, status, data):
 # * logs will be truncated (per thread writing, will not work simply with async)
 #
 async def async_import_user_data(user, token):
-    # loop = asyncio.get_running_loop()
-    loop = asyncio.get_event_loop()
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    loop = asyncio.get_running_loop()
     loop.run_in_executor(None, import_user_data, user, token)
 
 

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -254,7 +254,8 @@ def _store_user_data(user, status, data):
 # * logs will be truncated (per thread writing, will not work simply with async)
 #
 async def async_import_user_data(user, token):
-    loop = asyncio.get_running_loop()
+    # loop = asyncio.get_running_loop()
+    loop = asyncio.get_event_loop()
     loop.run_in_executor(None, import_user_data, user, token)
 
 

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -8,6 +8,7 @@ from django.utils.dateparse import parse_datetime
 
 from itou.external_data.models import ExternalDataImport, JobSeekerExternalData
 
+from concurrent.futures import ProcessPoolExecutor
 
 # PE Connect API data retrieval tools
 
@@ -253,15 +254,19 @@ def _store_user_data(user, status, data):
 # Experimental:
 # * logs will be truncated (per thread writing, will not work simply with async)
 #
-async def async_import_user_data(user, token):
-    asyncio.set_event_loop(asyncio.new_event_loop())
-    loop = asyncio.get_running_loop()
+
+# executor = ProcessPoolExecutor(max_workers=2)
+
+
+def async_import_user_data(user, token):
+    loop = asyncio.new_event_loop()
     loop.run_in_executor(None, import_user_data, user, token)
 
 
 def import_user_data(user, token):
     """
     Import external user data via PE Connect
+    This function is *synchronous*
     Returns a valid ExternalDataImport object when result is partial or ok.
     """
     # Create a new import with a pending status (will be async)

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -23,7 +23,7 @@ ESD_COMPENSATION_API = "peconnect-indemnisations/v1/indemnisation"
 ESD_PT_TRAININGS_API = "peconnect-formations/v1/formations"
 ESD_PT_LICENSES_API = "peconnect-formations/v1/permits"
 
-# Internal ----
+# Internal
 
 logger = logging.getLogger(__name__)
 
@@ -248,18 +248,70 @@ def _store_user_data(user, status, data):
     return data_import
 
 
-#  Public ----
-
-# Experimental:
-# * logs will be truncated (per thread writing, will not work simply with async)
-#
+#  Public
 
 
 def async_import_user_data(user, token):
     """
-    Using a new event loop because we're on main thread
-    Loops have a default executor but we can eventually provide on (ProcessPoolExecutor)
-    This would allow tuning the number of workers for this task for all the app.
+    Asynchronous update of user data:
+
+    This part of the app have to be processed asynchronously:
+        - many (blocking) HTTP requests are made sequentially in order to fetch data from PE,
+          rising up the total execution time to more than 5s in some cases,
+        - it is triggered from a synchronous signal receiver (see `signals.py`),
+        - it's mostly "fire & forget" and able to log any issue in it's own context.
+
+    "What happens in a loop stays in the loop":
+
+    This part is designed to be non-blocking in case of failure:
+        - exceptions thrown in a distinct loop are confined into this loop,
+        - every status update is logged in DB (OK, FAILED, PARTIAL),
+        - data retrieved are not considered vital and can be pulled after a new user login.
+
+    User data updates:
+
+    Refresh strategies can be implemented using data import status and import datetime (`ExternalDataImport` object).
+    The actual data refresh is triggered at each user login and repeated until import status is OK.
+
+    Using loops and executors:
+
+    An event loop is an isolated computation context, where you can use processes or threads (via executors)
+    to do actual tasks, sequentially.
+
+    Processes are suited for long IO computations (mainly for files) without inter-process communications.
+    Threads are better for CPU based or short-lived IO tasks, and they can share context (but don't do that).
+
+    An executor is:
+        - what "does" the real async work within the context of the event loop,
+        - created with every new event loop, with default values, but can be customized / overriden,
+        - either using processes or threads (threads by default).
+
+    See: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor
+
+    Using loops and executor in this case, is the simplest option:
+        - we don't expect a return value (even if provided),
+        - using default executor (based on threads), to process async data import,
+        - ORM calls are all made in the same thread (single task).
+
+    When a return value exists and has to be processed, using Python `async` and `futures` is the way to go.
+    See: https://docs.python.org/3/library/asyncio-eventloop.html#creating-futures-and-tasks
+
+    ---
+
+    PROS:
+        - context isolation: can fail, we don't care
+        - effective and simple async processing
+        - non-blocking
+
+    CONS:
+        - (very) limited scalability: use scarcely (threads are not magic, there are some physical limitations),
+        - everything using threads / loops should be very cautious when using Django ORM
+          (all parts of a DB task have to be done in the same thread).
+
+    TIPS:
+        - most of the time, it's better to code sync functions first and wrap them with an async behavior,
+        - this can however be tricky (when dealing with ORM/DB, UI threads...)
+        - Django, since version 3.1, offers methods to round edges for sync/async concerns (not used here).
     """
     loop = asyncio.new_event_loop()
     loop.run_in_executor(None, import_user_data, user, token)
@@ -268,23 +320,17 @@ def async_import_user_data(user, token):
 def import_user_data(user, token):
     """
     Import external user data via PE Connect
+    Returns a valid ExternalDataImport object when result is partial PARTIAL or OK.
     This function is *synchronous*
-    Returns a valid ExternalDataImport object when result is partial or ok.
     """
-    # Create a new import with a pending status (will be async)
-    data_import = user.externaldataimport_set.pe_imports().first() or ExternalDataImport(
-        source=ExternalDataImport.DATA_SOURCE_PE_CONNECT, user=user
-    )
-    data_import.status = ExternalDataImport.STATUS_PENDING
-    data_import.save()
-
     data_import, _ = ExternalDataImport.objects.get_or_create(
         source=ExternalDataImport.DATA_SOURCE_PE_CONNECT, user=user
     )
 
-    # Save pending status
-    data_import.status = ExternalDataImport.STATUS_PENDING
-    data_import.save()
+    # Save pending status if updating record
+    if data_import != ExternalDataImport.STATUS_PENDING:
+        data_import.status = ExternalDataImport.STATUS_PENDING
+        data_import.save()
 
     try:
         status, result = _get_aggregated_user_data(token)

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 def _call_api(api_path, token):
-    """ 
+    """
     Make a sync call to an API
     For further processing, returning smth else than `None` if considered a success
     """
@@ -320,7 +320,7 @@ def async_import_user_data(user, token):
 def import_user_data(user, token):
     """
     Import external user data via PE Connect
-    Returns a valid ExternalDataImport object when result is partial PARTIAL or OK.
+    Returns a valid ExternalDataImport object when result is PARTIAL or OK.
     This function is *synchronous*
     """
     data_import, _ = ExternalDataImport.objects.get_or_create(

--- a/itou/external_data/apps.py
+++ b/itou/external_data/apps.py
@@ -15,4 +15,4 @@ class ExternalDataConfig(AppConfig):
         When the app is loaded:
         import / activate registration to allauth login signals
         """
-        import itou.external_data.signals
+        import itou.external_data.signals  # noqa: F401

--- a/itou/external_data/signals.py
+++ b/itou/external_data/signals.py
@@ -5,9 +5,11 @@ from django.dispatch import receiver
 
 from itou.allauth.peamu.provider import PEAMUProvider
 
-from .apis.pe_connect import async_import_user_data
+from .apis.pe_connect import async_import_user_data,import_user_data
 from .models import ExternalDataImport
 
+import asyncio  
+from concurrent.futures import ProcessPoolExecutor
 
 @receiver(user_logged_in)
 def user_logged_in_receiver(sender, **kwargs):
@@ -27,7 +29,9 @@ def user_logged_in_receiver(sender, **kwargs):
 
         # If no data for user or import failed last time
         if not pe_data_import.exists() or pe_data_import.first().status != ExternalDataImport.STATUS_OK:
-            # SYNC can be dpne like:
+            # SYNC can be done like:
             # import_user_data(user, login.token)
             # ASYNC (default):
-            asyncio.run(async_import_user_data(user, login.token))
+            # asyncio.run(async_import_user_data(user, login.token))
+            loop = asyncio.new_event_loop()
+            loop.run_in_executor(None, import_user_data, user, login.token)

--- a/itou/external_data/signals.py
+++ b/itou/external_data/signals.py
@@ -1,11 +1,9 @@
-import asyncio
-
 from allauth.account.signals import user_logged_in
 from django.dispatch import receiver
 
 from itou.allauth.peamu.provider import PEAMUProvider
 
-from .apis.pe_connect import import_user_data
+from .apis.pe_connect import async_import_user_data
 from .models import ExternalDataImport
 
 
@@ -30,6 +28,4 @@ def user_logged_in_receiver(sender, **kwargs):
             # SYNC can be done like:
             # import_user_data(user, login.token)
             # ASYNC (default):
-            # asyncio.run(async_import_user_data(user, login.token))
-            loop = asyncio.new_event_loop()
-            loop.run_in_executor(None, import_user_data, user, login.token)
+            async_import_user_data(user, login.token)

--- a/itou/external_data/signals.py
+++ b/itou/external_data/signals.py
@@ -5,11 +5,9 @@ from django.dispatch import receiver
 
 from itou.allauth.peamu.provider import PEAMUProvider
 
-from .apis.pe_connect import async_import_user_data,import_user_data
+from .apis.pe_connect import import_user_data
 from .models import ExternalDataImport
 
-import asyncio  
-from concurrent.futures import ProcessPoolExecutor
 
 @receiver(user_logged_in)
 def user_logged_in_receiver(sender, **kwargs):

--- a/itou/external_data/tests.py
+++ b/itou/external_data/tests.py
@@ -7,7 +7,7 @@ import itou.external_data.apis.pe_connect as pec
 from itou.users.factories import JobSeekerFactory
 
 from .apis.pe_connect import import_user_data
-from .models import ExternalDataImport, JobSeekerExternalData
+from .models import ExternalDataImport
 
 
 # Test data import status (All ok, failed, partial)

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -9,7 +9,6 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
-from itou.external_data.models import ExternalDataImport
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,3 +18,6 @@ factory-boy==2.12.0  # https://github.com/FactoryBoy/factory_boy
 
 django-debug-toolbar==2.2  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.0.5  # https://github.com/django-extensions/django-extensions
+
+# Test & Mock
+requests-mock=1.8.0 # https://github.com/jamielennox/requests-mock

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,4 +20,4 @@ django-debug-toolbar==2.2  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.0.5  # https://github.com/django-extensions/django-extensions
 
 # Test & Mock
-requests-mock=1.8.0 # https://github.com/jamielennox/requests-mock
+requests-mock==1.8.0 # https://github.com/jamielennox/requests-mock


### PR DESCRIPTION
La partie qui traite de manière asynchrone l'import de données crashe à chaque fin d'opération (générant une erreur Sentry).

NB:  Cette erreur n'est pas visible par l'utilisateur, et les données sont correctement stockées.
