### PR TITLE
Pouvoir télécharger l'attestation du PASS IAE même lorsqu'il est expiré

### DIFF
--- a/itou/eligibility/models.py
+++ b/itou/eligibility/models.py
@@ -37,9 +37,6 @@ class EligibilityDiagnosisQuerySet(models.QuerySet):
     def by_author_kind_prescriber(self):
         return self.filter(author_kind=self.model.AUTHOR_KIND_PRESCRIBER)
 
-    def by_created_at_asc(self):
-        return self.order_by("created_at")
-
     def for_job_seeker(self, job_seeker):
         return self.filter(job_seeker=job_seeker).select_related(
             "author", "author_siae", "author_prescriber_organization"
@@ -77,7 +74,7 @@ class EligibilityDiagnosisManager(models.Manager):
         """
 
         last = None
-        query = self.for_job_seeker(job_seeker).by_created_at_asc()
+        query = self.for_job_seeker(job_seeker).order_by("created_at")
 
         # A diagnosis is considered valid for the duration of an approval,
         # we just retrieve the last one no matter if it's valid or not.
@@ -111,7 +108,7 @@ class EligibilityDiagnosisManager(models.Manager):
         """
 
         last = None
-        query = self.for_job_seeker(job_seeker).before(before).by_created_at_asc()
+        query = self.for_job_seeker(job_seeker).before(before).order_by("created_at")
 
         last = query.by_author_kind_prescriber().last()
         if not last and for_siae:

--- a/itou/eligibility/tests.py
+++ b/itou/eligibility/tests.py
@@ -151,6 +151,18 @@ class EligibilityDiagnosisManagerTest(TestCase):
         # A diagnosis made by a prescriber takes precedence.
         self.assertEqual(last_considered_valid, prescriber_diagnosis)
 
+    def test_last_before(self):
+        """
+        Test the `last_before()` method.
+        """
+
+        job_seeker = JobSeekerFactory()
+        EligibilityDiagnosisMadeBySiaeFactory(job_seeker=job_seeker)
+        expired_diagnosis = ExpiredEligibilityDiagnosisFactory(job_seeker=job_seeker)
+
+        last_before = EligibilityDiagnosis.objects.last_before(job_seeker, datetime.date.today())
+        self.assertEqual(last_before, expired_diagnosis)
+
 
 class EligibilityDiagnosisModelTest(TestCase):
     def test_create_diagnosis(self):

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -390,7 +390,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             and not self.can_be_cancelled
             and self.to_siae.is_subject_to_eligibility_rules
             and self.approval
-            and self.approval.is_valid
         )
 
     @property

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -112,6 +112,8 @@ class JobApplicationModelTest(TestCase):
         start = datetime.date.today() - relativedelta(years=2)
         ended_approval = ApprovalFactory(start_at=start)
 
+        # `hiring_start_at` must be set in order to pass the `can_be_cancelled` condition
+        # called by `can_download_approval_as_pdf`.
         job_application = JobApplicationWithApprovalFactory(approval=ended_approval, hiring_start_at=start)
         self.assertTrue(job_application.can_download_approval_as_pdf)
 

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -83,7 +83,6 @@ class JobApplicationModelTest(TestCase):
         are met:
         - the job_application.to_siae is subject to eligibility rules,
         - an approval exists (ie is not in the process of being delivered),
-        - this approval is valid,
         - the job_application has been accepted.
         """
         job_application = JobApplicationWithApprovalFactory()
@@ -105,13 +104,17 @@ class JobApplicationModelTest(TestCase):
         job_application = JobApplicationFactory(state=JobApplicationWorkflow.STATE_ACCEPTED)
         self.assertFalse(job_application.can_download_approval_as_pdf)
 
+    def test_can_download_expired_approval_as_pdf(self):
+        """
+        A user can download an expired approval PDF.
+        """
         # Approval has ended
         start = datetime.date.today() - relativedelta(years=2)
         end = start + relativedelta(years=1) - relativedelta(days=1)
         ended_approval = ApprovalFactory(start_at=start, end_at=end)
 
-        job_application = JobApplicationWithApprovalFactory(approval=ended_approval)
-        self.assertFalse(job_application.can_download_approval_as_pdf)
+        job_application = JobApplicationWithApprovalFactory(approval=ended_approval, hiring_start_at=start)
+        self.assertTrue(job_application.can_download_approval_as_pdf)
 
     def test_can_be_cancelled(self):
         today = datetime.date.today()

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -110,8 +110,7 @@ class JobApplicationModelTest(TestCase):
         """
         # Approval has ended
         start = datetime.date.today() - relativedelta(years=2)
-        end = start + relativedelta(years=1) - relativedelta(days=1)
-        ended_approval = ApprovalFactory(start_at=start, end_at=end)
+        ended_approval = ApprovalFactory(start_at=start)
 
         job_application = JobApplicationWithApprovalFactory(approval=ended_approval, hiring_start_at=start)
         self.assertTrue(job_application.can_download_approval_as_pdf)


### PR DESCRIPTION
### Quoi ?

Ajout de la possibilité de télécharger l'attestation du PASS IAE même lorsqu'il est expiré.

### Pourquoi ?

Un prescripteur, une DIRECCTE (contrôle a posteriori) peut lui demander l'attestation du PASS IAE.

Si le PASS a expiré, l'employeur ne peut plus le télécharger et ne peut pas fournir l'attestation demandée.

### Comment ?

Il a fallu modifier modifier la logique de récupération d'un diagnostic au passage.

Si le PASS IAE a expiré, il faut pouvoir chercher le diagnostic qui a permis de l'établir car un diagnostic plus récent peut exister.
