### PR TITLE
Boost design

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -38,7 +38,7 @@ class JobApplicationWorkflow(xwf_models.Workflow):
     STATE_CHOICES = (
         (STATE_NEW, _("Nouvelle candidature")),
         (STATE_PROCESSING, _("Candidature à l'étude")),
-        (STATE_POSTPONED, _("Embauche pour plus tard")),
+        (STATE_POSTPONED, _("Candidature en liste d'attente")),
         (STATE_ACCEPTED, _("Candidature acceptée")),
         (STATE_REFUSED, _("Candidature déclinée")),
         (STATE_CANCELLED, _("Embauche annulée")),

--- a/itou/templates/apply/includes/list_card_body.html
+++ b/itou/templates/apply/includes/list_card_body.html
@@ -43,6 +43,10 @@
                 {% if job_application.sender_kind == job_application.SENDER_KIND_SIAE_STAFF %}
                     <br>
                     <b>{{ job_application.sender_siae.display_name }}</b>
+                    {% if siae == job_application.sender_siae %}
+                        <br>
+                        <span class="badge badge-info">{% translate "Auto-prescription" %}</span>
+                    {% endif %}
                 {% endif %}
 
             </p>

--- a/itou/templates/apply/includes/list_card_body.html
+++ b/itou/templates/apply/includes/list_card_body.html
@@ -43,7 +43,7 @@
                 {% if job_application.sender_kind == job_application.SENDER_KIND_SIAE_STAFF %}
                     <br>
                     <b>{{ job_application.sender_siae.display_name }}</b>
-                    {% if siae == job_application.sender_siae %}
+                    {% if request.user.is_siae_staff %}
                         <br>
                         <span class="badge badge-info">{% translate "Auto-prescription" %}</span>
                     {% endif %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -35,7 +35,7 @@
 
             {% include "apply/includes/list_card_header.html" with job_application=job_application %}
 
-            {% include "apply/includes/list_card_body.html" with job_application=job_application siae=siae %}
+            {% include "apply/includes/list_card_body.html" with job_application=job_application %}
 
             <div class="card-footer">
                 <div class="row">
@@ -56,7 +56,7 @@
                         <div class="col-sm-3">
                             <span class="text-muted text-nowrap">
                                 {% blocktranslate with cancellation_date=job_application.cancellation_delay_end|date:"d/m/Y" %}
-                                    PASS IAE disponible au téléchargement après le {{cancellation_date}}
+                                    PASS IAE disponible au téléchargement après le {{ cancellation_date }}
                                 {% endblocktranslate %}
                             </span>
                         </div>

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -45,7 +45,7 @@
                     {% if job_application.can_download_approval_as_pdf %}
                         <div class="col-sm-3">
                             <a href="{% url 'approvals:approval_as_pdf' job_application_id=job_application.id %}" class="text-decoration-none disable-on-click matomo-event" data-matomo-category="agrement" data-matomo-action="telechargement-pdf" data-matomo-option="liste-candidatures">
-                                {% translate "Télécharger l'attestation" %}
+                                {% translate "Télécharger le PASS IAE" %}
                             </a>
                         </div>
                     {% endif %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -32,7 +32,7 @@
 
             {% include "apply/includes/list_card_header.html" with job_application=job_application %}
 
-            {% include "apply/includes/list_card_body.html" with job_application=job_application %}
+            {% include "apply/includes/list_card_body.html" with job_application=job_application siae=siae %}
 
             <div class="card-footer">
                 <div class="row">

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -12,12 +12,15 @@
     <h1>{% translate "Candidatures reçues" %}</h1>
     <h2 class="text-muted">{{ siae.display_name }}</h2>
 
-    <div class="alert alert-primary mt-3" role="alert">
-        {% blocktranslate %}
-            Toute demande de PASS IAE doit être effectuée <b>au plus tard le jour de l'embauche</b>.<br>
-            Les demandes rétroactives ne sont pas autorisées.
-        {% endblocktranslate %}
-    </div>
+    {% if siae.is_subject_to_eligibility_rules %}
+        <div class="alert alert-primary mt-3" role="alert">
+            {% blocktranslate %}
+                Toute demande de PASS IAE doit être effectuée <b>au plus tard le jour de l'embauche</b>.<br>
+                Les demandes rétroactives ne sont pas autorisées.
+            {% endblocktranslate %}
+        </div>
+    {% endif %}
+
     {% include "apply/includes/job_applications_filters.html" with filters=filters filters_form=filters_form %}
 
     {% if not job_applications_page %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -52,6 +52,15 @@
                             </a>
                         </div>
                     {% endif %}
+                    {% if siae.is_subject_to_eligibility_rules and job_application.approval and job_application.can_be_cancelled %}
+                        <div class="col-sm-3">
+                            <span class="text-muted text-nowrap">
+                                {% blocktranslate with cancellation_date=job_application.cancellation_delay_end|date:"d/m/Y" %}
+                                    PASS IAE disponible au téléchargement après le {{cancellation_date}}
+                                {% endblocktranslate %}
+                            </span>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
 

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -56,7 +56,7 @@
                                 data-matomo-category="agrement"
                                 data-matomo-action="telechargement-pdf"
                                 data-matomo-option="details-candidature">
-                                    {% translate "Télécharger l'attestation" %}
+                                    {% translate "Télécharger le PASS IAE" %}
                             </a>
                         {% endif %}
                     {% endif %}

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -62,7 +62,7 @@
                         {% if job_application.can_be_cancelled %}
                             <a class="btn btn-outline-secondary disabled w-100">
                                     {% blocktranslate with cancellation_date=job_application.cancellation_delay_end|date:"d/m/Y" %}
-                                        Disponible au téléchargement après le {{cancellation_date}}
+                                        Disponible au téléchargement après le {{ cancellation_date }}
                                     {% endblocktranslate %}
                             </a>
                         {% endif %}

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -59,6 +59,13 @@
                                     {% translate "Télécharger le PASS IAE" %}
                             </a>
                         {% endif %}
+                        {% if job_application.can_be_cancelled %}
+                            <a class="btn btn-outline-secondary disabled w-100">
+                                    {% blocktranslate with cancellation_date=job_application.cancellation_delay_end|date:"d/m/Y" %}
+                                        Disponible au téléchargement après le {{cancellation_date}}
+                                    {% endblocktranslate %}
+                            </a>
+                        {% endif %}
                     {% endif %}
 
                 </div>

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -32,7 +32,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                 "badge": "badge-danger",
             },
             {
-                "name": _("Candidatures acceptées et embauches prévues"),
+                "name": _("Candidatures acceptées ou mises en liste d'attente"),
                 "states": [JobApplicationWorkflow.STATE_ACCEPTED, JobApplicationWorkflow.STATE_POSTPONED],
                 "icon": "user-check",
                 "badge": "badge-secondary",


### PR DESCRIPTION
Le titre et la description sont en français et au format texte.

## SIAE > liste des candidatures > Nouveau badge
Mise en avant des auto-prescriptions à travers l'ajout d'un badge.

![image](https://user-images.githubusercontent.com/6150920/103661567-296e7100-4f6f-11eb-9d96-7f5f4c75e657.png)

## Le bouton "Télécharger l'attestation" devient "Télécharger le PASS IAE"
Bouton présent côté Prescripteur à deux endroits : dans la liste des candidatures et dans le détail d'une candidature.

## Pour les GEIQ et les EA, retrait de la note informative "Pass IAE et demande rétroactive"
Ces entreprises ne sont pas concernées par le PASS IAE.

![image](https://user-images.githubusercontent.com/6150920/103662932-cd0c5100-4f70-11eb-8bdb-2c057945cfe5.png)

## Mise à jour du nom d'un statut
"Embauche pour plus tard" a été remplacé par "Candidature en liste d'attente".

![image](https://user-images.githubusercontent.com/6150920/103673153-8b35d780-4f7d-11eb-8799-f6548e9db010.png)

![image](https://user-images.githubusercontent.com/6150920/103673212-9c7ee400-4f7d-11eb-9f97-08046f0b52fd.png)
 
![image](https://user-images.githubusercontent.com/6150920/103665067-45741180-4f73-11eb-9bc8-71c692132a74.png)

## Affichage de la date à laquelle il sera possible de télécharger un PASS IAE

![image](https://user-images.githubusercontent.com/6150920/103672674-e6b39580-4f7c-11eb-9b8e-6511ad48cbc3.png)
![image](https://user-images.githubusercontent.com/6150920/103672714-f4691b00-4f7c-11eb-8bff-4971e061cc09.png)

## Ajout d'un message informatif concernant les nouveaux membres
Le premier membre d'une structure ou d'une organisation est automatiquement nommé administrateur mais ce rôle laisse perplexe de nombreux usagers. Ajoutons un message informatif qui s'affiche pendant une semaine et qui dirige vers la documentation.
 
![image](https://user-images.githubusercontent.com/6150920/103885346-2c3ca380-50e0-11eb-9404-95325209567a.png)
