### PR TITLE
Boost design

### DIFF
--- a/itou/invitations/admin.py
+++ b/itou/invitations/admin.py
@@ -27,7 +27,7 @@ class BaseInvitationAdmin(admin.ModelAdmin):
     search_fields = ("email", "sender__email")
     # https://code.djangoproject.com/ticket/30354
     list_filter = ("accepted", IsValidFilter)
-    readonly_fields = ("is_valid", "created_at", "sent_at", "accepted_at")
+    readonly_fields = ("is_valid", "created_at", "sent_at", "accepted_at", "acceptance_link")
     raw_id_fields = ("sender",)
 
     def get_queryset(self, request):
@@ -36,8 +36,12 @@ class BaseInvitationAdmin(admin.ModelAdmin):
     def is_valid(self, obj):
         return not obj.has_expired
 
+    def acceptance_link(self, obj):
+        return obj.acceptance_link
+
     is_valid.boolean = True
     is_valid.short_description = _("En cours de validité")
+    acceptance_link.short_description = _("Lien")
 
 
 @admin.register(SiaeStaffInvitation)

--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -84,4 +84,4 @@ class JobApplicationTransitionLogAdmin(admin.ModelAdmin):
     list_filter = ("transition",)
     raw_id_fields = ("job_application", "user")
     readonly_fields = ("job_application", "transition", "from_state", "to_state", "user", "timestamp")
-    search_fields = ("transition", "user__username")
+    search_fields = ("transition", "user__username", "job_application__pk")

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -222,6 +222,9 @@ class JobApplicationEmailTest(TestCase):
         self.assertIn(job_application.sender.get_full_name(), email.body)
         self.assertIn(job_application.sender.email, email.body)
         self.assertIn(format_filters.format_phone(job_application.sender.phone), email.body)
+        self.assertIn(job_application.to_siae.display_name, email.body)
+        self.assertIn(job_application.to_siae.city, email.body)
+        self.assertIn(str(job_application.to_siae.pk), email.body)
 
     def test_new_for_prescriber(self):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(

--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -98,7 +98,7 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
     fieldsets = (
         (
             _("Structure"),
-            {"fields": ("siret", "kind", "name", "phone", "email", "code_safir_pole_emploi", "is_authorized")},
+            {"fields": ("pk", "siret", "kind", "name", "phone", "email", "code_safir_pole_emploi", "is_authorized")},
         ),
         (
             _("Adresse"),
@@ -142,6 +142,7 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
     )
     raw_id_fields = ("created_by",)
     readonly_fields = (
+        "pk",
         "coords",  # Quick tip to disable GeoDjango's Openlayers map.
         "created_by",
         "created_at",

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -84,6 +84,7 @@ class SiaeAdmin(admin.ModelAdmin):
     list_filter = (SiaeHasMembersFilter, "kind", "block_job_applications", "source", "department")
     raw_id_fields = ("created_by", "convention")
     readonly_fields = (
+        "pk",
         "coords",  # Quick tip to disable GeoDjango's Openlayers map.
         "source",
         "created_by",
@@ -96,6 +97,7 @@ class SiaeAdmin(admin.ModelAdmin):
             _("SIAE"),
             {
                 "fields": (
+                    "pk",
                     "siret",
                     "naf",
                     "kind",

--- a/itou/templates/apply/email/new_for_siae_body.txt
+++ b/itou/templates/apply/email/new_for_siae_body.txt
@@ -48,6 +48,8 @@
 
 {% endif %}
 
+{% translate "Candidature envoyée à l'entreprise" %} {{ job_application.to_siae.display_name }}, {{ job_application.to_siae.city }}. Identifiant sur la plateforme : {{ job_application.to_siae.pk }}.
+
 {% blocktranslate %}
 Toute demande de PASS IAE doit être effectuée au plus tard le jour de l'embauche. Les demandes rétroactives ne sont pas autorisées.
 {% endblocktranslate %}

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -134,12 +134,14 @@ class ItouUserAdmin(UserAdmin):
     ordering = ("-id",)
     raw_id_fields = ("created_by",)
     search_fields = UserAdmin.search_fields + ("pk",)
+    readonly_fields = ("pk",)
 
     fieldsets = UserAdmin.fieldsets + (
         (
             _("Informations"),
             {
                 "fields": (
+                    "pk",
                     "birthdate",
                     "phone",
                     "resume_link",


### PR DESCRIPTION
## Invitations - ajout du lien dans l'espace d'administration de Django

Certains utilisateurs ne reçoivent pas le mail leur permettant d'accepter une invitation et le support ne peut rien faire. Cette modification leur permet de copier / coller le lien d'une invitation afin de l'envoyer aux utilisateurs peinés.

![image](https://user-images.githubusercontent.com/6150920/104300510-df354480-54c6-11eb-985d-47e5291a012e.png)

## Ajout d'informations dans l'email de candidature à destination des employeurs

Les employeurs membres de plusieurs structures ne savent pas à qui sont destinées les nouvelles candidatures. Ajoutons donc le nom, la ville et l'identifiant de l'entreprise destinataire.

![image](https://user-images.githubusercontent.com/6150920/104303637-a008f280-54ca-11eb-992c-a34d1c7cd7c2.png)

## Affichage de certains identifiants dans l'espace d'administration de Django

Fiches concernées : structures, organisations et utilisateurs.

![image](https://user-images.githubusercontent.com/6150920/104306973-f1b37c00-54ce-11eb-951b-2c7079ef6526.png)

## Admin, rubrique "log des transitions des candidatures", recherche par PK de candidature