### PR TITLE
Utilisation de `readonly_fields` sur certaines FK dans l'admin

### DIFF
--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -85,7 +85,8 @@ class AuthorizationValidationRequired(admin.SimpleListFilter):
 class MembersInline(admin.TabularInline):
     model = models.PrescriberOrganization.members.through
     extra = 1
-    raw_id_fields = ("user", "updated_by")
+    raw_id_fields = ("user",)
+    readonly_fields = ("updated_by",)
 
 
 @admin.register(models.PrescriberOrganization)

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -13,6 +13,7 @@ class MembersInline(admin.TabularInline):
     model = models.Siae.members.through
     extra = 1
     raw_id_fields = ("user",)
+    readonly_fields = ("updated_by",)
 
 
 class JobsInline(admin.TabularInline):


### PR DESCRIPTION
Utilisation de `readonly_fields` pour ne pas subir la lenteur engendrée par la sélection de toutes les instances liées pour l’affichage dans la liste déroulante de l'admin.

Fixe un problème de performance dans l'admin.