### PR TITLE
Utilisation d'une carte plus pratique dans l'admin des villes

### DIFF
--- a/itou/cities/admin.py
+++ b/itou/cities/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.contrib.gis import forms as gis_forms
+from django.contrib.gis.db import models as gis_models
 
 from itou.cities import models
 
@@ -8,3 +10,7 @@ class CityAdmin(admin.ModelAdmin):
     list_display = ("name", "department", "post_codes", "code_insee")
     list_filter = ("department",)
     search_fields = ("name", "department", "post_codes", "code_insee")
+    formfield_overrides = {
+        # https://docs.djangoproject.com/en/2.2/ref/contrib/gis/forms-api/#widget-classes
+        gis_models.PointField: {"widget": gis_forms.OSMWidget(attrs={"map_width": 800, "map_height": 500})}
+    }


### PR DESCRIPTION
### Quoi ?

Utilisation de `OSMWidget` à la place de `OpenLayersWidget` pour afficher une carte plus pratique dans l'admin des villes.

### Pourquoi ?

Pour pouvoir changer les coordonnées de Berre-l'Étang sans avoir à faire une requête SQL ou avoir à formater les données pour pouvoir peupler un `PointField`.

### Captures d'écran

#### Avant

![old](https://user-images.githubusercontent.com/281139/110636004-0a2cd380-81ac-11eb-8688-139c2996d3bb.png)

#### Après

![new](https://user-images.githubusercontent.com/281139/110636001-08fba680-81ac-11eb-9629-ef6fc9098f51.png)
