### PR TITLE
Ajout de .vscode à .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ ENV/
 
 # Editors
 .tm_properties
+/.vscode/
 
 # Jetbrains / Pycharm
 *.iml


### PR DESCRIPTION
Utilisation d'un chemin absolu (root) et slash final pour indiquer répertoire uniquement.