### PR TITLE
Régularisation des SIAE créées par le support [V1 - abandonnée]

### DIFF
--- a/itou/siaes/management/commands/_import_siae/siae.py
+++ b/itou/siaes/management/commands/_import_siae/siae.py
@@ -13,7 +13,7 @@ from itou.utils.address.departments import department_from_postcode
 
 
 def does_siae_have_an_active_convention(siae):
-    asp_id = SIRET_TO_ASP_ID[siae.siret]
+    asp_id = SIRET_TO_ASP_ID.get(siae.siret)
     siae_key = (asp_id, siae.kind)
     return siae_key in ACTIVE_SIAE_KEYS
 


### PR DESCRIPTION
### Quoi ?

Régularisation (conversion en structure de source ASP) des structures créées par le support il y a plus de 30 jours glissants (délai décidé avec le support).

### Pourquoi ?

Le support créé occasionnellement des structures employeurs par manque de fraicheur de données ASP. Quand le SIRET de la structure apparait enfin dans les données ASP, elle est automatiquement régularisée.

Pourtant il existe à ce jour un reliquat de 13 structures (je ne parle ici que des SIAE pas des GEIQ/EA) créées par le support de janvier à novembre 2020, dont le SIRET n'est jamais apparu dans les données ASP.

Ces 13 structures ont des membres et des candidatures. Il faut les désactiver asap. Malheureusement il n'est pas possible d'appliquer un délai de grâce dans ce cas car pas d'objet convention (pas de données ASP).

Ces 13 structures seront donc "brutalement" désactivées. Pour éviter une frustration utilisateur bien justifiée, la liste des 13 structures a été communiquée au support qui tente un contact pour clarification.

### Quand ?

J'attends un retour d'Abdess. Cf https://itou-inclusion.slack.com/archives/C01181Y04LT/p1608559153016500
