### PR TITLE
Utilisation de `itou@example.com` plutôt que `test@example.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Vous pouvez personnaliser la configuration Compose en créant [un fichier `.env`
     $ make run
 
     # Équivalent de :
-    $ docker-compose -f docker-compose-dev.yml up
+    $ docker-compose up
 
 Ou pour utiliser [un débogueur interactif](https://github.com/docker/compose/issues/4677#issuecomment-320804194) type `ipdb` :
 
-    $ docker-compose -f docker-compose-dev.yml run --service-ports django
+    $ docker-compose run --service-ports django
 
 Une fois votre serveur de développement lancé, vous pouvez accéder au frontend à l'adresse http://localhost:8080/
 

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -509,8 +509,8 @@ class SiaeSignupTokenGeneratorTest(TestCase):
         The token generated for a siae created in the same request
         will work correctly.
         """
-        siae = Siae.objects.create(email="test@example.com")
-        siae_reload = Siae.objects.get(email="test@example.com")
+        siae = Siae.objects.create(email="itou@example.com")
+        siae_reload = Siae.objects.get(email="itou@example.com")
         p0 = MockedSiaeSignupTokenGenerator(datetime.datetime.now())
         tk1 = p0.make_token(siae)
         tk2 = p0.make_token(siae_reload)


### PR DESCRIPTION
Dans le but de détecter si le problème signalé par Mailjet vient de notre code.

Petit fix du README au passage.