### PR TITLE
Erreur Sentry eligibilité - retrait de code

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -255,8 +255,6 @@ def step_eligibility(request, siae_pk, template_name="apply/submit_step_eligibil
     data = request.POST if request.method == "POST" else None
     form_administrative_criteria = AdministrativeCriteriaForm(request.user, siae=None, data=data)
 
-    external_user_data = job_seeker.job_seeker_data if job_seeker.has_external_data else None
-
     if request.method == "POST" and form_administrative_criteria.is_valid():
         EligibilityDiagnosis.create_diagnosis(
             job_seeker, user_info, administrative_criteria=form_administrative_criteria.cleaned_data
@@ -268,7 +266,6 @@ def step_eligibility(request, siae_pk, template_name="apply/submit_step_eligibil
         "siae": siae,
         "job_seeker": job_seeker,
         "approvals_wrapper": approvals_wrapper,
-        "external_user_data": external_user_data,
         "form_administrative_criteria": form_administrative_criteria,
     }
     return render(request, template_name, context)


### PR DESCRIPTION
Une portion de code obsolète est en place coté éligibilité, créant des erreurs 
- la propriété `user.job_seeker_data` n'existe pas (c'est `user.jobseekerexternaldata`),
- ce code n'a vraiment rien à faire là (oubli lors de tests).
(voir https://sentry.data.gouv.fr/itou/itou-prod-5t/issues/1885721/)
