### PR TITLE
Fix issue about birthdate in forms

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -46,8 +46,8 @@ class CheckJobSeekerInfoForm(forms.ModelForm):
         self.fields["birthdate"].widget = DatePickerField(
             {
                 "viewMode": "years",
-                "minDate": DatePickerField.min_birthdate().strftime("%Y"),
-                "maxDate": DatePickerField.max_birthdate().strftime("%Y"),
+                "minDate": DatePickerField.min_birthdate().strftime("%Y/%m/%d"),
+                "maxDate": DatePickerField.max_birthdate().strftime("%Y/%m/%d"),
             }
         )
         self.fields["birthdate"].input_formats = [DatePickerField.DATE_FORMAT]
@@ -81,8 +81,8 @@ class CreateJobSeekerForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
         self.fields["birthdate"].widget = DatePickerField(
             {
                 "viewMode": "years",
-                "minDate": DatePickerField.min_birthdate().strftime("%Y"),
-                "maxDate": DatePickerField.max_birthdate().strftime("%Y"),
+                "minDate": DatePickerField.min_birthdate().strftime("%Y/%m/%d"),
+                "maxDate": DatePickerField.max_birthdate().strftime("%Y/%m/%d"),
                 "useCurrent": False,
                 "allowInputToggle": False,
             }

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -25,8 +25,8 @@ class EditUserInfoForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
             self.fields["birthdate"].widget = DatePickerField(
                 {
                     "viewMode": "years",
-                    "minDate": DatePickerField.min_birthdate().strftime("%Y"),
-                    "maxDate": DatePickerField.max_birthdate().strftime("%Y"),
+                    "minDate": DatePickerField.min_birthdate().strftime("%Y/%m/%d"),
+                    "maxDate": DatePickerField.max_birthdate().strftime("%Y/%m/%d"),
                     "useCurrent": False,
                     "allowInputToggle": False,
                 }


### PR DESCRIPTION
Before this fix, the widget was limiting the birthdate
even more than necessary.

For example :
maximum age is 16 years
today is October 19 2020
max birthdate should be October 19 2004
but the datepicker widget would limit to max birthdate January 1st 2004