### PR TITLE
MAJ sécurité Django 3.1.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.1.1  # https://github.com/avian2/unidecode
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.1.5  # pyup: < 4.0  # https://www.djangoproject.com/
+django==3.1.6  # pyup: < 4.0  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.42.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
### Quoi ?

Passage de Django en version 3.1.6

### Pourquoi ?

MAJ de sécurité mineure. 

Détails ici: https://www.djangoproject.com/weblog/2021/feb/01/security-releases/

### Comment ?

MAJ du fichier de requirements `base.txt`
