### PR TITLE
Diagnostic : champs d'action et expiration

### DIFF
--- a/itou/eligibility/factories.py
+++ b/itou/eligibility/factories.py
@@ -3,7 +3,8 @@ from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 
 from itou.eligibility import models
-from itou.users.factories import JobSeekerFactory, PrescriberFactory
+from itou.siaes.factories import SiaeFactory
+from itou.users.factories import JobSeekerFactory, PrescriberFactory, SiaeStaffFactory
 
 
 class EligibilityDiagnosisFactory(factory.django.DjangoModelFactory):
@@ -13,12 +14,26 @@ class EligibilityDiagnosisFactory(factory.django.DjangoModelFactory):
         model = models.EligibilityDiagnosis
 
     job_seeker = factory.SubFactory(JobSeekerFactory)
+
+
+class PrescriberEligibilityDiagnosisFactory(EligibilityDiagnosisFactory):
     author = factory.SubFactory(PrescriberFactory)
     author_kind = models.EligibilityDiagnosis.AUTHOR_KIND_PRESCRIBER
 
 
-class ExpiredEligibilityDiagnosisFactory(EligibilityDiagnosisFactory):
+class SiaeEligibilityDiagnosisFactory(EligibilityDiagnosisFactory):
+    author = factory.SubFactory(SiaeStaffFactory)
+    author_kind = models.EligibilityDiagnosis.AUTHOR_KIND_SIAE_STAFF
+    author_siae = factory.SubFactory(SiaeFactory)
 
+
+class ExpiredPrescriberEligibilityDiagnosisFactory(PrescriberEligibilityDiagnosisFactory):
+    created_at = factory.LazyAttribute(
+        lambda self: timezone.now() - relativedelta(months=models.EligibilityDiagnosis.EXPIRATION_DELAY_MONTHS, days=1)
+    )
+
+
+class ExpiredSiaeEligibilityDiagnosisFactory(SiaeEligibilityDiagnosisFactory):
     created_at = factory.LazyAttribute(
         lambda self: timezone.now() - relativedelta(months=models.EligibilityDiagnosis.EXPIRATION_DELAY_MONTHS, days=1)
     )

--- a/itou/eligibility/models.py
+++ b/itou/eligibility/models.py
@@ -17,9 +17,6 @@ class EligibilityDiagnosisQuerySet(models.QuerySet):
     def by_prescribers(self):
         return self.filter(author_kind=KIND_PRESCRIBER)
 
-    def by_siae(self, siae):
-        return self.filter(author_kind=KIND_SIAE_STAFF, author_siae=siae)
-
     def by_prescribers_or_siae(self, siae):
         return self.filter(Q(author_kind=KIND_PRESCRIBER) | Q(author_siae=siae))
 

--- a/itou/eligibility/tests.py
+++ b/itou/eligibility/tests.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
 
-from itou.eligibility.factories import EligibilityDiagnosisFactory, ExpiredEligibilityDiagnosisFactory
+from itou.eligibility.factories import (
+    ExpiredPrescriberEligibilityDiagnosisFactory,
+    PrescriberEligibilityDiagnosisFactory,
+)
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.prescribers.factories import AuthorizedPrescriberOrganizationWithMembershipFactory
 from itou.siaes.factories import SiaeWithMembershipFactory
@@ -62,10 +65,10 @@ class EligibilityDiagnosisModelTest(TestCase):
         self.assertIn(criteria3, administrative_criteria)
 
     def test_has_expired(self):
-        diagnosis = EligibilityDiagnosisFactory()
+        diagnosis = PrescriberEligibilityDiagnosisFactory()
         self.assertFalse(diagnosis.has_expired)
 
-        self.diagnosis = ExpiredEligibilityDiagnosisFactory()
+        self.diagnosis = ExpiredPrescriberEligibilityDiagnosisFactory()
         self.assertTrue(self.diagnosis.has_expired)
 
 

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -307,7 +307,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         )
 
     @property
-    def eligibility_diagnosis_by_siae_required(self):
+    def diagnosis_by_siae_required(self):
         """
         Returns True if an eligibility diagnosis must be made by an SIAE
         when processing an application, False otherwise.
@@ -317,9 +317,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         if self.job_seeker.has_valid_approval:
             return False
 
-        has_valid_diagnosis = (
-            self.has_valid_siae_eligibility_diagnosis or self.job_seeker.has_valid_prescriber_eligibility_diagnosis
-        )
+        has_valid_diagnosis = self.has_valid_siae_diagnosis or self.job_seeker.has_valid_prescriber_diagnosis
         return (
             (self.state.is_processing or self.state.is_postponed)
             and self.to_siae.is_subject_to_eligibility_rules
@@ -338,7 +336,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         )
 
     @property
-    def has_valid_siae_eligibility_diagnosis(self):
+    def has_valid_siae_diagnosis(self):
         diagnoses = self.job_seeker.eligibility_diagnoses.by_siae(siae=self.to_siae)
         if diagnoses and not diagnoses.latest("created_at").has_expired:
             return True

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -312,6 +312,11 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         Returns True if an eligibility diagnosis must be made by an SIAE
         when processing an application, False otherwise.
         """
+        # If a job seeker started an IAE pathway,
+        # doing a new diagnosis is useless.
+        if self.job_seeker.has_valid_approval:
+            return False
+
         has_valid_diagnosis = (
             self.has_valid_siae_eligibility_diagnosis or self.job_seeker.has_valid_prescriber_eligibility_diagnosis
         )

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -36,18 +36,18 @@ from itou.utils.templatetags import format_filters
 
 
 class JobApplicationModelTest(TestCase):
-    def test_eligibility_diagnosis_by_siae_required(self):
+    def test_diagnosis_by_siae_required(self):
         job_application = JobApplicationFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING, to_siae__kind=Siae.KIND_GEIQ
         )
-        self.assertFalse(job_application.job_seeker.has_valid_prescriber_eligibility_diagnosis)
-        self.assertFalse(job_application.eligibility_diagnosis_by_siae_required)
+        self.assertFalse(job_application.job_seeker.has_valid_prescriber_diagnosis)
+        self.assertFalse(job_application.diagnosis_by_siae_required)
 
         job_application = JobApplicationFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING, to_siae__kind=Siae.KIND_EI
         )
-        self.assertFalse(job_application.job_seeker.has_valid_prescriber_eligibility_diagnosis)
-        self.assertTrue(job_application.eligibility_diagnosis_by_siae_required)
+        self.assertFalse(job_application.job_seeker.has_valid_prescriber_diagnosis)
+        self.assertTrue(job_application.diagnosis_by_siae_required)
 
     def test_accepted_by(self):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(
@@ -57,31 +57,31 @@ class JobApplicationModelTest(TestCase):
         job_application.accept(user=user)
         self.assertEqual(job_application.accepted_by, user)
 
-    def test_has_valid_siae_eligibility_diagnosis(self):
+    def test_has_valid_siae_diagnosis(self):
         # No diagnosis.
         job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_PROCESSING)
-        self.assertFalse(job_application.has_valid_siae_eligibility_diagnosis)
+        self.assertFalse(job_application.has_valid_siae_diagnosis)
 
         # Has a diagnosis made by a prescriber.
         job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_PROCESSING)
         PrescriberEligibilityDiagnosisFactory(job_seeker=job_application.job_seeker)
-        self.assertFalse(job_application.has_valid_siae_eligibility_diagnosis)
+        self.assertFalse(job_application.has_valid_siae_diagnosis)
 
         # Has a diagnosis made by an SIAE.
         job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_PROCESSING)
         SiaeEligibilityDiagnosisFactory(job_seeker=job_application.job_seeker, author_siae=job_application.to_siae)
-        self.assertTrue(job_application.has_valid_siae_eligibility_diagnosis)
+        self.assertTrue(job_application.has_valid_siae_diagnosis)
 
         # Has a valid Pôle emploi diagnosis.
         job_seeker = JobSeekerFactory()
         PoleEmploiApprovalFactory(pole_emploi_id=job_seeker.pole_emploi_id, birthdate=job_seeker.birthdate)
         job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_PROCESSING, job_seeker=job_seeker)
-        self.assertFalse(job_application.has_valid_siae_eligibility_diagnosis)
+        self.assertFalse(job_application.has_valid_siae_diagnosis)
 
         # Has an expired diagnosis made by an Employer
         job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_PROCESSING)
         ExpiredSiaeEligibilityDiagnosisFactory(job_seeker=job_application.job_seeker)
-        self.assertFalse(job_application.has_valid_siae_eligibility_diagnosis)
+        self.assertFalse(job_application.has_valid_siae_diagnosis)
 
     def test_is_sent_by_authorized_prescriber(self):
         job_application = JobApplicationSentByJobSeekerFactory()

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -65,18 +65,23 @@ class JobApplicationModelTest(TestCase):
         # Has a diagnosis made by a prescriber.
         job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_PROCESSING)
         PrescriberEligibilityDiagnosisFactory(job_seeker=job_application.job_seeker)
-        self.assertFalse(job_application.has_valid_siae_diagnosis)
+        self.assertTrue(job_application.has_valid_siae_diagnosis)
 
-        # Has a diagnosis made by an SIAE.
+        # Has a diagnosis made by the same SIAE.
         job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_PROCESSING)
         SiaeEligibilityDiagnosisFactory(job_seeker=job_application.job_seeker, author_siae=job_application.to_siae)
         self.assertTrue(job_application.has_valid_siae_diagnosis)
+
+        # Has a diagnosis from another SIAE
+        job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_PROCESSING)
+        SiaeEligibilityDiagnosisFactory(job_seeker=job_application.job_seeker)
+        self.assertFalse(job_application.has_valid_siae_diagnosis)
 
         # Has a valid Pôle emploi diagnosis.
         job_seeker = JobSeekerFactory()
         PoleEmploiApprovalFactory(pole_emploi_id=job_seeker.pole_emploi_id, birthdate=job_seeker.birthdate)
         job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_PROCESSING, job_seeker=job_seeker)
-        self.assertFalse(job_application.has_valid_siae_diagnosis)
+        self.assertTrue(job_application.has_valid_siae_diagnosis)
 
         # Has an expired diagnosis made by an Employer
         job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_PROCESSING)

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -228,7 +228,7 @@
 
         <hr>
 
-        {% if job_application.eligibility_diagnosis_by_siae_required %}
+        {% if job_application.diagnosis_by_siae_required %}
             <p>
                 {% include "eligibility/includes/new_diagnosis_button.html" %}
             </p>
@@ -267,7 +267,7 @@
 
         <hr>
 
-        {% if job_application.eligibility_diagnosis_by_siae_required %}
+        {% if job_application.diagnosis_by_siae_required %}
             <p>
                 {% include "eligibility/includes/new_diagnosis_button.html" %}
             </p>

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -113,7 +113,7 @@ class User(AbstractUser, AddressMixin):
         return ApprovalsWrapper(self)
 
     @property
-    def has_valid_prescriber_eligibility_diagnosis(self):
+    def has_valid_prescriber_diagnosis(self):
         """
         Returns True if an ongoing diagnosis made by a prescriber exists,
         False otherwise.

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -128,6 +128,11 @@ class User(AbstractUser, AddressMixin):
         latest_approval = self.approvals_wrapper.latest_approval
         return latest_approval and latest_approval.is_valid and not latest_approval.originates_from_itou
 
+    @property
+    def has_valid_approval(self):
+        approval = self.approvals_wrapper.latest_approval
+        return approval and approval.is_valid
+
     @cached_property
     def has_eligibility_diagnoses(self):
         return self.eligibility_diagnoses.exists()

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -49,26 +49,26 @@ class ModelTest(TestCase):
         with self.assertRaises(ValidationError):
             User.create_job_seeker_by_proxy(proxy_user, **user_data)
 
-    def test_has_valid_prescriber_eligibility_diagnosis(self):
+    def test_has_valid_prescriber_diagnosis(self):
 
         # No diagnosis.
         job_seeker = JobSeekerFactory()
-        self.assertFalse(job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertFalse(job_seeker.has_valid_prescriber_diagnosis)
 
         # Has a diagnosis made by a prescriber.
         job_seeker = JobSeekerFactory()
         PrescriberEligibilityDiagnosisFactory(job_seeker=job_seeker)
-        self.assertTrue(job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertTrue(job_seeker.has_valid_prescriber_diagnosis)
 
         # Has a diagnosis made by an SIAE.
         job_seeker = JobSeekerFactory()
         SiaeEligibilityDiagnosisFactory(job_seeker=job_seeker)
-        self.assertFalse(job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertFalse(job_seeker.has_valid_prescriber_diagnosis)
 
         # Has a valid Pôle emploi diagnosis.
         job_seeker = JobSeekerFactory()
         PoleEmploiApprovalFactory(pole_emploi_id=job_seeker.pole_emploi_id, birthdate=job_seeker.birthdate)
-        self.assertTrue(job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertTrue(job_seeker.has_valid_prescriber_diagnosis)
 
         # Has an expired Pôle emploi diagnosis.
         job_seeker = JobSeekerFactory()
@@ -77,17 +77,17 @@ class ModelTest(TestCase):
         PoleEmploiApprovalFactory(
             pole_emploi_id=job_seeker.pole_emploi_id, birthdate=job_seeker.birthdate, start_at=start_at, end_at=end_at
         )
-        self.assertFalse(job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertFalse(job_seeker.has_valid_prescriber_diagnosis)
 
         # Has an expired diagnosis made by a Prescriber
         job_seeker = JobSeekerFactory()
         ExpiredPrescriberEligibilityDiagnosisFactory(job_seeker=job_seeker)
-        self.assertFalse(job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertFalse(job_seeker.has_valid_prescriber_diagnosis)
 
         # Has an expired diagnosis made by an Employer
         job_seeker = JobSeekerFactory()
         ExpiredSiaeEligibilityDiagnosisFactory(job_seeker=job_seeker)
-        self.assertFalse(job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertFalse(job_seeker.has_valid_prescriber_diagnosis)
 
     def test_get_eligibility_diagnosis(self):
         # No eligibility_diagnosis

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -220,8 +220,8 @@ class ProcessViewsTest(TestCase):
         siae_user = job_application.to_siae.members.first()
         self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
 
-        self.assertFalse(job_application.has_valid_siae_eligibility_diagnosis)
-        self.assertFalse(job_application.job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertFalse(job_application.has_valid_siae_diagnosis)
+        self.assertFalse(job_application.job_seeker.has_valid_prescriber_diagnosis)
 
         criterion1 = AdministrativeCriteria.objects.level1().get(pk=1)
         criterion2 = AdministrativeCriteria.objects.level2().get(pk=5)
@@ -251,7 +251,7 @@ class ProcessViewsTest(TestCase):
         next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
         self.assertEqual(response.url, next_url)
 
-        self.assertTrue(job_application.has_valid_siae_eligibility_diagnosis)
+        self.assertTrue(job_application.has_valid_siae_diagnosis)
 
         # Check diagnosis.
         eligibility_diagnosis = job_application.job_seeker.get_eligibility_diagnosis(siae=job_application.to_siae)

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -20,7 +20,6 @@ from itou.job_applications.factories import (
     JobApplicationWithApprovalFactory,
 )
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
-from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import Siae
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerWithAddressFactory
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -296,7 +296,6 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
 
         response = self.client.post(next_url)
         self.assertEqual(response.status_code, 302)
-
         self.assertTrue(new_job_seeker.has_valid_prescriber_diagnosis)
 
         next_url = reverse("apply:step_application", kwargs={"siae_pk": siae.pk})

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -292,12 +292,12 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.get(next_url)
         self.assertEqual(response.status_code, 200)
 
-        self.assertFalse(new_job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertFalse(new_job_seeker.has_valid_prescriber_diagnosis)
 
         response = self.client.post(next_url)
         self.assertEqual(response.status_code, 302)
 
-        self.assertTrue(new_job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertTrue(new_job_seeker.has_valid_prescriber_diagnosis)
 
         next_url = reverse("apply:step_application", kwargs={"siae_pk": siae.pk})
         self.assertEqual(response.url, next_url)
@@ -473,7 +473,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.post(next_url)
         self.assertEqual(response.status_code, 302)
 
-        self.assertFalse(new_job_seeker.has_valid_prescriber_eligibility_diagnosis)
+        self.assertFalse(new_job_seeker.has_valid_prescriber_diagnosis)
 
         next_url = reverse("apply:step_application", kwargs={"siae_pk": siae.pk})
         self.assertEqual(response.url, next_url)

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -45,7 +45,7 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
 
     eligibility_diagnosis = None
     if job_application.job_seeker.has_eligibility_diagnoses:
-        eligibility_diagnosis = job_application.job_seeker.get_eligibility_diagnosis()
+        eligibility_diagnosis = job_application.job_seeker.get_eligibility_diagnosis(siae=job_application.to_siae)
 
     context = {
         "approvals_wrapper": job_application.job_seeker.approvals_wrapper,

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -43,9 +43,7 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
     transition_logs = job_application.logs.select_related("user").all().order_by("timestamp")
     cancellation_days = JobApplication.CANCELLATION_DAYS_AFTER_HIRING_STARTED
 
-    eligibility_diagnosis = None
-    if job_application.job_seeker.has_eligibility_diagnoses:
-        eligibility_diagnosis = job_application.job_seeker.get_eligibility_diagnosis(siae=job_application.to_siae)
+    eligibility_diagnosis = job_application.job_seeker.get_eligibility_diagnosis(siae=job_application.to_siae)
 
     context = {
         "approvals_wrapper": job_application.job_seeker.approvals_wrapper,

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -247,7 +247,7 @@ def step_eligibility(request, siae_pk, template_name="apply/submit_step_eligibil
         # Only "authorized prescribers" can perform an eligibility diagnosis.
         not user_info.is_authorized_prescriber
         # Eligibility diagnosis already performed.
-        or job_seeker.has_valid_eligibility_diagnosis
+        or job_seeker.has_valid_prescriber_eligibility_diagnosis
     )
     if skip:
         return HttpResponseRedirect(next_url)

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -247,7 +247,7 @@ def step_eligibility(request, siae_pk, template_name="apply/submit_step_eligibil
         # Only "authorized prescribers" can perform an eligibility diagnosis.
         not user_info.is_authorized_prescriber
         # Eligibility diagnosis already performed.
-        or job_seeker.has_valid_prescriber_eligibility_diagnosis
+        or job_seeker.has_valid_prescriber_diagnosis
     )
     if skip:
         return HttpResponseRedirect(next_url)

--- a/itou/www/approvals_views/tests/tests.py
+++ b/itou/www/approvals_views/tests/tests.py
@@ -1,11 +1,10 @@
 from unittest.mock import PropertyMock, patch
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from django.urls import reverse
 from requests import exceptions as requests_exceptions
 
-from itou.eligibility.factories import EligibilityDiagnosisFactory
+from itou.eligibility.factories import PrescriberEligibilityDiagnosisFactory
 from itou.job_applications.factories import JobApplicationFactory, JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication
 from itou.users.factories import DEFAULT_PASSWORD
@@ -20,7 +19,7 @@ class TestDownloadApprovalAsPDF(TestCase):
         job_application = JobApplicationWithApprovalFactory()
         siae_member = job_application.to_siae.members.first()
         job_seeker = job_application.job_seeker
-        EligibilityDiagnosisFactory(job_seeker=job_seeker)
+        PrescriberEligibilityDiagnosisFactory(job_seeker=job_seeker)
 
         self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
 
@@ -42,7 +41,7 @@ class TestDownloadApprovalAsPDF(TestCase):
         job_application = JobApplicationFactory()
         siae_member = job_application.to_siae.members.first()
         job_seeker = job_application.job_seeker
-        EligibilityDiagnosisFactory(job_seeker=job_seeker)
+        PrescriberEligibilityDiagnosisFactory(job_seeker=job_seeker)
 
         self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
         response = self.client.get(
@@ -55,7 +54,7 @@ class TestDownloadApprovalAsPDF(TestCase):
         job_application = JobApplicationWithApprovalFactory()
         siae_member = job_application.to_siae.members.first()
         job_seeker = job_application.job_seeker
-        EligibilityDiagnosisFactory(job_seeker=job_seeker)
+        PrescriberEligibilityDiagnosisFactory(job_seeker=job_seeker)
 
         self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
 
@@ -71,7 +70,7 @@ class TestDownloadApprovalAsPDF(TestCase):
         # An approval has been delivered but it does not come from Itou.
         # Therefore, the linked diagnosis exists but is not in our database.
         # Don't create a diagnosis.
-        # EligibilityDiagnosisFactory(job_seeker=job_seeker)
+        # PrescriberEligibilityDiagnosisFactory(job_seeker=job_seeker)
 
         self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
 
@@ -89,9 +88,9 @@ class TestDownloadApprovalAsPDF(TestCase):
 
         # An approval has been delivered by Itou but there is no diagnosis.
         # It should raise an error.
-        # EligibilityDiagnosisFactory(job_seeker=job_seeker)
+        # PrescriberEligibilityDiagnosisFactory(job_seeker=job_seeker)
 
         self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
 
-        with self.assertRaises(ObjectDoesNotExist):
+        with self.assertRaises(AttributeError):
             self.client.get(reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk}))

--- a/itou/www/approvals_views/tests/tests.py
+++ b/itou/www/approvals_views/tests/tests.py
@@ -1,5 +1,6 @@
 from unittest.mock import PropertyMock, patch
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from django.urls import reverse
 from requests import exceptions as requests_exceptions
@@ -92,5 +93,5 @@ class TestDownloadApprovalAsPDF(TestCase):
 
         self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
 
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ObjectDoesNotExist):
             self.client.get(reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk}))

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ObjectDoesNotExist
 from django.http import FileResponse, Http404
 from django.shortcuts import get_object_or_404
 from django.template.response import SimpleTemplateResponse
@@ -40,7 +41,9 @@ def approval_as_pdf(request, job_application_id, template_name="approvals/approv
     # exist in the real world but not in our database.
     # Raise an error only if the diagnosis does not exist for an Itou approval.
     if job_application.approval.originates_from_itou:
-        diagnosis = job_seeker.get_eligibility_diagnosis()
+        diagnosis = job_seeker.get_eligibility_diagnosis(siae=siae)
+        if not diagnosis:
+            raise ObjectDoesNotExist
         diagnosis_author = diagnosis.author.get_full_name()
         diagnosis_author_org = diagnosis.author_prescriber_organization or diagnosis.author_siae
         if diagnosis_author_org:


### PR DESCRIPTION
Changements majeurs dans la gestion des diagnostics : 
- Si un candidat a un PASS IAE ou un agrément en cours de validité, il n'est plus demandé au prescripteur ou à l'employeur de valider un nouveau diagnostic, même si le dernier en date est expiré.
- Un diagnostic fait par un prescripteur est valable dans toutes les structures.
- Un diagnostic fait par un employeur n'est valable que dans sa structure. Si un diagnostic fait par un employeur existe mais que la candidature est envoyée par un prescripteur, ce dernier est invité à créer un nouveau diagnostic.

Attention : si un diagnostic fait par un prescripteur est antérieur à celui fait par une SIAE, c'est ce dernier qui est pris en compte. 