### PR TITLE
[C1] Boost 

### DIFF
--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -175,15 +175,15 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
 
         if not change:
             obj.created_by = request.user
-            if not obj.geocoding_score and obj.address_on_one_line:
+            if not obj.geocoding_score and obj.geocoding_address:
                 # Set geocoding.
-                obj.set_coords(obj.address_on_one_line, post_code=obj.post_code)
+                obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
 
-        if change and obj.address_on_one_line:
+        if change and obj.geocoding_address:
             old_obj = self.model.objects.get(id=obj.id)
-            if obj.address_on_one_line != old_obj.address_on_one_line:
+            if obj.geocoding_address != old_obj.geocoding_address:
                 # Refresh geocoding.
-                obj.set_coords(obj.address_on_one_line, post_code=obj.post_code)
+                obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
 
         super().save_model(request, obj, form, change)
 

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -147,15 +147,15 @@ class SiaeAdmin(admin.ModelAdmin):
         if not change:
             obj.created_by = request.user
             obj.source = models.Siae.SOURCE_STAFF_CREATED
-            if not obj.geocoding_score and obj.address_on_one_line:
+            if not obj.geocoding_score and obj.geocoding_address:
                 # Set geocoding.
-                obj.set_coords(obj.address_on_one_line, post_code=obj.post_code)
+                obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
 
-        if change and obj.address_on_one_line:
+        if change and obj.geocoding_address:
             old_obj = self.model.objects.get(id=obj.id)
-            if obj.address_on_one_line != old_obj.address_on_one_line:
+            if obj.geocoding_address != old_obj.geocoding_address:
                 # Refresh geocoding.
-                obj.set_coords(obj.address_on_one_line, post_code=obj.post_code)
+                obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
 
         # Pulled-up the save action:
         # many-to-many relationships / cross-tables references

--- a/itou/siaes/management/commands/_import_siae/siae.py
+++ b/itou/siaes/management/commands/_import_siae/siae.py
@@ -26,9 +26,9 @@ def could_siae_be_deleted(siae):
 
 
 def geocode_siae(siae):
-    assert siae.address_on_one_line
+    assert siae.geocoding_address
 
-    geocoding_data = get_geocoding_data(siae.address_on_one_line, post_code=siae.post_code)
+    geocoding_data = get_geocoding_data(siae.geocoding_address, post_code=siae.post_code)
 
     if geocoding_data:
         siae.geocoding_score = geocoding_data["score"]

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -63,7 +63,7 @@
         {% translate "Tableau de bord" %}
         {% if current_siae %} - <span class="text-muted">{{ current_siae.display_name }}</span>{% endif %}
         {% if current_prescriber_organization %} -
-        <span class="text-muted">{{ current_prescriber_organization.display_name }} - ({{ current_prescriber_organization.kind }})</span>
+        <span class="text-muted">{{ current_prescriber_organization.display_name }}</span>
             {% if current_prescriber_organization.is_authorized %}
                 {% include "includes/icon.html" with icon="award" class="h1 align-middle" size=30 %}
             {% endif %}
@@ -143,7 +143,9 @@
 
             {% if current_prescriber_organization %}
                 <div class="card">
-                    <h5 class="card-header">{% translate "Organisation" %}</h5>
+                    <h5 class="card-header">
+                        {% translate "Organisation" %} <span class="badge badge-secondary">{{ current_prescriber_organization.kind }} - ID {{ current_prescriber_organization.id }}</span>
+                    </h5>
                     <div class="card-body">
                         <p class="card-text">
                             {% include "includes/icon.html" with icon="bookmark" %}
@@ -199,7 +201,7 @@
             <div class="card">
                 <h5 class="card-header">
                     {% translate "Ma structure" %}
-                    (ID {{ current_siae.id }})
+                    <span class="badge badge-secondary">{{ current_siae.kind }} - ID {{ current_siae.id }}</span>
                 </h5>
                 <div class="card-body">
                     <p class="card-text">

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -144,7 +144,7 @@
             {% if current_prescriber_organization %}
                 <div class="card">
                     <h5 class="card-header">
-                        {% translate "Organisation" %} <span class="badge badge-secondary">{{ current_prescriber_organization.kind }} - ID {{ current_prescriber_organization.id }}</span>
+                        {% translate "Organisation" %} <span class="ml-1 badge badge-secondary">{{ current_prescriber_organization.kind }} - ID {{ current_prescriber_organization.id }}</span>
                     </h5>
                     <div class="card-body">
                         <p class="card-text">
@@ -201,7 +201,7 @@
             <div class="card">
                 <h5 class="card-header">
                     {% translate "Ma structure" %}
-                    <span class="badge badge-secondary">{{ current_siae.kind }} - ID {{ current_siae.id }}</span>
+                    <span class="ml-1 badge badge-secondary">{{ current_siae.kind }} - ID {{ current_siae.id }}</span>
                 </h5>
                 <div class="card-body">
                     <p class="card-text">

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -97,7 +97,7 @@
                                                     class="dropdown-item text-primary {% if s.pk == current_siae.pk %} font-weight-bold disabled{% endif %}"
                                                     type="submit"
                                                     name="siae_id"
-                                                    value="{{ s.pk }}">{{ s.display_name }}
+                                                    value="{{ s.pk }}">{{ s.display_name }} <span class="badge badge-primary">{{ s.kind }}</span> 
                                                 </button>
                                             {% endfor %}
                                         </form>
@@ -118,7 +118,7 @@
                                                     class="dropdown-item text-primary {% if po.pk == current_prescriber_organization.pk %} font-weight-bold disabled{% endif %}"
                                                     type="submit"
                                                     name="prescriber_organization_id"
-                                                    value="{{ po.pk }}">{{ po.display_name }} ({{ po.kind }})
+                                                    value="{{ po.pk }}">{{ po.display_name }} <span class="badge badge-primary">{{ s.kind }}</span> 
                                                 </button>
                                             {% endfor %}
                                         </form>

--- a/itou/utils/address/models.py
+++ b/itou/utils/address/models.py
@@ -90,6 +90,19 @@ class AddressMixin(models.Model):
         fields = [self.address_line_1, self.address_line_2, f"{self.post_code} {self.city}"]
         return ", ".join([field for field in fields if field])
 
+    @property
+    def geocoding_address(self):
+        """
+        Using `address_on_one_line` field for geocoding can lead to poor scores
+        (because of `address_line_2` field).
+        - use `address_on_one_line` for display
+        - use `geocoding_address` for geocoding process
+        """
+        if not all([self.address_line_1, self.post_code, self.city]):
+            return None
+        fields = [self.address_line_1, f"{self.post_code} {self.city}"]
+        return ", ".join([field for field in fields if field])
+
     def set_coords(self, address, post_code=None):
         geocoding_data = get_geocoding_data(address, post_code=post_code)
         if not geocoding_data:

--- a/itou/www/prescribers_views/forms.py
+++ b/itou/www/prescribers_views/forms.py
@@ -70,6 +70,6 @@ class EditPrescriberOrganizationForm(forms.ModelForm):
     def save(self, commit=True):
         prescriber_org = super().save(commit=False)
         if commit:
-            prescriber_org.set_coords(prescriber_org.address_on_one_line, post_code=prescriber_org.post_code)
+            prescriber_org.set_coords(prescriber_org.geocoding_address, post_code=prescriber_org.post_code)
             prescriber_org.save()
         return prescriber_org

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -108,7 +108,7 @@ class CreateSiaeForm(forms.ModelForm):
     def save(self, request, commit=True):
         siae = super().save(commit=commit)
         if commit:
-            siae.set_coords(siae.address_on_one_line, post_code=siae.post_code)
+            siae.set_coords(siae.geocoding_address, post_code=siae.post_code)
             siae.created_by = request.user
             siae.source = Siae.SOURCE_USER_CREATED
             siae.convention = self.current_siae.convention
@@ -179,7 +179,7 @@ class EditSiaeForm(forms.ModelForm):
     def save(self, commit=True):
         siae = super().save(commit=commit)
         if commit:
-            siae.set_coords(siae.address_on_one_line, post_code=siae.post_code)
+            siae.set_coords(siae.geocoding_address, post_code=siae.post_code)
             siae.save()
         return siae
 


### PR DESCRIPTION
### Quoi ?

1 - Une indication sur le type de structure est présente sur le dashboard et la liste de selection multistructure
2 - le complément d'adresse n'est plus utilisé pour le geocoding

### Pourquoi ?

1 -Les SIAE ou organisations de prescripteurs peuvent être plusieurs à avoir un même SIRET et un même nom (mais des types différents). 
On donne une indication plus claire de la structure de travail actuelle dans le dashboard et dans la liste de sélection.

2- Inclure systématiquement le complément d'adresse peut influer grandement sur le score de géocoding (et affecter les résultats de recherche)

### Captures d'écran

![structure-kind-dashboard](https://user-images.githubusercontent.com/147232/99684382-b32ab380-2a81-11eb-95e1-1c8fe16ddaab.png)
