### PR TITLE
Boost design

### DIFF
--- a/itou/templates/apply/email/new_for_siae_body.txt
+++ b/itou/templates/apply/email/new_for_siae_body.txt
@@ -48,4 +48,8 @@
 
 {% endif %}
 
+{% blocktranslate %}
+Toute demande de PASS IAE doit être effectuée au plus tard le jour de l'embauche. Les demandes rétroactives ne sont pas autorisées.
+{% endblocktranslate %}
+
 {% endblock body %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -8,9 +8,16 @@
 
 {% block content %}
 
+
     <h1>{% translate "Candidatures reçues" %}</h1>
     <h2 class="text-muted">{{ siae.display_name }}</h2>
 
+    <div class="alert alert-primary mt-3" role="alert">
+        {% blocktranslate %}
+            Toute demande de PASS IAE doit être effectuée <b>au plus tard le jour de l'embauche</b>.<br>
+            Les demandes rétroactives ne sont pas autorisées.
+        {% endblocktranslate %}
+    </div>
     {% include "apply/includes/job_applications_filters.html" with filters=filters filters_form=filters_form %}
 
     {% if not job_applications_page %}

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -70,7 +70,7 @@
                                         </button>
                                     </div>
                                     <div class="col pl-2">
-                                        <button type="submit" class="btn btn-success w-100" onClick="$(&quot;input[name='hiring_without_approval']&quot;).val('True')">
+                                        <button type="submit" class="btn btn-secondary w-100" onClick="$(&quot;input[name='hiring_without_approval']&quot;).val('True')">
                                             {% translate "Je n'ai pas besoin d'un PASS IAE" %}
                                         </button>
                                     </div>

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -43,7 +43,7 @@
                 La DIRECCTE doit nous indiquer si le conventionnement de votre structure est en cours en précisant le numéro de SIRET, le type de structure, l’adresse postale et l’adresse e-mail du correspondant technique ASP.<br>
             </p>
             <p>
-                <b>Si vous tentez d'inscrire une Entreprise Adaptée ou un GEIQ</b>, merci de nous contacter par e-mail à l’adresse <a href="mailto:{{ ITOU_EMAIL_ASSISTANCE }}">{{ ITOU_EMAIL_ASSISTANCE }}</a>.
+                <b>Si vous tentez d'inscrire une Entreprise Adaptée ou un GEIQ</b>, merci d'utiliser <a href="https://itou.typeform.com/to/RYfNLR79" target="_blank">ce formulaire</a>.
             </p>
         {% endblocktranslate %}
     </div>

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -29,6 +29,7 @@ from itou.utils.mocks.siret import API_INSEE_SIRET_RESULT_MOCK
 from itou.utils.password_validation import CnilCompositionPasswordValidator
 from itou.utils.perms.context_processors import get_current_organization_and_perms
 from itou.utils.perms.user import KIND_JOB_SEEKER, KIND_PRESCRIBER, KIND_SIAE_STAFF, get_user_info
+from itou.utils.resume.forms import ResumeFormMixin
 from itou.utils.templatetags import dict_filters, format_filters
 from itou.utils.tokens import SIAE_SIGNUP_MAGIC_LINK_TIMEOUT, SiaeSignupTokenGenerator
 from itou.utils.urls import get_absolute_url, get_safe_url
@@ -745,3 +746,17 @@ class UtilsEmailsSplitRecipientTest(TestCase):
         self.assertEqual(2, len(result))
         self.assertEqual(50, len(result[0].to))
         self.assertEqual(25, len(result[1].to))
+
+
+class ResumeFormMixinTest(TestCase):
+    def test_pole_emploi_internal_resume_link(self):
+        resume_link = "http://ds000-xxxx-00xx000.xxx00.pole-emploi.intra/docnums/portfolio-usager/XXXXXXXXXXX/CV.pdf?Expires=1590485264&Signature=XXXXXXXXXXXXXXXX"  # noqa E501
+        form = ResumeFormMixin(data={"resume_link": resume_link})
+        form.is_valid()
+        self.assertTrue(form.has_error("resume_link"))
+
+    def test_valid_resume_link(self):
+        resume_link = "https://www.moncv.fr/vive_moi.pdf"
+        form = ResumeFormMixin(data={"resume_link": resume_link})
+        form.is_valid()
+        self.assertFalse(form.has_error("resume_link"))

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -752,11 +752,11 @@ class ResumeFormMixinTest(TestCase):
     def test_pole_emploi_internal_resume_link(self):
         resume_link = "http://ds000-xxxx-00xx000.xxx00.pole-emploi.intra/docnums/portfolio-usager/XXXXXXXXXXX/CV.pdf?Expires=1590485264&Signature=XXXXXXXXXXXXXXXX"  # noqa E501
         form = ResumeFormMixin(data={"resume_link": resume_link})
-        form.is_valid()
+        self.assertFalse(form.is_valid())
         self.assertTrue(form.has_error("resume_link"))
 
     def test_valid_resume_link(self):
         resume_link = "https://www.moncv.fr/vive_moi.pdf"
         form = ResumeFormMixin(data={"resume_link": resume_link})
-        form.is_valid()
+        self.assertTrue(form.is_valid())
         self.assertFalse(form.has_error("resume_link"))

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -206,13 +206,13 @@ def step_send_resume(request, siae_pk, template_name="apply/submit_step_send_res
     form = ResumeFormMixin(data=request.POST or None)
 
     # Uploading a resume via Typeform without filling in the resume_link field
-    # will submit an empty form, which is an expected behavior.
+    # will submit an empty form which is an expected behavior.
     if request.method == "POST":
-        if form.is_valid():
+        if form.is_valid() or not form.has_error("resume_link"):
             job_seeker.resume_link = form.cleaned_data.get("resume_link")
             job_seeker.save()
-        next_url = reverse("apply:step_eligibility", kwargs={"siae_pk": siae.pk})
-        return HttpResponseRedirect(next_url)
+            next_url = reverse("apply:step_eligibility", kwargs={"siae_pk": siae.pk})
+            return HttpResponseRedirect(next_url)
 
     context = {"siae": siae, "job_seeker_signed_pk": job_seeker_signed_pk, "form": form}
     return render(request, template_name, context)

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -205,14 +205,12 @@ def step_send_resume(request, siae_pk, template_name="apply/submit_step_send_res
 
     form = ResumeFormMixin(data=request.POST or None)
 
-    # Uploading a resume via Typeform without filling in the resume_link field
-    # will submit an empty form which is an expected behavior.
-    if request.method == "POST":
-        if form.is_valid() or not form.has_error("resume_link"):
+    if request.method == "POST" and form.is_valid():
+        if form.cleaned_data.get("resume_link"):
             job_seeker.resume_link = form.cleaned_data.get("resume_link")
             job_seeker.save()
-            next_url = reverse("apply:step_eligibility", kwargs={"siae_pk": siae.pk})
-            return HttpResponseRedirect(next_url)
+        next_url = reverse("apply:step_eligibility", kwargs={"siae_pk": siae.pk})
+        return HttpResponseRedirect(next_url)
 
     context = {"siae": siae, "job_seeker_signed_pk": job_seeker_signed_pk, "form": form}
     return render(request, template_name, context)


### PR DESCRIPTION
Divers changements de l'interface.

# Mise en avant de l'impossibilité de délivrer un PASS IAE après le début de l'embauche

- Ajout d'une mention dans l'e-mail envoyé aux employeurs lors d'une nouvelle candidature.
- Ajout d'un message dans les listes de candidatures

![image](https://user-images.githubusercontent.com/6150920/98931137-ef886d80-24dd-11eb-8d15-2aecb72b594e.png)

# Mise à jour d'un lien lors de l'inscription d'un employeur

![image](https://user-images.githubusercontent.com/6150920/98932067-257a2180-24df-11eb-99a2-6d1e2493b0d4.png)

# Blocage des CV hébergés chez PE
Certains conseillers Pôle emploi partagent des CV hébergés sur leur intranet en pensant qu'ils sont public. Malheureusement, lorsque les employeurs tentent de télécharger le document, ils voient une erreur. Empêchons donc les prescripteurs d'ajouter le lien dès le début.

![image](https://user-images.githubusercontent.com/6150920/98964137-bca79f00-2508-11eb-85f5-7f0d4c8b8fc3.png)

# Résolution d'un bogue relatif au CV Typeform
Résolution probable d'un problème qui empêchait quelques CV Typeform d'être bien sauvegardés chez nous.
Avant : 
```
# form validation
job_seeker.resume_link = form.cleaned_data("resume_link")
job_seeker.save()
```
Quand un utilisateur télécharge un CV via Typeform, `form.cleaned_data("resume_link")` est vide. Mais `job_seeker.resume_link` est peut-être déjà renseigné si les robots de Typeform vont plus vite que nous, pauvres humains ! Après cette PR, `job_seeker.resume_link` ne sera mis à jour que si `form.cleaned_data("resume_link")` est présent.

# Modification de la modale qui permet l'obtention d'un PASS
Le second bouton est désormais gris afin de les différencier.
![image](https://user-images.githubusercontent.com/6150920/99262527-66936e00-281e-11eb-93e0-a95b30fae43b.png)

