### PR TITLE
Suppression des cartes dans l'admin des SIAE et des orgas de prescripteurs

### DIFF
--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -142,6 +142,7 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
     )
     raw_id_fields = ("created_by",)
     readonly_fields = (
+        "coords",  # Quick tip to disable GeoDjango's Openlayers map.
         "created_by",
         "created_at",
         "updated_at",

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -84,6 +84,7 @@ class SiaeAdmin(admin.ModelAdmin):
     list_filter = (SiaeHasMembersFilter, "kind", "block_job_applications", "source", "department")
     raw_id_fields = ("created_by", "convention")
     readonly_fields = (
+        "coords",  # Quick tip to disable GeoDjango's Openlayers map.
         "source",
         "created_by",
         "created_at",


### PR DESCRIPTION
### Quoi ?

Remplacement du widget de cartographie dans l'admin.

### Pourquoi ?

La carte (géoloc) dans l'interface d'admin est floue et pas trés utile. 

### Comment ?

![map](https://user-images.githubusercontent.com/281139/100120769-a094ed80-2e78-11eb-902c-41f73512fbcc.png)
