### PR TITLE
[BOOST] Retirer le choix d'obtention d'un PASS IAE pour les structures non-éligibles au diagnostic

### DIFF
--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -51,34 +51,34 @@
                 <button class="btn btn-success" type="submit">{% translate "Je l'embauche" %}</button>
             {% endif %}
         
-            {% endbuttons %}
+        {% endbuttons %}
             
-        <!-- Do we really need an approval ? 
-             Only valid for some SIAE (is_subject_to_eligibility_rules) -->
-        <div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-labelledby="confirmModal" aria-hidden="true">
-            <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
-                <div class="modal-content">
-                    <div class="modal-body p-4">
-                        <h4 class="modal-title text-center" id="mapModalLabel">Obtention d'un PASS IAE</h4>
-                        <p class="pt-2 text-center">Dans le cadre de cette embauche, souhaitez-vous obtenir un PASS IAE ?</p>
-                        <div id="mapPoll">
-                            <div class="row buttonsContainer">
-                                <div class="col pr-2">
-                                    <button type="submit" class="btn btn-success w-100">
-                                        Je l'embauche et j'obtiens un PASS IAE
-                                    </button>
-                                </div>
-                                <div class="col pl-2">
-                                    <button type="submit" class="btn btn-success w-100" onClick="$(&quot;input[name='hiring_without_approval']&quot;).val('True')">
-                                        Je n'ai pas besoin d'un PASS IAE
-                                    </button>
+        {% if job_application.to_siae.is_subject_to_eligibility_rules %}
+            <div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-labelledby="confirmModal" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+                    <div class="modal-content">
+                        <div class="modal-body p-4">
+                            <h4 class="modal-title text-center" id="mapModalLabel">Obtention d'un PASS IAE</h4>
+                            <p class="pt-2 text-center">Dans le cadre de cette embauche, souhaitez-vous obtenir un PASS IAE ?</p>
+                            <div id="mapPoll">
+                                <div class="row buttonsContainer">
+                                    <div class="col pr-2">
+                                        <button type="submit" class="btn btn-success w-100">
+                                            Je l'embauche et j'obtiens un PASS IAE
+                                        </button>
+                                    </div>
+                                    <div class="col pl-2">
+                                        <button type="submit" class="btn btn-success w-100" onClick="$(&quot;input[name='hiring_without_approval']&quot;).val('True')">
+                                            Je n'ai pas besoin d'un PASS IAE
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        {% endif %}
 
     </form>
 

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -44,11 +44,17 @@
         {% buttons %}
             <a class="btn btn-secondary"
                href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">{% translate "Annuler" %}</a>
-            <a href="#" class="btn btn-success" data-toggle="modal" data-target="#confirmModal">{% translate "Je l'embauche" %}</a>
-
-        {% endbuttons %}
             
-        <!-- Do we really need an approval ? -->
+            {% if job_application.to_siae.is_subject_to_eligibility_rules %}
+                <a href="#" class="btn btn-success" data-toggle="modal" data-target="#confirmModal">{% translate "Je l'embauche" %}</a>
+            {% else %}
+                <button class="btn btn-success" type="submit">{% translate "Je l'embauche" %}</button>
+            {% endif %}
+        
+            {% endbuttons %}
+            
+        <!-- Do we really need an approval ? 
+             Only valid for some SIAE (is_subject_to_eligibility_rules) -->
         <div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-labelledby="confirmModal" aria-hidden="true">
             <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
                 <div class="modal-content">


### PR DESCRIPTION
Lors de la confirmation d'une candidature (juste avant l'acceptation), certaines SIAEs pouvaient voir une popup permettant d'obtenir un PASS IAE ou non.

Inapproprié pour EA, EATT, GEIQ

Trello:
https://trello.com/c/ET5alkir/836-un-geiq-peut-demander-%C3%A0-obtenir-un-pass-iae