### PR TITLE
Améliorations mineures du script d'import des SIAE

### DIFF
--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -69,9 +69,9 @@ def update_existing_conventions(dry_run):
                 convention.siret_signature = siret_signature
                 convention.save()
 
-        is_active = does_siae_have_an_active_convention(siae)
-        if convention.is_active != is_active:
-            if is_active:
+        should_be_active = does_siae_have_an_active_convention(siae)
+        if convention.is_active != should_be_active:
+            if should_be_active:
                 reactivations += 1
                 if not dry_run:
                     convention.is_active = True

--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -16,6 +16,13 @@ def update_existing_conventions(dry_run):
     and check data integrity on the fly.
     """
     for siae in Siae.objects.filter(source=Siae.SOURCE_ASP, convention__isnull=False).select_related("convention"):
+        if siae.siret not in SIRET_TO_ASP_ID:
+            # This can happen in a dry run only, when a siae should have changed
+            # its SIRET during update_siret_and_auth_email_of_existing_siaes()
+            # but did not yet due to dry run.
+            assert dry_run
+            print(f"ignored unknown siret of siae.id={siae.id} due to dry run")
+            continue
         asp_id = SIRET_TO_ASP_ID[siae.siret]
         siret_signature = ASP_ID_TO_SIRET_SIGNATURE[asp_id]
 

--- a/itou/siaes/management/commands/_import_siae/utils.py
+++ b/itou/siaes/management/commands/_import_siae/utils.py
@@ -45,14 +45,15 @@ def timeit(f):
 def get_filename(filename_prefix, filename_extension, description):
     """
     Automatically detect the correct filename.
+    File can be gzipped or not.
     e.g. fluxIAE_Structure_14122020_075350.csv
-    e.g. fluxIAE_AnnexeFinanciere_14122020_063002.csv
+    e.g. fluxIAE_AnnexeFinanciere_14122020_063002.csv.gz
     """
     filenames = []
+    extensions = (filename_extension, f"{filename_extension}.gz")
     path = f"{CURRENT_DIR}/../data"
     for filename in os.listdir(path):
-        root, ext = os.path.splitext(filename)
-        if root.startswith(filename_prefix) and ext == filename_extension:
+        if filename.startswith(filename_prefix) and filename.endswith(extensions):
             filenames.append(filename)
 
     if len(filenames) == 0:


### PR DESCRIPTION
### Quoi ?

- Problème majeur: les données du 4 janvier 2021 ne contiennent aucune AF pour 2021. Bref en théorie on devrait désactiver et mettre en période de grâce la totalité de nos structures o_O. Du coup ajout d'un switch pour gérer cette situation exceptionnelle qui se reproduira chaque année.
- Par convénience, il n'est plus nécessaire de dézipper les CSV de l'ASP

### Pourquoi ?

A l'occasion des données ASP du 4 janvier 2021.
