### PR TITLE
Fix pour une erreur de geocoding lors de l'inscription d'un prescripteur

### DIFF
--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -287,13 +287,13 @@ class PrescriberSiretForm(forms.Form):
         # Perform another API call to fetch geocoding data.
         address_fields = [
             etablissement.address_line_1,
-            etablissement.address_line_2,
+            # `address_line_2` is omitted on purpose because it tends to return no results with the BAN API.
             etablissement.post_code,
             etablissement.city,
             etablissement.department,
         ]
         address_on_one_line = ", ".join([field for field in address_fields if field])
-        geocoding_data = get_geocoding_data(address_on_one_line, post_code=etablissement.post_code)
+        geocoding_data = get_geocoding_data(address_on_one_line, post_code=etablissement.post_code) or {}
 
         self.org_data = {
             "siret": siret,
@@ -303,9 +303,9 @@ class PrescriberSiretForm(forms.Form):
             "post_code": etablissement.post_code,
             "city": etablissement.city,
             "department": etablissement.department,
-            "longitude": geocoding_data["longitude"],
-            "latitude": geocoding_data["latitude"],
-            "geocoding_score": geocoding_data["score"],
+            "longitude": geocoding_data.get("longitude"),
+            "latitude": geocoding_data.get("latitude"),
+            "geocoding_score": geocoding_data.get("score"),
         }
 
         return siret


### PR DESCRIPTION
Une erreur 500 se produit dans le parcours d'inscription des prescripteurs quand une adresse ne parvient pas à être géolocalisée.

Pour le SIRET `48790347800021`, l'API SIRENE trouve cette adresse :

> 14 RUE NEUVE
> BATIMENT "ESPACE CAMBRESIS"
> BP 70318
> 59400 CAMBRAI

Or l'API BAN ne parvient pas à trouver une latitude/longitude pour cette adresse => ça se matérialise par une erreur 500.

C'est la partie BATIMENT "ESPACE CAMBRESIS" qui pose problème.

Ce fix propose de ne pas inclure cette partie dans les appels à l'API BAN.