### PR TITLE
Correction de la requête qui affiche la liste des candidatures des prescripteurs

### DIFF
--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -48,7 +48,8 @@ def list_for_prescriber(request, template_name="apply/list_for_prescriber.html")
         # current user for backward compatibility (in the past, a user could
         # create his prescriber's organization later on).
         job_applications = JobApplication.objects.filter(
-            Q(sender=request.user) | Q(sender_prescriber_organization=prescriber_organization)
+            (Q(sender=request.user) & Q(sender_prescriber_organization__isnull=True))
+            | Q(sender_prescriber_organization=prescriber_organization)
         )
     else:
         job_applications = request.user.job_applications_sent


### PR DESCRIPTION
### Quoi ?

Correction de la requête qui affiche la liste des candidatures des prescripteurs

### Pourquoi ?

Un prescripteur voit :

1. toutes les candidatures dont il est à l'origine
1. toutes les candidatures de l'organisation à laquelle il est connecté

Le point **1** date d'avant la possibilité de faire partie de plusieurs organisations et corrige un problème qui se présentait quand l'utilisateur était orienteur sans organisation.

Dans cette configuration, lorsqu'un orienteur rejoignait une organisation, il ne voyait plus ses anciennes candidatures.

Mais avec le multi-organisations pour les prescripteurs, il voit maintenant toutes les candidatures dont il est à l'origine peu importe l'organisation dans laquelle il se trouve.

### Comment

On s'assure de récupérer uniquement les anciennes candidatures dont le prescripteur est à l'origine et qui ne sont pas liées à une organisation.
