### PR TITLE
Migration vers emploi.inclusion.beta.gouv.fr

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -307,7 +307,7 @@ API_GEO_BASE_URL = "https://geo.api.gouv.fr"
 # https://dashboard.entreprise.api.gouv.fr/login (login is done through auth.api.gouv.fr)
 # https://doc.entreprise.api.gouv.fr/
 API_ENTREPRISE_BASE_URL = "https://entreprise.api.gouv.fr/v2"
-API_ENTREPRISE_CONTEXT = "inclusion.beta.gouv.fr"
+API_ENTREPRISE_CONTEXT = "emplois.inclusion.beta.gouv.fr"
 API_ENTREPRISE_RECIPIENT = os.environ.get("API_ENTREPRISE_RECIPIENT")
 API_ENTREPRISE_TOKEN = os.environ.get("API_ENTREPRISE_TOKEN")
 
@@ -351,7 +351,7 @@ TYPEFORM_SECRET = os.environ.get("TYPEFORM_SECRET")
 # Environment, sets the type of env of the app (DEMO, REVIEW_APP, STAGING, DEV…)
 ITOU_ENVIRONMENT = "PROD"
 ITOU_PROTOCOL = "https"
-ITOU_FQDN = "inclusion.beta.gouv.fr"
+ITOU_FQDN = "emplois.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact@inclusion.beta.gouv.fr"
 ITOU_EMAIL_ASSISTANCE = "assistance@inclusion.beta.gouv.fr"
 
@@ -369,7 +369,7 @@ ITOU_EMAIL_PRESCRIBER_NEW_HIRING_URL = "https://startupsbeta.typeform.com/to/X40
 # Some external libraries, as PDF Shift, need access to static files
 # but they can't access them when working locally.
 # Use the staging domain name when this case arises.
-ITOU_STAGING_DN = "staging.inclusion.beta.gouv.fr"
+ITOU_STAGING_DN = "staging.emplois.inclusion.beta.gouv.fr"
 
 SHOW_TEST_ACCOUNTS_BANNER = False
 

--- a/config/settings/demo.py
+++ b/config/settings/demo.py
@@ -1,7 +1,7 @@
 from .base import *
 from ._sentry import sentry_init
 
-ALLOWED_HOSTS = ["127.0.0.1", ".cleverapps.io", "demo.inclusion.beta.gouv.fr"]
+ALLOWED_HOSTS = ["127.0.0.1", ".cleverapps.io", "demo.inclusion.beta.gouv.fr", "demo.emploi.inclusion.beta.gouv.fr"]
 
 DATABASES = {
     "default": {

--- a/config/settings/demo.py
+++ b/config/settings/demo.py
@@ -16,7 +16,7 @@ DATABASES = {
 
 ITOU_ENVIRONMENT = "DEMO"
 ITOU_PROTOCOL = "https"
-ITOU_FQDN = "demo.inclusion.beta.gouv.fr"
+ITOU_FQDN = "demo.emplois.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact+demo@inclusion.beta.gouv.fr"
 DEFAULT_FROM_EMAIL = "noreply+demo@inclusion.beta.gouv.fr"
 

--- a/config/settings/demo.py
+++ b/config/settings/demo.py
@@ -1,7 +1,7 @@
 from .base import *
 from ._sentry import sentry_init
 
-ALLOWED_HOSTS = ["127.0.0.1", ".cleverapps.io", "demo.inclusion.beta.gouv.fr", "demo.emploi.inclusion.beta.gouv.fr"]
+ALLOWED_HOSTS = ["127.0.0.1", ".cleverapps.io", "demo.inclusion.beta.gouv.fr", "demo.emplois.inclusion.beta.gouv.fr"]
 
 DATABASES = {
     "default": {

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -1,7 +1,7 @@
 from .base import *
 from ._sentry import sentry_init
 
-ALLOWED_HOSTS = ["itou-prod.cleverapps.io", "inclusion.beta.gouv.fr", "emploi.inclusion.beta.gouv.fr"]
+ALLOWED_HOSTS = ["itou-prod.cleverapps.io", "inclusion.beta.gouv.fr", "emplois.inclusion.beta.gouv.fr"]
 
 DATABASES = {
     "default": {

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -16,7 +16,7 @@ DATABASES = {
 
 ITOU_ENVIRONMENT = "PROD"
 ITOU_PROTOCOL = "https"
-ITOU_FQDN = "inclusion.beta.gouv.fr"
+ITOU_FQDN = "emplois.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact@inclusion.beta.gouv.fr"
 DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"
 

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -1,7 +1,7 @@
 from .base import *
 from ._sentry import sentry_init
 
-ALLOWED_HOSTS = ["itou-prod.cleverapps.io", "inclusion.beta.gouv.fr"]
+ALLOWED_HOSTS = ["itou-prod.cleverapps.io", "inclusion.beta.gouv.fr", "emploi.inclusion.beta.gouv.fr"]
 
 DATABASES = {
     "default": {

--- a/config/settings/review_apps.py
+++ b/config/settings/review_apps.py
@@ -16,7 +16,7 @@ DATABASES = {
 
 ITOU_ENVIRONMENT = "REVIEW_APP"
 ITOU_PROTOCOL = "https"
-ITOU_FQDN = os.environ.get("DEPLOY_URL", "staging.inclusion.beta.gouv.fr")
+ITOU_FQDN = os.environ.get("DEPLOY_URL", "staging.emplois.inclusion.beta.gouv.fr")
 ITOU_EMAIL_CONTACT = "contact+staging@inclusion.beta.gouv.fr"
 DEFAULT_FROM_EMAIL = "noreply+staging@inclusion.beta.gouv.fr"
 

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -1,7 +1,7 @@
 from .base import *
 from ._sentry import sentry_init
 
-ALLOWED_HOSTS = ["127.0.0.1", "staging.inclusion.beta.gouv.fr"]
+ALLOWED_HOSTS = ["127.0.0.1", "staging.inclusion.beta.gouv.fr", "staging.emploi.inclusion.beta.gouv.fr"]
 
 DATABASES = {
     "default": {

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -16,7 +16,7 @@ DATABASES = {
 
 ITOU_ENVIRONMENT = "STAGING"
 ITOU_PROTOCOL = "https"
-ITOU_FQDN = "staging.inclusion.beta.gouv.fr"
+ITOU_FQDN = "staging.emplois.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact+staging@inclusion.beta.gouv.fr"
 DEFAULT_FROM_EMAIL = "noreply+staging@inclusion.beta.gouv.fr"
 

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -1,7 +1,7 @@
 from .base import *
 from ._sentry import sentry_init
 
-ALLOWED_HOSTS = ["127.0.0.1", "staging.inclusion.beta.gouv.fr", "staging.emploi.inclusion.beta.gouv.fr"]
+ALLOWED_HOSTS = ["127.0.0.1", "staging.inclusion.beta.gouv.fr", "staging.emplois.inclusion.beta.gouv.fr"]
 
 DATABASES = {
     "default": {

--- a/itou/templates/account/email/email_confirmation_message.txt
+++ b/itou/templates/account/email/email_confirmation_message.txt
@@ -10,4 +10,4 @@ Afin de finaliser votre inscription, cliquez sur le lien suivant :{% endblocktr
 {% if itou_environment == "DEMO" %}
 {% blocktranslate %}[DEMO] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEMO]{% endblocktranslate %}
 {% endif %}
-inclusion.beta.gouv.fr{% endautoescape %}
+emplois.inclusion.beta.gouv.fr{% endautoescape %}

--- a/itou/templates/account/email/password_reset_key_message.txt
+++ b/itou/templates/account/email/password_reset_key_message.txt
@@ -12,4 +12,4 @@ Nous vous invitons pour cela à cliquer sur le lien ci-dessous pour le réinitia
 Cet email a été envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte. Pour le bon développement de la Plateforme de l'inclusion, l'équipe ITOU a parfois besoin de réaliser des tests de fonctionnement. Nous vous prions sincèrement de nous en excuser. [DEMO]
 {% endblocktranslate %} 
 {% endif %}
-inclusion.beta.gouv.fr{% endautoescape %}
+emplois.inclusion.beta.gouv.fr{% endautoescape %}

--- a/itou/templates/approvals/includes/suspension_reason_alert.html
+++ b/itou/templates/approvals/includes/suspension_reason_alert.html
@@ -6,7 +6,7 @@
     </p>
     <p>
         {% translate "Pour plus d'informations, consultez" %}
-        <a href="https://doc.inclusion.beta.gouv.fr/pourquoi-une-plateforme-de-linclusion/pass-iae-agrement-plus-simple-cest-a-dire#suspension" rel="noopener" target="_blank">
+        <a href="{{ ITOU_DOC_URL }}/pourquoi-une-plateforme-de-linclusion/pass-iae-agrement-plus-simple-cest-a-dire#suspension" rel="noopener" target="_blank">
             {% translate "la note dédiée aux suspensions" %}
             {% include "includes/icon.html" with icon="external-link" %}
         </a>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -171,7 +171,7 @@
                                 {% include "includes/icon.html" with icon="award" %}
                                 <span>
                                     {% blocktranslate with name=current_prescriber_organization.display_name %}
-                                        {{ name }} est une organisation habilitée. Vous pouvez réaliser le <a href="https://doc.inclusion.beta.gouv.fr/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique#diagnostic_de_reference" target="_blank">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
+                                        {{ name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique#diagnostic_de_reference" target="_blank">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
                                     {% endblocktranslate %}
                                 </span>
                             </p>
@@ -271,7 +271,7 @@
                         <p class="card-text">
                             {% include "includes/icon.html" with icon="book-open" %}
                             <a
-                                href="https://doc.inclusion.beta.gouv.fr/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1"
+                                href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1"
                                 target="_blank">
                                     {% translate "Liste des critères d'éligibilité" %}
                             </a>

--- a/itou/templates/home/home.html
+++ b/itou/templates/home/home.html
@@ -58,7 +58,7 @@
                             <h5 class="card-title font-weight-light mb-4">
                                 {% translate "Découvrez l'espace de documentation pour tout comprendre" %}
                             </h5>
-                            <a class="btn btn-primary" href="https://doc.inclusion.beta.gouv.fr/" target=_blank>
+                            <a class="btn btn-primary" href="{{ ITOU_DOC_URL }}/" target=_blank>
                                 {% translate "En savoir plus" %}
                             </a>
                         </div>

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -19,7 +19,7 @@
     <meta property="og:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
     {# https://metatags.io Twitter #}
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }/">
+    <meta property="twitter:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}/">
     <meta property="twitter:title" content="{% translate "La plateforme de l'inclusion" %}">
     <meta property="twitter:description" content="{% translate "La plateforme de l'inclusion facilite le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs solidaires (structures de l'insertion par l'activité économique et du secteur adapté)" %}">
     <meta property="twitter:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
@@ -44,7 +44,7 @@
             <div class="layout-header py-2 px-0 px-sm-3">
                 <a href="/" class="text-decoration-none text-reset">
                     <div class="row pt-1 pl-3">
-                        <img src="{% static 'img/logo_header.svg' %}" alt="emplois.inclusion.beta.gouv.fr" class="layout-header-logo img-fluid">
+                        <img src="{% static 'img/logo_header.svg' %}" alt="{{ ITOU_FQDN }}" class="layout-header-logo img-fluid">
                     </div>
                 </a>
                 <div class="layout-header-content">
@@ -335,7 +335,7 @@
         {% endif %}
     {% endblock %}
 
-    {% if "emplois.inclusion.beta.gouv.fr" in ALLOWED_HOSTS %}
+    {% if ITOU_FQDN in ALLOWED_HOSTS %}
         {# Matomo/Piwik open source web analytics #}
         <script>
             var _paq = window._paq || [];

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -44,7 +44,7 @@
             <div class="layout-header py-2 px-0 px-sm-3">
                 <a href="/" class="text-decoration-none text-reset">
                     <div class="row pt-1 pl-3">
-                        <img src="{% static 'img/logo_header.svg' %}" alt="inclusion.beta.gouv.fr" class="layout-header-logo img-fluid">
+                        <img src="{% static 'img/logo_header.svg' %}" alt="emplois.inclusion.beta.gouv.fr" class="layout-header-logo img-fluid">
                     </div>
                 </a>
                 <div class="layout-header-content">
@@ -335,7 +335,7 @@
         {% endif %}
     {% endblock %}
 
-    {% if "inclusion.beta.gouv.fr" in ALLOWED_HOSTS %}
+    {% if "emplois.inclusion.beta.gouv.fr" in ALLOWED_HOSTS %}
         {# Matomo/Piwik open source web analytics #}
         <script>
             var _paq = window._paq || [];

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -178,7 +178,7 @@
 
                 <a class="nav-link" href="https://forum.inclusion.beta.gouv.fr" rel="noopener" target="_blank" aria-label="{% translate "Accéder au Forum de l'inclusion (nouvel onglet)" %}">{% translate "Forum" %} {% include "includes/icon.html" with icon="external-link" title=external_link_title %}</a>
 
-                <a class="nav-link" href="https://doc.inclusion.beta.gouv.fr/" rel="noopener" target="_blank" aria-label="{% translate "Accéder à l'espace de documentation (nouvel onglet)" %}">{% translate "Documentation" %} {% include "includes/icon.html" with icon="external-link" title=external_link_title %}</a>
+                <a class="nav-link" href="{{ ITOU_DOC_URL }}/" rel="noopener" target="_blank" aria-label="{% translate "Accéder à l'espace de documentation (nouvel onglet)" %}">{% translate "Documentation" %} {% include "includes/icon.html" with icon="external-link" title=external_link_title %}</a>
 
             </nav>
         </div>
@@ -239,7 +239,7 @@
                         <div class="col-sm-6">
                             <ul class="list-unstyled">
                                 <li>
-                                    <a href="https://doc.inclusion.beta.gouv.fr/reponses-a-mes-questions-faq?q=" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
+                                    <a href="{{ ITOU_DOC_URL }}/reponses-a-mes-questions-faq?q=" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
                                         {% translate "Besoin d'aide ?" %}
                                         {% include "includes/icon.html" with icon="external-link" title=external_link_title %}
                                     </a>
@@ -255,7 +255,7 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://doc.inclusion.beta.gouv.fr/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
+                                    <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
                                         {% translate "Qui peut bénéficier des contrats d'IAE ?" %}
                                         {% include "includes/icon.html" with icon="external-link" title=external_link_title %}
                                     </a>
@@ -267,7 +267,7 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://doc.inclusion.beta.gouv.fr/mentions/" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
+                                    <a href="{{ ITOU_DOC_URL }}/mentions/" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
                                         {% translate "Mentions légales" %}
                                         {% include "includes/icon.html" with icon="external-link" title=external_link_title %}
                                     </a>
@@ -313,7 +313,7 @@
             "removeCredit": true,  /* Remove credit link */
             "moreInfoLink": true,  /* Show more info link */
             "useExternalCss": false,  /* If false, the tarteaucitron.css file will be loaded */
-            "readmoreLink": "https://doc.inclusion.beta.gouv.fr/mentions/protection-des-donnees",  /* Change the default readmore link */
+            "readmoreLink": "{{ ITOU_DOC_URL }}/mentions/protection-des-donnees",  /* Change the default readmore link */
             "mandatory": false,  /* Show a message about mandatory cookies */
         });
 

--- a/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
+++ b/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
@@ -11,7 +11,7 @@ Si vous êtes bien un prescripteur habilité, nous avons besoin d'une preuve de 
 
 - si vous êtes une organisation habilitée par le préfet : merci de nous communiquer par retour de mail l'arrêté préfectoral portant mention de votre habilitation à valider l'éligibilité IAE des candidats. Pensez à nous communiquer l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
 
-- si votre organisation appartient à la liste des organisations habilitées au national (https://doc.inclusion.beta.gouv.fr/pourquoi-une-plateforme-de-linclusion/qui-sont-les-differents-prescripteurs/prescripteur-habilite#liste-des-prescripteurs-habilites-en-national) : merci de nous communiquer par retour de mail le type de structure et l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
+- si votre organisation appartient à la liste des organisations habilitées au national ({{ itou_doc_url }}/pourquoi-une-plateforme-de-linclusion/qui-sont-les-differents-prescripteurs/prescripteur-habilite#liste-des-prescripteurs-habilites-en-national) : merci de nous communiquer par retour de mail le type de structure et l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
 
 - si vous êtes une organisation conventionnée par un Conseil départemental pour le suivi des BRSA : vous devez demander au Conseil départemental de nous adresser un mail à {{ itou_email_assistance }} afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail). Communiquez à cette personne l'ID de votre structure en lui demandant de le mentionner dans l'e-mail attestant de votre habilitation pour que nous fassions le rapprochement
 

--- a/itou/templates/signup/includes/submit_rgpd.html
+++ b/itou/templates/signup/includes/submit_rgpd.html
@@ -14,14 +14,14 @@
 
             {% translate "Pour plus d'information sur le traitement de vos données personnelles ou pour exercer vos droits, consultez" %}
 
-            <a href="https://doc.inclusion.beta.gouv.fr/mentions/protection-des-donnees" rel="noopener" target="_blank">
+            <a href="{{ ITOU_DOC_URL }}/mentions/protection-des-donnees" rel="noopener" target="_blank">
                 {% translate "la section Protection des données" %}
                 {% include "includes/icon.html" with icon="external-link" %}
             </a>.
 
             {% translate 'En cliquant sur le bouton "Inscription", vous acceptez' %}
 
-            <a href="https://doc.inclusion.beta.gouv.fr/mentions/cgu" rel="noopener" target="_blank">
+            <a href="{{ ITOU_DOC_URL }}/mentions/cgu" rel="noopener" target="_blank">
                 {% translate "les conditions générales d'utilisation" %}
                 {% include "includes/icon.html" with icon="external-link" %}
             </a>.

--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -17,7 +17,7 @@
             {% translate "Les organisations habilitées permettent à leurs collaborateurs de valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique. Cette habilitation est officialisée par arrêté préfectoral." %}
         </p>
         <p>
-            <a href="https://doc.inclusion.beta.gouv.fr/pourquoi-une-plateforme-de-linclusion/qui-sont-les-differents-prescripteurs" rel="noopener" target="_blank">{% translate "En savoir plus sur les différents prescripteurs" %} {% include "includes/icon.html" with icon="external-link" %}</a>
+            <a href="{{ ITOU_DOC_URL }}/pourquoi-une-plateforme-de-linclusion/qui-sont-les-differents-prescripteurs" rel="noopener" target="_blank">{% translate "En savoir plus sur les différents prescripteurs" %} {% include "includes/icon.html" with icon="external-link" %}</a>
         </p>
     </div>
 

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -28,6 +28,7 @@ def remove_extra_line_breaks(text):
 def get_email_text_template(template, context):
     context.update(
         {
+            "itou_doc_url": settings.ITOU_DOC_URL,
             "itou_protocol": settings.ITOU_PROTOCOL,
             "itou_fqdn": settings.ITOU_FQDN,
             "itou_email_assistance": settings.ITOU_EMAIL_ASSISTANCE,

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -9,8 +9,9 @@ def expose_settings(request):
 
     return {
         "ALLOWED_HOSTS": settings.ALLOWED_HOSTS,
-        "ITOU_EMAIL_CONTACT": settings.ITOU_EMAIL_CONTACT,
+        "ITOU_DOC_URL": settings.ITOU_DOC_URL,
         "ITOU_EMAIL_ASSISTANCE": settings.ITOU_EMAIL_ASSISTANCE,
+        "ITOU_EMAIL_CONTACT": settings.ITOU_EMAIL_CONTACT,
         "ITOU_ENVIRONMENT": settings.ITOU_ENVIRONMENT,
         "ITOU_FQDN": settings.ITOU_FQDN,
         "ITOU_PROTOCOL": settings.ITOU_PROTOCOL,

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -390,11 +390,13 @@ class UtilsTemplateTagsTestCase(TestCase):
 
         # Full URL.
         context = {
-            "url": "https://inclusion.beta.gouv.fr/siae/search?distance=100&city=aubervilliers-93&page=55&page=1"
+            "url": "https://emplois.inclusion.beta.gouv.fr/siae/search?distance=100&city=aubervilliers-93&page=55&page=1"
         }
         template = Template("{% load url_add_query %}{% url_add_query url page=2 %}")
         out = template.render(Context(context))
-        expected = "https://inclusion.beta.gouv.fr/siae/search?distance=100&amp;city=aubervilliers-93&amp;page=2"
+        expected = (
+            "https://emplois.inclusion.beta.gouv.fr/siae/search?distance=100&amp;city=aubervilliers-93&amp;page=2"
+        )
         self.assertEqual(out, expected)
 
         # Relative URL.

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -388,15 +388,12 @@ class UtilsTemplateTagsTestCase(TestCase):
     def test_url_add_query(self):
         """Test `url_add_query` template tag."""
 
+        base_url = "https://emplois.inclusion.beta.gouv.fr"
         # Full URL.
-        context = {
-            "url": "https://emplois.inclusion.beta.gouv.fr/siae/search?distance=100&city=aubervilliers-93&page=55&page=1"
-        }
+        context = {"url": f"{base_url}/siae/search?distance=100&city=aubervilliers-93&page=55&page=1"}
         template = Template("{% load url_add_query %}{% url_add_query url page=2 %}")
         out = template.render(Context(context))
-        expected = (
-            "https://emplois.inclusion.beta.gouv.fr/siae/search?distance=100&amp;city=aubervilliers-93&amp;page=2"
-        )
+        expected = f"{base_url}/siae/search?distance=100&amp;city=aubervilliers-93&amp;page=2"
         self.assertEqual(out, expected)
 
         # Relative URL.


### PR DESCRIPTION
### Quoi ?

Migration vers `emploi.inclusion.beta.gouv.fr` depuis `inclusion.beta.gouv.fr`.

### Pourquoi ?

Pour libérer le nom de domaine `inclusion.beta.gouv.fr` qui deviendra une _landing page_ dans le but de clarifier la galaxie Itou.