### PR TITLE
Simplification de la méthode siae.prefetch_job_description_through

### DIFF
--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -67,10 +67,10 @@
                             <span class="badge badge-dark">{% translate "Priorité aux bénéficiaires de RQTH" %}</span>
                         </p>
                     {% endif %}
-                    {% if siae.job_description_through.exists and not siae.block_job_applications %}
+                    {% if siae.active_job_descriptions and not siae.block_job_applications %}
                         <h6 class="border-bottom border-gray pb-2">{% translate "Métiers proposés" %}</h6>
                         <ul class="mb-0">
-                        {% for job in siae.job_description_through.all %}
+                        {% for job in siae.active_job_descriptions %}
                             <li>
                                 <a href="{{ job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}">
                                     {{ job.display_name }}

--- a/itou/templates/siaes/card.html
+++ b/itou/templates/siaes/card.html
@@ -69,14 +69,14 @@
 
     {% else %}
 
-        {% if siae.job_description_through.exists %}
+        {% if siae.active_job_descriptions %}
             <hr>
             <p class="mb-2">
                 {% include "includes/icon.html" with icon="briefcase" %}
                 {% translate "Métiers proposés" %}
             </p>
             <ul>
-            {% for job in siae.job_description_through.all %}
+            {% for job in siae.active_job_descriptions %}
                 <li>
                     <a href="{{ job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}">{% translate job.display_name %}</a>
                 </li>

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -325,7 +325,7 @@ def step_application(request, siae_pk, template_name="apply/submit_step_applicat
     """
     Create and submit the job application.
     """
-    queryset = Siae.objects.prefetch_job_description_through()
+    queryset = Siae.objects.prefetch_related("job_description_through__appellation__rome")
     siae = get_object_or_404(queryset, pk=siae_pk)
 
     session_data = request.session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -43,8 +43,10 @@ def search_siaes_results(request, template_name="search/siaes_search_results.htm
                     When(_total_active_members__gte=1, then=Value(1)), default=Value(0), output_field=IntegerField()
                 )
             )
-            .prefetch_job_description_through(is_active=True)
-            .prefetch_related("members")
+            .prefetch_related(
+                "members",
+                "job_description_through__appellation__rome",
+            )
             # Sort in 4 subgroups in the following order, each subgroup being shuffled.
             # 1) has_active_members and not block_job_applications
             # These are the siaes which can currently hire, and should be on top.

--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -22,7 +22,7 @@ def card(request, siae_id, template_name="siaes/card.html"):
     # COVID-19 "Operation ETTI".
     Public view (previously private, made public during COVID-19).
     """
-    queryset = Siae.objects.prefetch_job_description_through(is_active=True)
+    queryset = Siae.objects.prefetch_related("job_description_through__appellation__rome")
     siae = get_object_or_404(queryset, pk=siae_id)
     back_url = get_safe_url(request, "back_url")
     context = {"siae": siae, "back_url": back_url}


### PR DESCRIPTION
### Quoi ?

Simplification de la méthode siae.prefetch_job_description_through.

### Pourquoi ?

Cette méthode me fait des noeuds au cerveau. Mais c'est peut-être juste moi, si c'est le cas, sentez-vous libre de refuser cette PR ! :-)

Je trouve que mélanger une logique `prefetch_related` et une logique de filtrage `is_active=True` au même endroit rend le code trop magique et difficilement lisible.

Je propose ici une alternative qui me parait plus lisible et transparente, en séparant les 2 logiques, tout en ne causant aucun impact significatif niveau requêtes SQL.

Avant :

![image](https://user-images.githubusercontent.com/10533583/110950009-fddf7c80-834b-11eb-9f05-b6d3a5fc2b5e.png)

Après :

![image](https://user-images.githubusercontent.com/10533583/110949965-ee603380-834b-11eb-8e15-51d6c69c4d22.png)

La différence semble être ces micro requêtes (2 ms) additionnelles :

![image](https://user-images.githubusercontent.com/10533583/110950192-341cfc00-834c-11eb-8cf4-700ea6fbfa80.png)

Franchement j'avoue ne pas bien comprendre d'où elles sortent.

En revanche les 2 grosses requêtes SQL principales au coeur de la recherche siae sont inchangées niveau perf.