### PR TITLE
Le test de format_address avec factory échoue parfois

### DIFF
--- a/itou/asp/tests.py
+++ b/itou/asp/tests.py
@@ -16,34 +16,33 @@ def _users_with_mock_address(idx):
     )
 
 
-def mock_get_geocoding_data(address, post_code, limit=1):
+def mock_get_geocoding_data(address, post_code=None, limit=1):
     return RESULTS_BY_ADDRESS.get(address)
 
 
+@mock.patch(
+    "itou.utils.address.format.get_geocoding_data",
+    side_effect=mock_get_geocoding_data,
+)
 class FormatASPAdresses(TestCase):
-    def test_empty(self):
+    def test_empty(self, _mock):
         result, error = format_address({})
         self.assertFalse(result)
         self.assertEqual(error, "Only valid for User objects")
 
-    def test_none(self):
+    def test_none(self, _mock):
         result, error = format_address(None)
         self.assertFalse(result)
         self.assertEqual(error, "Only valid for User objects")
 
-    def test_not_existing_address(self):
+    def test_not_existing_address(self, _mock):
         job_seeker = JobSeekerFactory(
             address_line_1="9, avenue de Huet", post_code="32531", city="MalletVille", department="32"
         )
         result, error = format_address(job_seeker)
         self.assertFalse(result)
-        self.assertTrue(error)
-        print(error)
+        self.assertEqual(error, "Geocoding error, unable to get result")
 
-    @mock.patch(
-        "itou.utils.address.format.get_geocoding_data",
-        side_effect=mock_get_geocoding_data,
-    )
     def test_sanity(self, _):
         """
         Sanity check:
@@ -55,10 +54,6 @@ class FormatASPAdresses(TestCase):
             self.assertIsNone(error)
             self.assertIsNotNone(result)
 
-    @mock.patch(
-        "itou.utils.address.format.get_geocoding_data",
-        side_effect=mock_get_geocoding_data,
-    )
     def test_asp_addresses(self, _):
         """
         Test some of the most common address format
@@ -170,11 +165,11 @@ class LaneTypeTest(TestCase):
         self.assertIsNone(find_lane_type_aliases("XXX"))
 
 
+@mock.patch(
+    "itou.utils.address.format.get_geocoding_data",
+    side_effect=mock_get_geocoding_data,
+)
 class LaneExtensionTest(TestCase):
-    @mock.patch(
-        "itou.utils.address.format.get_geocoding_data",
-        side_effect=mock_get_geocoding_data,
-    )
     def test_standard_extension(self, _):
         """Check if lane extension is included in ASP ref file"""
         user = _users_with_mock_address(0)
@@ -185,10 +180,6 @@ class LaneExtensionTest(TestCase):
         result, error = format_address(user, strict=False)
         self.assertEquals(result.get("std_extension"), LaneExtension.T.name)
 
-    @mock.patch(
-        "itou.utils.address.format.get_geocoding_data",
-        side_effect=mock_get_geocoding_data,
-    )
     def test_non_standard_extension(self, _):
         """Non-standard extension, i.e. not in ASP ref file"""
         user = _users_with_mock_address(17)

--- a/itou/asp/tests.py
+++ b/itou/asp/tests.py
@@ -3,7 +3,7 @@ from unittest import mock
 from django.test import TestCase
 
 from itou.asp.models import LaneExtension, LaneType, find_lane_type_aliases
-from itou.users.factories import JobSeekerWithAddressFactory
+from itou.users.factories import JobSeekerFactory, JobSeekerWithAddressFactory
 from itou.utils.address.format import format_address
 from itou.utils.mocks.address_format import BAN_GEOCODING_API_RESULTS_MOCK, RESULTS_BY_ADDRESS
 
@@ -21,18 +21,24 @@ def mock_get_geocoding_data(address, post_code, limit=1):
 
 
 class FormatASPAdresses(TestCase):
-    def test_valid_types(self):
-        """Check input validity for address parsing"""
+    def test_empty(self):
         result, error = format_address({})
         self.assertFalse(result)
-        self.assertTrue(error)
+        self.assertEqual(error, "Only valid for User objects")
+
+    def test_none(self):
         result, error = format_address(None)
         self.assertFalse(result)
-        self.assertTrue(error)
-        # formatting factories with strict type check must fail
-        result, error = format_address(JobSeekerWithAddressFactory())
+        self.assertEqual(error, "Only valid for User objects")
+
+    def test_not_existing_address(self):
+        job_seeker = JobSeekerFactory(
+            address_line_1="9, avenue de Huet", post_code="32531", city="MalletVille", department="32"
+        )
+        result, error = format_address(job_seeker)
         self.assertFalse(result)
         self.assertTrue(error)
+        print(error)
 
     @mock.patch(
         "itou.utils.address.format.get_geocoding_data",


### PR DESCRIPTION


### Quoi ?

Pour obtenir un résultat fiable, le patch défini explicitement l'adresse du `JobSeeker`.
Le test faisait aussi appel à l'API géo car celui ci n'était pas mocké certainement parce qu'il était prévu pour qu'il échoue avant l'appel de l'API, j'ai donc mocké tous les tests.

### Pourquoi ?

Pour éviter avoir un build stable et pouvoir le lancer hors ligne.

### Comment ?

En appliquant le mock au niveau de la classe.

Remarque, je ne suis pas certain du but initial de ce test.
Les 2 premiers commits de cet PR doivent ignorés (en attente de merge).