### PR TITLE
[FIX] Problème de template dans la gestion des collaborateurs de SIAE

### DIFF
--- a/itou/templates/siaes/deactivate_member.html
+++ b/itou/templates/siaes/deactivate_member.html
@@ -5,6 +5,6 @@
 
 {% block content %}
     {% with base_url="siaes_views" %}
-    {% include "includes/deactivate_member.html" %}    
+        {% include "includes/deactivate_member.html" %}    
     {% endwith %}
 {% endblock %}

--- a/itou/templates/siaes/deactivate_member.html
+++ b/itou/templates/siaes/deactivate_member.html
@@ -5,6 +5,6 @@
 
 {% block content %}
     {% with base_url="siaes_views" %}
-        {% include "includes/update_admin.html" %}    
+    {% include "includes/deactivate_member.html" %}    
     {% endwith %}
 {% endblock %}


### PR DESCRIPTION
### Quoi ?

Modification du template de confirmation du retrait d'un collaborateur pour une SIAE

### Pourquoi ?

Le template comporte des informations invalides (url / action)

