### PR TITLE
Boost design

### DIFF
--- a/itou/templates/account/login.html
+++ b/itou/templates/account/login.html
@@ -38,21 +38,17 @@
     {% endif %}
 
     {% bootstrap_field form.login %}
+
     {% bootstrap_field form.password %}
 
     <input type="hidden" id="account_type" name="account_type" value="{{ account_type }}">
 
     {% buttons %}
         <button type="submit" class="btn btn-primary">{% translate "Connexion" %}</button>
+        <a class="btn btn-link" href="{% url 'account_reset_password' %}">{% translate "Mot de passe oublié ?" %}</a>
     {% endbuttons %}
 
 </form>
-
-<hr>
-
-<p>
-    <a href="{% url 'account_reset_password' %}">{% translate "Mot de passe oublié ?" %}</a>
-</p>
 
 <hr>
 

--- a/itou/templates/account/messages/email_confirmation_sent.txt
+++ b/itou/templates/account/messages/email_confirmation_sent.txt
@@ -1,0 +1,7 @@
+{% comment %}
+django-allauth template override to avoid a "dot" after {{ email }} that confuses users:
+https://itou.zammad.com/#ticket/zoom/6640
+https://github.com/pennersr/django-allauth/blob/f9e0e4/allauth/templates/account/messages/email_confirmation_sent.txt
+{% endcomment %}
+{% load i18n %}
+{% blocktrans %}E-mail de confirmation envoyé à {{ email }}{% endblocktrans %}

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -231,7 +231,7 @@
             <p>
                 <a href="{% url 'apply:postpone' job_application_id=job_application.id %}"
                    class="btn btn-outline-success btn-block">
-                    {% translate "Je veux l'embaucher plus tard" %}
+                    {% translate "Mettre en liste d'attente" %}
                     {% include "includes/icon.html" with icon="arrow-right" %}
                 </a>
             </p>
@@ -241,7 +241,7 @@
         <p>
             <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
                class="btn btn-outline-danger btn-block">
-                {% translate "Je ne veux pas l'embaucher" %}
+                {% translate "Décliner la candidature" %}
                 {% include "includes/icon.html" with icon="arrow-right" %}
             </a>
         </p>
@@ -271,7 +271,7 @@
         <p>
             <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
                class="btn btn-outline-danger btn-block">
-                {% translate "Je ne veux pas l'embaucher" %}
+                {% translate "Décliner la candidature" %}
                 {% include "includes/icon.html" with icon="arrow-right" %}
             </a>
         </p>

--- a/itou/templates/apply/process_eligibility.html
+++ b/itou/templates/apply/process_eligibility.html
@@ -34,7 +34,7 @@
             {% translate "Si le candidat n'est pas éligible à l'insertion par l'activité économique, vous pouvez décliner sa candidature :" %}
         </p>
         <a href="{% url 'apply:refuse' job_application_id=job_application.id %}" class="btn btn-outline-danger btn-block">
-            {% translate "Je ne veux pas l'embaucher" %}
+            {% translate "Décliner la candidature" %}
             {% include "includes/icon.html" with icon="arrow-right" %}
         </a>
     </div>

--- a/itou/templates/apply/process_postpone.html
+++ b/itou/templates/apply/process_postpone.html
@@ -18,7 +18,7 @@
 
         {% buttons %}
             <a class="btn btn-secondary" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">{% translate "Annuler" %}</a>
-            <button type="submit" class="btn btn-success">{% translate "Je veux l'embaucher plus tard" %}</button>
+            <button type="submit" class="btn btn-success">{% translate "Mettre en liste d'attente" %}</button>
         {% endbuttons %}
 
     </form>

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -33,7 +33,7 @@
 
         {% buttons %}
             <a class="btn btn-secondary" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">{% translate "Annuler" %}</a>
-            <button type="submit" class="btn btn-danger">{% translate "Je ne veux pas l'embaucher" %}</button>
+            <button type="submit" class="btn btn-danger">{% translate "Décliner la candidature" %}</button>
         {% endbuttons %}
 
     </form>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -228,11 +228,13 @@
                 <h5 class="card-header">{% translate "Mes candidatures" %}</h5>
                 <div class="card-body">
                     {% for category in job_applications_categories %}
-                        <p class="card-text">
-                            {% include "includes/icon.html" with icon=category.icon %}
-                            <a href="{{ category.url }}">{{ category.name }}</a>
-                            <span class="badge {{ category.badge }}">{{ category.counter }}</span>
-                        </p>
+                        {% if category.counter %}
+                            <p class="card-text">
+                                {% include "includes/icon.html" with icon=category.icon %}
+                                <a href="{{ category.url }}">{{ category.name }}</a>
+                                <span class="badge {{ category.badge }}">{{ category.counter }}</span>
+                            </p>
+                        {% endif %}
                     {% endfor %}
                     <p class="card-text">
                         {% include "includes/icon.html" with icon="log-in" %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -107,7 +107,7 @@
                         {% else %}
                             <div class="btn-group">
                                 <button type="button" class="btn btn-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    {% translate "Se connecter" %}
+                                    {% translate "S'inscrire | Se connecter" %}
                                 </button>
                                 <div class="dropdown-menu">
                                     <a class="dropdown-item" href="{% url 'account_login' %}?account_type=job_seeker{% if redirect_field_value %}&{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -27,10 +27,10 @@ class SiaeMembershipInline(admin.TabularInline):
         return False
 
     def siae_id_link(self, obj):
-        app_label = obj.organization._meta.app_label
-        model_name = obj.organization._meta.model_name
+        app_label = obj.siae._meta.app_label
+        model_name = obj.siae._meta.model_name
         url = reverse(f"admin:{app_label}_{model_name}_change", args=[obj.siae_id])
-        return mark_safe(f'<a href="{url}">{obj.organization_id}</a>')
+        return mark_safe(f'<a href="{url}">{obj.siae_id}</a>')
 
 
 class PrescriberMembershipInline(admin.TabularInline):

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -23,6 +23,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
     prescriber_authorization_status_not_set = None
 
     if request.user.is_siae_staff:
+        siae = get_current_siae_or_404(request)
         job_applications_categories = [
             {
                 "name": _("Candidatures à traiter"),
@@ -47,7 +48,6 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                 "badge": "badge-secondary",
             },
         ]
-        siae = get_current_siae_or_404(request)
         job_applications = siae.job_applications_received.values("state").all()
         for category in job_applications_categories:
             category["counter"] = len([ja for ja in job_applications if ja["state"] in category["states"]])

--- a/itou/www/siaes_views/tests.py
+++ b/itou/www/siaes_views/tests.py
@@ -363,6 +363,8 @@ class CreateSiaeViewTest(TestCase):
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
+        mock_call_ban_geocoding_api.assert_called_once()
+
         new_siae = Siae.objects.get(siret=new_siret)
         self.assertTrue(new_siae.has_admin(user))
         self.assertEqual(siae.source, Siae.SOURCE_ASP)

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -39,6 +39,12 @@ class JobSeekerSignupForm(FullnameFormMixin, SignupForm):
         super(JobSeekerSignupForm, self).__init__(*args, **kwargs)
         self.fields["password1"].help_text = CnilCompositionPasswordValidator().get_help_text()
 
+    def clean_email(self):
+        email = super().clean_email()
+        if email.endswith("@pole-emploi.fr"):
+            raise ValidationError(gettext_lazy("Vous ne pouvez pas utiliser un e-mail Pôle emploi pour un candidat."))
+        return email
+
     def save(self, request):
         user = super().save(request)
 


### PR DESCRIPTION
- On affiche plus de point (`.`) juste après l'e-mail dans le message qui stipule qu'une confirmation d'e-mail a été envoyé
- Re-wording du bouton "Se connecter" pour "S'inscrire | Se connecter"
- Ajout de la possibilité pour tous les prescripteurs de modifier l'adresse postale de leur organisation
- Re-wording des boutons :
    - "Je ne veux pas l'embaucher" en "Décliner la candidature"
    - "Je veux l'embaucher plus tardr" en "Mettre en liste d'attente"
- Interdiction de créer un compte candidat avec un e-mail en `@pole-emploi.fr`
- Dans le tableau de bord d'une SIAE, on affiche plus les liens "_Candidatures à traiter_" ou "_Candidatures acceptées et embauches prévues_" ou "_Candidatures refusées/annulées_" si aucune candidature ne rentre dans ces catégories
- Déplacement du lien "Mot de passe oublié"
- Correction d'un bug dans l'admin utilisateur où le lien vers une SIAE n'apparaissait pas le cas échéant

---

![wording](https://user-images.githubusercontent.com/281139/94134109-de1dd000-fe61-11ea-994e-49af798dfd4f.png)

---

![password_reset](https://user-images.githubusercontent.com/281139/94134115-df4efd00-fe61-11ea-9ad6-ea2cc33a493b.png)

---

![Capture d’écran 2020-09-24 à 11 17 31](https://user-images.githubusercontent.com/281139/94134121-e118c080-fe61-11ea-9ddf-3fa5ef140601.png)
