### PR TITLE
Mise à jour de sécu de Django

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.1.1  # https://github.com/avian2/unidecode
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.1.6  # pyup: < 4.0  # https://www.djangoproject.com/
+django==3.1.7  # pyup: < 4.0  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.42.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
Mise à jour de Django vers [la version 3.1.7](https://www.djangoproject.com/weblog/2021/feb/19/security-releases/). 