### PR TITLE
Hotfix du cronjob metabase nocturne

### DIFF
--- a/itou/metabase/management/commands/_database_psycopg2.py
+++ b/itou/metabase/management/commands/_database_psycopg2.py
@@ -1,0 +1,20 @@
+import psycopg2
+from django.conf import settings
+
+
+class MetabaseDatabaseCursor:
+    def __enter__(self):
+        self.conn = psycopg2.connect(
+            host=settings.METABASE_HOST,
+            port=settings.METABASE_PORT,
+            dbname=settings.METABASE_DATABASE,
+            user=settings.METABASE_USER,
+            password=settings.METABASE_PASSWORD,
+        )
+        self.cur = self.conn.cursor()
+        return self.cur, self.conn
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.conn.commit()
+        self.cur.close()
+        self.conn.close()

--- a/itou/metabase/management/commands/_database_sqlalchemy.py
+++ b/itou/metabase/management/commands/_database_sqlalchemy.py
@@ -1,4 +1,3 @@
-import psycopg2
 from django.conf import settings
 from sqlalchemy import create_engine
 
@@ -22,21 +21,3 @@ PG_ENGINE = create_engine(
     f"postgresql://{settings.METABASE_USER}:{settings.METABASE_PASSWORD}"
     f"@{settings.METABASE_HOST}:{settings.METABASE_PORT}/{settings.METABASE_DATABASE}"
 )
-
-
-class MetabaseDatabaseCursor:
-    def __enter__(self):
-        self.conn = psycopg2.connect(
-            host=settings.METABASE_HOST,
-            port=settings.METABASE_PORT,
-            dbname=settings.METABASE_DATABASE,
-            user=settings.METABASE_USER,
-            password=settings.METABASE_PASSWORD,
-        )
-        self.cur = self.conn.cursor()
-        return self.cur, self.conn
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.conn.commit()
-        self.cur.close()
-        self.conn.close()

--- a/itou/metabase/management/commands/populate_metabase.py
+++ b/itou/metabase/management/commands/populate_metabase.py
@@ -33,7 +33,7 @@ from itou.approvals.models import Approval, PoleEmploiApproval
 from itou.job_applications.models import JobApplication
 from itou.jobs.models import Rome
 from itou.metabase.management.commands import _approvals, _job_applications, _job_seekers, _organizations, _siaes
-from itou.metabase.management.commands._database import MetabaseDatabaseCursor
+from itou.metabase.management.commands._database_psycopg2 import MetabaseDatabaseCursor
 from itou.metabase.management.commands._utils import chunked_queryset, compose, convert_boolean_to_int
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -66,7 +66,8 @@ import pandas as pd
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from itou.metabase.management.commands._database import PG_ENGINE, MetabaseDatabaseCursor
+from itou.metabase.management.commands._database_psycopg2 import MetabaseDatabaseCursor
+from itou.metabase.management.commands._database_sqlalchemy import PG_ENGINE
 from itou.metabase.management.commands._missions_ai_ehpad import MISSIONS_AI_EPHAD_SQL_REQUEST
 from itou.siaes.management.commands._import_siae.utils import get_filename, timeit
 from itou.siaes.models import Siae


### PR DESCRIPTION
### Quoi ?

Refactoring pour que le cronjob metabase nocturne `populate_metabase.py` retombe en marche, tout en continuant à n'installer `sqlalchemy` que en local dev et pas en production.

### Pourquoi ?

Le cronjob metabase nocturne a cassé la nuit dernière :

https://sentry.data.gouv.fr/itou/itou-prod-5t/issues/1896613/?referrer=alert_email

### Comment ?

Cette PR sépare mieux le code `psycopg2` vs `sqlalchemy` ce qui fait que `populate_metabase.py` n'importe plus `sqlalchemy` (dont il n'a pas besoin).