### PR TITLE
Utilisation de readonly_fields sur tous les MembersInline

### DIFF
--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -86,7 +86,7 @@ class MembersInline(admin.TabularInline):
     model = models.PrescriberOrganization.members.through
     extra = 1
     raw_id_fields = ("user",)
-    readonly_fields = ("updated_by",)
+    readonly_fields = ("is_active", "created_at", "updated_at", "updated_by")
 
 
 @admin.register(models.PrescriberOrganization)

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -13,7 +13,7 @@ class MembersInline(admin.TabularInline):
     model = models.Siae.members.through
     extra = 1
     raw_id_fields = ("user",)
-    readonly_fields = ("updated_by",)
+    readonly_fields = ("is_active", "created_at", "updated_at", "updated_by")
 
 
 class JobsInline(admin.TabularInline):

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -16,7 +16,16 @@ class SiaeMembershipInline(admin.TabularInline):
     model = SiaeMembership
     extra = 0
     raw_id_fields = ("siae",)
-    readonly_fields = ("siae", "siae_id_link", "joined_at", "is_siae_admin")
+    readonly_fields = (
+        "siae",
+        "siae_id_link",
+        "joined_at",
+        "is_siae_admin",
+        "is_active",
+        "created_at",
+        "updated_at",
+        "updated_by",
+    )
     can_delete = False
     show_change_link = True
     fk_name = "user"
@@ -38,7 +47,16 @@ class PrescriberMembershipInline(admin.TabularInline):
     model = PrescriberMembership
     extra = 0
     raw_id_fields = ("organization",)
-    readonly_fields = ("organization", "organization_id_link", "joined_at", "is_admin")
+    readonly_fields = (
+        "organization",
+        "organization_id_link",
+        "joined_at",
+        "is_admin",
+        "is_active",
+        "created_at",
+        "updated_at",
+        "updated_by",
+    )
     can_delete = False
     fk_name = "user"
 


### PR DESCRIPTION
Utilisation de readonly_fields pour ne pas subir la lenteur engendrée par la sélection de toutes les instances liées pour l’affichage dans la liste déroulante de l'admin.

Fixe un problème de performance dans l'admin.