### PR TITLE
Suppression de la mention "Agrément expiré"

### DIFF
--- a/itou/metabase/management/commands/_job_applications.py
+++ b/itou/metabase/management/commands/_job_applications.py
@@ -14,7 +14,7 @@ SENDER_KIND_CHOICES = (
 
 def get_job_application_origin(ja):
     if ja.sender_kind == JobApplication.SENDER_KIND_PRESCRIBER:
-        if ja.sender_prescriber_organization and ja.sender_prescriber_organization.is_authorized:
+        if ja.is_sent_by_authorized_prescriber:
             return "Prescripteur habilité"
         return "Orienteur"
     return get_choice(choices=SENDER_KIND_CHOICES, key=ja.sender_kind)

--- a/itou/templates/apply/includes/list_card_body.html
+++ b/itou/templates/apply/includes/list_card_body.html
@@ -33,7 +33,7 @@
                     {% if job_application.sender_prescriber_organization %}
                         <br>
                         <b>{{ job_application.sender_prescriber_organization.display_name }}</b>
-                        {% if job_application.sender_prescriber_organization.is_authorized %}
+                        {% if job_application.is_sent_by_authorized_prescriber %}
                             <br>
                             <span class="badge badge-warning">{% translate "Prescripteur habilité" %}</span>
                         {% endif %}

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -79,7 +79,7 @@
                     <div class="card-text">
                         {# Employers need to know the expiration date of an approval #}
                         {# to decide whether they may accept a job application or not. #}
-                        {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
+                        {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval job_application=job_application %}
                     </div>
                 </div>
             </div>

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -166,7 +166,7 @@
             <li>
                 {% translate "Structure :" %}
                 <b>{{ job_application.sender_prescriber_organization.display_name }}</b>
-                {% if job_application.sender_prescriber_organization.is_authorized %}
+                {% if job_application.is_sent_by_authorized_prescriber %}
                     <span class="badge badge-warning">{% translate "Prescripteur habilité" %}</span>
                 {% endif %}
             </li>

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -5,6 +5,7 @@
 
     Usage:
         {% include "approvals/includes/status.html" with approval=approval %}
+        {% include "approvals/includes/status.html" with approval=approval job_application=job_application %}
 
 {% endcomment %}
 
@@ -77,10 +78,18 @@
 
 {% elif approval.is_in_waiting_period %}
 
-    <p class="text-danger">
-        {% blocktranslate with end=approval.end_at|date:"d/m/Y" since=approval.end_at|timesince %}
-            <b>Expiré</b> le {{ end }} (depuis {{ since }})
-        {% endblocktranslate %}
-    </p>
+    {% comment %}
+    Hide the "expired" status when a job application is sent by an authorized prescriber
+    for a job seeker with an approval in waiting period. The "expired" status suggests to
+    employers that they cannot hire the job seeker. But authorized prescribers can bypass
+    approvals in waiting period.
+    {% endcomment %}
+    {% if not job_application.is_sent_by_authorized_prescriber %}
+        <p class="text-danger">
+            {% blocktranslate with end=approval.end_at|date:"d/m/Y" since=approval.end_at|timesince %}
+                <b>Expiré</b> le {{ end }} (depuis {{ since }})
+            {% endblocktranslate %}
+        </p>
+    {% endif %}
 
 {% endif %}


### PR DESCRIPTION
### Quoi ?

Suppression de la mention "Agrément expiré" lorsqu'une candidature est envoyée par un prescripteur habilité pour un candidat dont l'agrément est en période de carence.

### Pourquoi ?

Lorsqu'un candidat avec agrément expiré a été envoyé par un prescripteur habilité, l'employeur reçoit la candidature avec la mention "Agrément expiré".

Il décline alors la candidature car il pense que l'embauche est impossible.

Or il lui suffit de valider l'embauche pour générer un nouveau Pass IAE.

### Comment

On masque la mention "Agrément expiré" pour ne pas semer le doute dans la tête de l'employeur.