### PR TITLE
Multi-organisation pour les prescripteurs

### DIFF
--- a/itou/invitations/models.py
+++ b/itou/invitations/models.py
@@ -164,7 +164,7 @@ class PrescriberWithOrgInvitation(InvitationAbstract):
 
     def guest_can_join_organization(self, request):
         user = get_object_or_404(get_user_model(), email=self.email)
-        return user == request.user and user.is_prescriber and not user.prescriberorganization_set.exists()
+        return user == request.user and user.is_prescriber
 
     def set_guest_type(self, user):
         user.is_prescriber = True

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -102,6 +102,13 @@
                                     </div>
                                 </div>
                             {% endif %}
+
+                            {% if user.is_prescriber %}
+                                <div class="btn-group">
+                                    Spotted you, prescriber !
+                                </div>
+                            {% endif %}
+
                             </div>
 
                         {% else %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -92,7 +92,7 @@
                                             {% csrf_token %}
                                             {% for s in user_siaes %}
                                                 <button
-                                                    class="dropdown-item text-primary"
+                                                    class="dropdown-item text-primary {% if s.pk == current_siae.pk %} font-weight-bold disabled{% endif %}"
                                                     type="submit"
                                                     name="siae_id"
                                                     value="{{ s.pk }}">{{ s.display_name }}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -109,14 +109,14 @@
                                         {% translate "Changer de structure" %}
                                     </button>
                                     <div class="dropdown-menu dropdown-menu-right dropdown-menu-lg-left">
-                                        <form action="{% url 'dashboard:switch_siae' %}" method="post">
+                                        <form action="{% url 'dashboard:switch_prescriber_organization' %}" method="post">
                                             {% csrf_token %}
-                                            {% for s in user_siaes %}
+                                            {% for po in user_prescriberorganizations %}
                                                 <button
                                                     class="dropdown-item text-primary"
                                                     type="submit"
                                                     name="siae_id"
-                                                    value="{{ s.pk }}">{{ s.display_name }}
+                                                    value="{{ po.pk }}">{{ po.display_name }}
                                                 </button>
                                             {% endfor %}
                                         </form>

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -113,9 +113,9 @@
                                             {% csrf_token %}
                                             {% for po in user_prescriberorganizations %}
                                                 <button
-                                                    class="dropdown-item text-primary"
+                                                    class="dropdown-item text-primary {% if po.pk == current_prescriber_organization.pk %} font-weight-bold disabled{% endif %}"
                                                     type="submit"
-                                                    name="siae_id"
+                                                    name="prescriber_organization_id"
                                                     value="{{ po.pk }}">{{ po.display_name }}
                                                 </button>
                                             {% endfor %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -103,9 +103,24 @@
                                 </div>
                             {% endif %}
 
-                            {% if user.is_prescriber %}
+                            {% if user.is_prescriber and user_prescriberorganizations|length > 1 %}
                                 <div class="btn-group">
-                                    Spotted you, prescriber !
+                                    <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-display="static">
+                                        {% translate "Changer de structure" %}
+                                    </button>
+                                    <div class="dropdown-menu dropdown-menu-right dropdown-menu-lg-left">
+                                        <form action="{% url 'dashboard:switch_siae' %}" method="post">
+                                            {% csrf_token %}
+                                            {% for s in user_siaes %}
+                                                <button
+                                                    class="dropdown-item text-primary"
+                                                    type="submit"
+                                                    name="siae_id"
+                                                    value="{{ s.pk }}">{{ s.display_name }}
+                                                </button>
+                                            {% endfor %}
+                                        </form>
+                                    </div>
                                 </div>
                             {% endif %}
 

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -42,10 +42,26 @@ def get_current_organization_and_perms(request):
 
         prescriber_org_pk = request.session.get(settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY)
         if prescriber_org_pk:
+            first_idx = 0
             membership = current_user.prescribermembership_set.select_related("organization")
-            user_prescriberorganizations = [po.organization for po in membership]
-            prescriber_organization = user_prescriberorganizations[0]
-            user_is_prescriber_org_admin = membership[0].is_admin
+
+            for idx, m in enumerate(membership):
+                # Same as above:
+                # In order to avoid an extra SQL query, fetch related organizations
+                # and artifially reconstruct the list of organizations the user belongs to
+                # (and other stuff while at it)
+                user_prescriberorganizations.append(m.organization)
+                if m.organization.pk == prescriber_org_pk:
+                    prescriber_organization = m.organization
+                    user_is_prescriber_org_admin = m.is_admin
+                    first_idx = idx
+
+            if first_idx != 0:
+                # Put selected prescriber organization first (UI)
+                user_prescriberorganizations[0], user_prescriberorganizations[first_idx] = (
+                    user_prescriberorganizations[first_idx],
+                    user_prescriberorganizations[0],
+                )
 
     context = {
         "current_prescriber_organization": prescriber_organization,

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -30,28 +30,22 @@ def get_current_organization_and_perms(request):
                 request.user.siaemembership_set.select_related("siae").filter(siae__pk__in=user_siae_set_pks).all()
             )
             user_siaes = [membership.siae for membership in memberships]
-            first_siae_idx = 0
-            for idx, membership in enumerate(memberships):
+            for membership in memberships:
                 if membership.siae_id == siae_pk:
                     siae = membership.siae
                     user_is_siae_admin = membership.is_siae_admin
-                    first_siae_idx = idx
                     break
             if siae is None:
                 if request.path != reverse("account_logout"):
                     raise PermissionDenied
 
-            if first_siae_idx != 0:
-                user_siaes[0], user_siaes[first_siae_idx] = user_siaes[first_siae_idx], user_siaes[0]
-
         # Prescriber organization ?
         prescriber_org_pk = request.session.get(settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY)
 
         if prescriber_org_pk:
-            first_prescriber_idx = 0
             memberships = current_user.prescribermembership_set.select_related("organization")
 
-            for idx, membership in enumerate(memberships):
+            for membership in memberships:
                 # Same as above:
                 # In order to avoid an extra SQL query, fetch related organizations
                 # and artifially reconstruct the list of organizations the user belongs to
@@ -60,14 +54,6 @@ def get_current_organization_and_perms(request):
                 if membership.organization.pk == prescriber_org_pk:
                     prescriber_organization = membership.organization
                     user_is_prescriber_org_admin = membership.is_admin
-                    first_prescriber_idx = idx
-
-            if first_prescriber_idx != 0:
-                # Put selected prescriber organization first (UI)
-                user_prescriberorganizations[0], user_prescriberorganizations[first_prescriber_idx] = (
-                    user_prescriberorganizations[first_prescriber_idx],
-                    user_prescriberorganizations[0],
-                )
 
     context = {
         "current_prescriber_organization": prescriber_organization,

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -21,7 +21,7 @@ def get_current_organization_and_perms(request):
     current_user = request.user
 
     if current_user.is_authenticated:
-
+        # SIAE ?
         siae_pk = request.session.get(settings.ITOU_SESSION_CURRENT_SIAE_KEY)
         if siae_pk:
             # Sorry I could not find an elegant DNRY one-query solution ¯\_(ツ)_/¯
@@ -44,7 +44,9 @@ def get_current_organization_and_perms(request):
             if first_siae_idx != 0:
                 user_siaes[0], user_siaes[first_siae_idx] = user_siaes[first_siae_idx], user_siaes[0]
 
+        # Prescriber organization ?
         prescriber_org_pk = request.session.get(settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY)
+
         if prescriber_org_pk:
             first_prescriber_idx = 0
             memberships = current_user.prescribermembership_set.select_related("organization")

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -12,12 +12,15 @@ def get_current_organization_and_perms(request):
     """
 
     prescriber_organization = None
+    user_prescriberorganizations = []
     siae = None
     user_is_prescriber_org_admin = False
     user_is_siae_admin = False
     user_siaes = []
 
-    if request.user.is_authenticated:
+    current_user = request.user
+
+    if current_user.is_authenticated:
 
         siae_pk = request.session.get(settings.ITOU_SESSION_CURRENT_SIAE_KEY)
         if siae_pk:
@@ -39,11 +42,10 @@ def get_current_organization_and_perms(request):
 
         prescriber_org_pk = request.session.get(settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY)
         if prescriber_org_pk:
-            membership = request.user.prescribermembership_set.select_related("organization").get(
-                organization_id=prescriber_org_pk
-            )
-            prescriber_organization = membership.organization
-            user_is_prescriber_org_admin = membership.is_admin
+            membership = current_user.prescribermembership_set.select_related("organization")
+            user_prescriberorganizations = [po.organization for po in membership]
+            prescriber_organization = user_prescriberorganizations[0]
+            user_is_prescriber_org_admin = membership[0].is_admin
 
     context = {
         "current_prescriber_organization": prescriber_organization,
@@ -51,6 +53,7 @@ def get_current_organization_and_perms(request):
         "user_is_prescriber_org_admin": user_is_prescriber_org_admin,
         "user_is_siae_admin": user_is_siae_admin,
         "user_siaes": user_siaes,
+        "user_prescriberorganizations": user_prescriberorganizations,
     }
 
     context.update(

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -40,6 +40,7 @@ def get_current_organization_and_perms(request):
             if siae is None:
                 if request.path != reverse("account_logout"):
                     raise PermissionDenied
+
             if first_siae_idx != 0:
                 user_siaes[0], user_siaes[first_siae_idx] = user_siaes[first_siae_idx], user_siaes[0]
 

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -53,13 +53,15 @@ class ItouCurrentOrganizationMiddleware:
                         return redirect("account_logout")
 
             elif user.is_prescriber:
+                # FIXME: don't take the first one
+
                 if user.prescriberorganization_set.exists():
-                    request.session[
-                        settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY
-                    ] = user.prescriberorganization_set.first().pk
+                    # request.session[
+                    #    settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY
+                    # ] = user.prescriberorganization_set.first().pk
+                    pass
                 elif request.session.get(settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY):
                     del request.session[settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY]
-
         response = self.get_response(request)
 
         # After the view is called.

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -53,14 +53,11 @@ class ItouCurrentOrganizationMiddleware:
                         return redirect("account_logout")
 
             elif user.is_prescriber:
-                # FIXME: don't take the first one
-
-                if user.prescriberorganization_set.exists():
-                    # request.session[
-                    #    settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY
-                    # ] = user.prescriberorganization_set.first().pk
-                    pass
-                elif request.session.get(settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY):
+                # Prescriber user can now select an organization from their dashboard
+                # (if they are member of several prescriber organizations)
+                if not user.prescriberorganization_set.exists() and request.session.get(
+                    settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY
+                ):
                     del request.session[settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY]
         response = self.get_response(request)
 

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -53,12 +53,20 @@ class ItouCurrentOrganizationMiddleware:
                         return redirect("account_logout")
 
             elif user.is_prescriber:
-                # Prescriber user can now select an organization from their dashboard
+                # Prescriber users can now select an organization from their dashboard
                 # (if they are member of several prescriber organizations)
                 if not user.prescriberorganization_set.exists() and request.session.get(
                     settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY
                 ):
                     del request.session[settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY]
+                else:
+                    # Choose first prescriber organization for user if none selected yet
+                    # (f.i. after login)
+                    request.session[settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY] = (
+                        request.session.get(settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY)
+                        or user.prescriberorganization_set.first().pk
+                    )
+
         response = self.get_response(request)
 
         # After the view is called.

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -53,7 +53,7 @@ class ItouCurrentOrganizationMiddleware:
                         return redirect("account_logout")
 
             elif user.is_prescriber:
-                # Prescriber users can now select an organization from their dashboard
+                # Prescriber users can now select an organization
                 # (if they are member of several prescriber organizations)
                 if user.prescriberorganization_set.exists():
                     # Choose first prescriber organization for user if none is selected yet

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -55,17 +55,18 @@ class ItouCurrentOrganizationMiddleware:
             elif user.is_prescriber:
                 # Prescriber users can now select an organization from their dashboard
                 # (if they are member of several prescriber organizations)
-                if not user.prescriberorganization_set.exists() and request.session.get(
-                    settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY
-                ):
-                    del request.session[settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY]
-                else:
-                    # Choose first prescriber organization for user if none selected yet
+                if user.prescriberorganization_set.exists():
+                    # Choose first prescriber organization for user if none is selected yet
                     # (f.i. after login)
                     request.session[settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY] = (
                         request.session.get(settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY)
                         or user.prescriberorganization_set.first().pk
                     )
+                elif request.session.get(settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY):
+                    # If the user is an "orienteur"
+                    # => No need to track the current org in session (none)
+                    # => Remove any old session entry if needed
+                    del request.session[settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY]
 
         response = self.get_response(request)
 

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -12,7 +12,7 @@ from django.template import Context, Template
 from django.test import RequestFactory, SimpleTestCase, TestCase
 from factory import Faker
 
-from itou.prescribers.factories import PrescriberOrganizationFactory, PrescriberOrganizationWithMembershipFactory
+from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
 from itou.siaes.models import Siae, SiaeMembership

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -98,6 +98,9 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
         request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = siae3.pk
         request.session.save()
 
+        # Note: the siae are reordered, with the current siae first
+        # (explains the `siae3, siae2, siae1` order below)
+
         with self.assertNumQueries(1):
             result = get_current_organization_and_perms(request)
             expected = {
@@ -105,7 +108,7 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                 "current_siae": siae3,
                 "user_is_prescriber_org_admin": False,
                 "user_is_siae_admin": False,
-                "user_siaes": [siae1, siae2, siae3],
+                "user_siaes": [siae3, siae2, siae1],
                 "user_prescriberorganizations": [],
                 "matomo_custom_variables": OrderedDict(
                     [

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -98,9 +98,6 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
         request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = siae3.pk
         request.session.save()
 
-        # Note: the siaes Are reordered, with the current siae first
-        # (explains the `siae3, siae2, siae1` order below)
-
         with self.assertNumQueries(1):
             result = get_current_organization_and_perms(request)
             expected = {
@@ -108,7 +105,7 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                 "current_siae": siae3,
                 "user_is_prescriber_org_admin": False,
                 "user_is_siae_admin": False,
-                "user_siaes": [siae3, siae2, siae1],
+                "user_siaes": [siae1, siae2, siae3],
                 "user_prescriberorganizations": [],
                 "matomo_custom_variables": OrderedDict(
                     [

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -98,7 +98,7 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
         request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = siae3.pk
         request.session.save()
 
-        # Note: the siae are reordered, with the current siae first
+        # Note: the siaes Are reordered, with the current siae first
         # (explains the `siae3, siae2, siae1` order below)
 
         with self.assertNumQueries(1):
@@ -161,7 +161,6 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
 
         organization2 = PrescriberOrganizationWithMembershipFactory()
         organization2.members.add(user)
-        # FIXME: make factory with no admin rights
 
         factory = RequestFactory()
         request = factory.get("/")

--- a/itou/www/dashboard/urls.py
+++ b/itou/www/dashboard/urls.py
@@ -10,4 +10,7 @@ urlpatterns = [
     path("", views.dashboard, name="index"),
     path("edit_user_info", views.edit_user_info, name="edit_user_info"),
     path("switch_siae", views.switch_siae, name="switch_siae"),
+    path(
+        "switch_prescriber_organization", views.switch_prescriber_organization, name="switch_prescriber_organization"
+    ),
 ]

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
 from itou.job_applications.models import JobApplicationWorkflow
+from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae
 from itou.utils.perms.prescriber import get_current_org_or_404
 from itou.utils.perms.siae import get_current_siae_or_404
@@ -142,8 +143,13 @@ def switch_siae(request):
 @require_POST
 def switch_prescriber_organization(request):
     """
-    Switch prescriber organization for a user with multiple memberships
+    Switch prescriber organization for a user with multiple memberships.
     """
-    # FIXME: implement
     dashboard_url = reverse_lazy("dashboard:index")
+
+    pk = request.POST["prescriber_organization_id"]
+    queryset = PrescriberOrganization.objects
+    prescriber_organization = get_object_or_404(queryset, pk=pk)
+    request.session[settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY] = prescriber_organization.pk
+
     return HttpResponseRedirect(dashboard_url)

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -12,7 +12,6 @@ from django.views.decorators.http import require_POST
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae
-from itou.utils.perms.prescriber import get_current_org_or_404
 from itou.utils.perms.siae import get_current_siae_or_404
 from itou.utils.tokens import resume_signer
 from itou.utils.urls import get_safe_url

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -21,7 +21,6 @@ from itou.www.dashboard.forms import EditUserInfoForm
 @login_required
 def dashboard(request, template_name="dashboard/dashboard.html"):
     job_applications_categories = []
-    prescriber_authorization_status_not_set = None
 
     if request.user.is_siae_staff:
         siae = get_current_siae_or_404(request)
@@ -56,12 +55,8 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                 "url"
             ] = f"{reverse('apply:list_for_siae')}?{'&'.join([f'states={c}' for c in category['states']])}"
 
-    if request.user.is_prescriber_with_org:
-        get_current_org_or_404(request)
-
     context = {
         "job_applications_categories": job_applications_categories,
-        "prescriber_authorization_status_not_set": prescriber_authorization_status_not_set,
     }
 
     return render(request, template_name, context)
@@ -141,3 +136,11 @@ def switch_siae(request):
     request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = siae.pk
 
     return HttpResponseRedirect(dashboard_url)
+
+
+@login_required
+def switch_prescriber_organization(request):
+    """
+    Switch prescriber organization for a user with multiple memberships
+    """
+    # FIXME: implement

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -139,8 +139,11 @@ def switch_siae(request):
 
 
 @login_required
+@require_POST
 def switch_prescriber_organization(request):
     """
     Switch prescriber organization for a user with multiple memberships
     """
     # FIXME: implement
+    dashboard_url = reverse_lazy("dashboard:index")
+    return HttpResponseRedirect(dashboard_url)

--- a/itou/www/invitations_views/forms.py
+++ b/itou/www/invitations_views/forms.py
@@ -71,8 +71,7 @@ class NewPrescriberWithOrgInvitationForm(NewInvitationMixinForm):
     def _invited_user_exists_error(self, email):
         """
         If the guest is already a user, he should be a prescriber
-        but without belonging to another organization.
-        Reminder: we do not handle multi-structure prescribers for the moment.
+        with or without belonging to another organization.
         """
         self.user = get_user_model().objects.filter(email__iexact=email).first()
         if self.user:
@@ -80,15 +79,10 @@ class NewPrescriberWithOrgInvitationForm(NewInvitationMixinForm):
                 error = forms.ValidationError(_("Cet utilisateur n'est pas un prescripteur."))
                 self.add_error("email", error)
             else:
-                user_belongs_to_another_org = self.user.prescriberorganization_set.exists()
-                if user_belongs_to_another_org:
-                    error = forms.ValidationError(_("Cette personne est membre d'une autre organisation."))
+                user_is_member = self.organization.members.filter(email=self.user.email).exists()
+                if user_is_member:
+                    error = forms.ValidationError(_("Cette personne fait déjà partie de votre organisation."))
                     self.add_error("email", error)
-                else:
-                    user_is_member = self.organization.members.filter(email=self.user.email).exists()
-                    if user_is_member:
-                        error = forms.ValidationError(_("Cette personne fait déjà partie de votre organisation."))
-                        self.add_error("email", error)
 
     def _extend_expiration_date_or_error(self, email):
         invitation_model = self.Meta.model

--- a/itou/www/invitations_views/forms.py
+++ b/itou/www/invitations_views/forms.py
@@ -71,7 +71,7 @@ class NewPrescriberWithOrgInvitationForm(NewInvitationMixinForm):
     def _invited_user_exists_error(self, email):
         """
         If the guest is already a user, he should be a prescriber
-        with or without belonging to another organization.
+        whether he belongs to another organization or not
         """
         self.user = get_user_model().objects.filter(email__iexact=email).first()
         if self.user:

--- a/itou/www/invitations_views/tests/tests_prescriber_organization.py
+++ b/itou/www/invitations_views/tests/tests_prescriber_organization.py
@@ -181,7 +181,6 @@ class TestAcceptPrescriberWithOrgInvitation(TestCase):
         current_org = get_current_org_or_404(self.response.wsgi_request)
         # A user can be member of one or more organizations
         self.assertTrue(current_org in self.user.prescriberorganization_set.all())
-        # self.assertEqual(self.invitation.organization.pk, current_org.pk)
 
     def test_accept_prescriber_org_invitation(self):
         response = self.client.get(self.invitation.acceptance_link, follow=True)


### PR DESCRIPTION
Sur le modèle de ce qui a été fait pour les SIAE, les prescripteurs peuvent maintenant être rattachés à plusieurs organisations.

La sélection de l'organisation s'effectue à partir du dashboard.

Le système d'invitation a été légèrement modifié pour permettre les invitations entre prescripteurs (ayant des membres enregistrés).