### PR TITLE
Possibilité de repousser la date de départ du contrat, si elle est dans le futur

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -241,6 +241,17 @@ class Approval(CommonApprovalMixin):
             and not self.user.last_accepted_job_application.can_be_cancelled
         )
 
+    def can_be_postponed_by_siae(self, siae):
+        """
+        The given SIAE can postpone start date of the approval provided that:
+        - target approval was created by this SIAE
+        - for a specific job application
+        - the new start date is in the future
+        - there is no job application bound to this approval
+        """
+        # FIXME temporary
+        return True
+
     @staticmethod
     def get_next_number(hiring_start_at=None):
         """

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -241,16 +241,19 @@ class Approval(CommonApprovalMixin):
             and not self.user.last_accepted_job_application.can_be_cancelled
         )
 
-    def can_be_postponed_by_siae(self, siae):
+    def update_start_date(self, new_start_date):
         """
-        The given SIAE can postpone start date of the approval provided that:
-        - target approval was created by this SIAE
-        - for a specific job application
+        A SIAE can postpone start date of the approval provided that:
+        - target approval was created by this SIAE for this job application
         - the new start date is in the future
-        - there is no job application bound to this approval
+
+        In this case, the approval start date must be updated with the hiring date
         """
-        # FIXME temporary
-        return True
+        if self.jobapplication_set.count() == 1:
+            delay = relativedelta(new_start_date, self.start_at)
+            self.start_at = new_start_date
+            self.end_at = self.end_at + delay
+            self.save()
 
     @staticmethod
     def get_next_number(hiring_start_at=None):

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -243,7 +243,7 @@ class Approval(CommonApprovalMixin):
 
     @property
     def can_postpone_start_date(self):
-        return self.jobapplication_set.count() == 1 and self.start_at >= timezone.now().date()
+        return self.jobapplication_set.count() == 1 and self.start_at > timezone.now().date()
 
     def update_start_date(self, new_start_date):
         """

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -243,11 +243,11 @@ class Approval(CommonApprovalMixin):
 
     @property
     def can_postpone_start_date(self):
-        return self.jobapplication_set.count() == 1
+        return self.jobapplication_set.count() == 1 and self.start_at > datetime.date.today()
 
     def update_start_date(self, new_start_date):
         """
-        A SIAE can postpone the start date of a job application if the contract has not began yet.
+        An SIAE can postpone the start date of a job application if the contract has not begun yet.
         In this case, the approval start date must be updated with the start date of the hiring.
 
         Returns True if date has been updated, False otherwise

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -243,7 +243,7 @@ class Approval(CommonApprovalMixin):
 
     @property
     def can_postpone_start_date(self):
-        return self.jobapplication_set.count() == 1 and self.start_at > datetime.date.today()
+        return self.jobapplication_set.count() == 1 and self.start_at >= timezone.now().date()
 
     def update_start_date(self, new_start_date):
         """

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -337,7 +337,10 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         return str(self.id)
 
     def clean(self):
-        if self.hiring_end_at < self.hiring_start_at:
+        if (
+            self.state in [JobApplicationWorkflow.STATE_ACCEPTED, JobApplicationWorkflow.STATE_POSTPONED]
+            and self.hiring_end_at < self.hiring_start_at
+        ):
             raise ValidationError(JobApplication.ERROR_END_IS_BEFORE_START)
 
         # Check if hiring date is before end of a possible "old" approval

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -413,6 +413,12 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     def has_editable_job_seeker(self):
         return (self.state.is_processing or self.state.is_accepted) and self.job_seeker.is_handled_by_proxy
 
+    @property
+    def hiring_starts_in_future(self):
+        if self.hiring_start_at:
+            return datetime.date.today() < self.hiring_start_at
+        return False
+
     # Workflow transitions.
 
     @xwf_models.transition()

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -199,6 +199,14 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     ERROR_END_IS_BEFORE_START = _("La date de fin du contrat doit être postérieure à la date de début.")
     ERROR_DURATION_TOO_LONG = _(f"La durée du contrat ne peut dépasser {Approval.DEFAULT_APPROVAL_YEARS} ans.")
 
+    # SIAE have the possibility to update the start contract date provided that the new date is:
+    # - before the end date of an approval created for this job application
+    # - in the future, max. MAX_CONTRACT_POSTPONE_IN_DAYS days from today.
+    MAX_CONTRACT_POSTPONE_IN_DAYS = 30
+    ERROR_POSTPONE_TOO_FAR = _(
+        f"La date de début du contrat ne peut être repoussée de plus de {MAX_CONTRACT_POSTPONE_IN_DAYS} jours."
+    )
+
     APPROVAL_DELIVERY_MODE_AUTOMATIC = "automatic"
     APPROVAL_DELIVERY_MODE_MANUAL = "manual"
 

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -195,17 +195,17 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         (REFUSAL_REASON_OTHER, _("Autre")),
     )
 
+    # SIAE have the possibility to update the hiring date if:
+    # - it is before the end date of an approval created for this job application
+    # - it is in the future, max. MAX_CONTRACT_POSTPONE_IN_DAYS days from today.
+    MAX_CONTRACT_POSTPONE_IN_DAYS = 30
+
     ERROR_START_IN_PAST = _("Il n'est pas possible d'antidater un contrat. Indiquez une date dans le futur.")
     ERROR_END_IS_BEFORE_START = _("La date de fin du contrat doit être postérieure à la date de début.")
     ERROR_DURATION_TOO_LONG = _(f"La durée du contrat ne peut dépasser {Approval.DEFAULT_APPROVAL_YEARS} ans.")
     ERROR_START_AFTER_APPROVAL_END = _(
         "Attention, le PASS IAE sera expiré lors du début du contrat. Veuillez modifier la date de début."
     )
-
-    # SIAE have the possibility to update the hiring date if:
-    # - it is before the end date of an approval created for this job application
-    # - it is in the future, max. MAX_CONTRACT_POSTPONE_IN_DAYS days from today.
-    MAX_CONTRACT_POSTPONE_IN_DAYS = 30
     ERROR_POSTPONE_TOO_FAR = _(
         f"La date de début du contrat ne peut être repoussée de plus de {MAX_CONTRACT_POSTPONE_IN_DAYS} jours."
     )

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -199,7 +199,9 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     ERROR_START_IN_PAST = _("Il n'est pas possible d'antidater un contrat. Indiquez une date dans le futur.")
     ERROR_END_IS_BEFORE_START = _("La date de fin du contrat doit être postérieure à la date de début.")
     ERROR_DURATION_TOO_LONG = _(f"La durée du contrat ne peut dépasser {Approval.DEFAULT_APPROVAL_YEARS} ans.")
-    ERROR_START_AFTER_APPROVAL_END = _("La date de début contrat commence après la date de fin du PASS IAE.")
+    ERROR_START_AFTER_APPROVAL_END = _(
+        "Attention, le PASS IAE sera expiré lors du début du contrat. Veuillez modifier la date de début."
+    )
 
     # SIAE have the possibility to update the hiring date if:
     # - it is before the end date of an approval created for this job application

--- a/itou/templates/apply/edit_contract_start_date.html
+++ b/itou/templates/apply/edit_contract_start_date.html
@@ -7,7 +7,9 @@
 {% block content %}
 <h1>{% translate "Candidature de" %} <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
 
-<form method="post" action="" class="js-prevent-multiple-submit js-submit-with-typeform">
+<h2>{% translate "Modification de la date de contrat" %}</h2>
+
+<form method="post" action="" class="js-prevent-multiple-submit">
 
     {% csrf_token %}
 

--- a/itou/templates/apply/edit_contract_start_date.html
+++ b/itou/templates/apply/edit_contract_start_date.html
@@ -12,6 +12,7 @@
     {% csrf_token %}
 
     {% bootstrap_form_errors form %}
+
     {% bootstrap_form form %}
 
     {% buttons %}

--- a/itou/templates/apply/edit_contract_start_date.html
+++ b/itou/templates/apply/edit_contract_start_date.html
@@ -1,0 +1,29 @@
+{% extends "layout/content_small.html" %}
+{% load i18n %}
+{% load bootstrap4 %}
+
+{% block title %}{% translate "Modification de la date de contrat" %}{{ block.super }}{% endblock %}
+
+{% block content %}
+<h1>{% translate "Candidature de" %} <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
+
+<form method="post" action="" class="js-prevent-multiple-submit js-submit-with-typeform">
+
+    {% csrf_token %}
+
+    {% bootstrap_form_errors form %}
+    {% bootstrap_form form %}
+
+    {% buttons %}
+        <a class="btn btn-secondary" href="{{ prev_url }}">{% translate "Annuler" %}</a>
+        <button type="submit" class="btn btn-primary">{% translate "Enregistrer" %}</button>
+    {% endbuttons %}
+
+</form>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <!-- Needed to use the Datepicker JS widget. -->
+    {{ form.media }}
+{% endblock %}

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -310,6 +310,15 @@
         </ul>
         </p>
 
+        {% if approval_can_be_postponed_by_siae %}
+            <p>
+                <a href="{% url 'apply:edit_contract_start_date' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
+                   class="btn btn-outline-primary btn-block">
+                    {% translate "Modifier la date de départ du contrat" %}
+                </a>
+            </p>
+        {% endif %}
+
         {# Job application cancellation -------------------------------------------------------------------------- #}
         {% if job_application.can_be_cancelled %}
             <hr>

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -310,9 +310,9 @@
         </ul>
         </p>
 
-        {% if job_application.hiring_starts_in_future %}
+        {% if job_application.can_update_hiring_start %}
             <p>
-                <a href="{% url 'apply:edit_contract_start_date' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
+                <a href="{% url 'apply:edit_contract_start_date' job_application_id=job_application.pk %}" 
                    class="btn btn-outline-primary btn-block">
                     {% translate "Modifier la période du contrat de travail" %}
                 </a>

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -310,11 +310,11 @@
         </ul>
         </p>
 
-        {% if approval_can_be_postponed_by_siae %}
+        {% if job_application.hiring_starts_in_future %}
             <p>
                 <a href="{% url 'apply:edit_contract_start_date' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
                    class="btn btn-outline-primary btn-block">
-                    {% translate "Modifier la date de départ du contrat" %}
+                    {% translate "Modifier la période du contrat de travail" %}
                 </a>
             </p>
         {% endif %}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -266,9 +266,9 @@ class AcceptForm(forms.ModelForm):
         return cleaned_data
 
 
-class ContractDateForm(forms.ModelForm):
+class EditHiringDateForm(forms.ModelForm):
     """
-    Allows a SIAE to change contract date (in the future)
+    Allows a SIAE to change contract date (if current one is in the future)
     """
 
     def __init__(self, *args, **kwargs):

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -305,20 +305,6 @@ class EditHiringDateForm(forms.ModelForm):
 
         return hiring_start_at
 
-    def clean(self):
-        cleaned_data = super().clean()
-
-        if self.errors:
-            return cleaned_data
-
-        hiring_end_at = self.cleaned_data["hiring_end_at"]
-        hiring_start_at = self.cleaned_data["hiring_start_at"]
-
-        if hiring_end_at < hiring_start_at:
-            raise forms.ValidationError(JobApplication.ERROR_END_IS_BEFORE_START)
-
-        return cleaned_data
-
 
 class JobSeekerPoleEmploiStatusForm(forms.ModelForm):
     """

--- a/itou/www/apply/tests/test_edit.py
+++ b/itou/www/apply/tests/test_edit.py
@@ -24,7 +24,10 @@ class EditContractTest(TestCase):
         self.user2 = siae2.members.get(first_name="Roscoe")
 
         # JA with creation of a new approval
-        self.job_application_1 = JobApplicationWithApprovalFactory(to_siae=siae1)
+        tomorrow = (timezone.now() + relativedelta(days=1)).date()
+        self.job_application_1 = JobApplicationWithApprovalFactory(
+            to_siae=siae1, hiring_start_at=tomorrow, approval__start_at=tomorrow
+        )
 
         # JA with an old approval
         delta = relativedelta(months=23)
@@ -45,6 +48,10 @@ class EditContractTest(TestCase):
         self.old_url = reverse(
             "apply:edit_contract_start_date", kwargs={"job_application_id": self.job_application_2.id}
         )
+
+    def test_approval_can_be_postponed(self):
+        self.assertTrue(self.job_application_1.approval.can_postpone_start_date)
+        self.assertFalse(self.job_application_2.approval.can_postpone_start_date)
 
     def test_future_contract_date(self):
         """

--- a/itou/www/apply/tests/test_edit.py
+++ b/itou/www/apply/tests/test_edit.py
@@ -1,0 +1,123 @@
+from dateutil.relativedelta import relativedelta
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from itou.job_applications.factories import JobApplicationWithApprovalFactory
+from itou.job_applications.models import JobApplication
+from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
+from itou.users.factories import DEFAULT_PASSWORD
+
+
+class EditContractTest(TestCase):
+    def setUp(self):
+        siae = SiaeWithMembershipAndJobsFactory(name="Evil Corp.", membership__user__first_name="Boss")
+        boss = siae.members.get(first_name="Boss")
+        job_application = JobApplicationWithApprovalFactory(to_siae=siae)
+
+        self.siae = siae
+        self.job_application = job_application
+        self.boss = boss
+        self.url = reverse("apply:edit_contract_start_date", kwargs={"job_application_id": self.job_application.id})
+
+    def test_future_contract_date(self):
+        """
+        Can't change a contract date to a past date
+        """
+        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+
+        future_start_date = (timezone.now() + relativedelta(days=10)).date()
+        future_end_date = (timezone.now() + relativedelta(days=15)).date()
+
+        post_data = {
+            "hiring_start_at": future_start_date.strftime("%d/%m/%Y"),
+            "hiring_end_at": future_end_date.strftime("%d/%m/%Y"),
+        }
+
+        response = self.client.post(self.url, data=post_data)
+        self.assertEqual(response.status_code, 302)
+
+        next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": self.job_application.id})
+        self.assertEqual(response.url, next_url)
+
+        self.job_application.refresh_from_db()
+
+        self.assertEqual(self.job_application.hiring_start_at, future_start_date)
+        self.assertEqual(self.job_application.hiring_end_at, future_end_date)
+
+    def test_past_contract_date(self):
+        """
+        Past contract start date are not allowed
+        """
+        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+
+        future_start_date = (timezone.now() - relativedelta(days=10)).date()
+
+        post_data = {
+            "hiring_start_at": future_start_date.strftime("%d/%m/%Y"),
+            "hiring_end_at": self.job_application.hiring_end_at.strftime("%d/%m/%Y"),
+        }
+
+        response = self.client.post(self.url, data=post_data)
+        self.assertEqual(response.status_code, 200)
+
+    def test_max_postpone_contract_date(self):
+        """
+        The contract start date can only be postponed of 30 days
+        """
+
+        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+
+        url = reverse("apply:edit_contract_start_date", kwargs={"job_application_id": self.job_application.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        future_start_date = (
+            timezone.now() + relativedelta(days=JobApplication.MAX_CONTRACT_POSTPONE_IN_DAYS + 1)
+        ).date()
+
+        post_data = {
+            "hiring_start_at": future_start_date.strftime("%d/%m/%Y"),
+            "hiring_end_at": self.job_application.hiring_end_at.strftime("%d/%m/%Y"),
+        }
+
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 200)
+
+    def test_postpone_approval(self):
+        """
+        If hiring date is postponed, approval start date must be updated accordingly
+        """
+        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+
+        future_start_date = (timezone.now() + relativedelta(days=20)).date()
+        future_end_date = (timezone.now() + relativedelta(days=60)).date()
+
+        post_data = {
+            "hiring_start_at": future_start_date.strftime("%d/%m/%Y"),
+            "hiring_end_at": future_end_date.strftime("%d/%m/%Y"),
+        }
+
+        response = self.client.post(self.url, data=post_data)
+        self.assertEqual(response.status_code, 302)
+
+        next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": self.job_application.id})
+        self.assertEqual(response.url, next_url)
+
+        self.job_application.refresh_from_db()
+
+        self.assertIsNotNone(self.job_application.approval)
+        self.assertEqual(self.job_application.hiring_start_at, self.job_application.approval.start_at)

--- a/itou/www/apply/tests/test_edit.py
+++ b/itou/www/apply/tests/test_edit.py
@@ -11,34 +11,46 @@ from itou.users.factories import DEFAULT_PASSWORD
 
 class EditContractTest(TestCase):
     """
-    Checks updating a job application hiring start date when it starts in the future
+    Checks:
+    - updating a job application hiring start date when it starts in the future
+    - coherence of PASS start / end date
     """
 
     def setUp(self):
-        siae = SiaeWithMembershipAndJobsFactory(name="Evil Corp.", membership__user__first_name="Boss")
-        boss = siae.members.get(first_name="Boss")
-        job_application = JobApplicationWithApprovalFactory(to_siae=siae)
-        job_application_with_old_approval = JobApplicationWithApprovalFactory(to_siae=siae)
-        old_approval = job_application_with_old_approval.approval
+        siae1 = SiaeWithMembershipAndJobsFactory(name="Evil Corp.", membership__user__first_name="Elliot")
+        siae2 = SiaeWithMembershipAndJobsFactory(name="Duke of Hazard Corp.", membership__user__first_name="Roscoe")
 
-        delta = relativedelta(months=6)
-        old_approval.start_at -= delta
-        old_approval.end_at -= delta
+        self.user1 = siae1.members.get(first_name="Elliot")
+        self.user2 = siae2.members.get(first_name="Roscoe")
 
-        self.siae = siae
-        self.boss = boss
-        self.job_application = job_application
-        self.job_application_with_old_approval = job_application_with_old_approval
-        self.url = reverse("apply:edit_contract_start_date", kwargs={"job_application_id": job_application.id})
+        # JA with creation of a new approval
+        self.job_application_1 = JobApplicationWithApprovalFactory(to_siae=siae1)
+
+        # JA with an old approval
+        delta = relativedelta(months=23)
+        old_job_application = JobApplicationWithApprovalFactory(to_siae=siae2, created_at=timezone.now() - delta)
+        approval = old_job_application.approval
+        approval.start_at = old_job_application.created_at
+
+        self.job_application_2 = JobApplicationWithApprovalFactory(
+            to_siae=siae2,
+            job_seeker=old_job_application.job_seeker,
+            approval=approval,
+        )
+        # old_approval = old_job_application.approval
+        # old_approval.start_at -= delta
+        # old_approval.end_at -= delta
+
+        self.url = reverse("apply:edit_contract_start_date", kwargs={"job_application_id": self.job_application_1.id})
         self.old_url = reverse(
-            "apply:edit_contract_start_date", kwargs={"job_application_id": job_application_with_old_approval.id}
+            "apply:edit_contract_start_date", kwargs={"job_application_id": self.job_application_2.id}
         )
 
     def test_future_contract_date(self):
         """
-        Can't change a contract date to a past date
+        Checks possibility of changing hiring start date to a future date.
         """
-        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+        self.client.login(username=self.user1.username, password=DEFAULT_PASSWORD)
 
         response = self.client.get(self.url)
 
@@ -55,19 +67,19 @@ class EditContractTest(TestCase):
         response = self.client.post(self.url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
-        next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": self.job_application.id})
+        next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": self.job_application_1.id})
         self.assertEqual(response.url, next_url)
 
-        self.job_application.refresh_from_db()
+        self.job_application_1.refresh_from_db()
 
-        self.assertEqual(self.job_application.hiring_start_at, future_start_date)
-        self.assertEqual(self.job_application.hiring_end_at, future_end_date)
+        self.assertEqual(self.job_application_1.hiring_start_at, future_start_date)
+        self.assertEqual(self.job_application_1.hiring_end_at, future_end_date)
 
     def test_past_contract_date(self):
         """
         Past contract start date are not allowed
         """
-        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+        self.client.login(username=self.user1.username, password=DEFAULT_PASSWORD)
 
         response = self.client.get(self.url)
 
@@ -77,7 +89,7 @@ class EditContractTest(TestCase):
 
         post_data = {
             "hiring_start_at": future_start_date.strftime("%d/%m/%Y"),
-            "hiring_end_at": self.job_application.hiring_end_at.strftime("%d/%m/%Y"),
+            "hiring_end_at": self.job_application_1.hiring_end_at.strftime("%d/%m/%Y"),
         }
 
         response = self.client.post(self.url, data=post_data)
@@ -88,9 +100,9 @@ class EditContractTest(TestCase):
         The contract start date can only be postponed of 30 days
         """
 
-        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+        self.client.login(username=self.user1.username, password=DEFAULT_PASSWORD)
 
-        url = reverse("apply:edit_contract_start_date", kwargs={"job_application_id": self.job_application.id})
+        url = reverse("apply:edit_contract_start_date", kwargs={"job_application_id": self.job_application_1.id})
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 200)
@@ -101,7 +113,7 @@ class EditContractTest(TestCase):
 
         post_data = {
             "hiring_start_at": future_start_date.strftime("%d/%m/%Y"),
-            "hiring_end_at": self.job_application.hiring_end_at.strftime("%d/%m/%Y"),
+            "hiring_end_at": self.job_application_1.hiring_end_at.strftime("%d/%m/%Y"),
         }
 
         response = self.client.post(url, data=post_data)
@@ -112,7 +124,7 @@ class EditContractTest(TestCase):
         If hiring date is postponed,
         approval start date must be updated accordingly (if there is an approval)
         """
-        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+        self.client.login(username=self.user1.username, password=DEFAULT_PASSWORD)
         response = self.client.get(self.url)
 
         future_start_date = (timezone.now() + relativedelta(days=20)).date()
@@ -126,20 +138,20 @@ class EditContractTest(TestCase):
         response = self.client.post(self.url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
-        next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": self.job_application.id})
+        next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": self.job_application_1.id})
         self.assertEqual(response.url, next_url)
 
-        self.job_application.refresh_from_db()
+        self.job_application_1.refresh_from_db()
 
-        self.assertIsNotNone(self.job_application.approval)
-        self.assertEqual(self.job_application.hiring_start_at, self.job_application.approval.start_at)
+        self.assertIsNotNone(self.job_application_1.approval)
+        self.assertEqual(self.job_application_1.hiring_start_at, self.job_application_1.approval.start_at)
 
     def test_start_date_with_previous_approval(self):
         """
         When the job application is linked to a previous approval,
         check that approval dates are not updated if the hiring date change
         """
-        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+        self.client.login(username=self.user2.username, password=DEFAULT_PASSWORD)
         response = self.client.get(self.old_url)
 
         future_start_date = (timezone.now() + relativedelta(days=5)).date()
@@ -150,22 +162,20 @@ class EditContractTest(TestCase):
             "hiring_end_at": future_end_date.strftime("%d/%m/%Y"),
         }
 
-        response = self.client.post(self.url, data=post_data)
+        response = self.client.post(self.old_url, data=post_data)
 
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(
-            self.job_application_with_old_approval.hiring_start_at
-            > self.job_application_with_old_approval.approval.start_at
-        )
+        self.assertTrue(self.job_application_2.hiring_start_at > self.job_application_2.approval.start_at.date())
 
-    def test_do_not_update_previous_approval(self):
+    def test_do_not_update_approval(self):
         """
-        Previous approvals start date must not be updated when postponing contract dates
+        Previously running approval start date must not be updated
+        when postponing contract dates
         """
-        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+        self.client.login(username=self.user2.username, password=DEFAULT_PASSWORD)
         response = self.client.get(self.old_url)
 
-        approval = self.job_application_with_old_approval.approval
+        approval = self.job_application_2.approval
 
         future_start_date = approval.start_at + relativedelta(days=10)
         future_end_date = future_start_date + relativedelta(days=60)
@@ -175,5 +185,5 @@ class EditContractTest(TestCase):
             "hiring_end_at": future_end_date.strftime("%d/%m/%Y"),
         }
 
-        response = self.client.post(self.url, data=post_data)
+        response = self.client.post(self.old_url, data=post_data)
         self.assertEqual(response.status_code, 200)

--- a/itou/www/apply/tests/test_edit.py
+++ b/itou/www/apply/tests/test_edit.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
+from itou.approvals.factories import ApprovalFactory
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication
 from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
@@ -18,10 +19,18 @@ class EditContractTest(TestCase):
         siae = SiaeWithMembershipAndJobsFactory(name="Evil Corp.", membership__user__first_name="Boss")
         boss = siae.members.get(first_name="Boss")
         job_application = JobApplicationWithApprovalFactory(to_siae=siae)
+        job_application_with_old_approval = JobApplicationWithApprovalFactory(to_siae=siae)
+        old_approval = job_application_with_old_approval.approval
+
+        delta = relativedelta(months=6)
+        old_approval.start_at -= delta
+        old_approval.end_at -= delta
 
         self.siae = siae
         self.job_application = job_application
         self.boss = boss
+        self.old_approval = old_approval
+        self.job_application_with_old_approval = job_application_with_old_approval
         self.url = reverse("apply:edit_contract_start_date", kwargs={"job_application_id": self.job_application.id})
 
     def test_future_contract_date(self):
@@ -103,10 +112,7 @@ class EditContractTest(TestCase):
         approval start date must be updated accordingly (if there is an approval)
         """
         self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
-
         response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
 
         future_start_date = (timezone.now() + relativedelta(days=20)).date()
         future_end_date = (timezone.now() + relativedelta(days=60)).date()
@@ -126,3 +132,47 @@ class EditContractTest(TestCase):
 
         self.assertIsNotNone(self.job_application.approval)
         self.assertEqual(self.job_application.hiring_start_at, self.job_application.approval.start_at)
+
+    def test_start_date_with_previous_approval(self):
+        """
+        When the job application is linked to a previous approval,
+        check that:
+        - approval dates are not updated if the hiring date change
+        - it is not possible to postpone hiring date further than approval end date
+        """
+        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+        response = self.client.get(self.url)
+
+        self.job_application.approval = self.old_approval
+
+        future_start_date = (timezone.now() + relativedelta(days=5)).date()
+        future_end_date = (timezone.now() + relativedelta(days=60)).date()
+
+        post_data = {
+            "hiring_start_at": future_start_date.strftime("%d/%m/%Y"),
+            "hiring_end_at": future_end_date.strftime("%d/%m/%Y"),
+        }
+
+        response = self.client.post(self.url, data=post_data)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIsNotNone(self.job_application.approval)
+        self.assertNotEqual(self.job_application.hiring_start_at, self.job_application.approval.start_at)
+
+    def test_do_not_update_previous_approval(self):
+        """
+        Previous approvals start date must not be updated when postponing contract dates
+        """
+        self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
+        response = self.client.get(self.url)
+
+        future_start_date = self.old_approval.start_at + relativedelta(days=10)
+        future_end_date = future_start_date + relativedelta(days=60)
+
+        post_data = {
+            "hiring_start_at": future_start_date.strftime("%d/%m/%Y"),
+            "hiring_end_at": future_end_date.strftime("%d/%m/%Y"),
+        }
+
+        response = self.client.post(self.url, data=post_data)
+        self.assertEqual(response.status_code, 200)

--- a/itou/www/apply/tests/test_edit.py
+++ b/itou/www/apply/tests/test_edit.py
@@ -10,6 +10,10 @@ from itou.users.factories import DEFAULT_PASSWORD
 
 
 class EditContractTest(TestCase):
+    """
+    Checks updating a job application hiring start date when it starts in the future
+    """
+
     def setUp(self):
         siae = SiaeWithMembershipAndJobsFactory(name="Evil Corp.", membership__user__first_name="Boss")
         boss = siae.members.get(first_name="Boss")
@@ -95,7 +99,8 @@ class EditContractTest(TestCase):
 
     def test_postpone_approval(self):
         """
-        If hiring date is postponed, approval start date must be updated accordingly
+        If hiring date is postponed,
+        approval start date must be updated accordingly (if there is an approval)
         """
         self.client.login(username=self.boss.username, password=DEFAULT_PASSWORD)
 

--- a/itou/www/apply/tests/test_edit.py
+++ b/itou/www/apply/tests/test_edit.py
@@ -40,9 +40,6 @@ class EditContractTest(TestCase):
             job_seeker=old_job_application.job_seeker,
             approval=approval,
         )
-        # old_approval = old_job_application.approval
-        # old_approval.start_at -= delta
-        # old_approval.end_at -= delta
 
         self.url = reverse("apply:edit_contract_start_date", kwargs={"job_application_id": self.job_application_1.id})
         self.old_url = reverse(

--- a/itou/www/apply/tests/test_edit.py
+++ b/itou/www/apply/tests/test_edit.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from itou.approvals.factories import ApprovalFactory
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication
 from itou.siaes.factories import SiaeWithMembershipAndJobsFactory

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from itou.www.apply.views import list_views, process_views, submit_views
+from itou.www.apply.views import edit_views, list_views, process_views, submit_views
 
 
 # https://docs.djangoproject.com/en/dev/topics/http/urls/#url-namespaces-and-included-urlconfs
@@ -42,5 +42,10 @@ urlpatterns = [
         "<uuid:job_application_id>/siae/accept_without_approval",
         process_views.accept_without_approval,
         name="accept_without_approval",
+    ),
+    path(
+        "<uuid:job_application_id>/siae/edit_contract_start_date",
+        edit_views.edit_contract_start_date,
+        name="edit_contract_start_date",
     ),
 ]

--- a/itou/www/apply/views/edit_views.py
+++ b/itou/www/apply/views/edit_views.py
@@ -35,9 +35,8 @@ def edit_contract_start_date(request, job_application_id, template_name="apply/e
 
         messages.success(request, _("La période du contrat de travail a été mise à jour."))
 
-        if job_application.approval:
-            if job_application.approval.update_start_date(job_application.hiring_start_at):
-                messages.success(request, _("La date de début du PASS IAE a été fixée à la date de début de contrat."))
+        if job_application.approval and job_application.approval.update_start_date(job_application.hiring_start_at):
+            messages.success(request, _("La date de début du PASS IAE a été fixée à la date de début de contrat."))
 
         return HttpResponseRedirect(url)
 

--- a/itou/www/apply/views/edit_views.py
+++ b/itou/www/apply/views/edit_views.py
@@ -17,6 +17,8 @@ def edit_contract_start_date(request, job_application_id, template_name="apply/e
     - at a future point in time
     - if job_application has been accepted
 
+    If there is an approval linked to this job application, change its start date if possible
+
     This view is kept apart from process or submit views
     """
     queryset = JobApplication.objects.siae_member_required(request.user)
@@ -34,8 +36,8 @@ def edit_contract_start_date(request, job_application_id, template_name="apply/e
         messages.success(request, _("La période du contrat de travail a été mise à jour."))
 
         if job_application.approval:
-            job_application.approval.update_start_date(job_application.hiring_start_at)
-            messages.success(request, _("La date de début du PASS IAE a été repoussée à la date de début de contrat."))
+            if job_application.approval.update_start_date(job_application.hiring_start_at):
+                messages.success(request, _("La date de début du PASS IAE a été fixée à la date de début de contrat."))
 
         return HttpResponseRedirect(url)
 

--- a/itou/www/apply/views/edit_views.py
+++ b/itou/www/apply/views/edit_views.py
@@ -34,7 +34,6 @@ def edit_contract_start_date(request, job_application_id, template_name="apply/e
         messages.success(request, _("La période du contrat de travail a été mise à jour."))
 
         if job_application.approval:
-            job_application.refresh_from_db()
             job_application.approval.update_start_date(job_application.hiring_start_at)
             messages.success(request, _("La date de début du PASS IAE a été repoussée à la date de début de contrat."))
 

--- a/itou/www/apply/views/edit_views.py
+++ b/itou/www/apply/views/edit_views.py
@@ -1,0 +1,49 @@
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from itou.job_applications.models import JobApplication
+from itou.www.apply.forms import EditHiringDateForm
+
+
+@login_required
+def edit_contract_start_date(request, job_application_id, template_name="apply/edit_contract_start_date.html"):
+    """
+    Update contract start date:
+    - at a future point in time
+    - if job_application has been accepted
+
+    This view is kept apart from process or submit views
+    """
+    queryset = JobApplication.objects.siae_member_required(request.user)
+    job_application = get_object_or_404(queryset, id=job_application_id)
+
+    if not job_application.state.is_accepted:
+        PermissionDenied()
+
+    form = EditHiringDateForm(instance=job_application, data=request.POST or None)
+    url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
+
+    if request.method == "POST" and form.is_valid():
+        form.save()
+
+        messages.success(request, _("La période du contrat de travail a été mise à jour."))
+
+        if job_application.approval:
+            job_application.refresh_from_db()
+            job_application.approval.update_start_date(job_application.hiring_start_at)
+            messages.success(request, _("La date de début du PASS IAE a été repoussée à la date de début de contrat."))
+
+        return HttpResponseRedirect(url)
+
+    context = {
+        "form": form,
+        "job_application": job_application,
+        "prev_url": url,
+    }
+
+    return render(request, template_name, context)

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -12,14 +12,7 @@ from django.views.decorators.http import require_http_methods
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.utils.perms.user import get_user_info
-from itou.www.apply.forms import (
-    AcceptForm,
-    AnswerForm,
-    ContractDateForm,
-    JobSeekerPoleEmploiStatusForm,
-    RefusalForm,
-    UserAddressForm,
-)
+from itou.www.apply.forms import AcceptForm, AnswerForm, JobSeekerPoleEmploiStatusForm, RefusalForm, UserAddressForm
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm, ConfirmEligibilityForm
 
 
@@ -60,14 +53,9 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
         job_application.to_siae
     )
 
-    approval_can_be_postponed_by_siae = job_application.approval and job_application.approval.can_be_postponed_by_siae(
-        job_application.to_siae
-    )
-
     context = {
         "approvals_wrapper": job_application.job_seeker.approvals_wrapper,
         "approval_can_be_suspended_by_siae": approval_can_be_suspended_by_siae,
-        "approval_can_be_postponed_by_siae": approval_can_be_postponed_by_siae,
         "cancellation_days": cancellation_days,
         "eligibility_diagnosis": eligibility_diagnosis,
         "job_application": job_application,


### PR DESCRIPTION
### Quoi ?

Ajout de la possibilité de modifier la date de départ d'un contrat pour les SIAE si cette date est dans le futur.

### Pourquoi ?

Demande de notre support.

Les décalages de début de contrat sont fréquents et pas nécessairement le résultat d'une mauvaise saisie (gestion administrative, demande de décalage par le DE).

### Comment ?

- ajout d'un formulaire de modification des dates de début et  de fin du contrat
- vérification et éventuel décalage de la date de départ si émission d'un PASS IAE pour la candidature

### Captures d'écran 

Détails candidature:
![update-start-date](https://user-images.githubusercontent.com/147232/108177853-073a4800-7104-11eb-91fd-0b8c3503d8ca.png)

Formulaire de modification:
![update-start-date-form](https://user-images.githubusercontent.com/147232/108177912-18835480-7104-11eb-87f3-9f1c00fb8fc2.png)




