### PR TITLE
Réparation de la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: 🌍 Install spatial libraries
-      run: sudo apt-get install binutils libproj-dev gdal-bin
+      run: sudo apt-get update && sudo apt-get install binutils libproj-dev gdal-bin
     - name: 🧩 Add extentions to Postgres and create a database to check migrations
       run: |
         psql <<SQL


### PR DESCRIPTION
### Quoi ?

La CI est cassée car les paquets ne s'installent pas correctement : la source n'est pas trouvée.

### Pourquoi ?

Il faut lancer `apt-get update` avant l'installation afin de rafraîchir la source.
