### PR TITLE
La C.I. échoue à cause de tests unitaires instables

### DIFF
--- a/itou/prescribers/tests.py
+++ b/itou/prescribers/tests.py
@@ -96,7 +96,7 @@ class ModelTest(TestCase):
 
     def test_active_member_with_many_memberships(self):
         organization1 = PrescriberOrganizationWith2MembershipFactory(membership2__is_active=False)
-        user = organization1.members.all()[1]
+        user = organization1.members.filter(prescribermembership__is_admin=False).first()
         organization2 = PrescriberOrganizationWith2MembershipFactory()
         organization2.members.add(user)
 

--- a/itou/siaes/tests.py
+++ b/itou/siaes/tests.py
@@ -192,7 +192,8 @@ class ModelTest(TestCase):
 
     def test_active_member_with_many_memberships(self):
         siae1 = SiaeWith2MembershipsFactory(membership2__is_active=False)
-        user = siae1.members.all()[1]
+        # user = siae1.members.all()[1]
+        user = siae1.members.filter(siaemembership__is_siae_admin=False).first()
         siae2 = SiaeWith2MembershipsFactory()
         siae2.members.add(user)
 

--- a/itou/www/prescribers_views/tests.py
+++ b/itou/www/prescribers_views/tests.py
@@ -132,7 +132,7 @@ class UserMembershipDeactivationTest(TestCase):
         (must be done by another admin)
         """
         organization = PrescriberOrganizationWithMembershipFactory()
-        admin = organization.members.first()
+        admin = organization.members.filter(prescribermembership__is_admin=True).first()
         memberships = admin.prescribermembership_set.all()
         membership = memberships.first()
 
@@ -152,7 +152,8 @@ class UserMembershipDeactivationTest(TestCase):
         Everything should be fine ...
         """
         organization = PrescriberOrganizationWith2MembershipFactory()
-        admin, guest = organization.members.all()
+        admin = organization.members.filter(prescribermembership__is_admin=True).first()
+        guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
         memberships = guest.prescribermembership_set.all()
         membership = memberships.first()
@@ -196,7 +197,8 @@ class UserMembershipDeactivationTest(TestCase):
         As such he must be able to login.
         """
         organization = PrescriberOrganizationWith2MembershipFactory()
-        admin, guest = organization.members.all()
+        admin = organization.members.filter(prescribermembership__is_admin=True).first()
+        guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
         self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
         url = reverse("prescribers_views:deactivate_member", kwargs={"user_id": guest.id})
@@ -249,7 +251,8 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         Check the ability for an admin to add another admin to the organization
         """
         organization = PrescriberOrganizationWith2MembershipFactory()
-        admin, guest = organization.members.all()
+        admin = organization.members.filter(prescribermembership__is_admin=True).first()
+        guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
         self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
         url = reverse("prescribers_views:update_admin_role", kwargs={"action": "add", "user_id": guest.id})
@@ -270,7 +273,8 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         Check the ability for an admin to remove another admin
         """
         organization = PrescriberOrganizationWith2MembershipFactory()
-        admin, guest = organization.members.all()
+        admin = organization.members.filter(prescribermembership__is_admin=True).first()
+        guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
         membership = guest.prescribermembership_set.first()
         membership.is_admin = True
@@ -296,7 +300,8 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         Non-admin users can't update admin members
         """
         organization = PrescriberOrganizationWith2MembershipFactory()
-        admin, guest = organization.members.all()
+        admin = organization.members.filter(prescribermembership__is_admin=True).first()
+        guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
         self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
         url = reverse("prescribers_views:update_admin_role", kwargs={"action": "remove", "user_id": admin.id})
@@ -324,7 +329,8 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         """
         suspicious_action = "h4ckm3"
         organization = PrescriberOrganizationWith2MembershipFactory()
-        admin, guest = organization.members.all()
+        admin = organization.members.filter(prescribermembership__is_admin=True).first()
+        guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
         self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
 

--- a/itou/www/siaes_views/tests.py
+++ b/itou/www/siaes_views/tests.py
@@ -529,7 +529,7 @@ class UserMembershipDeactivationTest(TestCase):
         (must be done by another admin)
         """
         siae = SiaeWithMembershipFactory()
-        admin = siae.members.first()
+        admin = siae.members.filter(siaemembership__is_siae_admin=True).first()
         memberships = admin.siaemembership_set.all()
         membership = memberships.first()
 
@@ -549,8 +549,8 @@ class UserMembershipDeactivationTest(TestCase):
         Everything should be fine ...
         """
         siae = SiaeWith2MembershipsFactory()
-        admin = siae.members.first()
-        guest = siae.members.all()[1]
+        admin = siae.members.filter(siaemembership__is_siae_admin=True).first()
+        guest = siae.members.filter(siaemembership__is_siae_admin=False).first()
 
         membership = guest.siaemembership_set.first()
         self.assertFalse(guest in siae.active_admin_members)
@@ -580,7 +580,7 @@ class UserMembershipDeactivationTest(TestCase):
         Non-admin user can't change memberships
         """
         siae = SiaeWith2MembershipsFactory()
-        guest = siae.members.all()[1]
+        guest = siae.members.filter(siaemembership__is_siae_admin=False).first()
         self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
         url = reverse("siaes_views:deactivate_member", kwargs={"user_id": guest.id})
         response = self.client.post(url)
@@ -594,7 +594,8 @@ class UserMembershipDeactivationTest(TestCase):
         are activated/invited again, they will be able to log in.
         """
         siae = SiaeWith2MembershipsFactory()
-        admin, guest = siae.members.all()
+        admin = siae.members.filter(siaemembership__is_siae_admin=True).first()
+        guest = siae.members.filter(siaemembership__is_siae_admin=False).first()
 
         self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
         url = reverse("siaes_views:deactivate_member", kwargs={"user_id": guest.id})
@@ -650,7 +651,8 @@ class SIAEAdminMembersManagementTest(TestCase):
         Check the ability for an admin to add another admin to the siae
         """
         siae = SiaeWith2MembershipsFactory()
-        admin, guest = siae.members.all()
+        admin = siae.members.filter(siaemembership__is_siae_admin=True).first()
+        guest = siae.members.filter(siaemembership__is_siae_admin=False).first()
 
         self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
         url = reverse("siaes_views:update_admin_role", kwargs={"action": "add", "user_id": guest.id})
@@ -671,7 +673,8 @@ class SIAEAdminMembersManagementTest(TestCase):
         Check the ability for an admin to remove another admin
         """
         siae = SiaeWith2MembershipsFactory()
-        admin, guest = siae.members.all()
+        admin = siae.members.filter(siaemembership__is_siae_admin=True).first()
+        guest = siae.members.filter(siaemembership__is_siae_admin=False).first()
 
         membership = guest.siaemembership_set.first()
         membership.is_siae_admin = True
@@ -697,7 +700,8 @@ class SIAEAdminMembersManagementTest(TestCase):
         Non-admin users can't update admin members
         """
         siae = SiaeWith2MembershipsFactory()
-        admin, guest = siae.members.all()
+        admin = siae.members.filter(siaemembership__is_siae_admin=True).first()
+        guest = siae.members.filter(siaemembership__is_siae_admin=False).first()
 
         self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
         url = reverse("siaes_views:update_admin_role", kwargs={"action": "remove", "user_id": admin.id})
@@ -725,7 +729,8 @@ class SIAEAdminMembersManagementTest(TestCase):
         """
         suspicious_action = "h4ckm3"
         siae = SiaeWith2MembershipsFactory()
-        admin, guest = siae.members.all()
+        admin = siae.members.filter(siaemembership__is_siae_admin=True).first()
+        guest = siae.members.filter(siaemembership__is_siae_admin=False).first()
 
         self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
         # update: less test with RE_PATH

--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -166,7 +166,6 @@ def deactivate_member(request, user_id, template_name="siaes/deactivate_member.h
     siae = get_current_siae_or_404(request)
     user = request.user
     target_member = User.objects.get(pk=user_id)
-    user_is_admin = user in siae.active_admin_members
     user_is_admin = siae.has_admin(user)
 
     if not user_is_admin:

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -780,7 +780,7 @@ class PrescriberSignupTest(TestCase):
         self.assertRedirects(response, reverse("account_email_verification_sent"))
 
         # Check new org is ok:
-        same_siret_orgs = PrescriberOrganization.objects.filter(siret=siret).all()
+        same_siret_orgs = PrescriberOrganization.objects.filter(siret=siret).order_by("kind").all()
         self.assertEqual(2, len(same_siret_orgs))
         org1, org2 = same_siret_orgs
         self.assertEqual(PrescriberOrganization.Kind.ML.value, org1.kind)


### PR DESCRIPTION
### Quoi ?

L'initialisation des utilisateurs pour certains tests partaient du principe que leur restitution par les factories était naturellement ordonné.

### Pourquoi ?

Certains tests unitaires (du domaine des `memberships`) échouent soit en local, soit lors des phases de C.I.

Après lancement de nombreuses suites de tests unitaires et analyse, environ 40% (!) des suites de tests échouent.

### Comment ?

Lors de la création des utilisateurs de tests, on s'assure qu'ils ont bien les caractéristiques attendues en filtrant explicitement les résultats sur la valeur de certain champs (`membership.is_admin` par ex.).

On évite de récupérer une liste d'utilisateurs en désordre, et avec des problèmes d'autorisation / permission.
