### PR TITLE
Les anciens membres d'une structure recoivent encore certaines notifications par e-mail

### DIFF
--- a/itou/invitations/models.py
+++ b/itou/invitations/models.py
@@ -194,7 +194,7 @@ class PrescriberWithOrgInvitation(InvitationAbstract):
     # Emails
     @property
     def email_accepted_notif_organization_members(self):
-        members = self.organization.members.exclude(email__in=[self.sender.email, self.email])
+        members = self.organization.active_members.exclude(email__in=[self.sender.email, self.email])
         to = [member.email for member in members]
         context = {
             "first_name": self.first_name,
@@ -287,7 +287,7 @@ class SiaeStaffInvitation(InvitationAbstract):
     # Emails
     @property
     def email_accepted_notif_siae_members(self):
-        members = self.siae.members.exclude(email__in=[self.sender.email, self.email])
+        members = self.siae.active_members.exclude(email__in=[self.sender.email, self.email])
         to = [member.email for member in members]
         context = {
             "first_name": self.first_name,

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -470,7 +470,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     # Emails.
 
     def get_siae_recipents_email_list(self):
-        return list(self.to_siae.members.filter(is_active=True).values_list("email", flat=True))
+        return list(self.to_siae.active_members.values_list("email", flat=True))
 
     @property
     def email_new_for_siae(self):


### PR DESCRIPTION
### Quoi ?

Des e-mails d'une structure sont envoyés à tort à des destinataires erronés.

### Pourquoi ?

Des utilisateurs anciens membres d'une structure continuent de recevoir certains e-mails destinés aux membres **actifs** de cette structure (lors d'invitations de nouveau membres par ex.).

### Comment ?

Il est nécessaire de filtrer sur le champs `active_members` et non `members` pour obtenir la liste correcte des destinataires.
