### PR TITLE
Afficher un message si une fiche de poste a déjà reçu beaucoup de candidatures

### DIFF
--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -5,8 +5,8 @@ import factory.fuzzy
 from dateutil.relativedelta import relativedelta
 
 from itou.approvals.factories import ApprovalFactory
-from itou.jobs.models import Appellation
 from itou.job_applications import models
+from itou.jobs.models import Appellation
 from itou.prescribers.factories import (
     AuthorizedPrescriberOrganizationWithMembershipFactory,
     PrescriberOrganizationWithMembershipFactory,

--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -5,6 +5,7 @@ import factory.fuzzy
 from dateutil.relativedelta import relativedelta
 
 from itou.approvals.factories import ApprovalFactory
+from itou.jobs.models import Appellation
 from itou.job_applications import models
 from itou.prescribers.factories import (
     AuthorizedPrescriberOrganizationWithMembershipFactory,
@@ -45,8 +46,11 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
 
         if extracted:
             # A list of jobs were passed in, use them.
-            for appellation in extracted:
-                siae_job_description = SiaeJobDescription.objects.create(siae=self.to_siae, appellation=appellation)
+            for siae_job_description in extracted:
+                if isinstance(siae_job_description, Appellation):
+                    siae_job_description = SiaeJobDescription.objects.create(
+                        siae=self.to_siae, appellation=siae_job_description
+                    )
                 self.selected_jobs.add(siae_job_description)
 
 

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -236,12 +236,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     CANCELLATION_DAYS_AFTER_HIRING_STARTED = 4
     WEEKS_BEFORE_CONSIDERED_OLD = 3
 
-    PENDING_STATES = [
-        JobApplicationWorkflow.STATE_NEW,
-        JobApplicationWorkflow.STATE_PROCESSING,
-        JobApplicationWorkflow.STATE_POSTPONED,
-    ]
-
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
     job_seeker = models.ForeignKey(
@@ -365,6 +359,10 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     def save(self, *args, **kwargs):
         self.updated_at = timezone.now()
         return super().save(*args, **kwargs)
+
+    @property
+    def is_pending(self):
+        return self.state in JobApplicationWorkflow.PENDING_STATES
 
     @property
     def is_sent_by_proxy(self):

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -236,6 +236,12 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     CANCELLATION_DAYS_AFTER_HIRING_STARTED = 4
     WEEKS_BEFORE_CONSIDERED_OLD = 3
 
+    PENDING_STATES = [
+        JobApplicationWorkflow.STATE_NEW,
+        JobApplicationWorkflow.STATE_PROCESSING,
+        JobApplicationWorkflow.STATE_POSTPONED,
+    ]
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
     job_seeker = models.ForeignKey(

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -524,13 +524,10 @@ class JobApplicationNotificationsTest(TestCase):
 class NewQualifiedJobAppEmployersNotificationTest(TestCase):
     def test_one_selected_job(self):
         siae = SiaeWithMembershipAndJobsFactory()
-        job_application = JobApplicationFactory(to_siae=siae)
-
-        # Add a selected job description to the application
         job_descriptions = siae.job_description_through.all()
+
         selected_job = job_descriptions[0]
-        job_application.selected_jobs.add(selected_job)
-        job_application.save()
+        job_application = JobApplicationFactory(to_siae=siae, selected_jobs=[selected_job])
 
         membership = siae.siaemembership_set.first()
         self.assertFalse(membership.notifications)
@@ -546,10 +543,8 @@ class NewQualifiedJobAppEmployersNotificationTest(TestCase):
 
         # A job application is sent concerning another job_description.
         # He should then be subscribed to two different notifications.
-        job_application = JobApplicationFactory(to_siae=siae)
         selected_job = job_descriptions[1]
-        job_application.selected_jobs.add(selected_job)
-        job_application.save()
+        job_application = JobApplicationFactory(to_siae=siae, selected_jobs=[selected_job])
 
         NewQualifiedJobAppEmployersNotification.subscribe(recipient=membership, subscribed_pks=[selected_job.pk])
         self.assertTrue(
@@ -567,11 +562,9 @@ class NewQualifiedJobAppEmployersNotificationTest(TestCase):
 
     def test_multiple_selected_jobs_multiple_recipients(self):
         siae = SiaeWithMembershipAndJobsFactory()
-        job_descriptions = siae.job_description_through.all()
+        job_descriptions = siae.job_description_through.all()[:2]
 
-        user = SiaeStaffFactory(siae=siae)
-        siae.members.add(user)
-        membership = siae.siaemembership_set.get(user=user)
+        membership = siae.siaemembership_set.first()
         NewQualifiedJobAppEmployersNotification.subscribe(
             recipient=membership, subscribed_pks=[job_descriptions[0].pk]
         )
@@ -584,13 +577,9 @@ class NewQualifiedJobAppEmployersNotificationTest(TestCase):
         )
 
         # Two selected jobs. Each user subscribed to one of them. We should have two recipients.
-        job_application = JobApplicationFactory(to_siae=siae)
-        job_application.selected_jobs.add(job_descriptions[0])
-        job_application.selected_jobs.add(job_descriptions[1])
-        job_application.save()
-
+        job_application = JobApplicationFactory(to_siae=siae, selected_jobs=job_descriptions)
         notification = NewQualifiedJobAppEmployersNotification(job_application=job_application)
-        notification.SEND_TO_UNSET_RECIPIENTS = False  # Disable default subscription to test "manual" subscription
+
         self.assertEqual(len(notification.recipients_emails), 2)
 
     def test_default_subscription(self):
@@ -601,12 +590,8 @@ class NewQualifiedJobAppEmployersNotificationTest(TestCase):
         user = SiaeStaffFactory(siae=siae)
         siae.members.add(user)
 
-        job_application = JobApplicationFactory(to_siae=siae)
-
-        # Add a job description to the application
         selected_job = siae.job_description_through.first()
-        job_application.selected_jobs.add(selected_job)
-        job_application.save()
+        job_application = JobApplicationFactory(to_siae=siae, selected_jobs=[selected_job])
 
         notification = NewQualifiedJobAppEmployersNotification(job_application=job_application)
 
@@ -615,13 +600,10 @@ class NewQualifiedJobAppEmployersNotificationTest(TestCase):
 
     def test_unsubscribe(self):
         siae = SiaeWithMembershipAndJobsFactory()
-        job_application = JobApplicationFactory(to_siae=siae)
+        selected_job = siae.job_description_through.first()
+        job_application = JobApplicationFactory(to_siae=siae, selected_jobs=[selected_job])
         self.assertEqual(siae.members.count(), 1)
 
-        # Add a job description to the application
-        selected_job = siae.job_description_through.first()
-        job_application.selected_jobs.add(selected_job)
-        job_application.save()
         recipient = siae.siaemembership_set.first()
 
         NewQualifiedJobAppEmployersNotification.subscribe(recipient=recipient, subscribed_pks=[selected_job.pk])

--- a/itou/siaes/factories.py
+++ b/itou/siaes/factories.py
@@ -101,13 +101,13 @@ class SiaeWith4MembershipsFactory(SiaeFactory):
     membership4 = factory.RelatedFactory(SiaeMembershipFactory, "siae", is_siae_admin=False, user__is_active=False)
 
 
-class SiaeWithMembershipAndJobsFactory(SiaeWithMembershipFactory):
+class SiaeWithJobsFactory(SiaeFactory):
     """
-    Generates an Siae() object with a member and random jobs (based on given ROME codes) for unit tests.
+    Generates an Siae() object with random jobs (based on given ROME codes) for unit tests.
     https://factoryboy.readthedocs.io/en/latest/recipes.html#simple-many-to-many-relationship
 
     Usage:
-        SiaeWithMembershipAndJobsFactory(romes=("N1101", "N1105", "N1103", "N4105"))
+        SiaeWithJobsFactory(romes=("N1101", "N1105", "N1103", "N4105"))
     """
 
     @factory.post_generation
@@ -121,6 +121,18 @@ class SiaeWithMembershipAndJobsFactory(SiaeWithMembershipFactory):
         # Pick random results.
         appellations = Appellation.objects.order_by("?")[: len(romes)]
         self.jobs.add(*appellations)
+
+
+class SiaeWithMembershipAndJobsFactory(SiaeWithMembershipFactory, SiaeWithJobsFactory):
+    """
+    Generates an Siae() object with a member and random jobs (based on given ROME codes) for unit tests.
+    https://factoryboy.readthedocs.io/en/latest/recipes.html#simple-many-to-many-relationship
+
+    Usage:
+        SiaeWithMembershipAndJobsFactory(romes=("N1101", "N1105", "N1103", "N4105"))
+    """
+
+    pass
 
 
 class SiaeConventionPendingGracePeriodFactory(SiaeConventionFactory):

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -459,9 +459,9 @@ class SiaeJobDescriptionQuerySet(models.QuerySet):
 
     def with_annotation_is_popular(self):
         # Avoid an infinite loop
-        from itou.job_applications.models import JobApplication
+        from itou.job_applications.models import JobApplicationWorkflow
 
-        job_apps_filters = {"jobapplication__state__in": JobApplication.PENDING_STATES}
+        job_apps_filters = {"jobapplication__state__in": JobApplicationWorkflow.PENDING_STATES}
         annotation = self.with_job_applications_count(filters=job_apps_filters).annotate(
             is_popular=Case(
                 When(job_applications_count__gt=self.model.POPULAR_THRESHOLD, then=True),

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -9,7 +9,6 @@ from django.db.models import BooleanField, Case, Count, F, Prefetch, Q, When
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes
-from django.utils.functional import cached_property
 from django.utils.http import urlsafe_base64_encode
 from django.utils.translation import gettext_lazy as _
 
@@ -51,7 +50,11 @@ class SiaeQuerySet(models.QuerySet):
         )
 
     def prefetch_job_description_through(self, **kwargs):
-        qs = SiaeJobDescription.objects.filter(**kwargs).with_is_popular().select_related("appellation__rome")
+        qs = (
+            SiaeJobDescription.objects.filter(**kwargs)
+            .with_annotation_is_popular()
+            .select_related("appellation__rome")
+        )
         return self.prefetch_related(Prefetch("job_description_through", queryset=qs))
 
     def member_required(self, user):
@@ -454,7 +457,7 @@ class SiaeJobDescriptionQuerySet(models.QuerySet):
             ),
         )
 
-    def with_is_popular(self):
+    def with_annotation_is_popular(self):
         # Avoid an infinite loop
         from itou.job_applications.models import JobApplication
 

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -514,10 +514,6 @@ class SiaeJobDescription(models.Model):
     def get_absolute_url(self):
         return reverse("siaes_views:job_description_card", kwargs={"job_description_id": self.pk})
 
-    @cached_property
-    def is_popular(self):
-        return self.jobapplication_set.pending().count() > 20
-
 
 class SiaeConvention(models.Model):
     """

--- a/itou/siaes/tests.py
+++ b/itou/siaes/tests.py
@@ -206,11 +206,11 @@ class SiaeJobDescriptionQuerySetTest(TestCase):
     def setUp(self):
         self.siae = SiaeWithJobsFactory()
 
-    def test_with_is_popular(self):
+    def test_with_annotation_is_popular(self):
         siae_job_descriptions = self.siae.job_description_through.all()
 
         # Test attribute presence
-        siae_job_description = SiaeJobDescription.objects.with_is_popular().first()
+        siae_job_description = SiaeJobDescription.objects.with_annotation_is_popular().first()
         self.assertTrue(hasattr(siae_job_description, "is_popular"))
 
         # Test popular threshold: popular job description
@@ -218,13 +218,17 @@ class SiaeJobDescriptionQuerySetTest(TestCase):
         for _ in range(SiaeJobDescription.POPULAR_THRESHOLD + 1):
             JobApplicationFactory(to_siae=self.siae, selected_jobs=[popular_job_description])
 
-        self.assertTrue(SiaeJobDescription.objects.with_is_popular().get(pk=popular_job_description.pk).is_popular)
+        self.assertTrue(
+            SiaeJobDescription.objects.with_annotation_is_popular().get(pk=popular_job_description.pk).is_popular
+        )
 
         # Test popular threshold: unpopular job description
         unpopular_job_description = siae_job_descriptions[1]
         JobApplicationFactory(to_siae=self.siae, selected_jobs=[unpopular_job_description])
 
-        self.assertFalse(SiaeJobDescription.objects.with_is_popular().get(pk=unpopular_job_description.pk).is_popular)
+        self.assertFalse(
+            SiaeJobDescription.objects.with_annotation_is_popular().get(pk=unpopular_job_description.pk).is_popular
+        )
 
         # Popular job descriptions count related **pending** job applications.
         # They should ignore other states.
@@ -234,7 +238,7 @@ class SiaeJobDescriptionQuerySetTest(TestCase):
                 to_siae=self.siae, selected_jobs=[popular_job_description], state=JobApplicationWorkflow.STATE_ACCEPTED
             )
 
-        self.assertFalse(SiaeJobDescription.objects.with_is_popular().get(pk=job_description.pk).is_popular)
+        self.assertFalse(SiaeJobDescription.objects.with_annotation_is_popular().get(pk=job_description.pk).is_popular)
 
     def test_with_job_applications_count(self):
         job_description = self.siae.job_description_through.first()

--- a/itou/siaes/tests.py
+++ b/itou/siaes/tests.py
@@ -16,9 +16,7 @@ from itou.siaes.factories import (
     SiaeWithMembershipAndJobsFactory,
     SiaeWithMembershipFactory,
 )
-
 from itou.siaes.models import Siae, SiaeJobDescription
-from itou.users.factories import SiaeStaffFactory
 
 
 class SiaeFactoriesTest(TestCase):

--- a/itou/siaes/tests.py
+++ b/itou/siaes/tests.py
@@ -233,10 +233,14 @@ class SiaeJobDescriptionQuerySetTest(TestCase):
         # Popular job descriptions count related **pending** job applications.
         # They should ignore other states.
         job_description = siae_job_descriptions[2]
-        for _ in range(SiaeJobDescription.POPULAR_THRESHOLD + 1):
-            JobApplicationFactory(
-                to_siae=self.siae, selected_jobs=[popular_job_description], state=JobApplicationWorkflow.STATE_ACCEPTED
-            )
+        threshold_exceeded = SiaeJobDescription.POPULAR_THRESHOLD + 1
+
+        JobApplicationFactory.create_batch(
+            threshold_exceeded,
+            to_siae=self.siae,
+            selected_jobs=[popular_job_description],
+            state=JobApplicationWorkflow.STATE_ACCEPTED,
+        )
 
         self.assertFalse(SiaeJobDescription.objects.with_annotation_is_popular().get(pk=job_description.pk).is_popular)
 

--- a/itou/siaes/tests.py
+++ b/itou/siaes/tests.py
@@ -4,19 +4,24 @@ from django.conf import settings
 from django.core import mail
 from django.test import RequestFactory, TestCase
 
+from itou.job_applications.factories import JobApplicationFactory
+from itou.job_applications.models import JobApplicationWorkflow
 from itou.siaes.factories import (
     SiaeAfterGracePeriodFactory,
     SiaeFactory,
     SiaePendingGracePeriodFactory,
     SiaeWith2MembershipsFactory,
     SiaeWith4MembershipsFactory,
+    SiaeWithJobsFactory,
     SiaeWithMembershipAndJobsFactory,
     SiaeWithMembershipFactory,
 )
-from itou.siaes.models import Siae
+
+from itou.siaes.models import Siae, SiaeJobDescription
+from itou.users.factories import SiaeStaffFactory
 
 
-class FactoriesTest(TestCase):
+class SiaeFactoriesTest(TestCase):
     def test_siae_with_membership_factory(self):
         siae = SiaeWithMembershipFactory()
         self.assertEqual(siae.members.count(), 1)
@@ -48,7 +53,7 @@ class FactoriesTest(TestCase):
         self.assertEqual(siae.active_admin_members.count(), 1)
 
 
-class ModelTest(TestCase):
+class SiaeModelTest(TestCase):
     def test_is_kind(self):
         siae = SiaeFactory(kind=Siae.KIND_GEIQ)
         self.assertTrue(siae.is_kind_geiq)
@@ -186,3 +191,56 @@ class ModelTest(TestCase):
         self.assertFalse(user in siae1.active_members)
         self.assertEqual(siae2.members.count(), 3)
         self.assertEqual(siae2.active_members.count(), 3)
+
+
+class SiaeQuerySetTest(TestCase):
+    def test_prefetch_job_description_through(self):
+        siae = SiaeWithJobsFactory()
+
+        siae_result = Siae.objects.prefetch_job_description_through().get(pk=siae.pk)
+        self.assertTrue(hasattr(siae_result, "job_description_through"))
+
+        first_job_description = siae_result.job_description_through.first()
+        self.assertTrue(hasattr(first_job_description, "is_popular"))
+
+
+class SiaeJobDescriptionQuerySetTest(TestCase):
+    def setUp(self):
+        self.siae = SiaeWithJobsFactory()
+
+    def test_with_is_popular(self):
+        siae_job_descriptions = self.siae.job_description_through.all()
+
+        # Test attribute presence
+        siae_job_description = SiaeJobDescription.objects.with_is_popular().first()
+        self.assertTrue(hasattr(siae_job_description, "is_popular"))
+
+        # Test popular threshold: popular job description
+        popular_job_description = siae_job_descriptions[0]
+        for _ in range(SiaeJobDescription.POPULAR_THRESHOLD + 1):
+            JobApplicationFactory(to_siae=self.siae, selected_jobs=[popular_job_description])
+
+        self.assertTrue(SiaeJobDescription.objects.with_is_popular().get(pk=popular_job_description.pk).is_popular)
+
+        # Test popular threshold: unpopular job description
+        unpopular_job_description = siae_job_descriptions[1]
+        JobApplicationFactory(to_siae=self.siae, selected_jobs=[unpopular_job_description])
+
+        self.assertFalse(SiaeJobDescription.objects.with_is_popular().get(pk=unpopular_job_description.pk).is_popular)
+
+        # Popular job descriptions count related **pending** job applications.
+        # They should ignore other states.
+        job_description = siae_job_descriptions[2]
+        for _ in range(SiaeJobDescription.POPULAR_THRESHOLD + 1):
+            JobApplicationFactory(
+                to_siae=self.siae, selected_jobs=[popular_job_description], state=JobApplicationWorkflow.STATE_ACCEPTED
+            )
+
+        self.assertFalse(SiaeJobDescription.objects.with_is_popular().get(pk=job_description.pk).is_popular)
+
+    def test_with_job_applications_count(self):
+        job_description = self.siae.job_description_through.first()
+        JobApplicationFactory(to_siae=self.siae, selected_jobs=[job_description])
+        siae_job_description = SiaeJobDescription.objects.with_job_applications_count().get(pk=job_description.pk)
+        self.assertTrue(hasattr(siae_job_description, "job_applications_count"))
+        self.assertEqual(siae_job_description.job_applications_count, 1)

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -75,7 +75,7 @@
                                 <a href="{{ job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}">
                                     {{ job.display_name }}
                                 </a>
-                                {% if job.jobapplication_set.count > 20 %}
+                                {% if job.is_popular %}
                                    <small>
                                        <span class="ml-3">
                                             {% include "includes/icon.html" with icon="trending-up" size=15 class="mr-1 text-danger" %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -79,7 +79,9 @@
                                    <small>
                                        <span class="ml-3">
                                             {% include "includes/icon.html" with icon="layers" size=15 class="mr-1 text-danger" %}
-                                            {% translate "Plus de 20 candidatures reçues" %}
+                                            {% blocktranslate with threshold=job.POPULAR_THRESHOLD %} 
+                                                Plus de {{ threshold }} candidatures reçues
+                                            {% endblocktranslate %}
                                         </span>
                                    </small>
                                 {% endif %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -78,7 +78,7 @@
                                 {% if job.is_popular %}
                                    <small>
                                        <span class="ml-3">
-                                            {% include "includes/icon.html" with icon="trending-up" size=15 class="mr-1 text-danger" %}
+                                            {% include "includes/icon.html" with icon="layers" size=15 class="mr-1 text-danger" %}
                                             {% translate "Plus de 20 candidatures reçues" %}
                                         </span>
                                    </small>

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -75,6 +75,14 @@
                                 <a href="{{ job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}">
                                     {{ job.display_name }}
                                 </a>
+                                {% if job.jobapplication_set.count > 20 %}
+                                   <small>
+                                       <span class="ml-3">
+                                            {% include "includes/icon.html" with icon="trending-up" size=15 class="mr-1 text-danger" %}
+                                            {% translate "Plus de 20 candidatures reçues" %}
+                                        </span>
+                                   </small>
+                                {% endif %}
                             </li>
                         {% endfor %}
                         </ul>


### PR DESCRIPTION
### Quoi ?

Affichage d'un message informatif dans la recherche employeurs si une fiche de poste a reçu plus de 20 candidatures. Cette limite étant une variable de la classe `SiaeJobDescription`, elle sera donc facilement modifiable.

### Pourquoi ?

Les candidats et prescripteurs envoient des candidatures sans savoir que l'employeur en a déjà reçu beaucoup trop.   

### Comment ?

Nous ajoutons également un `Manager` au modèle `SiaeJobDescription` afin de pouvoir annoter des `querysets` de manière lisible.

Cette PR ne génère qu'une requête de plus : il y en avant 9 avant contre 10 maintenant.

### Captures d'écran

![image](https://user-images.githubusercontent.com/6150920/110781255-f5ad1180-8265-11eb-929d-26b03bc1873b.png)
