### PR TITLE
Set line length of Black in config file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         pip install -r requirements/dev.txt
     - name: ✨ Black, isort and Flake8
       run: |
-        black --check --line-length 119 itou
+        black --check itou
         isort --check-only itou
         flake8 itou --count --show-source --statistics
     - name: 🤹‍ Django tests

--- a/Makefile
+++ b/Makefile
@@ -14,19 +14,19 @@ cdsitepackages:
 	docker exec -ti -w /usr/local/lib/python3.7/site-packages itou_django /bin/bash
 
 quality:
-	docker exec -ti itou_django black --check --line-length 119 itou
+	docker exec -ti itou_django black --check itou
 	docker exec -ti itou_django isort --check-only itou
 	docker exec -ti itou_django flake8 itou
 
 style:
-	docker exec -ti itou_django black --line-length 119 itou
+	docker exec -ti itou_django black itou
 	docker exec -ti itou_django isort itou
 
 setup_git_pre_commit_hook:
 	touch .git/hooks/pre-commit
 	chmod +x .git/hooks/pre-commit
 	echo "\
-	docker exec -t itou_django black --line-length 119 itou\n\
+	docker exec -t itou_django black itou\n\
 	docker exec -t itou_django isort itou\n\
 	" > .git/hooks/pre-commit
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line_length = 119


### PR DESCRIPTION
### Quoi ?

Le formateur de code Black est utilisé avec un paramètre spécifique concernant la longueur des lignes (119 au lieu de 88 par défaut), ce paramètre est actuellement passé en ligne de commande ou bien doit être configuré dans l'éditeur car il n'est pas lu depuis un fichier de conf de la base de code.

### Pourquoi ?

Pour éviter de devoir configurer son éditeur et simplifier l'appel en CLI.

### Comment ?

Seul le fichier `pyproject.toml` est lu par Black. Nouveau fichier :(

---

Liens intéressant :

- https://black.readthedocs.io/en/stable/pyproject_toml.html
