### PR TITLE
Le moteur de recherche des prescripteurs devient public

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -171,11 +171,7 @@
 
                 <a class="nav-link{% if request.path == '/' or '/search/employers' in request.path %} active{% endif %}" href="/">{% translate "Rechercher des employeurs" %}</a>
 
-                {% if user.is_authenticated %}
-                    {# Do not confuse unlogged users with a prescriber search, especially jobseekers  #}
-                    {# who may be unfamiliar with the prescriber concept. #}
-                    <a class="nav-link{% if '/search/prescribers' in request.path %} active{% endif %}" href="{% url 'search:prescribers_home' %}">{% translate "Rechercher des prescripteurs" %}</a>
-                {% endif %}
+                <a class="nav-link{% if '/search/prescribers' in request.path %} active{% endif %}" href="{% url 'search:prescribers_home' %}">{% translate "Rechercher des prescripteurs" %}</a>
 
                 <a class="nav-link" href="https://forum.inclusion.beta.gouv.fr" rel="noopener" target="_blank" aria-label="{% translate "Accéder au Forum de l'inclusion (nouvel onglet)" %}">{% translate "Forum" %} {% include "includes/icon.html" with icon="external-link" title=external_link_title %}</a>
 

--- a/itou/templates/layout/content.html
+++ b/itou/templates/layout/content.html
@@ -3,7 +3,7 @@
 
     {% block pre_content %}{% endblock %}
 
-    <main class="layout-section layout-section-white">
+    <main class="{% block content_container_css_classes %}layout-section layout-section-white{% endblock %}">
         <div class="layout-content">
             {% block content %}{% endblock %}
         </div>

--- a/itou/templates/prescribers/card.html
+++ b/itou/templates/prescribers/card.html
@@ -29,34 +29,28 @@
         <div>{{ prescriber_org.description|linebreaks }}</div>
     {% endif %}
 
-    {% if prescriber_org.email or prescriber_org.phone or prescriber_org.website %}
+    {% if user.is_authenticated and prescriber_org.email %}
+        <p>
+            {% translate "E-mail" as email_label %}
+            {% include "includes/icon.html" with icon="mail" title=email_label %}
+            <a href="mailto:{{ prescriber_org.email }}">{{ prescriber_org.email }}</a>
+        </p>
+    {% endif %}
 
-        <hr>
+    {% if user.is_authenticated and prescriber_org.phone %}
+        <p>
+            {% translate "Téléphone" as phone_label %}
+            {% include "includes/icon.html" with icon="phone" title=phone_label %}
+            <a href="tel:{{ prescriber_org.phone }}">{{ prescriber_org.phone|format_phone }}</a>
+        </p>
+    {% endif %}
 
-        {% if prescriber_org.email %}
-            <p>
-                {% translate "E-mail" as email_label %}
-                {% include "includes/icon.html" with icon="mail" title=email_label %}
-                <a href="mailto:{{ prescriber_org.email }}">{{ prescriber_org.email }}</a>
-            </p>
-        {% endif %}
-
-        {% if prescriber_org.phone %}
-            <p>
-                {% translate "Téléphone" as phone_label %}
-                {% include "includes/icon.html" with icon="phone" title=phone_label %}
-                <a href="tel:{{ prescriber_org.phone }}">{{ prescriber_org.phone|format_phone }}</a>
-            </p>
-        {% endif %}
-
-        {% if prescriber_org.website %}
-            <p>
-                {% translate "Site Internet" as website_label %}
-                {% include "includes/icon.html" with icon="external-link" title=website_label %}
-                <a href="{{ prescriber_org.website }}" rel="noopener" target="_blank">{{ prescriber_org.website }}</a>
-            </p>
-        {% endif %}
-
+    {% if prescriber_org.website %}
+        <p>
+            {% translate "Site Internet" as website_label %}
+            {% include "includes/icon.html" with icon="external-link" title=website_label %}
+            <a href="{{ prescriber_org.website }}" rel="noopener" target="_blank">{{ prescriber_org.website }}</a>
+        </p>
     {% endif %}
 
     {% if back_url %}

--- a/itou/templates/search/prescribers_search_home.html
+++ b/itou/templates/search/prescribers_search_home.html
@@ -22,3 +22,7 @@
     </section>
 
 {% endblock %}
+
+{# The "content" block is empty here, so we hide it to avoid a gap in UI. #}
+{% block content_container_css_classes %}{{ block.super }} d-none{% endblock %}
+{% block content %}{% endblock %}

--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -54,7 +54,11 @@
                             {{ prescriber_org.name }}
                         </a>
                     </h5>
-                    <h6 class="card-subtitle mb-2 text-muted">{{ prescriber_org.address_on_one_line }}</h6>
+                    <h6 class="card-subtitle mb-2 text-muted">{{ prescriber_org.get_kind_display }}</h6>
+                    <hr>
+                    <h6 class="card-subtitle mb-2 text-muted">
+                        {{ prescriber_org.address_on_one_line }}
+                    </h6>
                     <p class="card-text">
                         {% blocktranslate with distance=prescriber_org.distance.km|floatformat:1 %}
                             <span class="badge badge-dark">{{ distance }} Km</span>

--- a/itou/templates/search/siaes_search_home.html
+++ b/itou/templates/search/siaes_search_home.html
@@ -22,3 +22,7 @@
     </section>
 
 {% endblock %}
+
+{# The "content" block is empty here, so we hide it to avoid a gap in UI. #}
+{% block content_container_css_classes %}{{ block.super }} d-none{% endblock %}
+{% block content %}{% endblock %}

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -67,7 +67,6 @@ def search_siaes_results(request, template_name="search/siaes_search_results.htm
     return render(request, template_name, context)
 
 
-@login_required
 def search_prescribers_home(request, template_name="search/prescribers_search_home.html"):
     """
     The search home page has a different design from the results page.
@@ -77,7 +76,6 @@ def search_prescribers_home(request, template_name="search/prescribers_search_ho
     return render(request, template_name, context)
 
 
-@login_required
 def search_prescribers_results(request, template_name="search/prescribers_search_results.html"):
 
     form = PrescriberSearchForm(data=request.GET or None)

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.decorators import login_required
 from django.db.models import Case, Count, IntegerField, Q, Value, When
 from django.shortcuts import render
 


### PR DESCRIPTION
### Quoi ?

Le moteur de recherche des prescripteurs devient public.

### Pourquoi ?

Itou est seul à posséder cette cartographie des prescripteurs. On décide de le mettre à disposition de tout le monde.