### PR TITLE
Interdire l'accès de nouveaux utilisateurs aux structures qui ont déjà des membres 

### DIFF
--- a/itou/templates/siaes/email/new_signup_activation_email_to_official_contact_body.txt
+++ b/itou/templates/siaes/email/new_signup_activation_email_to_official_contact_body.txt
@@ -14,7 +14,7 @@
 
 {% translate "Ouvrez le lien suivant pour procéder à l'inscription" %} : {{ signup_magic_link }}
 
-{% translate "Si vous n'êtes pas à l'origine de cette demande, peut-être s'agit-il d'un collaborateur ou d'une collaboratrice. translateférez-lui cet email pour lui permettre de s'inscrire." %}
+{% translate "Si vous n'êtes pas à l'origine de cette demande, peut-être s'agit-il d'un collaborateur ou d'une collaboratrice. Transférez-lui cet email pour lui permettre de s'inscrire." %}
 
 {% translate "Si vous êtes certain que cette demande n'émane d'aucun de vos collaborateurs ou collaboratrices, vous pouvez simplement ignorer notre e-mail." %}
 

--- a/itou/templates/signup/signup_select_siae.html
+++ b/itou/templates/signup/signup_select_siae.html
@@ -11,10 +11,6 @@
     <small class="text-muted">{% translate "Employeur solidaire" %}</small>
 </h1>
 
-<div class="alert alert-info" role="info">
-    {% translate "Pour des raisons de sécurité, merci de compléter les informations suivantes." %}
-</div>
-
 <div class="alert alert-warning" role="info">
     {% blocktranslate with doc_opening_schedule_url=form.DOC_OPENING_SCHEDULE_URL%}
         Les inscriptions s'ouvrent aux régions progressivement. <a href="{{ doc_opening_schedule_url }}" rel="noopener" target="_blank">Vérifiez que la Plateforme est bien disponible sur votre territoire.</a> Seules les ETTI sont ouvertes en France entière.

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -218,9 +218,7 @@ class SelectSiaeForm(forms.Form):
         max_length=14,
         validators=[validate_siret],
         strip=True,
-        help_text=gettext_lazy(
-            "Saisissez 14 chiffres. Numéro connu possiblement de l'Agence de services et de paiement (ASP)"
-        ),
+        help_text=gettext_lazy("Saisissez 14 chiffres."),
         required=False,
     )
 

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -48,10 +48,10 @@ def select_siae(request, template_name="signup/signup_select_siae.html"):
         siae = form.selected_siae
 
         if siae.has_members:
-            message = (_(
+            message = _(
                 "Cette structure a déjà des membres. Pour des raisons de sécurité, "
                 "merci de contacter les autres membres afin qu'ils vous invitent."
-            ))
+            )
             messages.warning(request, message)
         else:
             siae.new_signup_activation_email_to_official_contact(request).send()

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -48,15 +48,19 @@ def select_siae(request, template_name="signup/signup_select_siae.html"):
         siae = form.selected_siae
 
         if siae.has_members:
-            return HttpResponseRedirect(siae.signup_magic_link)
-
-        siae.new_signup_activation_email_to_official_contact(request).send()
-        message = _(
-            f"Nous venons de vous envoyer un e-mail à l'adresse {siae.obfuscated_auth_email} "
-            f"pour continuer votre inscription. Veuillez consulter votre boite "
-            f"de réception."
-        )
-        messages.success(request, message)
+            message = (_(
+                "Cette structure a déjà des membres. Pour des raisons de sécurité, "
+                "merci de contacter les autres membres afin qu'ils vous invitent."
+            ))
+            messages.warning(request, message)
+        else:
+            siae.new_signup_activation_email_to_official_contact(request).send()
+            message = _(
+                f"Nous venons de vous envoyer un e-mail à l'adresse {siae.obfuscated_auth_email} "
+                f"pour continuer votre inscription. Veuillez consulter votre boite "
+                f"de réception."
+            )
+            messages.success(request, message)
         return HttpResponseRedirect(reverse("home:hp"))
 
     context = {"form": form}


### PR DESCRIPTION
Pour tester : 

SIAE qui a des membres : 
- type : EI
- SIRET : 34445638900016

SIAE qui n'a pas de membre : 
- type : ACI 
- SIRET : 87985594800011

Le message d'erreur est probablement à retravailler.

Messages Eric