### PR TITLE
Titre des dashboard Metabase externalisés

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -410,6 +410,11 @@ METABASE_INSERT_BATCH_SIZE = 1000
 METABASE_SITE_URL = "https://stats.inclusion.beta.gouv.fr"
 METABASE_SECRET_KEY = os.environ.get("METABASE_SECRET_KEY", "")
 
+# Metabase embedded dashboard IDs
+PUBLIC_STATS_DASHBOARD_ID = 34
+ADVANCED_STATS_DASHBOARD_ID = 43
+DIRECCTE_STATS_DASHBOARD_ID = 36
+
 # Huey / async
 # Workers are run in prod via `CC_WORKER_COMMAND = django-admin run_huey`.
 # ------------------------------------------------------------------------------

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 
 {% block title %}{% translate "Statistiques et pilotage" %}{{ block.super }}{% endblock %}
+
 {% block content %}
+    <h1>{{ page_title }}</h1>
     <script src="{{ stats_base_url }}/app/iframeResizer.js"></script>
     <iframe
         src="{{ iframeurl }}"

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -5,6 +5,14 @@
 
 {% block content %}
     <h1>{{ page_title }}</h1>
+
+    {% if related_link %}
+        <div class="mb-4">
+            {% include "includes/icon.html" with icon="arrow-right" %}
+            <a href="{% url related_link %}">{{ related_title }}</a>
+        </div>
+    {% endif %}
+
     <script src="{{ stats_base_url }}/app/iframeResizer.js"></script>
     <iframe
         src="{{ iframeurl }}"

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -14,5 +14,10 @@ def _get_token(payload):
 
 
 def metabase_embedded_url(dashboard_id):
-    payload = {"resource": {"dashboard": dashboard_id}, "params": {}, "exp": round(time.time()) + (60 * 10)}
+    """
+    Creates an embed/signed URL for embedded Metabase dashboards:
+    * expiration delay of token set at 24H
+    * do not display title of the dashboard in the iframe
+    """
+    payload = {"resource": {"dashboard": dashboard_id}, "params": {}, "exp": round(time.time()) + (60 * 60 * 24)}
     return settings.METABASE_SITE_URL + "/embed/dashboard/" + _get_token(payload) + "#titled=false"

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -15,4 +15,4 @@ def _get_token(payload):
 
 def metabase_embedded_url(dashboard_id):
     payload = {"resource": {"dashboard": dashboard_id}, "params": {}, "exp": round(time.time()) + (60 * 10)}
-    return settings.METABASE_SITE_URL + "/embed/dashboard/" + _get_token(payload)
+    return settings.METABASE_SITE_URL + "/embed/dashboard/" + _get_token(payload) + "#titled=false"

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -29,7 +29,7 @@ def public_stats(request, template_name=_STATS_HTML_TEMPLATE):
     """
     context = {
         "iframeurl": metabase_embedded_url(PUBLIC_STATS_DASHBOARD_ID),
-        "page_title": _("Page statistique"),
+        "page_title": _("Statistiques"),
         "stats_base_url": settings.METABASE_SITE_URL,
     }
     return render(request, template_name, context)
@@ -43,6 +43,7 @@ def advanced_stats(request, template_name=_STATS_HTML_TEMPLATE):
     """
     context = {
         "iframeurl": metabase_embedded_url(ADVANCED_STATS_DASHBOARD_ID),
+        "page_title": _("Statistiques avancées"),
         "stats_base_url": settings.METABASE_SITE_URL,
     }
     return render(request, template_name, context)
@@ -57,6 +58,7 @@ def reporting(request, template_name=_STATS_HTML_TEMPLATE):
     """
     context = {
         "iframeurl": metabase_embedded_url(DIRECCTE_STATS_DASHBOARD_ID),
+        "page_title": _("Données par territoire"),
         "stats_base_url": settings.METABASE_SITE_URL,
     }
     return render(request, template_name, context)

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -15,11 +15,6 @@ from itou.utils.perms.decorators import can_view_stats
 # Each signed dashboard has the same look (at the moment)
 _STATS_HTML_TEMPLATE = "stats/stats.html"
 
-# Metabase dashboard IDs
-PUBLIC_STATS_DASHBOARD_ID = 34
-ADVANCED_STATS_DASHBOARD_ID = 43
-DIRECCTE_STATS_DASHBOARD_ID = 36
-
 
 def public_stats(request, template_name=_STATS_HTML_TEMPLATE):
     """
@@ -28,8 +23,10 @@ def public_stats(request, template_name=_STATS_HTML_TEMPLATE):
     https://stats.inclusion.beta.gouv.fr/public/dashboard/f1527a13-1508-498d-8014-b2fe487a3a70
     """
     context = {
-        "iframeurl": metabase_embedded_url(PUBLIC_STATS_DASHBOARD_ID),
+        "iframeurl": metabase_embedded_url(settings.PUBLIC_STATS_DASHBOARD_ID),
         "page_title": _("Statistiques"),
+        "related_link": "stats:advanced_stats",
+        "related_title": _("Vers les statistiques avancées"),
         "stats_base_url": settings.METABASE_SITE_URL,
     }
     return render(request, template_name, context)
@@ -42,8 +39,10 @@ def advanced_stats(request, template_name=_STATS_HTML_TEMPLATE):
     https://stats.inclusion.beta.gouv.fr/public/dashboard/c65faf79-3b89-4416-9faa-ff5182f41468
     """
     context = {
-        "iframeurl": metabase_embedded_url(ADVANCED_STATS_DASHBOARD_ID),
+        "iframeurl": metabase_embedded_url(settings.ADVANCED_STATS_DASHBOARD_ID),
         "page_title": _("Statistiques avancées"),
+        "related_link": "stats:public_stats",
+        "related_title": _("Vers les statistiques"),
         "stats_base_url": settings.METABASE_SITE_URL,
     }
     return render(request, template_name, context)
@@ -57,7 +56,7 @@ def reporting(request, template_name=_STATS_HTML_TEMPLATE):
     is displayed on the dashboard page
     """
     context = {
-        "iframeurl": metabase_embedded_url(DIRECCTE_STATS_DASHBOARD_ID),
+        "iframeurl": metabase_embedded_url(settings.DIRECCTE_STATS_DASHBOARD_ID),
         "page_title": _("Données par territoire"),
         "stats_base_url": settings.METABASE_SITE_URL,
     }


### PR DESCRIPTION
Les titres étaient auparavant inclus dans l'iframe metabase. 

Ils sont maintenant dans la view/template Django

Les filtres dynamiques pour les régions / départements sont en place (affichage personalisé, via filtres metabase)