### PR TITLE
Redirection de emploi vers emplois (avec un S)

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -1,7 +1,13 @@
 from .base import *
 from ._sentry import sentry_init
 
-ALLOWED_HOSTS = ["itou-prod.cleverapps.io", "inclusion.beta.gouv.fr", "emplois.inclusion.beta.gouv.fr"]
+# See `itou.utils.new_dns.middleware.NewDnsRedirectMiddleware`.
+ALLOWED_HOSTS = [
+    "itou-prod.cleverapps.io",
+    "inclusion.beta.gouv.fr",
+    "emploi.inclusion.beta.gouv.fr",
+    "emplois.inclusion.beta.gouv.fr",
+]
 
 DATABASES = {
     "default": {

--- a/itou/utils/new_dns/middleware.py
+++ b/itou/utils/new_dns/middleware.py
@@ -14,7 +14,7 @@ class NewDnsRedirectMiddleware:
         host = request.get_host().partition(":")[0]
         new_host = None
 
-        if host == "inclusion.beta.gouv.fr":
+        if host == "inclusion.beta.gouv.fr" or host == "emploi.inclusion.beta.gouv.fr":
             new_host = "emplois.inclusion.beta.gouv.fr"
 
         elif host == "demo.inclusion.beta.gouv.fr":

--- a/itou/utils/new_dns/tests.py
+++ b/itou/utils/new_dns/tests.py
@@ -19,6 +19,16 @@ class NewDnsRedirectMiddlewareTest(SimpleTestCase):
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response["Location"], f"https://emplois.inclusion.beta.gouv.fr{path}")
 
+    @override_settings(ALLOWED_HOSTS=["emploi.inclusion.beta.gouv.fr", "emplois.inclusion.beta.gouv.fr"])
+    def test_emploi_redirect(self):
+        path = "/accounts/login/?account_type=job_seeker"
+        request = self.request_factory.get(path, HTTP_HOST="emploi.inclusion.beta.gouv.fr")
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], f"https://emplois.inclusion.beta.gouv.fr{path}")
+
     @override_settings(ALLOWED_HOSTS=["staging.inclusion.beta.gouv.fr", "staging.emplois.inclusion.beta.gouv.fr"])
     def test_staging_redirect(self):
         path = "/accounts/login/?account_type=job_seeker"


### PR DESCRIPTION
### Quoi ?

Redirection de `emploi.inclusion.beta.gouv.fr` vers `emplois.inclusion.beta.gouv.fr` (avec un `S` à emplois)

### Pourquoi ?

On suppose que des personnes vont taper `emploi` sans `s` et on ne veut pas les perdre. 