### PR TITLE
Modification des informations d'un candidat 

### DIFF
--- a/itou/fixtures/django/04_test_users.json
+++ b/itou/fixtures/django/04_test_users.json
@@ -256,7 +256,6 @@
    "pk": 8,
    "fields": {
       "password": "pbkdf2_sha256$180000$CPDNpTjYqjR1$skD6ISRz3Q1/9PsgtJagpxfjWZzpWydnQwMvbXgT0yA=",
-      "last_login": "2020-04-09T14:08:07Z",
       "is_superuser": false,
       "username": "test+de-proxy@inclusion.beta.gouv.fr",
       "first_name": "Sylvie",

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -401,6 +401,10 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             and self.refusal_reason == self.REFUSAL_REASON_DEACTIVATION
         )
 
+    @property
+    def can_update_job_seeker(self):
+        return (self.state.is_processing or self.state.is_accepted) and self.job_seeker.is_handled_by_proxy
+
     # Workflow transitions.
 
     @xwf_models.transition()

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -402,7 +402,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         )
 
     @property
-    def can_update_job_seeker(self):
+    def has_editable_job_seeker(self):
         return (self.state.is_processing or self.state.is_accepted) and self.job_seeker.is_handled_by_proxy
 
     # Workflow transitions.

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -12,9 +12,7 @@
     <h3 class="font-weight-normal text-muted">{% translate "Candidat" %}</h3>
 
     <ul>
-
-        <li>{% translate "Date de la candidature :" %} <b>{{ job_application.created_at|date:"d F Y à H:i" }}</b></li>
-
+        
         <li>{% translate "Prénom :" %} <b>{{ job_application.job_seeker.first_name }}</b></li>
 
         <li>{% translate "Nom :" %} <b>{{ job_application.job_seeker.last_name }}</b></li>
@@ -43,6 +41,25 @@
                     href="{{ job_application.job_seeker.resume_link }}">{{ job_application.job_seeker.resume_link }}</a>
             </li>
         {% endif %}
+    
+    </ul>
+
+    {% if job_application.can_update_job_seeker %}
+        <p>
+            <a href="{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
+               class="btn btn-outline-primary btn-block">
+                {% translate "Modifier les informations" %}
+            </a>
+        </p>
+    {% endif %}
+
+    {# Job application info ------------------------------------------------------------------------- #}
+
+    <hr>
+    <h3 class="font-weight-normal text-muted">{% translate "Candidature" %}</h3>
+
+    <ul>
+        <li>{% translate "Date de la candidature :" %} <b>{{ job_application.created_at|date:"d F Y à H:i" }}</b></li>
 
         {% if job_application.selected_jobs.exists %}
             <li>
@@ -56,9 +73,8 @@
         {% else %}
             <li>{% translate "Candidature spontanée" %}</li>
         {% endif %}
-
     </ul>
-
+    
     <div class="alert alert-secondary">
         <p><b>{% translate "Message :" %}</b></p>
         {{ job_application.message|linebreaks }}

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -40,11 +40,10 @@
             <li>{% translate "Lien vers CV :" %} <a
                     href="{{ job_application.job_seeker.resume_link }}">{{ job_application.job_seeker.resume_link }}</a>
             </li>
-        {% endif %
-}
+        {% endif %}
     </ul>
 
-    {% if job_application.can_update_job_seeker %}
+    {% if job_application.has_editable_job_seeker %}
         <p>
             <a href="{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
                class="btn btn-outline-primary btn-block">

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -12,7 +12,7 @@
     <h3 class="font-weight-normal text-muted">{% translate "Candidat" %}</h3>
 
     <ul>
-        
+
         <li>{% translate "Prénom :" %} <b>{{ job_application.job_seeker.first_name }}</b></li>
 
         <li>{% translate "Nom :" %} <b>{{ job_application.job_seeker.last_name }}</b></li>
@@ -40,8 +40,8 @@
             <li>{% translate "Lien vers CV :" %} <a
                     href="{{ job_application.job_seeker.resume_link }}">{{ job_application.job_seeker.resume_link }}</a>
             </li>
-        {% endif %}
-    
+        {% endif %
+}
     </ul>
 
     {% if job_application.can_update_job_seeker %}
@@ -74,7 +74,7 @@
             <li>{% translate "Candidature spontanée" %}</li>
         {% endif %}
     </ul>
-    
+
     <div class="alert alert-secondary">
         <p><b>{% translate "Message :" %}</b></p>
         {{ job_application.message|linebreaks }}

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -1,0 +1,29 @@
+{% extends "layout/content_small.html" %}
+{% load i18n %}
+{% load bootstrap4 %}
+
+{% block title %}{% translate "Modification d'un candidat" %}{{ block.super }}{% endblock %}
+
+{% block content %}
+<h1>{% translate "Candidature de" %} <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
+
+<form method="post" action="" class="js-prevent-multiple-submit js-submit-with-typeform">
+
+    {% csrf_token %}
+
+    {% bootstrap_form_errors form %}
+    {% bootstrap_form form exclude="resume_link" %}
+
+    {% buttons %}
+        <a class="btn btn-secondary" href="{{ prev_url }}">{% translate "Annuler" %}</a>
+        <button type="submit" class="btn btn-primary">{% translate "Enregistrer" %}</button>
+    {% endbuttons %}
+
+</form>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <!-- Needed to use the Datepicker JS widget. -->
+    {{ form.media }}
+{% endblock %}

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -122,6 +122,12 @@ class User(AbstractUser, AddressMixin):
             return None
         return ApprovalsWrapper(self)
 
+    @property
+    def is_handled_by_proxy(self):
+        if self.is_job_seeker and self.created_by and not self.last_login:
+            return True
+        return False
+
     @cached_property
     def is_peamu(self):
         social_accounts = self.socialaccount_set.all()

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.utils import timezone
 
 from itou.users.factories import JobSeekerFactory, PrescriberFactory, UserFactory
 
@@ -90,3 +91,15 @@ class ModelTest(TestCase):
         email = email.title()
         with self.assertRaises(ValidationError):
             UserFactory(email=email)
+
+    def test_is_handled_by_proxy(self):
+        job_seeker = JobSeekerFactory()
+        self.assertFalse(job_seeker.is_handled_by_proxy)
+
+        prescriber = PrescriberFactory()
+        job_seeker = JobSeekerFactory(created_by=prescriber)
+        self.assertTrue(job_seeker.is_handled_by_proxy)
+
+        # Job seeker activates his account. He is in control now!
+        job_seeker.last_login = timezone.now()
+        self.assertFalse(job_seeker.is_handled_by_proxy)

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -37,6 +37,8 @@ class EditUserInfoForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
     class Meta:
         model = get_user_model()
         fields = [
+            "first_name",
+            "last_name",
             "birthdate",
             "phone",
             "address_line_1",

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
+from itou.job_applications.factories import JobApplicationSentByPrescriberFactory
 from itou.siaes.factories import (
     SiaeAfterGracePeriodFactory,
     SiaeFactory,
@@ -60,6 +61,8 @@ class EditUserInfoViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
         post_data = {
+            "first_name": "Bob",
+            "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
             "phone": "0610203050",
             "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
@@ -68,6 +71,8 @@ class EditUserInfoViewTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         user = get_user_model().objects.get(id=user.id)
+        self.assertEqual(user.first_name, post_data["first_name"])
+        self.assertEqual(user.last_name, post_data["last_name"])
         self.assertEqual(user.phone, post_data["phone"])
         self.assertEqual(user.birthdate.strftime("%d/%m/%Y"), post_data["birthdate"])
 

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -1,4 +1,5 @@
 from allauth.account.models import EmailAddress, EmailConfirmationHMAC
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.test import TestCase
@@ -75,6 +76,50 @@ class EditUserInfoViewTest(TestCase):
         self.assertEqual(user.last_name, post_data["last_name"])
         self.assertEqual(user.phone, post_data["phone"])
         self.assertEqual(user.birthdate.strftime("%d/%m/%Y"), post_data["birthdate"])
+
+
+class EditJobSeekerInfo(TestCase):
+    def test_edit(self):
+        job_application = JobApplicationSentByPrescriberFactory()
+        user = job_application.to_siae.members.first()
+
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = job_application.to_siae.pk
+
+        back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+        url = f"{url}?back_url={back_url}"
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        post_data = {
+            "first_name": "Bob",
+            "last_name": "Saint Clar",
+            "birthdate": "20/12/1978",
+            "phone": "0610203050",
+            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+        }
+        response = self.client.post(url, data=post_data)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, back_url)
+
+        job_seeker = get_user_model().objects.get(id=job_application.job_seeker.id)
+        self.assertEqual(job_seeker.first_name, post_data["first_name"])
+        self.assertEqual(job_seeker.last_name, post_data["last_name"])
+        self.assertEqual(job_seeker.birthdate.strftime("%d/%m/%Y"), post_data["birthdate"])
+        self.assertEqual(job_seeker.phone, post_data["phone"])
+
+    def test_edit_not_allowed(self):
+        job_application = JobApplicationSentByPrescriberFactory()
+        user = job_application.sender
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
 
 
 class ChangeEmailViewTest(TestCase):

--- a/itou/www/dashboard/urls.py
+++ b/itou/www/dashboard/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path("", views.dashboard, name="index"),
     path("edit_user_email", views.edit_user_email, name="edit_user_email"),
     path("edit_user_info", views.edit_user_info, name="edit_user_info"),
+    path("edit_job_seeker_info/<uuid:job_application_id>", views.edit_job_seeker_info, name="edit_job_seeker_info"),
     path("switch_siae", views.switch_siae, name="switch_siae"),
     path(
         "switch_prescriber_organization", views.switch_prescriber_organization, name="switch_prescriber_organization"


### PR DESCRIPTION
### Quoi ?

Au niveau du code : 
- Modification du formulaire d'édition des informations utilisateur
- Ajout d'un bouton sur la page de détail d'une candidature
- Ajout d'une vue pour gérer la modification des informations d'un candidat par l'employeur
- Modification d'une donnée du jeu de test

µAu niveau fonctionnel : 
- Un employeur ne peut pas modifier les informations d'un candidat s'il est considéré comme "autonome", c'est-à-dire s'il s'est connecté de lui-même avec son compte, même si ce dernier a été créé par un tiers. 
- Le bouton permettant la modification apparaît si la candidature est en attente ou acceptée.

### Pourquoi ?

Les employeurs aimeraient modifier certaines informations sur leurs candidats car elles sont parfois erronées ou obsolètes.
En parallèle, les candidats aimeraient modifier leur prénom et leur nom de famille de manière autonome.

### Captures d'écran

![image](https://user-images.githubusercontent.com/6150920/105167842-88a8b580-5b19-11eb-80ed-19a1744e6b88.png)


![image](https://user-images.githubusercontent.com/6150920/105167774-6fa00480-5b19-11eb-93eb-4ae27980aeb6.png)

### Comment tester ?
- Connectez-vous avec le compte candidat et vérifiez que vous pouvez bien modifier le prénom et le nom de famille.
- Connectez-vous avec un compte employeur et vérifiez que vous pouvez modifier les informations d'un candidat si la candidature est en attente ou acceptée et si le candidat a été créé par un tiers. Concrètement, traitez les candidatures de Sylvie Martin (test+de-proxy@inclusion.beta.gouv.fr).
