### PR TITLE
Correctif pour afficher un message informatif à propos des nouveaux domaines

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -194,6 +194,15 @@
                         {% translate "La version de votre navigateur n'est plus supportée. Veuillez utiliser une version plus récente pour améliorer votre expérience sur notre site." %}
                     </div>
 
+                    {# Temporary message during the transition to the new domains. #}
+                    {% if "https://inclusion.beta.gouv.fr" in request.META.HTTP_REFERER or "https://staging.inclusion.beta.gouv.fr" in request.META.HTTP_REFERER or "https://demo.inclusion.beta.gouv.fr" in request.META.HTTP_REFERER %}
+                        <div class="alert alert-warning" role="alert">
+                            {% blocktranslate %}
+                                Notre nom de domaine change. Nous vous accueillons maintenant sur <b>{{ ITOU_FQDN }}</b>
+                            {% endblocktranslate %}
+                        </div>
+                    {% endif %}
+
                 {% endblock %}
             </div>
         </div>

--- a/itou/utils/new_dns/middleware.py
+++ b/itou/utils/new_dns/middleware.py
@@ -1,7 +1,4 @@
-from django.contrib import messages
 from django.http import HttpResponsePermanentRedirect
-from django.utils import safestring
-from django.utils.translation import gettext as _
 
 
 class NewDnsRedirectMiddleware:
@@ -27,9 +24,6 @@ class NewDnsRedirectMiddleware:
             new_host = "staging.emplois.inclusion.beta.gouv.fr"
 
         if new_host:
-            message = _(f"Notre nom de domaine change. Nous vous accueillons maintenant sur <b>{new_host}</b>")
-            message = safestring.mark_safe(message)
-            messages.warning(request, message)
             return HttpResponsePermanentRedirect(f"https://{new_host}{request.get_full_path()}")
 
         return self.get_response(request)

--- a/itou/utils/new_dns/tests.py
+++ b/itou/utils/new_dns/tests.py
@@ -1,5 +1,3 @@
-from django.contrib.messages.middleware import MessageMiddleware
-from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 
@@ -16,8 +14,6 @@ class NewDnsRedirectMiddlewareTest(SimpleTestCase):
         path = "/accounts/login/?account_type=job_seeker"
         request = self.request_factory.get(path, HTTP_HOST="inclusion.beta.gouv.fr")
 
-        SessionMiddleware().process_request(request)
-        MessageMiddleware().process_request(request)
         response = self.middleware(request)
 
         self.assertEqual(response.status_code, 301)
@@ -28,8 +24,6 @@ class NewDnsRedirectMiddlewareTest(SimpleTestCase):
         path = "/accounts/login/?account_type=job_seeker"
         request = self.request_factory.get(path, HTTP_HOST="staging.inclusion.beta.gouv.fr")
 
-        SessionMiddleware().process_request(request)
-        MessageMiddleware().process_request(request)
         response = self.middleware(request)
 
         self.assertEqual(response.status_code, 301)
@@ -40,8 +34,6 @@ class NewDnsRedirectMiddlewareTest(SimpleTestCase):
         path = "/accounts/login/?account_type=job_seeker"
         request = self.request_factory.get(path, HTTP_HOST="demo.inclusion.beta.gouv.fr")
 
-        SessionMiddleware().process_request(request)
-        MessageMiddleware().process_request(request)
         response = self.middleware(request)
 
         self.assertEqual(response.status_code, 301)
@@ -51,8 +43,6 @@ class NewDnsRedirectMiddlewareTest(SimpleTestCase):
     def test_non_redirect(self):
         request = self.request_factory.get("/", HTTP_HOST="localhost", SERVER_PORT="8080")
 
-        SessionMiddleware().process_request(request)
-        MessageMiddleware().process_request(request)
         response = self.middleware(request)
 
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
### Quoi ?

Correctif pour afficher un message informatif à propos des nouveaux domaines

### Pourquoi ?

L'utilisation du framework dans le _middleware_ était téméraire et ne pouvait pas fonctionner.

### Comment ?

On affiche le message dans le template de base en se basant sur l'en-tête `HTTP Referer`.