### PR TITLE
Fix incorrect siae.name for newly created siaes

### DIFF
--- a/itou/siaes/management/commands/_import_siae/siae.py
+++ b/itou/siaes/management/commands/_import_siae/siae.py
@@ -60,7 +60,8 @@ def build_siae(row, kind):
     siae.convention_end_date = get_siae_convention_end_date(siae)
     siae.naf = row.naf
     siae.source = Siae.SOURCE_ASP
-    siae.name = row.name
+    siae.name = row["name"]  # row.name surprisingly returns the row index.
+    assert not siae.name.isnumeric()
 
     siae.phone = row.phone
     phone_is_valid = siae.phone and len(siae.phone) == 10

--- a/itou/siaes/management/commands/import_siae.py
+++ b/itou/siaes/management/commands/import_siae.py
@@ -346,6 +346,18 @@ class Command(BaseCommand):
         self.dry_run = dry_run
         self.set_logger(options.get("verbosity"))
 
+        # BEGINNING OF ONE TIME FIX - WILL BE DROPPED
+        for siae in Siae.objects.filter(source="ASP").all():
+            if siae.name.isnumeric():
+                row = EXTERNAL_ID_TO_SIAE_ROW[siae.external_id]
+                new_name = row["name"]
+                assert not new_name.isnumeric()
+                self.log(f"siae.id={siae.id} will have its name fixed " f"from {siae.name} to {new_name}")
+                if not self.dry_run:
+                    siae.name = new_name
+                    siae.save()
+        # END OF ONE TIME FIX - WILL BE DROPPED
+
         self.fix_missing_external_ids()
         self.delete_siaes_without_external_id()
         self.delete_user_created_siaes_without_members()


### PR DESCRIPTION
`row.name` in pandas surprisingly returns an unexpected integer
instead of the siae name.
We fix that by using `row["name"]` instead,
and use a one time fix for the 20 or so affected siaes.