### PR TITLE
Améliorations mineures des scripts d'import de structures

### DIFF
--- a/itou/siaes/management/commands/_import_siae/utils.py
+++ b/itou/siaes/management/commands/_import_siae/utils.py
@@ -3,6 +3,7 @@
 Various helpers shared by the import_siae, import_geiq and import_ea_eatt scripts.
 
 """
+import os
 from functools import wraps
 from time import time
 
@@ -10,6 +11,8 @@ from itou.siaes.models import Siae
 from itou.utils.address.models import AddressMixin
 from itou.utils.apis.geocoding import get_geocoding_data
 
+
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 SHOW_IMPORT_SIAE_METHOD_TIMER = False
 
@@ -35,6 +38,30 @@ def timeit(f):
         return result
 
     return wrap
+
+
+def get_filename(filename_prefix, filename_extension, description):
+    """
+    Automatically detect the correct filename.
+    e.g. fluxIAE_Structure_14122020_075350.csv
+    e.g. fluxIAE_AnnexeFinanciere_14122020_063002.csv
+    """
+    filenames = []
+    path = f"{CURRENT_DIR}/../data"
+    for filename in os.listdir(path):
+        root, ext = os.path.splitext(filename)
+        if root.startswith(filename_prefix) and ext == filename_extension:
+            filenames.append(filename)
+
+    if len(filenames) == 0:
+        raise RuntimeError(f"No match found for {description}")
+    if len(filenames) > 1:
+        raise RuntimeError(f"Too many matches for {description}")
+    assert len(filenames) == 1
+
+    filename = filenames[0]
+    print(f"Selected file {filename} for {description}.")
+    return os.path.join(path, filename)
 
 
 def clean_string(s):

--- a/itou/siaes/management/commands/_import_siae/vue_af.py
+++ b/itou/siaes/management/commands/_import_siae/vue_af.py
@@ -17,23 +17,16 @@ For convenience we systematically call such an (asp_id, kind) identifier
 an "siae_key" throughout the import_siae.py script code.
 
 """
-import os
-
 import pandas as pd
 from django.utils import timezone
 
-from itou.siaes.management.commands._import_siae.utils import remap_columns, timeit
+from itou.siaes.management.commands._import_siae.utils import get_filename, remap_columns, timeit
 from itou.siaes.models import Siae, SiaeFinancialAnnex
 from itou.utils.validators import validate_af_number
 
 
-CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-VUE_AF_FILENAME = f"{CURRENT_DIR}/../data/fluxIAE_AnnexeFinanciere_14122020_063002.csv"
-
-
 @timeit
-def get_vue_af_df(filename=VUE_AF_FILENAME):
+def get_vue_af_df():
     """
     "Vue AF" is short for "Vue Annexes Financières".
     This export makes us able to know which siae is or is not "conventionnée" as of today.
@@ -45,6 +38,10 @@ def get_vue_af_df(filename=VUE_AF_FILENAME):
     - end_date
     - state
     """
+    filename = get_filename(
+        filename_prefix="fluxIAE_AnnexeFinanciere_", filename_extension=".csv", description="Vue AF"
+    )
+
     df = pd.read_csv(
         filename,
         sep="|",

--- a/itou/siaes/management/commands/_import_siae/vue_structure.py
+++ b/itou/siaes/management/commands/_import_siae/vue_structure.py
@@ -11,22 +11,15 @@ It contains almost all data to build a siae from scratch with 2 exceptions:
 - it does not contain the auth_email (see "Liste Correspondants technique" instead).
 
 """
-import os
-
 import numpy as np
 import pandas as pd
 
-from itou.siaes.management.commands._import_siae.utils import remap_columns, timeit
+from itou.siaes.management.commands._import_siae.utils import get_filename, remap_columns, timeit
 from itou.utils.validators import validate_naf, validate_siret
 
 
-CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-VUE_STRUCTURE_FILENAME = f"{CURRENT_DIR}/../data/fluxIAE_Structure_14122020_075350.csv"
-
-
 @timeit
-def get_vue_structure_df(filename=VUE_STRUCTURE_FILENAME):
+def get_vue_structure_df():
     """
     The "Vue Structure" export has the following fields:
     - asp_id
@@ -40,6 +33,10 @@ def get_vue_structure_df(filename=VUE_STRUCTURE_FILENAME):
     - kind (found in the "Vue AF" export)
     - website (nowhere to be found)
     """
+    filename = get_filename(
+        filename_prefix="fluxIAE_Structure_", filename_extension=".csv", description="Vue Structure"
+    )
+
     df = pd.read_csv(
         filename,
         sep="|",

--- a/itou/siaes/management/commands/import_ea_eatt.py
+++ b/itou/siaes/management/commands/import_ea_eatt.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import numpy as np
 import pandas as pd
@@ -8,6 +7,7 @@ from django.core.management.base import BaseCommand
 from itou.siaes.management.commands._import_siae.utils import (
     clean_string,
     geocode_siae,
+    get_filename,
     remap_columns,
     sync_structures,
     timeit,
@@ -15,11 +15,6 @@ from itou.siaes.management.commands._import_siae.utils import (
 from itou.siaes.models import Siae
 from itou.utils.address.departments import department_from_postcode
 from itou.utils.validators import validate_siret
-
-
-CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-EA_EATT_DATASET_FILENAME = f"{CURRENT_DIR}/data/Liste_Contact_EA_20201214.xlsx"
 
 
 def convert_kind(raw_kind):
@@ -31,7 +26,11 @@ def convert_kind(raw_kind):
 
 
 @timeit
-def get_ea_eatt_df(filename=EA_EATT_DATASET_FILENAME):
+def get_ea_eatt_df():
+    filename = get_filename(
+        filename_prefix="Liste_Contact_EA_", filename_extension=".xlsx", description="Export EA/EATT"
+    )
+
     df = pd.read_excel(filename, converters={"SIRET": str, "CODE_POST": str})
 
     column_mapping = {

--- a/itou/siaes/management/commands/import_geiq.py
+++ b/itou/siaes/management/commands/import_geiq.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import numpy as np
 import pandas as pd
@@ -8,6 +7,7 @@ from django.core.management.base import BaseCommand
 from itou.siaes.management.commands._import_siae.utils import (
     clean_string,
     geocode_siae,
+    get_filename,
     remap_columns,
     sync_structures,
     timeit,
@@ -17,13 +17,10 @@ from itou.utils.address.departments import department_from_postcode
 from itou.utils.validators import validate_siret
 
 
-CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-GEIQ_DATASET_FILENAME = f"{CURRENT_DIR}/data/Geiq_-_liste_02-10-2020.xls"
-
-
 @timeit
-def get_geiq_df(filename=GEIQ_DATASET_FILENAME):
+def get_geiq_df():
+    filename = get_filename(filename_prefix="Geiq_-_liste_", filename_extension=".xls", description="Export GEIQ")
+
     df = pd.read_excel(filename, converters={"siret": str, "zip": str})
 
     column_mapping = {


### PR DESCRIPTION
### Quoi ?

Améliorations mineures des scripts d'import de structures

1) Détection automatique des noms de fichiers.

2) Attente de 7 jours avant de supprimer des GEIQ/EA crées par le staff et non plus suppression immédiate.

### Pourquoi ?

1) Pour simplifier les imports. Plus besoin d'un commit à chaque fois! Je vais MAJ la doc du repo privée aussi.

2) Sans ce changement, si une GEIQ/EA a été créée juste avant l'import, elle sera supprimée si personne ne s'y est encore inscrit. Avec ce changement, on donne 7 jours à la personne pour s'inscrire avant de virer sa structure.

