### PR TITLE
Rétablissement de tblib

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,8 +1,13 @@
 -r ./base.txt
 
+ipdb==0.13.4  # https://github.com/gotcha/ipdb
+
+# tblib is used to avoid parallel tests to crash hard if an exception occurs.
+# https://code.djangoproject.com/ticket/25497#comment:6
+tblib==1.7.0  # https://github.com/ionelmc/python-tblib
+
 # Werkzeug is required to use django-extensions's runserver_plus.
 Werkzeug==1.0.1  # pyup: < 2 # https://github.com/pallets/werkzeug
-ipdb==0.13.4  # https://github.com/gotcha/ipdb
 
 # Last jedi release (0.18.0) is incompatible with ipython
 # https://github.com/ipython/ipython/issues/12740


### PR DESCRIPTION
### Quoi ?

Rétablissement de `tblib`.

### Pourquoi ?

Sans `tblib`, les [tests lancés en parallèle échouent](https://code.djangoproject.com/ticket/25497#comment:6).
