### PR TITLE
[BUG] Limite de 50 destinataires pour l'API mailjet

### DIFF
--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -75,7 +75,8 @@ def sanitize_mailjet_recipients(email_message):
     """
 
     if (
-        len(email_message.to) <= _MAILJET_MAX_RECIPIENTS
+        len(email_message.to)
+        <= _MAILJET_MAX_RECIPIENTS
         # and len(email_message.cc) <= _MAILJET_MAX_RECIPIENTS
         # and len(email_message.bcc) <= _MAILJET_MAX_RECIPIENTS
     ):

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -81,7 +81,7 @@ def sanitize_mailjet_recipients(email_message):
 
     for tos in part_to:
         copy_email = deepcopy(email_message)
-        copy_email.to = list(tos)
+        copy_email.to = tos
         sanitized_emails.append(copy_email)
 
     return sanitized_emails

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -1,5 +1,4 @@
 import re
-from copy import deepcopy
 
 from django.conf import settings
 from django.core import mail
@@ -76,12 +75,13 @@ def sanitize_mailjet_recipients(email_message):
         return [email_message]
 
     sanitized_emails = []
-    part_to = chunks(email_message.to, _MAILJET_MAX_RECIPIENTS)
+    to_chunks = chunks(email_message.to, _MAILJET_MAX_RECIPIENTS)
     # We could also combine to, cc and bcc, but it's useless for now
 
-    for tos in part_to:
-        copy_email = deepcopy(email_message)
-        copy_email.to = tos
+    for to_chunk in to_chunks:
+        copy_kvs = {k: email_message.__dict__[k] for k in ("from_email", "cc", "bcc", "subject", "body")}
+        copy_email = EmailMessage(**copy_kvs)
+        copy_email.to = to_chunk
         sanitized_emails.append(copy_email)
 
     return sanitized_emails

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -51,6 +51,7 @@ def get_email_message(to, context, subject, body, from_email=settings.DEFAULT_FR
 
 # Mailjet max number of recipients (CC, BCC, TO)
 _MAILJET_MAX_RECIPIENTS = 50
+_EMAIL_KEYS = ("from_email", "cc", "bcc", "subject", "body")
 
 
 def sanitize_mailjet_recipients(email_message):
@@ -79,7 +80,7 @@ def sanitize_mailjet_recipients(email_message):
     # We could also combine to, cc and bcc, but it's useless for now
 
     for to_chunk in to_chunks:
-        copy_kvs = {k: email_message.__dict__[k] for k in ("from_email", "cc", "bcc", "subject", "body")}
+        copy_kvs = {k: email_message.__dict__[k] for k in _EMAIL_KEYS}
         copy_email = EmailMessage(**copy_kvs)
         copy_email.to = to_chunk
         sanitized_emails.append(copy_email)
@@ -116,7 +117,7 @@ def _serializeEmailMessage(email_message):
         "reply_to": email_message.reply_to,
         "cc": email_message.cc,
         "bcc": email_message.bcc,
-        # FIXME: "headers": email_message.headers,
+        # FIXME: if needed "headers": email_message.headers,
         "body": email_message.body,
     }
 

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -1,6 +1,5 @@
 import re
 from copy import deepcopy
-from itertools import islice
 
 from django.conf import settings
 from django.core import mail
@@ -53,9 +52,12 @@ def get_email_message(to, context, subject, body, from_email=settings.DEFAULT_FR
 _MAILJET_MAX_RECIPIENTS = 50
 
 
-def partition(list, size):
-    it = iter(list)
-    return iter(lambda: tuple(islice(it, size)), ())
+def chunks(lst, n):
+    """
+    Split `lst` in `n` even parts (plus reminder)
+    """
+    for i in range(0, len(lst), n):
+        yield lst[i : i + n]
 
 
 def sanitize_mailjet_recipients(email_message):
@@ -80,7 +82,7 @@ def sanitize_mailjet_recipients(email_message):
         return [email_message]
 
     sanitized_emails = []
-    part_to = partition(email_message.to, _MAILJET_MAX_RECIPIENTS)
+    part_to = chunks(email_message.to, _MAILJET_MAX_RECIPIENTS)
     # We could also combine to, cc and bcc, but it's useless for now
 
     for tos in part_to:

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -68,26 +68,20 @@ def sanitize_mailjet_recipients(email_message):
     This function:
     * partitions email recipients with more than 50 elements
     * creates new emails with a number of recipients in the Mailjet limit
+    * **only** checks for `TO` recipients owerflows
 
     `email_message` is an EmailMessage object (not serialized)
 
     Returns a **list** of "sanitized" emails.
     """
 
-    if (
-        len(email_message.to)
-        <= _MAILJET_MAX_RECIPIENTS
-        # and len(email_message.cc) <= _MAILJET_MAX_RECIPIENTS
-        # and len(email_message.bcc) <= _MAILJET_MAX_RECIPIENTS
-    ):
+    if len(email_message.to) <= _MAILJET_MAX_RECIPIENTS:
         # We're ok, return a list containing the original message
         return [email_message]
 
     sanitized_emails = []
     part_to = partition(email_message.to, _MAILJET_MAX_RECIPIENTS)
     # We could also combine to, cc and bcc, but it's useless for now
-    # part_cc = partition(email_message.cc, _MAILJET_MAX_RECIPIENTS)
-    # part_bcc = partition(email_message.bcc, _MAILJET_MAX_RECIPIENTS)
 
     for tos in part_to:
         copy_email = deepcopy(email_message)

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -9,6 +9,8 @@ from django.core.mail.message import EmailMessage
 from django.template.loader import get_template
 from huey.contrib.djhuey import task
 
+from itou.utils.iterators import chunks
+
 
 # This is the "real" email backend used by the async wrapper / email backend
 ASYNC_EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
@@ -52,14 +54,6 @@ def get_email_message(to, context, subject, body, from_email=settings.DEFAULT_FR
 _MAILJET_MAX_RECIPIENTS = 50
 
 
-def chunks(lst, n):
-    """
-    Split `lst` in `n` even parts (plus reminder)
-    """
-    for i in range(0, len(lst), n):
-        yield lst[i : i + n]
-
-
 def sanitize_mailjet_recipients(email_message):
     """
     Mailjet API has a **50** number limit for anytype of email recipient:
@@ -89,8 +83,6 @@ def sanitize_mailjet_recipients(email_message):
         copy_email = deepcopy(email_message)
         copy_email.to = list(tos)
         sanitized_emails.append(copy_email)
-
-    assert len(sanitized_emails) > 1
 
     return sanitized_emails
 

--- a/itou/utils/iterators.py
+++ b/itou/utils/iterators.py
@@ -1,0 +1,10 @@
+# Iterator bazaar
+# Misc. utils functions related to list processing and iterators
+
+
+def chunks(lst, n):
+    """
+    Split `lst` in `n` even parts
+    """
+    for i in range(0, len(lst), n):
+        yield lst[i : i + n]

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -630,6 +630,18 @@ class UtilsEmailsSplitRecipientTest(TestCase):
     (Mailjet API Limit)
     """
 
+    def test_email_copy(self):
+        fake_email = Faker("email", locale="fr_FR")
+        message = EmailMessage(from_email="unit-test@tests.com", body="xxx", to=[fake_email], subject="test")
+        result = sanitize_mailjet_recipients(message)
+
+        self.assertEqual(1, len(result))
+
+        self.assertEqual("xxx", result[0].body)
+        self.assertEqual("unit-test@tests.com", result[0].from_email)
+        self.assertEqual(fake_email, result[0].to[0])
+        self.assertEqual("test", result[0].subject)
+
     def test_dont_split_emails(self):
         recipients = []
         # Only one email is needed

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -7,8 +7,10 @@ from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import ValidationError
+from django.core.mail.message import EmailMessage
 from django.template import Context, Template
 from django.test import RequestFactory, SimpleTestCase, TestCase
+from factory import Faker
 
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.prescribers.models import PrescriberOrganization
@@ -20,6 +22,7 @@ from itou.utils.address.departments import department_from_postcode
 from itou.utils.apis.api_entreprise import EtablissementAPI
 from itou.utils.apis.geocoding import process_geocoding_data
 from itou.utils.apis.siret import process_siret_data
+from itou.utils.emails import sanitize_mailjet_recipients
 from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
 from itou.utils.mocks.siret import API_INSEE_SIRET_RESULT_MOCK
@@ -39,9 +42,6 @@ from itou.utils.validators import (
     validate_siren,
     validate_siret,
 )
-from django.core.mail.message import EmailMessage
-from factory import Faker
-from itou.utils.emails import sanitize_mailjet_recipients
 
 
 class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
@@ -629,6 +629,7 @@ class UtilsEmailsSplitRecipientTest(TestCase):
     Test behavior of email backend when sending emails with more than 50 recipients
     (Mailjet API Limit)
     """
+
     def test_dont_split_emails(self):
         recipients = []
         # Only one email is needed


### PR DESCRIPTION
Si les champs:
* TO
* CC
* BCC
d'un e-mail contiennent plus de 50 éléments, l'API Mailjet refuse de les envoyer.

Seul le champ "TO" est découpé pour l'instant (pas de cas d'overflow des CC et BCC)

Ce draft découpe les éléments destinataires en bloc de 50 éléments max. et les dispatche dans plusieurs e-mails.