### PR TITLE
Ajout d'un template de pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+Le titre et la description sont en français et au format texte.
+
+### Quoi ?
+
+Résumé des changements apportés.
+
+### Pourquoi ?
+
+Indiquer le problème que nous sommes en train de résoudre et les objectifs métier ou technique sont visés par ces changements.
+
+### Comment ?
+
+Attirer l'attention sur les décisions d'architecture ou de conception importantes.
+
+### Captures d'écran (optionnel)
+
+Utile pour les changements liés à l'UI.
+
+### Autre (optionnel)
+
+- si des tests manquent, indiquer la raison, la probabilité, et les risques associés à ce manque
+- être explicite sur le délai attendu pour une revue de code
+- être explicite sur la qualité attendue pour la revue de code
+- etc.
+
+---
+
+Liens intéressant :
+
+- https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
+- https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/
+- https://gist.github.com/mikepea/863f63d6e37281e329f8


### PR DESCRIPTION
Proposition d'une aide à la rédaction de pull request.

L'objectif est d'homogénéiser notre façon de faire pour éviter d'avoir tantôt une description ou un titre manquant, tantôt une capture d'écran en guise de descriptions des changements.

https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository