### PR TITLE
Boost design

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -373,16 +373,13 @@
         <script src="{% static "js/matomo.js" %}"></script>
     {% endif %}
 
-    {# Display "Je donne mon avis" only on HP. #}
-    {# The rationale behind it: "Je donne mon avis" is imposed by DINUM but is redundant with Hotjar. #}
-    {# Hotjar is way more powerful. Compromise: display "Je donne mon avis" only on HP. #}
-    {% if request.path == "/" %}
-        <div class="fixed-sm-bottom text-center text-sm-right p-3 pr-sm-2 pb-sm-2">
-            <a href="https://voxusagers.numerique.gouv.fr/Demarches/2436?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=ca117c905602fb63fda68b31ee0f5bdd" target="_blank">
-              <img src="{% static 'img/je-donne-mon-avis.svg' %}" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche" style="width: 150px;">
-            </a>
-        </div>
-    {% endif %}
+    {# Sticky FAQ link is not displayed on small devices #}
+    <div class="rounded-pill bg-white shadow fixed-sm-bottom d-none d-sm-block m-4 py-2 px-3 text-center text-sm-right">
+        <a href="{{ ITOU_DOC_URL }}/reponses-a-mes-questions-faq?q=" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
+            {% translate "Besoin d'aide ?" %}
+            {% include "includes/icon.html" with icon="external-link" title=external_link_title %}
+        </a>
+    </div>
 
 </body>
 </html>

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -373,13 +373,24 @@
         <script src="{% static "js/matomo.js" %}"></script>
     {% endif %}
 
-    {# Sticky FAQ link is not displayed on small devices #}
-    <div class="rounded-pill bg-white shadow fixed-sm-bottom d-none d-sm-block m-4 py-2 px-3 text-center text-sm-right">
-        <a href="{{ ITOU_DOC_URL }}/reponses-a-mes-questions-faq?q=" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
-            {% translate "Besoin d'aide ?" %}
-            {% include "includes/icon.html" with icon="external-link" title=external_link_title %}
-        </a>
-    </div>
+    {# Display "Je donne mon avis" only on HP. #}
+    {# The rationale behind it: "Je donne mon avis" is imposed by DINUM but is redundant with Hotjar. #}
+    {# Hotjar is way more powerful. Compromise: display "Je donne mon avis" only on HP. #}
+    {% if request.path == "/" %}
+        <div class="fixed-sm-bottom text-center text-sm-right p-3 pr-sm-2 pb-sm-2">
+            <a href="https://voxusagers.numerique.gouv.fr/Demarches/2436?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=ca117c905602fb63fda68b31ee0f5bdd" target="_blank">
+              <img src="{% static 'img/je-donne-mon-avis.svg' %}" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche" style="width: 150px;">
+            </a>
+        </div>
+    {% else %}
+        {# Sticky FAQ link is not displayed on HP and on small devices #}
+        <div class="rounded-pill bg-white shadow fixed-sm-bottom d-none d-sm-block m-4 py-2 px-3 text-center text-sm-right">
+            <a href="{{ ITOU_DOC_URL }}/reponses-a-mes-questions-faq?q=" rel="noopener" target="_blank" aria-label="{% translate "Ouverture dans un nouvel onglet" %}">
+                {% translate "Besoin d'aide ?" %}
+                {% include "includes/icon.html" with icon="external-link" title=external_link_title %}
+            </a>
+        </div>
+    {% endif %}
 
 </body>
 </html>


### PR DESCRIPTION
### Quoi ?

Pouvoir accéder à la FAQ / aide rapidement en rendant le lien plus visible

### Pourquoi ?

Session boost design - semaine du 08/02/2021

### Comment ?

Retrait de l'ancien bouton, "Je donne mon avis" 

Ajout d'un bouton sticky en bas de page, contenant un lien vers la FAQ:
- ce lien n'est pas contextuel pour le moment
- ce bouton ne s'affiche pas sur les "small devices"

### Captures d'écran

En bas à droite

![sticky-help-button](https://user-images.githubusercontent.com/147232/107377928-c8950400-6aeb-11eb-827b-26c9b7ea59ac.png)


