### PR TITLE
On ne tient plus compte des SIRET fermés

### DIFF
--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -3,7 +3,7 @@ import logging
 import requests
 from django.conf import settings
 from django.utils.http import urlencode
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 
 from itou.utils.address.departments import department_from_postcode
 
@@ -15,6 +15,8 @@ class EtablissementAPI:
     """
     https://doc.entreprise.api.gouv.fr/?json#etablissements-v2
     """
+
+    ERROR_IS_CLOSED = gettext_lazy("La base Sirene indique que l'état administratif de l'établissement est fermé.")
 
     def __init__(self, siret, object="Inscription à la Plateforme de l'inclusion"):
         self.data, self.error = self.get(siret, object)
@@ -44,7 +46,7 @@ class EtablissementAPI:
                 error = _("SIRET non reconnu.")
             else:
                 logger.error("Error while fetching `%s`: %s", url, e)
-                error = _("Problème de connexion à l'API Entreprise. Veuillez réessayer ultérieurement.")
+                error = _("Problème de connexion à la base Sirene. Veuillez réessayer ultérieurement.")
 
         if data and data.get("errors"):
             error = data["errors"][0]
@@ -74,3 +76,7 @@ class EtablissementAPI:
     @property
     def department(self):
         return department_from_postcode(self.post_code)
+
+    @property
+    def is_closed(self):
+        return self.data["etablissement"]["etat_administratif"]["value"] == "F"

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -618,3 +618,4 @@ class ApiEntrepriseTest(SimpleTestCase):
         self.assertEqual(etablissement.address_line_2, "22-24")
         self.assertEqual(etablissement.post_code, "57000")
         self.assertEqual(etablissement.city, "METZ")
+        self.assertFalse(etablissement.is_closed)

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -272,6 +272,9 @@ class PrescriberSiretForm(forms.Form):
         if etablissement.error:
             raise forms.ValidationError(etablissement.error)
 
+        if etablissement.is_closed:
+            raise forms.ValidationError(etablissement.ERROR_IS_CLOSED)
+
         # Perform another API call to fetch geocoding data.
         address_fields = [
             etablissement.address_line_1,


### PR DESCRIPTION
Fix pour les prescripteurs qui peuvent s'inscrire avec une organisation fermée, ce qui génère des doublons d'organisations.

![Capture d’écran 2020-09-10 à 15 46 29](https://user-images.githubusercontent.com/281139/92739278-034c1200-f37d-11ea-9046-07ece74412bc.png)
