### PR TITLE
Extract pour contrôle DGEFP

### DIFF
--- a/itou/metabase/management/commands/_job_seekers.py
+++ b/itou/metabase/management/commands/_job_seekers.py
@@ -91,9 +91,7 @@ def get_latest_diagnosis_criteria(job_seeker, criteria_id):
     latest_diagnosis = get_latest_diagnosis(job_seeker)
     if latest_diagnosis:
         # We have to do all this in python to benefit from prefetch_related.
-        result = len([ac for ac in latest_diagnosis.administrative_criteria.all() if ac.id == criteria_id])
-        assert result in [0, 1]
-        return result
+        return len([ac for ac in latest_diagnosis.administrative_criteria.all() if ac.id == criteria_id])
     return None
 
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -37,3 +37,10 @@ requests-mock==1.8.0  # https://github.com/jamielennox/requests-mock
 # ------------------------------------------------------------------------------
 # sqlalchemy.create_engine is required for pandas.to_sql used in populate_metabase_fluxiae.py
 sqlalchemy==1.3.20  # https://github.com/sqlalchemy/sqlalchemy
+
+
+# Data extracts
+# ------------------------------------------------------------------------------
+# xlwt is required for pandas.to_excel used in dgefp_control.py script (see private repo)
+# very convenient to store a dataframe as an excel file
+xlwt==1.3.0


### PR DESCRIPTION
### Quoi ?

Extract à la demande d'Eric pour la DGEFP qui veut préparer son premier contrôle a posteriori.

- le script `dgefp_control.py` est dans le repo privé et fait l'objet d'une PR là-bas : https://github.com/betagouv/itou-private/pull/20 <= à reviewer aussi svp 🙏 
- ajout d'une dépendance `xlwt` uniquement en local dev bien pratique pour exporter une dataframe dans un fichier excel en une ligne `df.to_excel("exports/dgefp_control.xls", index=False)`
- petit refactoring de code pour être réutilisé par le script `dgefp_control.py` (DNRY)

### Comment ?

La requête était bien trop complexe pour être faite en SQL, notamment pour les 15 colonnes, 1 par critère administratif. J'ai donc saisi l'occasion de faire un script python one-shot et de documenter un petit workflow simple (voir le docstring en tête du script).

C'est un extract one-shot donc n'ayant pas vocation à être dans le repo public, uniquement le repo privé pour mémoire, à côté des autres scripts one-shot.

### Revue de code ?

Pas strictement nécéssaire mais encouragée pour votre curiosité.
