### PR TITLE
Fix pour afficher le message de changement de domaine

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -195,7 +195,7 @@
                     </div>
 
                     {# Temporary message during the transition to the new domains. #}
-                    {% if "https://inclusion.beta.gouv.fr" in request.META.HTTP_REFERER or "https://staging.inclusion.beta.gouv.fr" in request.META.HTTP_REFERER or "https://demo.inclusion.beta.gouv.fr" in request.META.HTTP_REFERER %}
+                    {% if not request.META.HTTP_REFERER %}
                         <div class="alert alert-warning" role="alert">
                             {% blocktranslate %}
                                 Notre nom de domaine change. Nous vous accueillons maintenant sur <b>{{ ITOU_FQDN }}</b>


### PR DESCRIPTION
### Quoi ?

Fix pour afficher le message de changement de domaine.

### Pourquoi ?

Les navigateurs ne font pas transiter l'en-tête HTTP referer dans les redirections.

### Comment ?

On affiche un message temporairement prévenant les usagers d'un changement de domaine uniquement quand il n'y a pas de referer, donc à chaque accès direct.