### PR TITLE
Remise à flot des recettes jetables

### DIFF
--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -38,15 +38,15 @@ jobs:
     # Environment variables
     - name: 🏷 Set review app name
       run:
-        echo ::set-env name=REVIEW_APP_NAME::$(echo "c1-review-$BRANCH" | sed -r 's/[-;\\/._]+/-/g')
+        echo "REVIEW_APP_NAME=`echo \"c1-review-$BRANCH\" | sed -r 's/[-;\\/._]+/-/g'`" >> $GITHUB_ENV
 
     - name: 🏷 Set database name
       run:
-        echo ::set-env name=REVIEW_APP_DB_NAME::$(echo $REVIEW_APP_NAME | sed -r 's/-/_/g')
+        echo "REVIEW_APP_DB_NAME=`echo $REVIEW_APP_NAME | sed -r 's/-/_/g'`" >> $GITHUB_ENV
 
     - name: 🏷 Set deploy url
       run:
-        echo ::set-env name=DEPLOY_URL::$(echo "$REVIEW_APP_NAME.cleverapps.io")
+        echo "DEPLOY_URL=`echo \"$REVIEW_APP_NAME.cleverapps.io\"`" >> $GITHUB_ENV
     # End of environment variables
 
     - name: 🧫 Create a review app on Clever Cloud

--- a/.github/workflows/review-app-removal.yml
+++ b/.github/workflows/review-app-removal.yml
@@ -28,11 +28,11 @@ jobs:
 
     - name: 🏷 Set review app name
       run:
-        echo ::set-env name=REVIEW_APP_NAME::$(echo "c1-review-$BRANCH" | sed -r 's/[-;\\/._]+/-/g')
+        echo "REVIEW_APP_NAME=`echo \"c1-review-$BRANCH\" | sed -r 's/[-;\\/._]+/-/g'`" >> $GITHUB_ENV
 
     - name: 🏷 Set database name
       run:
-        echo ::set-env name=REVIEW_APP_DB_NAME::$(echo $REVIEW_APP_NAME | sed -r 's/-/_/g')
+        echo "REVIEW_APP_DB_NAME=`echo $REVIEW_APP_NAME | sed -r 's/-/_/g'`" >> $GITHUB_ENV
 
     - name: 🤝 Find the application on Clever Cloud
       run: |


### PR DESCRIPTION
Les recettes jetables sont cassées ! :scream: Cela est dû à [une évolution récente des actions GitHub](echo "$REVIEW_APP_NAME.cleverapps.io") qui déprécie les commandes `set-env` et `add-path`.

Cette PR remplace ces commandes par celles conseillées par GitHub.