### PR TITLE
À l'ouverture du lien "Besoin d'aide ?" le focus est mis dans le champ de recherche

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -231,7 +231,7 @@
                         <div class="col-sm-6">
                             <ul class="list-unstyled">
                                 <li>
-                                    <a href="https://doc.inclusion.beta.gouv.fr/reponses-a-mes-questions-faq" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
+                                    <a href="https://doc.inclusion.beta.gouv.fr/reponses-a-mes-questions-faq?q=" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
                                         {% translate "Besoin d'aide ?" %}
                                         {% include "includes/icon.html" with icon="external-link" title=external_link_title %}
                                     </a>


### PR DESCRIPTION
### Quoi ?

À l'ouverture du lien "Besoin d'aide ?" qui pointe vers la FAQ, le focus est mis dans le champ de recherche.

### Pourquoi ?

Le champ de recherche est difficilement visible sur la FAQ et il est impossible d'en modifier la présentation : les gens ne le trouvent pas.

### Comment ?

En modifiant le lien externe en ajoutant `?q=` dans la _querystring_.