### PR TITLE
Boost

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -418,7 +418,9 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
 
     @property
     def has_editable_job_seeker(self):
-        return (self.state.is_processing or self.state.is_accepted) and self.job_seeker.is_handled_by_proxy
+        return (
+            self.state.is_new or self.state.is_processing or self.state.is_accepted
+        ) and self.job_seeker.is_handled_by_proxy
 
     @property
     def hiring_starts_in_future(self):

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -395,6 +395,8 @@ class JobApplicationNotificationsTest(TestCase):
         # Body.
         self.assertIn(approval.user.get_full_name(), email.subject)
         self.assertIn(approval.number_with_spaces, email.body)
+        self.assertIn(approval.start_at.strftime("%d/%m/%Y"), email.body)
+        self.assertIn(approval.end_at.strftime("%d/%m/%Y"), email.body)
         self.assertIn(approval.user.last_name, email.body)
         self.assertIn(approval.user.first_name, email.body)
         self.assertIn(approval.user.birthdate.strftime("%d/%m/%Y"), email.body)

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -37,8 +37,8 @@
         {% endif %}
 
         {% if job_application.job_seeker.resume_link %}
-            <li>{% translate "Lien vers CV :" %} <a
-                    href="{{ job_application.job_seeker.resume_link }}">{{ job_application.job_seeker.resume_link }}</a>
+            <li>
+                <a href="{{ job_application.job_seeker.resume_link }}">{% translate "Lien vers CV" %}</a>
             </li>
         {% endif %}
     </ul>

--- a/itou/templates/approvals/email/deliver_body.txt
+++ b/itou/templates/approvals/email/deliver_body.txt
@@ -7,6 +7,7 @@ Merci d'avoir confirmé l'embauche d'un candidat sur les emplois de l'inclusion.
 {% endblocktranslate %}
 
 {% translate "PASS IAE N° :" %} {{ job_application.approval.number_with_spaces }}
+{% blocktranslate with start_at=job_application.approval.start_at|date:"d/m/Y" end_at=job_application.approval.end_at|date:"d/m/Y" %}Valide du {{ start_at }} au {{ end_at }}{% endblocktranslate %}
 
 {% translate "Délivré pour l'embauche de :" %}
 {% translate "Nom :" %} {{ job_application.approval.user.last_name }}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -224,7 +224,7 @@
                     <p class="card-text">
                         {% include "includes/icon.html" with icon="briefcase" %}
                         <a href="{% url 'siaes_views:configure_jobs' %}">
-                            {% translate "Configurer les descriptions de postes" %}
+                            {% translate "Publier/gérer les fiches de postes" %}
                         </a>
                     </p>
                     {% if current_siae.is_active and user_is_siae_admin %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -200,15 +200,6 @@
                         {% translate "La version de votre navigateur n'est plus supportée. Veuillez utiliser une version plus récente pour améliorer votre expérience sur notre site." %}
                     </div>
 
-                    {# Temporary message during the transition to the new domains. #}
-                    {% if not request.META.HTTP_REFERER %}
-                        <div class="alert alert-warning" role="alert">
-                            {% blocktranslate %}
-                                Notre nom de domaine change. Nous vous accueillons maintenant sur <b>{{ ITOU_FQDN }}</b>
-                            {% endblocktranslate %}
-                        </div>
-                    {% endif %}
-
                 {% endblock %}
             </div>
         </div>

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -62,7 +62,7 @@
                         {% if siae.brand %}<small class="text-muted">({{ siae.name|title }})</small>{% endif %}
                     </h5>
                     <h6 class="card-subtitle mb-2 text-muted">{{ siae.address_on_one_line }}</h6>
-                    {% if siae.is_kind_ea %}
+                    {% if siae.is_kind_ea or siae.is_kind_eatt %}
                         <p class="card-text">
                             <span class="badge badge-dark">{% translate "Priorité aux bénéficiaires de RQTH" %}</span>
                         </p>

--- a/itou/templates/siaes/configure_jobs.html
+++ b/itou/templates/siaes/configure_jobs.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-    <h1>{% translate "Configurer vos fiches de postes" %}</h1>
+    <h1>{% translate "Publier/gérer les fiches de postes" %}</h1>
 
     <h2 class="text-muted">{{ siae.display_name }}</h2>
 

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -22,7 +22,9 @@ class UserExistsForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.user = None
 
-    email = forms.EmailField(label=gettext_lazy("E-mail personnel du candidat"))
+    email = forms.EmailField(
+        label=gettext_lazy("E-mail personnel du candidat"), widget=forms.TextInput(attrs={"autocomplete": "off"})
+    )
 
     def clean_email(self):
         email = self.cleaned_data["email"]

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -88,6 +88,10 @@ class EditJobSeekerInfo(TestCase):
         job_application = JobApplicationSentByPrescriberFactory()
         user = job_application.to_siae.members.first()
 
+        # Ensure that the job seeker is not autonomous (i.e. he did not register by himself).
+        job_application.job_seeker.created_by = user
+        job_application.job_seeker.save()
+
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
         self.client.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = job_application.to_siae.pk
 

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -149,6 +149,9 @@ def edit_job_seeker_info(request, job_application_id, template_name="dashboard/e
     if not current_siae_pk or current_siae_pk != job_application.to_siae.pk:
         raise PermissionDenied
 
+    if not job_application.has_editable_job_seeker:
+        raise PermissionDenied
+
     dashboard_url = reverse_lazy("dashboard:index")
     back_url = get_safe_url(request, "back_url", fallback_url=dashboard_url)
     form = EditUserInfoForm(instance=job_application.job_seeker, data=request.POST or None)


### PR DESCRIPTION
### Quoi ?

- Suppression du message d'alerte "Notre nom de domaine change…"
- Désactivation de l'*autocomplete* sur le champ "E-mail personnel du candidat" (pour éviter des erreurs de saisie)
- Sur le tableau de bord des SIAE, le lien "Configurer vos fiches de postes" devient "Publier/gérer les fiches de postes"
- Affichage des dates du PASS IAE dans l'e-mail de confirmation d'envoi du PASS ("Valide du … au …")
- Ajout de la possibilité de modifier les informations d'un candidat en liste d'attente (c'est à dire quand la candidature est à l'état `new`)
- Affichage du badge "Priorité aux bénéficiaires de RQTH" pour les EATT
- On affiche plus le lien complet du CV pour éviter de casser la mise en page quand le lien est trop long

### Suppression du message d'alerte "Notre nom de domaine change…"

![alert_dns](https://user-images.githubusercontent.com/281139/111297639-20281180-864e-11eb-849e-9c626c88b5a8.png)

### Désactivation de l'*autocomplete* sur le champ "E-mail personnel du candidat"

<img width="1433" alt="marc_voit_un_autocomplete_en_local_dev" src="https://user-images.githubusercontent.com/281139/111297647-21593e80-864e-11eb-96d1-ad286ffd40e9.png">

### "Configurer vos fiches de postes" devient "Publier/gérer les fiches de postes"

![wording_fdp](https://user-images.githubusercontent.com/281139/111297650-228a6b80-864e-11eb-9f9f-b60c72d65f40.png)

### Ajout de la possibilité de modifier les informations d'un candidat en liste d'attente

![change_info](https://user-images.githubusercontent.com/281139/111297952-8319a880-864e-11eb-933b-9dee26fc9c25.png)

### Affichage du badge "Priorité aux bénéficiaires de RQTH" pour les EATT

![badge_eatt](https://user-images.githubusercontent.com/281139/111297654-228a6b80-864e-11eb-8459-094ec5873aa6.png)

### On affiche plus le lien complet du CV

![cv_link](https://user-images.githubusercontent.com/281139/111297657-23230200-864e-11eb-8027-f67589ff29c7.png)
