### PR TITLE
Ajout d'un middleware pour gérer les redirections vers les nouveaux domaines

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -100,7 +100,10 @@ DJANGO_MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ITOU_MIDDLEWARE = ["itou.utils.perms.middleware.ItouCurrentOrganizationMiddleware"]
+ITOU_MIDDLEWARE = [
+    "itou.utils.new_dns.middleware.NewDnsRedirectMiddleware",
+    "itou.utils.perms.middleware.ItouCurrentOrganizationMiddleware",
+]
 
 MIDDLEWARE = DJANGO_MIDDLEWARE + ITOU_MIDDLEWARE
 

--- a/itou/utils/new_dns/middleware.py
+++ b/itou/utils/new_dns/middleware.py
@@ -1,0 +1,35 @@
+from django.contrib import messages
+from django.http import HttpResponsePermanentRedirect
+from django.utils import safestring
+from django.utils.translation import gettext as _
+
+
+class NewDnsRedirectMiddleware:
+    """
+    Redirect to new domain names.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+
+        host = request.get_host().partition(":")[0]
+        new_host = None
+
+        if host == "inclusion.beta.gouv.fr":
+            new_host = "emplois.inclusion.beta.gouv.fr"
+
+        elif host == "demo.inclusion.beta.gouv.fr":
+            new_host = "demo.emplois.inclusion.beta.gouv.fr"
+
+        elif host == "staging.inclusion.beta.gouv.fr":
+            new_host = "staging.emplois.inclusion.beta.gouv.fr"
+
+        if new_host:
+            message = _(f"Notre nom de domaine change. Nous vous accueillons maintenant sur <b>{new_host}</b>")
+            message = safestring.mark_safe(message)
+            messages.warning(request, message)
+            return HttpResponsePermanentRedirect(f"https://{new_host}{request.get_full_path()}")
+
+        return self.get_response(request)

--- a/itou/utils/new_dns/tests.py
+++ b/itou/utils/new_dns/tests.py
@@ -1,0 +1,58 @@
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from itou.utils.new_dns.middleware import NewDnsRedirectMiddleware
+
+
+class NewDnsRedirectMiddlewareTest(SimpleTestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+        self.middleware = NewDnsRedirectMiddleware(HttpResponse)
+
+    @override_settings(ALLOWED_HOSTS=["inclusion.beta.gouv.fr", "emplois.inclusion.beta.gouv.fr"])
+    def test_inclusion_redirect(self):
+        path = "/accounts/login/?account_type=job_seeker"
+        request = self.request_factory.get(path, HTTP_HOST="inclusion.beta.gouv.fr")
+
+        SessionMiddleware().process_request(request)
+        MessageMiddleware().process_request(request)
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], f"https://emplois.inclusion.beta.gouv.fr{path}")
+
+    @override_settings(ALLOWED_HOSTS=["staging.inclusion.beta.gouv.fr", "staging.emplois.inclusion.beta.gouv.fr"])
+    def test_staging_redirect(self):
+        path = "/accounts/login/?account_type=job_seeker"
+        request = self.request_factory.get(path, HTTP_HOST="staging.inclusion.beta.gouv.fr")
+
+        SessionMiddleware().process_request(request)
+        MessageMiddleware().process_request(request)
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], f"https://staging.emplois.inclusion.beta.gouv.fr{path}")
+
+    @override_settings(ALLOWED_HOSTS=["demo.inclusion.beta.gouv.fr", "demo.emplois.inclusion.beta.gouv.fr"])
+    def test_demo_redirect(self):
+        path = "/accounts/login/?account_type=job_seeker"
+        request = self.request_factory.get(path, HTTP_HOST="demo.inclusion.beta.gouv.fr")
+
+        SessionMiddleware().process_request(request)
+        MessageMiddleware().process_request(request)
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], f"https://demo.emplois.inclusion.beta.gouv.fr{path}")
+
+    @override_settings(ALLOWED_HOSTS=["localhost"])
+    def test_non_redirect(self):
+        request = self.request_factory.get("/", HTTP_HOST="localhost", SERVER_PORT="8080")
+
+        SessionMiddleware().process_request(request)
+        MessageMiddleware().process_request(request)
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
### Quoi ?

Ajout d'un middleware pour gérer les redirections vers les nouveaux domaines.

### Pourquoi ?

Dans le cadre du chantier de stratégie d'identité commune ("Identité de la plateforme"), on décide de clarifier la proposition de valeur des produits ITOU auprès des différentes cibles touchées.

Par conséquent, les noms de domaines suivants changent :

- `inclusion.beta.gouv.fr` => `emplois.inclusion.beta.gouv.fr`
- `staging.inclusion.beta.gouv.fr` => `staging.emplois.inclusion.beta.gouv.fr`
- `demo.inclusion.beta.gouv.fr` => `demo.emplois.inclusion.beta.gouv.fr`

### Comment ?

Après avoir tenté pas mal de trucs dont…

- une redirection au niveau d'AlwaysData qui ne gère pas les redirections HTTPS
- une redirection via une balise `meta http-equiv="refresh"` et GitHub pages qui ne prenait pas en compte les liens profonds

…il nous reste une solution à tenter en gérant la redirection au niveau de l'application via un `middleware`.