### PR TITLE
Ajout de la possibilité de modifier une suspension

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -241,24 +241,6 @@ class Approval(CommonApprovalMixin):
             and not self.user.last_accepted_job_application.can_be_cancelled
         )
 
-    def suspend(self, start_at, end_at, siae, reason, reason_explanation, created_by):
-        """
-        Suspend current Approval.
-        """
-        if not self.can_be_suspended_by_siae(siae):
-            raise RuntimeError(_("Approval cannot be suspended by this SIAE."))
-        suspension = Suspension(
-            approval=self,
-            start_at=start_at,
-            end_at=end_at,
-            siae=siae,
-            reason=reason,
-            reason_explanation=reason_explanation,
-            created_by=created_by,
-        )
-        suspension.save()
-        return suspension
-
     @staticmethod
     def get_next_number(hiring_start_at=None):
         """
@@ -502,6 +484,12 @@ class Suspension(models.Model):
         }
         return self._meta.model.objects.exclude(pk=self.pk).filter(**args)
 
+    def can_be_updated_by_siae(self, siae):
+        """
+        Only the SIAE currently hiring the job seeker can edit a suspension.
+        """
+        return self.is_in_progress and siae == self.approval.user.last_accepted_job_application.to_siae
+
     @staticmethod
     def get_max_end_at(start_at):
         return start_at + relativedelta(months=Suspension.MAX_DURATION_MONTHS) - relativedelta(days=1)
@@ -511,8 +499,6 @@ class Suspension(models.Model):
         """
         Used when adding a new suspension to the given approval.
         """
-        if approval.is_suspended:
-            raise RuntimeError(_("A suspension is already in progress."))
         if approval.last_old_suspension:
             return approval.last_old_suspension.end_at + relativedelta(days=1)
         return approval.user.last_accepted_job_application.hiring_start_at

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -492,12 +492,15 @@ class Suspension(models.Model):
 
     @staticmethod
     def get_max_end_at(start_at):
+        """
+        Returns the maximum date on which a suspension can end.
+        """
         return start_at + relativedelta(months=Suspension.MAX_DURATION_MONTHS) - relativedelta(days=1)
 
     @staticmethod
     def next_min_start_at(approval):
         """
-        Used when adding a new suspension to the given approval.
+        Returns the minimum date on which a suspension can begin.
         """
         if approval.last_old_suspension:
             return approval.last_old_suspension.end_at + relativedelta(days=1)

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -326,50 +326,6 @@ class ApprovalModelTest(TestCase):
         siae2 = SiaeFactory()
         self.assertFalse(job_application.approval.can_be_suspended_by_siae(siae2))
 
-    def test_suspend(self):
-
-        today = datetime.date.today()
-
-        # Create a job application with an approval.
-        job_application = JobApplicationWithApprovalFactory(
-            state=JobApplicationWorkflow.STATE_ACCEPTED,
-            # Ensure that the job_application cannot be canceled.
-            hiring_start_at=today
-            - relativedelta(days=JobApplication.CANCELLATION_DAYS_AFTER_HIRING_STARTED)
-            - relativedelta(days=1),
-        )
-
-        # Prepare suspension data.
-        approval = job_application.approval
-        data = {
-            "start_at": today,
-            "end_at": today + relativedelta(months=3),
-            "siae": job_application.to_siae,
-            "reason": Suspension.Reason.MATERNITY,
-            "reason_explanation": "",
-            "created_by": job_application.to_siae.members.first(),
-        }
-
-        # Suspend approval.
-        suspension = approval.suspend(
-            start_at=data["start_at"],
-            end_at=data["end_at"],
-            siae=data["siae"],
-            reason=data["reason"],
-            reason_explanation=data["reason_explanation"],
-            created_by=data["created_by"],
-        )
-
-        # Check suspension data.
-        suspension = approval.suspension_set.first()
-        self.assertEqual(suspension.approval, approval)
-        self.assertEqual(suspension.start_at, data["start_at"])
-        self.assertEqual(suspension.end_at, data["end_at"])
-        self.assertEqual(suspension.siae, data["siae"])
-        self.assertEqual(suspension.reason, data["reason"])
-        self.assertEqual(suspension.reason_explanation, data["reason_explanation"])
-        self.assertEqual(suspension.created_by, data["created_by"])
-
     def test_get_or_create_from_valid(self):
 
         # With an existing valid `PoleEmploiApproval`.

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load static %}
+{% load call_method %}
 {% comment %}
 
     Usage:
@@ -56,12 +57,14 @@
                             du {{ start }} au {{ end }}
                         {% endblocktranslate %}
                         <small>({{ s.get_reason_display }})</small>
-                        {% if s.is_in_progress and current_siae and current_siae == approval.user.last_accepted_job_application.to_siae %}
-                            <a href="{% url 'approvals:suspension_update' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">
-                                <small>{% translate "Modifier" %}</small>
-                            </a>
+                        {% if current_siae %}
+                            {% call_method s "can_be_updated_by_siae" current_siae as can_be_updated %}
+                            {% if can_be_updated %}
+                                <a href="{% url 'approvals:suspension_update' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">
+                                    <small>{% translate "Modifier" %}</small>
+                                </a>
+                            {% endif %}
                         {% endif %}
-
                     </li>
                 {% endfor %}
             </ul>

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -60,11 +60,6 @@
                             <a href="{% url 'approvals:suspension_update' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">
                                 <small>{% translate "Modifier" %}</small>
                             </a>
-                            {% comment %}
-                            <a href="{% url 'approvals:suspension_update' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">
-                                <small>{% translate "Annuler" %}</small>
-                            </a>
-                            {% endcomment %}
                         {% endif %}
 
                     </li>

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -56,6 +56,17 @@
                             du {{ start }} au {{ end }}
                         {% endblocktranslate %}
                         <small>({{ s.get_reason_display }})</small>
+                        {% if s.is_in_progress and current_siae and current_siae == approval.user.last_accepted_job_application.to_siae %}
+                            <a href="{% url 'approvals:suspension_update' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">
+                                <small>{% translate "Modifier" %}</small>
+                            </a>
+                            {% comment %}
+                            <a href="{% url 'approvals:suspension_update' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">
+                                <small>{% translate "Annuler" %}</small>
+                            </a>
+                            {% endcomment %}
+                        {% endif %}
+
                     </li>
                 {% endfor %}
             </ul>

--- a/itou/templates/approvals/includes/suspension_reason_alert.html
+++ b/itou/templates/approvals/includes/suspension_reason_alert.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+
+<div class="alert alert-warning pb-0" role="alert">
+    <p>
+        {% translate "Un abandon de poste, une fin de contrat de travail, ou tout autre motif ne figurant pas dans la liste officielle des motifs de suspension, ne peuvent donner lieu à une suspension." %}
+    </p>
+    <p>
+        {% translate "Pour plus d'informations, consultez" %}
+        <a href="https://doc.inclusion.beta.gouv.fr/pourquoi-une-plateforme-de-linclusion/pass-iae-agrement-plus-simple-cest-a-dire#suspension" rel="noopener" target="_blank">
+            {% translate "la note dédiée aux suspensions" %}
+            {% include "includes/icon.html" with icon="external-link" %}
+        </a>
+        {% translate "avant de faire votre demande." %}
+    </p>
+</div>

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -34,19 +34,7 @@
             {% for field in form %}
                 {# Display a warning message before the "reason" field. #}
                 {% if field.name == "reason" %}
-                    <div class="alert alert-warning pb-0" role="alert">
-                        <p>
-                            {% translate "Un abandon de poste, une fin de contrat de travail, ou tout autre motif ne figurant pas dans la liste officielle des motifs de suspension, ne peuvent donner lieu à une suspension." %}
-                        </p>
-                        <p>
-                            {% translate "Pour plus d'informations, consultez" %}
-                            <a href="https://doc.inclusion.beta.gouv.fr/pourquoi-une-plateforme-de-linclusion/pass-iae-agrement-plus-simple-cest-a-dire#suspension" rel="noopener" target="_blank">
-                                {% translate "la note dédiée aux suspensions" %}
-                                {% include "includes/icon.html" with icon="external-link" %}
-                            </a>
-                            {% translate "avant de faire votre demande." %}
-                        </p>
-                    </div>
+                    {% include "approvals/includes/suspension_reason_alert.html" %}
                 {% endif %}
                 {% bootstrap_field field %}
             {% endfor %}

--- a/itou/templates/approvals/suspension_update.html
+++ b/itou/templates/approvals/suspension_update.html
@@ -1,0 +1,48 @@
+{% extends "layout/content_small.html" %}
+{% load i18n %}
+{% load bootstrap4 %}
+
+{% block title %}{% translate "Modifier la suspension de PASS IAE" %}{{ block.super }}{% endblock %}
+
+{% block content %}
+
+    <h1>
+        {% blocktranslate with full_name=suspension.approval.user.get_full_name|title %}
+            Modifier la suspension de PASS IAE
+            <br>
+            <span class="text-muted">{{ full_name }}</span>
+        {% endblocktranslate %}
+    </h1>
+
+    <form method="post" action="" class="js-prevent-multiple-submit">
+
+        {% csrf_token %}
+
+        {% bootstrap_form_errors form %}
+
+        {% for field in form %}
+            {# Display a warning message before the "reason" field. #}
+            {% if field.name == "reason" %}
+                {% include "approvals/includes/suspension_reason_alert.html" %}
+            {% endif %}
+            {% bootstrap_field field %}
+        {% endfor %}
+
+        {% buttons %}
+            <a class="btn btn-secondary" href="{{ back_url }}">
+                {% translate "Retour" %}
+            </a>
+            <button type="submit" class="btn btn-primary">
+                {% translate "Valider la suspension" %}
+            </button>
+        {% endbuttons %}
+
+    </form>
+
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <!-- Needed to use the Datepicker JS widget. -->
+    {{ form.media }}
+{% endblock %}

--- a/itou/utils/templatetags/call_method.py
+++ b/itou/utils/templatetags/call_method.py
@@ -1,0 +1,20 @@
+"""
+https://docs.djangoproject.com/en/dev/howto/custom-template-tags/
+"""
+from django import template
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def call_method(obj, method_name, *args):
+    """
+    Allows to pass arguments to model methods in Django templates.
+
+    Usage:
+        {% load call_method %}
+        {% call_method obj 'method_name' argument %}
+    """
+    method = getattr(obj, method_name)
+    return method(*args)

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -411,6 +411,16 @@ class UtilsTemplateTagsTestCase(TestCase):
         expected = "?page=1"
         self.assertEqual(out, expected)
 
+    def test_call_method(self):
+        """Test `call_method` template tag."""
+        siae = SiaeWithMembershipFactory()
+        user = siae.members.first()
+        context = {"siae": siae, "user": user}
+        template = Template("{% load call_method %}{% call_method siae 'has_member' user %}")
+        out = template.render(Context(context))
+        expected = "True"
+        self.assertEqual(out, expected)
+
 
 class UtilsTemplateFiltersTestCase(TestCase):
     def test_format_phone(self):

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -16,15 +16,15 @@ class SuspensionForm(forms.ModelForm):
         self.approval = approval
         super().__init__(*args, **kwargs)
 
-        today = timezone.now().date()
+        if not self.instance:
+            today = timezone.now().date()
+            min_start_at_str = Suspension.next_min_start_at(self.approval).strftime("%Y/%m/%d")
+            max_end_at_str = Suspension.get_max_end_at(today).strftime("%Y/%m/%d")
+            today_str = today.strftime("%Y/%m/%d")
+            # A suspension is backdatable but cannot start in the future.
+            self.fields["start_at"].widget = DatePickerField({"minDate": min_start_at_str, "maxDate": today_str})
+            self.fields["end_at"].widget = DatePickerField({"minDate": min_start_at_str, "maxDate": max_end_at_str})
 
-        min_start_at_str = Suspension.next_min_start_at(self.approval).strftime("%Y/%m/%d")
-        max_end_at_str = Suspension.get_max_end_at(today).strftime("%Y/%m/%d")
-        today_str = today.strftime("%Y/%m/%d")
-
-        # A suspension is backdatable but cannot start in the future.
-        self.fields["start_at"].widget = DatePickerField({"minDate": min_start_at_str, "maxDate": today_str})
-        self.fields["end_at"].widget = DatePickerField({"minDate": min_start_at_str, "maxDate": max_end_at_str})
         for field in ["start_at", "end_at"]:
             self.fields[field].input_formats = [DatePickerField.DATE_FORMAT]
 

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -42,6 +42,8 @@ class SuspensionForm(forms.ModelForm):
             "siae": forms.HiddenInput(),
             "approval": forms.HiddenInput(),
             "reason": forms.RadioSelect(),
+            "start_at": DatePickerField(),
+            "end_at": DatePickerField(),
         }
         help_texts = {
             "start_at": mark_safe(

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -7,9 +7,9 @@ from itou.approvals.models import Suspension
 from itou.utils.widgets import DatePickerField
 
 
-class SuspendApprovalForm(forms.ModelForm):
+class SuspensionForm(forms.ModelForm):
     """
-    Suspend an approval.
+    Create or edit a suspension.
     """
 
     def __init__(self, approval, *args, **kwargs):

--- a/itou/www/approvals_views/tests/tests.py
+++ b/itou/www/approvals_views/tests/tests.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.utils.http import urlencode
 from requests import exceptions as requests_exceptions
 
+from itou.approvals.factories import SuspensionFactory
 from itou.approvals.models import Suspension
 from itou.eligibility.factories import EligibilityDiagnosisFactory
 from itou.job_applications.factories import JobApplicationFactory, JobApplicationWithApprovalFactory
@@ -103,6 +104,9 @@ class TestDownloadApprovalAsPDF(TestCase):
 
 class ApprovalSuspendViewTest(TestCase):
     def test_suspend_approval(self):
+        """
+        Test the creation of a suspension.
+        """
 
         today = timezone.now().date()
 
@@ -157,3 +161,57 @@ class ApprovalSuspendViewTest(TestCase):
         self.assertRedirects(response, back_url)
 
         self.assertEqual(1, approval.suspension_set.count())
+        suspension = approval.suspension_set.first()
+        self.assertEqual(suspension.created_by, siae_user)
+
+    def test_update_suspension(self):
+        """
+        Test the update of a suspension.
+        """
+
+        today = timezone.now().date()
+
+        job_application = JobApplicationWithApprovalFactory(
+            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            # Ensure that the job_application cannot be canceled.
+            hiring_start_at=today
+            - relativedelta(days=JobApplication.CANCELLATION_DAYS_AFTER_HIRING_STARTED)
+            - relativedelta(days=1),
+        )
+
+        approval = job_application.approval
+        siae_user = job_application.to_siae.members.first()
+        start_at = today
+        end_at = today + relativedelta(days=10)
+
+        suspension = SuspensionFactory(approval=approval, start_at=start_at, end_at=end_at, created_by=siae_user)
+
+        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+
+        back_url = "/"
+        params = urlencode({"back_url": back_url})
+        url = reverse("approvals:suspension_update", kwargs={"suspension_id": suspension.pk})
+        url = f"{url}?{params}"
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        new_end_at = end_at + relativedelta(days=30)
+
+        post_data = {
+            "approval": suspension.approval.pk,
+            "start_at": suspension.start_at.strftime("%d/%m/%Y"),
+            "end_at": new_end_at.strftime("%d/%m/%Y"),
+            "siae": suspension.siae.pk,
+            "reason": suspension.reason,
+            "reason_explanation": suspension.reason_explanation,
+        }
+
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, back_url)
+
+        self.assertEqual(1, approval.suspension_set.count())
+        suspension = approval.suspension_set.first()
+        self.assertEqual(suspension.updated_by, siae_user)
+        self.assertEqual(suspension.end_at, new_end_at)

--- a/itou/www/approvals_views/urls.py
+++ b/itou/www/approvals_views/urls.py
@@ -9,4 +9,5 @@ app_name = "approvals"
 urlpatterns = [
     path("download/<uuid:job_application_id>", views.approval_as_pdf, name="approval_as_pdf"),
     path("suspend/<int:approval_id>", views.suspend, name="suspend"),
+    path("suspension/<int:suspension_id>/edit", views.suspension_update, name="suspension_update"),
 ]


### PR DESCRIPTION
### Quoi ?

Nouvelle interface permettant de modifier une suspension.

### Pourquoi ?

Les gens se trompent parfois de date de début et de date de fin ou bien une suspension peut être raccourcie ou prolongée.

### Captures d'écran

![a](https://user-images.githubusercontent.com/281139/103785605-b121b180-503b-11eb-8df2-b726e3dcbdd0.png)

---

![b](https://user-images.githubusercontent.com/281139/103785609-b252de80-503b-11eb-9de7-61b6e64ee3f2.png)
