### PR TITLE
Réactivation de PDF Shift 

### DIFF
--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -46,11 +46,11 @@
 
                     </div>
                     {% if job_application.can_download_approval_as_pdf %}
-                         <!-- <div class="col-sm-3">
+                        <div class="col-sm-3">
                             <a href="{# url 'approvals:approval_as_pdf' job_application_id=job_application.id #}" class="text-decoration-none disable-on-click matomo-event" data-matomo-category="agrement" data-matomo-action="telechargement-pdf" data-matomo-option="liste-candidatures">
                                 {% translate "Télécharger le PASS IAE" %}
                             </a>
-                        </div> -->
+                        </div>
                     {% endif %}
                     {% if siae.is_subject_to_eligibility_rules and job_application.approval and job_application.can_be_cancelled %}
                         <div class="col-sm-3">

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -57,14 +57,14 @@
                             </a>
                         {% endif %}
                         {% if job_application.can_download_approval_as_pdf %}
-                             <!-- <a
+                            <a
                                 href="{# url 'approvals:approval_as_pdf' job_application_id=job_application.id #}"
                                 class="btn btn-outline-primary float-right disable-on-click matomo-event"
                                 data-matomo-category="agrement"
                                 data-matomo-action="telechargement-pdf"
                                 data-matomo-option="details-candidature">
                                     {% translate "Télécharger le PASS IAE" %}
-                            </a> -->
+                            </a>
                         {% endif %}
                         {% if job_application.can_be_cancelled %}
                             <a class="btn btn-outline-secondary disabled w-100">

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -35,14 +35,6 @@
         </div>
     {% endif %}
 
-    {% if current_siae and current_siae.is_subject_to_eligibility_rules %}
-        <div class="alert alert-primary">
-            {% blocktranslate %}
-                Le téléchargement des PASS IAE est indisponible momentanément car un problème technique impacte la génération de PDF sur notre site. Nous nous excusons pour la gêne occasionnée.
-            {% endblocktranslate %}
-        </div>
-    {% endif %}
-
     {% if current_prescriber_organization and current_prescriber_organization.has_pending_authorization %}
         <div class="alert alert-warning pb-0" role="alert">
             <p>

--- a/itou/www/approvals_views/tests/tests.py
+++ b/itou/www/approvals_views/tests/tests.py
@@ -2,27 +2,22 @@ from unittest.mock import PropertyMock, patch
 
 from dateutil.relativedelta import relativedelta
 from django.core import mail
-
-# from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import urlencode
+from requests import exceptions as requests_exceptions
 
 from itou.approvals.factories import SuspensionFactory
 from itou.approvals.models import Approval, Prolongation, Suspension
 from itou.eligibility.factories import EligibilityDiagnosisFactory
-
-# from itou.job_applications.factories import JobApplicationFactory, JobApplicationWithApprovalFactory
-from itou.job_applications.factories import JobApplicationWithApprovalFactory
+from itou.job_applications.factories import JobApplicationFactory, JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.prescribers.factories import AuthorizedPrescriberOrganizationWithMembershipFactory
 from itou.users.factories import DEFAULT_PASSWORD
 
 from .pdfshift_mock import BITES_FILE
-
-
-# from requests import exceptions as requests_exceptions
 
 
 @patch.object(JobApplication, "can_be_cancelled", new_callable=PropertyMock, return_value=False)
@@ -40,78 +35,73 @@ class TestDownloadApprovalAsPDF(TestCase):
             reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk})
         )
 
-        # Temporarily disable approval download due to PDF Shift unavailability.
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("dashboard:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("pdf", response.get("Content-Type"))
 
-        # self.assertEqual(response.status_code, 200)
-        # self.assertEqual(response.status_code, 200)
-        # self.assertIn("pdf", response.get("Content-Type"))
+    def test_impossible_download_when_approval_is_missing(self, *args, **kwargs):
+        """
+        The button to download an approval is show only when
+        certain conditions are met.
+        Nevertheless, don't trust the client. Make sure we raise an error
+        if the same conditions are not met in this view.
+        """
+        # Create a job application without an approval.
+        job_application = JobApplicationFactory()
+        siae_member = job_application.to_siae.members.first()
+        job_seeker = job_application.job_seeker
+        EligibilityDiagnosisFactory(job_seeker=job_seeker)
 
-    # def test_impossible_download_when_approval_is_missing(self, *args, **kwargs):
-    #     """
-    #     The button to download an approval is show only when
-    #     certain conditions are met.
-    #     Nevertheless, don't trust the client. Make sure we raise an error
-    #     if the same conditions are not met in this view.
-    #     """
-    #     # Create a job application without an approval.
-    #     job_application = JobApplicationFactory()
-    #     siae_member = job_application.to_siae.members.first()
-    #     job_seeker = job_application.job_seeker
-    #     EligibilityDiagnosisFactory(job_seeker=job_seeker)
+        self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
+        response = self.client.get(
+            reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk})
+        )
+        self.assertEqual(response.status_code, 404)
 
-    #     self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
-    #     response = self.client.get(
-    #         reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk})
-    #     )
-    #     self.assertEqual(response.status_code, 404)
+    @patch("pdfshift.convert", side_effect=requests_exceptions.ConnectionError)
+    def test_pdfshift_api_is_down(self, *args, **kwargs):
+        job_application = JobApplicationWithApprovalFactory()
+        siae_member = job_application.to_siae.members.first()
+        job_seeker = job_application.job_seeker
+        EligibilityDiagnosisFactory(job_seeker=job_seeker)
 
-    # @patch("pdfshift.convert", side_effect=requests_exceptions.ConnectionError)
-    # def test_pdfshift_api_is_down(self, *args, **kwargs):
-    #     job_application = JobApplicationWithApprovalFactory()
-    #     siae_member = job_application.to_siae.members.first()
-    #     job_seeker = job_application.job_seeker
-    #     EligibilityDiagnosisFactory(job_seeker=job_seeker)
+        self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
 
-    #     self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
+        with self.assertRaises(ConnectionAbortedError):
+            self.client.get(reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk}))
 
-    #     with self.assertRaises(ConnectionAbortedError):
-    #         self.client.get(reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk}))
+    @patch("pdfshift.convert", return_value=BITES_FILE)
+    @patch("itou.approvals.models.CommonApprovalMixin.originates_from_itou", False)
+    def test_download_approval_even_if_diagnosis_is_missing(self, *args, **kwargs):
+        job_application = JobApplicationWithApprovalFactory()
+        siae_member = job_application.to_siae.members.first()
 
-    # @patch("pdfshift.convert", return_value=BITES_FILE)
-    # @patch("itou.approvals.models.CommonApprovalMixin.originates_from_itou", False)
-    # def test_download_approval_even_if_diagnosis_is_missing(self, *args, **kwargs):
-    #     job_application = JobApplicationWithApprovalFactory()
-    #     siae_member = job_application.to_siae.members.first()
+        # An approval has been delivered but it does not come from Itou.
+        # Therefore, the linked diagnosis exists but is not in our database.
+        # Don't create a diagnosis.
+        # EligibilityDiagnosisFactory(job_seeker=job_seeker)
 
-    #     # An approval has been delivered but it does not come from Itou.
-    #     # Therefore, the linked diagnosis exists but is not in our database.
-    #     # Don't create a diagnosis.
-    #     # EligibilityDiagnosisFactory(job_seeker=job_seeker)
+        self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
 
-    #     self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
+        response = self.client.get(
+            reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk})
+        )
 
-    #     response = self.client.get(
-    #         reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk})
-    #     )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("pdf", response.get("Content-Type"))
 
-    #     self.assertEqual(response.status_code, 200)
-    #     self.assertIn("pdf", response.get("Content-Type"))
+    @patch("itou.approvals.models.CommonApprovalMixin.originates_from_itou", True)
+    def test_no_download_if_missing_diagnosis(self, *args, **kwargs):
+        job_application = JobApplicationWithApprovalFactory()
+        siae_member = job_application.to_siae.members.first()
 
-    # @patch("itou.approvals.models.CommonApprovalMixin.originates_from_itou", True)
-    # def test_no_download_if_missing_diagnosis(self, *args, **kwargs):
-    #     job_application = JobApplicationWithApprovalFactory()
-    #     siae_member = job_application.to_siae.members.first()
+        # An approval has been delivered by Itou but there is no diagnosis.
+        # It should raise an error.
+        # EligibilityDiagnosisFactory(job_seeker=job_seeker)
 
-    #     # An approval has been delivered by Itou but there is no diagnosis.
-    #     # It should raise an error.
-    #     # EligibilityDiagnosisFactory(job_seeker=job_seeker)
+        self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
 
-    #     self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
-
-    #     with self.assertRaises(ObjectDoesNotExist):
-    #         self.client.get(reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk}))
+        with self.assertRaises(ObjectDoesNotExist):
+            self.client.get(reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk}))
 
 
 class ApprovalSuspendViewTest(TestCase):

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -21,9 +21,6 @@ from itou.www.approvals_views.forms import DeclareProlongationForm, SuspensionFo
 @login_required
 def approval_as_pdf(request, job_application_id, template_name="approvals/approval_as_pdf.html"):
 
-    # Temporarily disable approval download due to PDF Shift unavailability.
-    return HttpResponseRedirect(reverse_lazy("dashboard:index"))
-
     siae = get_current_siae_or_404(request)
 
     queryset = JobApplication.objects.select_related("job_seeker", "approval", "to_siae")


### PR DESCRIPTION
### Quoi ?

Réactivation de PDF Shift.

### Pourquoi ?

PDF Shift a terminé sa migration depuis OVH vers AWS.

On réactive comme avant, la gestion du timeout viendra dans les jours qui suivent.