### PR TITLE
Agréments : favorisation des PASS IAE par rapport aux agréments PE

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -745,9 +745,22 @@ class ApprovalsWrapper:
         # This allows to always choose the longest and most recent approval.
         # Dates are converted to timestamp so that the subtraction operator
         # can be used in the lambda.
-        return sorted(
+        merged_approvals = sorted(
             merged_approvals, key=lambda x: (-time.mktime(x.end_at.timetuple()), time.mktime(x.start_at.timetuple()))
         )
+
+        # If an ongoing PASS IAE exists, consider it's the latest valid approval
+        # even if a PoleEmploiApproval is more recent.
+        for i, approval in enumerate(merged_approvals[1:], start=1):
+            if (
+                approval.originates_from_itou
+                and not merged_approvals[i - 1].originates_from_itou
+                and approval.is_valid
+            ):
+                merged_approvals.insert(0, merged_approvals.pop(i))
+                break
+
+        return merged_approvals
 
     @property
     def has_valid_pole_emploi_eligibility_diagnosis(self):


### PR DESCRIPTION
# Quoi ?

Changement de la méthode de tri des agréments (Pôle emploi / PASS IAE) en favorisant les PASS IAE valides.

# Pourquoi ? 

Notre algorithme actuel trie les agréments en fonction de leur date de début et de leur date de fin (méthode `ApprovalsWrapper._merge_approvals`) sans prendre en compte leur type. Si le premier agrément renvoyé est un agrément Pôle emploi, le système délivre un nouveau PASS IAE en reprenant les dates de l'agrément original.
Mais que se passe-t-il si un PASS IAE valide fait partie de la liste ? Le système tente de créer un PASS, détecte qu'il en existe déjà un et renvoie une erreur 500 car il ne peut pas créer de doublon. L'employeur est alors bloqué.