### PR TITLE
Boost design

### DIFF
--- a/clevercloud/demo-after-success.sh
+++ b/clevercloud/demo-after-success.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
 
 ###################################################################
-###################### Review apps entrypoint #####################
+########################## Demo entrypoint ########################
 ###################################################################
+
+# ///////////////////////////// ! \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+# The demo uses the same CC instance as review apps but with
+# its own database.
 
 # -----------------------------------------------------------------
 # -------------------- A note on the Database ---------------------
+# -----------------------------------------------------------------
 # Review apps share the same Clever Cloud Postgresql add-on,
 # review_apps_databases, creating a new database for each one.
 # This is a workaround and may change in the future when
@@ -43,3 +48,13 @@ PGPASSWORD=$POSTGRESQL_ADDON_PASSWORD psql -h $POSTGRESQL_ADDON_HOST -p $POSTGRE
 # does not have execution rights on the $APP_HOME directory.
 echo "Loading fixtures"
 ls -d $APP_HOME/itou/fixtures/django/* | xargs django-admin loaddata
+
+echo "Updating super admin password"
+django-admin shell <<EOF
+import os
+from django.contrib.auth import get_user_model
+password = os.environ.get("ADMIN_PASSWORD")
+user = get_user_model().objects.get(email="admin@test.com")
+user.set_password(password)
+user.save()
+EOF

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -472,3 +472,6 @@ EMAIL_BACKEND = "itou.utils.emails.AsyncEmailBackend"
 # Number of retries & retry delay parameters for emails (for async process)
 SEND_EMAIL_DELAY_BETWEEN_RETRIES_IN_SECONDS = 5 * 60
 SEND_EMAIL_RETRY_TOTAL_TIME_IN_SECONDS = 24 * 3600
+
+# Le marché de l'inclusion
+LEMARCHE_OPEN_REGIONS = ["Hauts-de-France", "Grand Est", "Île-de-France"]

--- a/config/settings/dev.py.template
+++ b/config/settings/dev.py.template
@@ -74,3 +74,7 @@ ITOU_FQDN = "localhost:8080"
 # ------------------------------------------------------------------------------
 
 ALLOW_POPULATING_METABASE = True
+
+# Le marché de l'inclusion
+# Match open regions with SIAE created by our fixtures.
+LEMARCHE_OPEN_REGIONS = ["Occitanie"]

--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -94,15 +94,10 @@ b {
     z-index: 1;
 }
 
-/* Add shadow at the bottom of the banner. */
-.layout-banner-container::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    box-shadow: 0 18px 20px -20px gray;
+/* Add shadow at the bottom of the banner.
+Don't use :after pseudo-selector as it introduced a bug in IE and Edge. */
+.banner-bottom-shadow {
+    box-shadow: 0 18px 20px -20px grey;
 }
 
 .layout-banner {

--- a/itou/templates/apply/includes/list_card_footer.html
+++ b/itou/templates/apply/includes/list_card_footer.html
@@ -14,13 +14,22 @@
         <div>
             {{ job_application.message|linebreaks }}
         </div>
-        {% if job_application.state.is_refused and job_application.answer %}
-            <p>
-                <b>{% translate "Réponse :" %}</b>
-            </p>
-            <div>
-                {{ job_application.answer|linebreaks }}
-            </div>
+        {% if job_application.state.is_refused %}
+            {% if user.is_prescriber %}
+                <p>
+                    <b>{% translate "Motif du refus :" %}</b>
+                </p>
+                <p>{{ job_application.get_refusal_reason_display }}</p>
+            {% endif %}
+
+            {% if job_application.answer %}
+                <p>
+                    <b>{% translate "Réponse :" %}</b>
+                </p>
+                <div>
+                    {{ job_application.answer|linebreaks }}
+                </div>
+            {% endif %}
         {% endif %}
     </div>
 </div>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -304,4 +304,15 @@
 
     </div>
 
+    {% if current_siae and current_siae.region in lemarche_regions %}
+        <div class="layout layout-column-full border-top bg-light text-center p-4 mt-5 card">
+            <p class="h5 mb-3">{% translate "Développez votre clientèle avec le marché de l'inclusion" %}</p>
+            <p class="mb-1">
+                <a href="https://lemarche.inclusion.beta.gouv.fr" rel="noopener" target="_blank" class="btn btn-primary">
+                    {% translate "C'est parti !" %}
+                    {% include "includes/icon.html" with icon="external-link" %}
+                </a>
+            </p>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/itou/templates/home/home.html
+++ b/itou/templates/home/home.html
@@ -19,6 +19,7 @@
         </div>
 
         <div class="layout-banner layout-banner-work-labour"></div>
+        <div class="banner-bottom-shadow"></div>
 
     </section>
 

--- a/itou/templates/siaes/edit_siae.html
+++ b/itou/templates/siaes/edit_siae.html
@@ -10,13 +10,7 @@
 
 <h2 class="text-muted">
     {{ siae.display_name }}
-    {# Display non-user-edited name too. #}
-    {% if siae.brand %}<small>({{ siae.name|title }})</small>{% endif %}
 </h2>
-
-<div class="alert alert-info" role="alert">
-    {% blocktranslate %}Si vous devez modifier le nom de votre structure, <a href="mailto:{{ ITOU_EMAIL_CONTACT }}">contactez-nous</a>.{% endblocktranslate %}
-</div>
 
 <form method="post" action="" class="js-prevent-multiple-submit">
 
@@ -26,7 +20,10 @@
 
     {% csrf_token %}
 
-    {% bootstrap_form form %}
+    {% bootstrap_label "Nom à afficher sur la plateforme" label_title="a" label_for=form.brand.id  %}
+    {% bootstrap_field form.brand show_label=False %}
+
+    {% bootstrap_form form exclude="brand" %}
 
     <div class="alert alert-warning" role="alert">
         <p>

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -56,6 +56,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
             ] = f"{reverse('apply:list_for_siae')}?{'&'.join([f'states={c}' for c in category['states']])}"
 
     context = {
+        "lemarche_regions": settings.LEMARCHE_OPEN_REGIONS,
         "job_applications_categories": job_applications_categories,
     }
 

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -170,7 +170,10 @@ class EditSiaeForm(forms.ModelForm):
             "department",
         ]
         help_texts = {
-            "brand": gettext_lazy("Si ce champ est renseigné, il sera utilisé en tant que nom sur la fiche."),
+            "brand": gettext_lazy(
+                "Si ce champ est renseigné, il sera utilisé en tant que nom "
+                "sur la fiche et dans les résultats de recherche."
+            ),
             "description": gettext_lazy("Texte de présentation de votre structure."),
             "phone": gettext_lazy("Par exemple 0610203040"),
             "website": gettext_lazy("Votre site web doit commencer par http:// ou https://"),


### PR DESCRIPTION
# Un prescripteur peut désormais voir la raison du refus d'une candidature
![image](https://user-images.githubusercontent.com/6150920/99381174-2f2ecb00-28cb-11eb-86d1-d31078060739.png)

# Lien vers la place de marché dans le tableau de bord de certaines SIAE
Les employeurs dont les SIAE sont dans les Hauts-de-France, dans le Grand Est ou en Île-de-France voient le bandeau suivant :
 
![image](https://user-images.githubusercontent.com/6150920/99538628-86a56780-29ad-11eb-9e44-0b65318d64f5.png)

# Résolution d'un bogue d'affichage concernant les utilisateurs de Microsoft Edge et Internet Explorer
Étonnamment, ou pas, ces navigateurs ont du mal avec les pseudo-sélecteurs et notamment avec `:after`. Ce dernier était utilisé sur la page d'accueil pour créer une ombre sous l'image principale. Une classe sur la `section` ajoutait l'ombre grâce à la position `absolute` et au pseudo-sélecteur `:after`. Or IE interprétait cela comme une zone de premier plan qui "cachait" les balises incluses dans `section`. Le formulaire, inclus dans la section, était hors de portée. 
J'ai remplacé le pseudo-sélecteur par une `div` avec une classe dédiée. C'est moins joli mais cela semble plus universel.

# Démo
Changement du mot de passe par défaut du super administrateur. Il est désormais tenu secret dans la configuration de Clever. :zipper_mouth_face: 

# Fiche SIAE, champ "enseigne"
Modification du `label` du champ `brand`, du texte d'aide et suppression de la zone bleue.
![image](https://user-images.githubusercontent.com/6150920/99676792-3a275e00-2a79-11eb-913a-6e65086a5d52.png)

![image](https://user-images.githubusercontent.com/6150920/99677137-aace7a80-2a79-11eb-9da2-5cf7a0ecb2af.png)

