### PR TITLE
Affichage de l'email saisi lors de l'oubli d'un mot de passe

### DIFF
--- a/itou/templates/account/password_reset_done.html
+++ b/itou/templates/account/password_reset_done.html
@@ -7,13 +7,24 @@
 {% block title %}{% translate "Réinitialisation du mot de passe" %}{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1>{% translate "Réinitialisation du mot de passe" %}</h1>
+
+<h1>{% translate "Si un compte existe, vous recevrez un e-mail de réinitialisation" %}</h1>
+
+{% if request.GET.email %}
+    {# Give the user a chance to check that there is no typing error in email before contacting support. #}
+    <h2 class="text-muted">{{ request.GET.email }}</h2>
+{% endif %}
 
 {% if user.is_authenticated %}
     {% include "account/snippets/already_logged_in.html" %}
 {% endif %}
 
-<p>{% translate "Nous vous avons envoyé par e-mail les instructions pour réinitialiser votre mot de passe." %}</p>
+<p>{% translate "Il contient les instructions pour réinitialiser votre mot de passe." %}</p>
 
-<p>{% translate "Si vous ne recevez pas d'e-mail dans les minutes qui suivent, pensez à vérifier votre courrier indésirable ou recommencez l'opération en vérifiant qu'il n'y a pas d'erreur de saisie dans votre e-mail." %}</p>
+<p>{% translate "Si vous le ne recevez pas dans les minutes qui suivent :" %}</p>
+
+<ul>
+    <li>{% translate "vérifiez votre courrier indésirable" %}</li>
+    <li>{% translate "vérifiez qu'il n'y a pas d'erreur dans votre e-mail" %}</li>
+</ul>
 {% endblock %}

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -9,6 +9,7 @@ from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.html import escape
+from django.utils.http import urlencode
 from django.utils.translation import gettext as _
 
 from itou.cities.factories import create_test_cities
@@ -740,7 +741,9 @@ class PasswordResetTest(TestCase):
         post_data = {"email": user.email}
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, reverse("account_reset_password_done"))
+        args = urlencode({"email": user.email})
+        next_url = reverse("account_reset_password_done")
+        self.assertEqual(response.url, f"{next_url}?{args}")
 
         # Check sent email.
         self.assertEqual(len(mail.outbox), 1)
@@ -778,8 +781,9 @@ class PasswordResetTest(TestCase):
         self.assertEqual(response.status_code, 200)
         post_data = {"email": "nonexistent@email.com"}
         response = self.client.post(url, data=post_data)
-        self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, reverse("account_reset_password_done"))
+        args = urlencode({"email": post_data["email"]})
+        next_url = reverse("account_reset_password_done")
+        self.assertEqual(response.url, f"{next_url}?{args}")
 
 
 class PasswordChangeTest(TestCase):

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -11,6 +11,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_GET
 
@@ -22,13 +23,21 @@ from itou.www.signup import forms
 
 
 class ItouPasswordResetView(PasswordResetView):
+    def form_valid(self, form):
+        form.save(self.request)
+        # Pass the email in the querystring so that it can displayed in the template.
+        args = urlencode({"email": form.data["email"]})
+        return HttpResponseRedirect(f"{self.get_success_url()}?{args}")
+
     def form_invalid(self, form):
         """
         Avoid user enumeration: django-allauth displays an error message to the user
         when an email does not exist. We deliberately hide it by redirecting to the
         success page in all cases.
         """
-        return HttpResponseRedirect(self.get_success_url())
+        # Pass the email in the querystring so that it can displayed in the template.
+        args = urlencode({"email": form.data["email"]})
+        return HttpResponseRedirect(f"{self.get_success_url()}?{args}")
 
 
 @require_GET


### PR DESCRIPTION
Objectif : permettre aux gens de voir qu'ils ont peut-être une typo dans leur email

### Avant

![avant](https://user-images.githubusercontent.com/281139/95340292-45ea0700-08b5-11eb-89b9-6e3e3c0719bd.png)

### Après

![apres](https://user-images.githubusercontent.com/281139/95340326-4d111500-08b5-11eb-9616-350b2e6ceb9f.png)

