### PR TITLE
Mise à jour vers pandas v1.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,7 +42,7 @@ django_select2==7.4.2  # https://github.com/codingjoe/django-select2
 # ------------------------------------------------------------------------------
 
 # Manipulate ASP CSV exports having 30+ (!) columns easily
-pandas==1.0.3  # https://github.com/pandas-dev/pandas
+pandas==1.2.3  # https://github.com/pandas-dev/pandas
 
 # Eye candy progress bar
 tqdm==4.46.1  # https://github.com/tqdm/tqdm


### PR DESCRIPTION
### Quoi ?

Mise à jour de pandas depuis la version v1.0 vers la v1.2

### Pourquoi ?

L'installation de pandas v1.0 échoue dans Archlinux à jour au 2 mars 2021.
L'installation déclenche la compilation du paquet numpy et échoue car le code utilise du code obsolète:

```
numpy/random/mtrand/mtrand.c:45406:25: attention: « _PyUnicode_get_wstr_length » est obsolète [-Wdeprecated-declarations]
      45406 |                         (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
```

### Comment ?

Via pip !
La dernière version ne semble pas comporter de changements majeurs qui nécessite une migration de notre code.

---

Liens intéressant :

- https://pandas.pydata.org/docs/whatsnew/v1.2.0.html
