### PR TITLE
Suppression du délai d'1h avant de pouvoir repositionner un candidat en tant que SIAE

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -109,11 +109,11 @@ class JobApplicationQuerySet(models.QuerySet):
             if getattr(job_application, fk_field)
         ]
 
-    def created_in_past_hours(self, hours):
+    def created_in_past(self, seconds=0, minutes=0, hours=0):
         """
-        Returns objects created during the specified hours period.
+        Returns objects created during the specified time period.
         """
-        past_dt = timezone.now() - timezone.timedelta(hours=hours)
+        past_dt = timezone.now() - timezone.timedelta(seconds=seconds, minutes=minutes, hours=hours)
         return self.filter(created_at__gte=past_dt)
 
     def manual_approval_delivery_required(self):

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -132,7 +132,7 @@ class JobApplicationModelTest(TestCase):
 
 
 class JobApplicationQuerySetTest(TestCase):
-    def test_created_in_past_hours(self):
+    def test_created_in_past(self):
 
         now = timezone.now()
         hours_ago_10 = now - timezone.timedelta(hours=10)
@@ -143,10 +143,10 @@ class JobApplicationQuerySetTest(TestCase):
         JobApplicationSentByJobSeekerFactory(created_at=hours_ago_20)
         JobApplicationSentByJobSeekerFactory(created_at=hours_ago_30)
 
-        self.assertEqual(JobApplication.objects.created_in_past_hours(5).count(), 0)
-        self.assertEqual(JobApplication.objects.created_in_past_hours(15).count(), 1)
-        self.assertEqual(JobApplication.objects.created_in_past_hours(25).count(), 2)
-        self.assertEqual(JobApplication.objects.created_in_past_hours(35).count(), 3)
+        self.assertEqual(JobApplication.objects.created_in_past(hours=5).count(), 0)
+        self.assertEqual(JobApplication.objects.created_in_past(hours=15).count(), 1)
+        self.assertEqual(JobApplication.objects.created_in_past(hours=25).count(), 2)
+        self.assertEqual(JobApplication.objects.created_in_past(hours=35).count(), 3)
 
     def test_get_unique_fk_objects(self):
         # Create 3 job applications for 2 candidates to check

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -250,6 +250,7 @@ def step_check_prev_applications(request, siae_pk, template_name="apply/submit_s
     # Pending a clean solution to this issue, we drop the 24-hour restriction for employers only.
     # This allow them to submit a clean application.
     if not request.user.is_siae_staff and prev_applications.created_in_past_hours(24).exists():
+    if not request.user.is_siae_staff and prev_applications.created_in_past(hours=24).exists():
         if request.user == job_seeker:
             msg = _("Vous avez déjà postulé chez cet employeur durant les dernières 24 heures.")
         else:
@@ -349,7 +350,7 @@ def step_application(request, siae_pk, template_name="apply/submit_step_applicat
 
         # Prevent multiple rapid clicks on the submit button to create multiple
         # job applications.
-        if job_seeker.job_applications.filter(to_siae=siae).created_in_past_hours(1).exists():
+        if job_seeker.job_applications.filter(to_siae=siae).created_in_past(seconds=10).exists():
             return HttpResponseRedirect(next_url)
 
         sender_prescriber_organization_pk = session_data.get("sender_prescriber_organization_pk")

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -244,12 +244,6 @@ def step_check_prev_applications(request, siae_pk, template_name="apply/submit_s
     prev_applications = job_seeker.job_applications.filter(to_siae=siae)
 
     # Limit the possibility of applying to the same SIAE for 24 hours.
-    # ---
-    # Some employers cancel applications because they cannot change information.
-    # Then they are contacting the support to say that they cannot apply again.
-    # Pending a clean solution to this issue, we drop the 24-hour restriction for employers only.
-    # This allow them to submit a clean application.
-    if not request.user.is_siae_staff and prev_applications.created_in_past_hours(24).exists():
     if not request.user.is_siae_staff and prev_applications.created_in_past(hours=24).exists():
         if request.user == job_seeker:
             msg = _("Vous avez déjà postulé chez cet employeur durant les dernières 24 heures.")


### PR DESCRIPTION
### Quoi ?

Suppression du délai d'1h avant de pouvoir repositionner un candidat pour les SIAE.

### Pourquoi ?

Car il est impossible pour une SIAE de repositionner un candidat pour qui elle aurait décliné une candidature par erreur.

### Comment ?

À l'origine on avait toujours un délai arbitraire de 24 heures avant de pouvoir repositionner un candidat.

Un contrôle côté serveur permettant d'empêcher la double soumission de formulaire était basé sur la même valeur.

On fait passer ce contrôle côté serveur à 10 secondes.