### PR TITLE
Mise en avant des candidatures sans activité depuis plus de 3 semaines

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -147,18 +147,14 @@ class JobApplicationQuerySet(models.QuerySet):
         Stop the deluge of database queries that is caused by accessing related
         objects in job applications's lists.
         """
-        qs = (
-            self.select_related(
-                "approval",
-                "job_seeker",
-                "sender",
-                "sender_siae",
-                "sender_prescriber_organization",
-                "to_siae__convention",
-            )
-            .prefetch_related("selected_jobs__appellation")
-            .prefetch_related("logs")
-        )
+        qs = self.select_related(
+            "approval",
+            "job_seeker",
+            "sender",
+            "sender_siae",
+            "sender_prescriber_organization",
+            "to_siae__convention",
+        ).prefetch_related("selected_jobs__appellation")
 
         return qs.with_has_suspended_approval().with_is_pending_for_too_long().order_by("-created_at")
 
@@ -653,12 +649,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         email.send()
 
 
-class JobApplicationTransitionLogQuerySet(models.QuerySet):
-    def most_recent(self):
-        # Ordering is set in JobApplicationTransitionLog.Meta
-        return self.first()
-
-
 class JobApplicationTransitionLog(xwf_models.BaseTransitionLog):
     """
     JobApplication's transition logs are stored in this table.
@@ -669,7 +659,6 @@ class JobApplicationTransitionLog(xwf_models.BaseTransitionLog):
     EXTRA_LOG_ATTRIBUTES = (("user", "user", None),)
     job_application = models.ForeignKey(JobApplication, related_name="logs", on_delete=models.CASCADE)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, on_delete=models.SET_NULL)
-    objects = models.Manager.from_queryset(JobApplicationTransitionLogQuerySet)()
 
     class Meta:
         verbose_name = _("Log des transitions de la candidature")

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -451,7 +451,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     @cached_property
     def is_old(self):
         """
-        A job application is considered to be old when:
+        A job application is considered old when:
         - it was sent before a certain period of time
         - or the employer did not answer since a long time ago.
         """

--- a/itou/templates/apply/includes/list_card_header.html
+++ b/itou/templates/apply/includes/list_card_header.html
@@ -16,7 +16,9 @@
 
     <br>
 
-    {% if request.user.is_prescriber %}
+    {% if request.user.is_job_seeker %}
+        <small class="text-muted">{{ job_application.created_at|date:"d F Y à H:i" }}</small>
+    {% else %}
         {% if job_application.last_state_change %}
             <small class="text-muted"><b>{% translate "Envoyée le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}</small>
             <br>
@@ -25,12 +27,9 @@
             </small>
         {% else %}
             <small class="{% if job_application.is_old %}text-danger{% else %}text-muted{% endif %}">
-            <b>{% translate "Sans réponse depuis le " %}{{ job_application.created_at|date:"d F Y à H:i" }}</b>
+            <b>{% translate "Sans réponse depuis le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}
             </small>
         {% endif %}
-
-    {% else %}
-        <small class="text-muted">{{ job_application.created_at|date:"d F Y à H:i" }}</small>
     {% endif %}
 
 

--- a/itou/templates/apply/includes/list_card_header.html
+++ b/itou/templates/apply/includes/list_card_header.html
@@ -16,19 +16,16 @@
 
     <br>
 
-    {% if request.user.is_job_seeker %}
+
         <small class="text-muted">{{ job_application.created_at|date:"d F Y à H:i" }}</small>
-    {% else %}
-        {% if job_application.last_change == job_application.created_at %}
-            <small class="{% if job_application.is_pending_for_too_long %}text-danger{% else %}text-muted{% endif %}">
-            <b>{% translate "Sans réponse depuis le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}
-            </small>
-        {% else %}
-            <small class="text-muted"><b>{% translate "Envoyée le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}</small>
+
+        {% if job_application.is_pending_for_too_long and not request.user_is_job_seeker %}
             <br>
-            <small class="{% if job_application.is_pending_for_too_long %}text-danger{% else %}text-muted{% endif %}">
-            <b>{% translate "Mise à jour du statut le " %}</b>{{ job_application.last_change|date:"d F Y à H:i" }}
+            <small class="text-danger font-weight-bold">
+                {% blocktranslate with weeks=job_application.WEEKS_BEFORE_CONSIDERED_OLD %}
+                    En attente de réponse depuis plus de {{ weeks }} semaines.
+                {% endblocktranslate %}
             </small>
         {% endif %}
-    {% endif %}
+
 </div>

--- a/itou/templates/apply/includes/list_card_header.html
+++ b/itou/templates/apply/includes/list_card_header.html
@@ -19,18 +19,16 @@
     {% if request.user.is_job_seeker %}
         <small class="text-muted">{{ job_application.created_at|date:"d F Y à H:i" }}</small>
     {% else %}
-        {% if job_application.last_state_change %}
-            <small class="text-muted"><b>{% translate "Envoyée le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}</small>
-            <br>
-            <small class="{% if job_application.is_old and job_application.is_pending %}text-danger{% else %}text-muted{% endif %}">
-            <b>{% translate "Mise à jour du statut le " %}</b>{{ job_application.last_state_change.timestamp|date:"d F Y à H:i" }}
+        {% if job_application.last_change == job_application.created_at %}
+            <small class="{% if job_application.is_pending_for_too_long %}text-danger{% else %}text-muted{% endif %}">
+            <b>{% translate "Sans réponse depuis le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}
             </small>
         {% else %}
-            <small class="{% if job_application.is_old %}text-danger{% else %}text-muted{% endif %}">
-            <b>{% translate "Sans réponse depuis le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}
+            <small class="text-muted"><b>{% translate "Envoyée le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}</small>
+            <br>
+            <small class="{% if job_application.is_pending_for_too_long %}text-danger{% else %}text-muted{% endif %}">
+            <b>{% translate "Mise à jour du statut le " %}</b>{{ job_application.last_change|date:"d F Y à H:i" }}
             </small>
         {% endif %}
     {% endif %}
-
-
 </div>

--- a/itou/templates/apply/includes/list_card_header.html
+++ b/itou/templates/apply/includes/list_card_header.html
@@ -17,11 +17,11 @@
     <br>
 
     {% if request.user.is_prescriber %}
-        {% if job_application.last_answer_from_siae %}
+        {% if job_application.last_state_change %}
             <small class="text-muted"><b>{% translate "Envoyée le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}</small>
             <br>
             <small class="{% if job_application.is_old and job_application.is_pending %}text-danger{% else %}text-muted{% endif %}">
-            <b>{% translate "Dernière réponse le " %}</b>{{ job_application.last_answer_from_siae.timestamp|date:"d F Y à H:i" }}
+            <b>{% translate "Dernier changement le " %}</b>{{ job_application.last_state_change.timestamp|date:"d F Y à H:i" }}
             </small>
         {% else %}
             <small class="{% if job_application.is_old %}text-danger{% else %}text-muted{% endif %}">

--- a/itou/templates/apply/includes/list_card_header.html
+++ b/itou/templates/apply/includes/list_card_header.html
@@ -16,6 +16,22 @@
 
     <br>
 
-    <small class="text-muted">{{ job_application.created_at|date:"d F Y à H:i" }}</small>
+    {% if request.user.is_prescriber %}
+        {% if job_application.last_answer_from_siae %}
+            <small class="text-muted"><b>{% translate "Envoyée le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}</small>
+            <br>
+            <small class="{% if job_application.is_old and job_application.is_pending %}text-danger{% else %}text-muted{% endif %}">
+            <b>{% translate "Dernière réponse le " %}</b>{{ job_application.last_answer_from_siae.timestamp|date:"d F Y à H:i" }}
+            </small>
+        {% else %}
+            <small class="{% if job_application.is_old %}text-danger{% else %}text-muted{% endif %}">
+            <b>{% translate "Sans réponse depuis le " %}{{ job_application.created_at|date:"d F Y à H:i" }}</b>
+            </small>
+        {% endif %}
+
+    {% else %}
+        <small class="text-muted">{{ job_application.created_at|date:"d F Y à H:i" }}</small>
+    {% endif %}
+
 
 </div>

--- a/itou/templates/apply/includes/list_card_header.html
+++ b/itou/templates/apply/includes/list_card_header.html
@@ -23,7 +23,7 @@
             <small class="text-muted"><b>{% translate "Envoyée le " %}</b>{{ job_application.created_at|date:"d F Y à H:i" }}</small>
             <br>
             <small class="{% if job_application.is_old and job_application.is_pending %}text-danger{% else %}text-muted{% endif %}">
-            <b>{% translate "Dernier changement le " %}</b>{{ job_application.last_state_change.timestamp|date:"d F Y à H:i" }}
+            <b>{% translate "Mise à jour du statut le " %}</b>{{ job_application.last_state_change.timestamp|date:"d F Y à H:i" }}
             </small>
         {% else %}
             <small class="{% if job_application.is_old %}text-danger{% else %}text-muted{% endif %}">


### PR DESCRIPTION
### Quoi ?

Mise à jour de l'interface des prescripteurs et des employeurs et plus précisément de leur liste de candidatures.

### Pourquoi ?

Beaucoup de candidatures sont non traitées par les SIAE (pour plus de détails, voir la carte sur Trello). Nous voulons inciter les prescripteurs à relancer les employeurs quand les candidatures n'ont pas reçu de réponse depuis trop longtemps.
Une candidature est considérée comme trop vieille si elle n'a pas reçu de réponse depuis trois semaines. La "réponse" est le dernier log de transition.

### Comment ?

Sur le tableau de bord Prescripteur et Employeur, ajout d'une phrase pour chaque candidature si les conditions suivantes sont remplies : 
- le dernier changement de statut a été effectué il y a plus de trois semaines
- elle est "en attente" : nouvelle, à l'étude ou pour plus tard. 

### Captures d'écran

![image](https://user-images.githubusercontent.com/6150920/112014116-e3b35480-8b2a-11eb-8f83-27a9c2acfe45.png)

