### PR TITLE
BUG: l'export XLS des PASS IAE freeze la plateforme

### DIFF
--- a/itou/approvals/export.py
+++ b/itou/approvals/export.py
@@ -13,7 +13,7 @@ from itou.job_applications.models import JobApplication
 # XLS export of currently valid approvals
 # Currently used by admin site and admin command (export_approvals)
 
-LOG = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 FIELDS = [
     "id_pole_emploi",
@@ -57,7 +57,7 @@ def export_approvals(export_format="file"):
     current_dt = datetime.datetime.now()
     ws.title = "Export PASS SIAE " + current_dt.strftime(DATE_FMT)
 
-    LOG.info("Loading data...")
+    logger.info("Loading data...")
     data = [FIELDS]
 
     st = time.clock()
@@ -89,13 +89,13 @@ def export_approvals(export_format="file"):
         ]
         data.append(line)
 
-    LOG.info(f"Took: {time.clock() - st} sec.")
+    logger.info(f"Took: {time.clock() - st} sec.")
 
     # These values were formerly computed dynamically in the rendering loop
     # It is *way* faster to use static values to change the width of columns once
     max_widths = [14, 39, 33, 14, 15, 19, 17, 11, 37, 21, 14, 73, 9, 19, 19]
 
-    LOG.info("Writing data...")
+    logger.info("Writing data...")
     st = time.clock()
     for i, row in enumerate(data, 1):
         for j, cell_value in enumerate(row, 1):
@@ -105,8 +105,8 @@ def export_approvals(export_format="file"):
     for idx, width in enumerate(max_widths, 1):
         ws.column_dimensions[get_column_letter(idx)].width = width
 
-    LOG.info(f"Exported {export_count} records")
-    LOG.info(f"Took: {time.clock() - st} sec.")
+    logger.info(f"Exported {export_count} records")
+    logger.info(f"Took: {time.clock() - st} sec.")
 
     suffix = current_dt.strftime("%d%m%Y_%H%M%S")
     filename = f"export_pass_iae_{suffix}.xlsx"

--- a/itou/approvals/export.py
+++ b/itou/approvals/export.py
@@ -1,7 +1,7 @@
 import datetime
+import logging
 import time
 from tempfile import NamedTemporaryFile
-import logging
 
 from django.conf import settings
 from openpyxl import Workbook

--- a/itou/approvals/export.py
+++ b/itou/approvals/export.py
@@ -1,11 +1,12 @@
 import datetime
+import time
+from tempfile import NamedTemporaryFile
 
 from django.conf import settings
 from openpyxl import Workbook
 from openpyxl.utils import get_column_letter
-from openpyxl.writer.excel import save_virtual_workbook
 
-from itou.approvals.models import Approval
+from itou.job_applications.models import JobApplication
 
 
 # XLS export of currently valid approvals
@@ -51,37 +52,51 @@ def export_approvals(export_format="file"):
     current_dt = datetime.datetime.now()
     ws.title = "Export PASS SIAE " + current_dt.strftime(DATE_FMT)
 
+    print("Loading data...")
     data = [FIELDS]
-    approvals = Approval.objects.all().select_related("user").prefetch_related("jobapplication_set__to_siae")
 
-    for approval in approvals:
-        # The same approval can be used for multiple job applications.
-        for job_application in approval.jobapplication_set.all():
-            line = [
-                approval.user.pole_emploi_id,
-                approval.user.first_name,
-                approval.user.last_name,
-                approval.user.birthdate.strftime(DATE_FMT),
-                approval.number,
-                approval.start_at.strftime(DATE_FMT),
-                approval.end_at.strftime(DATE_FMT),
-                approval.user.post_code,
-                approval.user.city,
-                job_application.to_siae.post_code,
-                job_application.to_siae.siret,
-                job_application.to_siae.name,
-                job_application.to_siae.kind,
-            ]
-            data.append(line)
+    st = time.clock()
 
-    # Getting the column to auto-adjust to max field size
-    max_width = [0] * (len(FIELDS) + 1)
+    # Let try
+    job_applications = JobApplication.objects.exclude(approval=None).select_related(
+        "job_seeker", "approval", "to_siae"
+    )
 
+    for ja in job_applications:
+        line = [
+            ja.job_seeker.pole_emploi_id,
+            ja.job_seeker.first_name,
+            ja.job_seeker.last_name,
+            ja.job_seeker.birthdate.strftime(DATE_FMT),
+            ja.approval.number,
+            ja.approval.start_at.strftime(DATE_FMT),
+            ja.approval.end_at.strftime(DATE_FMT),
+            ja.job_seeker.post_code,
+            ja.job_seeker.city,
+            ja.to_siae.post_code,
+            ja.to_siae.siret,
+            ja.to_siae.name,
+            ja.to_siae.kind,
+        ]
+        data.append(line)
+
+    print(f"Took: {time.clock() - st} sec.")
+
+    # These values were formerly computed dynamically in the rendering loop
+    # It is *way* faster to use static values to change the width of columns once
+    max_widths = [14, 39, 33, 14, 15, 19, 17, 11, 37, 21, 14, 73, 9]
+
+    print("Writing data...")
+    st = time.clock()
     for i, row in enumerate(data, 1):
         for j, cell_value in enumerate(row, 1):
-            max_width[j] = max(max_width[j], len(cell_value))
             ws.cell(i, j).value = cell_value
-            ws.column_dimensions[get_column_letter(j)].width = max_width[j]
+
+    # Formating columns once (not in the loop)
+    for idx, width in enumerate(max_widths, 1):
+        ws.column_dimensions[get_column_letter(idx)].width = width
+
+    print(f"Took: {time.clock() - st} sec.")
 
     suffix = current_dt.strftime("%d%m%Y_%H%M%S")
     filename = f"export_pass_iae_{suffix}.xlsx"
@@ -91,4 +106,8 @@ def export_approvals(export_format="file"):
         wb.save(path)
         return path
     elif export_format == "stream":
-        return filename, save_virtual_workbook(wb)
+        # save_virtual_workbook is deprecated
+        with NamedTemporaryFile() as tmp_file:
+            wb.save(tmp_file.name)
+            tmp_file.seek(0)
+            return filename, tmp_file.read()

--- a/itou/approvals/management/commands/export_approvals.py
+++ b/itou/approvals/management/commands/export_approvals.py
@@ -18,8 +18,5 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         self.stdout.write("Exporting approvals / PASS IAE")
-
         result = export_approvals()
-
-        self.stdout.write("Done!")
         self.stdout.write(f"Approvals / PASS IAE export file written to: '{result}'")

--- a/itou/approvals/management/commands/export_approvals.py
+++ b/itou/approvals/management/commands/export_approvals.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     help = "Export the content of the Approvals from the database into an xlsx file."
 
     def handle(self, **options):
-        self.stdout.write("Exporting approvals")
+        self.stdout.write("Exporting approvals / PASS IAE")
 
         result = export_approvals()
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,10 @@ pytz==2020.1  # https://github.com/stub42/pytz
 requests==2.24.0  # https://github.com/psf/requests
 python-dateutil==2.8.1  # https://pypi.org/project/python-dateutil/
 openpyxl==3.0.3  # https://openpyxl.readthedocs.io/en/stable/
+
+# lxml improves performance of Excel file generation with openpyxl
 lxml==4.6.2  # https://lxml.de/
+
 Unidecode==1.1.1  # https://github.com/avian2/unidecode
 
 # Django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,7 @@ pytz==2020.1  # https://github.com/stub42/pytz
 requests==2.24.0  # https://github.com/psf/requests
 python-dateutil==2.8.1  # https://pypi.org/project/python-dateutil/
 openpyxl==3.0.3  # https://openpyxl.readthedocs.io/en/stable/
+lxml==4.6.2  # https://lxml.de/
 Unidecode==1.1.1  # https://github.com/avian2/unidecode
 
 # Django


### PR DESCRIPTION
### Quoi ?

Modification et optimisation de l'utilitaire d'export des PASS IAE au format Excel.

### Pourquoi ?

L'utilisation de cet utilitaire via l'admin Django fige la plateforme (temps de rendu trop long)

N'impacte pas la génération via Management Command.

### Comment ?

- optimisation du changement de la taille des cellules
- changement de la requête SQL, pas flagrant en temps de traitement mais plus lisible
- utilisation de fichiers temporaires au lieu de la méthode `save_virtual_workbook` (deprecated)
- ajout de `lxml` pour le rendering XLS (plus rapide)

### Autre (optionnel)

Les tests en mode `WRITE_ONLY` sont non-concluants:
- vraiment plus lents pour la génération (petit gain au streaming toutefois)
- nécessite une modification du code
- bousille le formatage des cellules

A tester en staging / recette avec données, d'ou la présence des `print` et des timers.
(pas taper)

