### PR TITLE
Réduction du nombre de requêtes SQL à l'import PE

### DIFF
--- a/itou/allauth_adapters/peamu/adapter.py
+++ b/itou/allauth_adapters/peamu/adapter.py
@@ -24,9 +24,9 @@ class PEAMUOAuth2Adapter(OAuth2Adapter):
     def complete_login(self, request, app, token, **kwargs):
         id_token = token.token
         headers = {"Authorization": f"Bearer {id_token}"}
-        resp = requests.get(self.profile_url, params=None, headers=headers, timeout=settings.REQUESTS_TIMEOUT)
-        resp.raise_for_status()
-        extra_data = resp.json()
+        response = requests.get(self.profile_url, params=None, headers=headers, timeout=settings.REQUESTS_TIMEOUT)
+        response.raise_for_status()
+        extra_data = response.json()
         extra_data["id_token"] = id_token
         login = self.get_provider().sociallogin_from_response(request, extra_data)
         return login

--- a/itou/allauth_adapters/peamu/tests.py
+++ b/itou/allauth_adapters/peamu/tests.py
@@ -30,7 +30,7 @@ class PEAMUTests(OAuth2TestsMixin, TestCase):
             """,
         )
 
-    @mock.patch("itou.external_data.signals.save_pe_token_on_peamu_login")
+    @mock.patch("itou.external_data.signals.import_user_pe_data_on_peamu_login")
     def test_data_created_by_peamu_login(self, mock_login_signal):
         test_email = "john.doe@example.com"
         self.login(self.get_mocked_response())
@@ -56,7 +56,7 @@ class PEAMUTests(OAuth2TestsMixin, TestCase):
         self.assertEqual(email_address.user.is_siae_staff, False)
         self.assertEqual(email_address.user.is_staff, False)
 
-    @mock.patch("itou.external_data.signals.save_pe_token_on_peamu_login")
+    @mock.patch("itou.external_data.signals.import_user_pe_data_on_peamu_login")
     def test_peamu_connection_for_existing_non_peamu_user(self, mock_login_signal):
         email = "user@example.com"
         user = get_user_model().objects.create(username="user", is_active=True, email=email, is_job_seeker=True)
@@ -77,7 +77,7 @@ class PEAMUTests(OAuth2TestsMixin, TestCase):
         self.assertEqual(EmailAddress.objects.filter(email=email).count(), 1)
         self.assertEqual(EmailAddress.objects.filter(email="john.doe@example.com").count(), 0)
 
-    @mock.patch("itou.external_data.signals.save_pe_token_on_peamu_login")
+    @mock.patch("itou.external_data.signals.import_user_pe_data_on_peamu_login")
     def test_email_verification_is_skipped_for_peamu_account(self, mock_login_signal):
         test_email = "john.doe@example.com"
         self.login(self.get_mocked_response())
@@ -88,7 +88,7 @@ class PEAMUTests(OAuth2TestsMixin, TestCase):
         self.assertFalse(EmailConfirmation.objects.filter(email_address__email=test_email).exists())
         self.assertEqual(len(mail.outbox), 0)
 
-    @mock.patch("itou.external_data.signals.save_pe_token_on_peamu_login")
+    @mock.patch("itou.external_data.signals.import_user_pe_data_on_peamu_login")
     def test_username_is_based_on_first_name(self, mock_login_signal):
         first_name = "jessica"
         last_name = "parker"
@@ -98,7 +98,7 @@ class PEAMUTests(OAuth2TestsMixin, TestCase):
         user = get_user_model().objects.get(email=email)
         self.assertEqual(user.username, "jessica")
 
-    @mock.patch("itou.external_data.signals.save_pe_token_on_peamu_login")
+    @mock.patch("itou.external_data.signals.import_user_pe_data_on_peamu_login")
     def test_username_is_based_on_email_if_first_name_is_exotic(self, mock_login_signal):
         first_name = "明"
         last_name = "小"
@@ -108,7 +108,7 @@ class PEAMUTests(OAuth2TestsMixin, TestCase):
         user = get_user_model().objects.get(email=email)
         self.assertEqual(user.username, "john.doe")
 
-    @mock.patch("itou.external_data.signals.save_pe_token_on_peamu_login")
+    @mock.patch("itou.external_data.signals.import_user_pe_data_on_peamu_login")
     def test_user_signed_up_signal(self, mock_login_signal):
         sent_signals = []
 

--- a/itou/external_data/models.py
+++ b/itou/external_data/models.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 
 class ExternalDataImportQuerySet(models.QuerySet):
-    def pe_imports(self):
+    def pe_sources(self):
         return self.filter(source=ExternalDataImport.DATA_SOURCE_PE_CONNECT)
 
 

--- a/itou/external_data/signals.py
+++ b/itou/external_data/signals.py
@@ -4,10 +4,10 @@ from django.dispatch import receiver
 from itou.allauth_adapters.peamu.provider import PEAMUProvider
 
 from .models import ExternalDataImport
-from .tasks import import_pe_data
+from .tasks import huey_import_user_pe_data
 
 
-def save_pe_token_on_peamu_login(sender, **kwargs):
+def import_user_pe_data_on_peamu_login(sender, **kwargs):
     """
     Get token from succesful login for async PE API calls
     This is a receiver for a allauth signal (`user_logged_in`)
@@ -18,15 +18,14 @@ def save_pe_token_on_peamu_login(sender, **kwargs):
     # This part only for users login-in with PE
     if user and login and login.account.provider == PEAMUProvider.id:
         # Format and store data if needed
-        pe_data_import = user.externaldataimport_set.pe_imports()
-
-        # If no data for user or import failed last time
-        if not pe_data_import.exists() or pe_data_import.first().status != ExternalDataImport.STATUS_OK:
+        latest_pe_data_import = user.externaldataimport_set.pe_sources().first()
+        if latest_pe_data_import is None or latest_pe_data_import.status != ExternalDataImport.STATUS_OK:
+            # No data for user or the import failed last time
             # Async via Huey
-            import_pe_data(user.pk, str(login.token))
+            huey_import_user_pe_data(user, str(login.token), latest_pe_data_import)
 
 
 @receiver(user_logged_in)
 def user_logged_in_receiver(sender, **kwargs):
     # Wrapper required to mock the db_task of Huey in unit tests
-    save_pe_token_on_peamu_login(sender, **kwargs)
+    import_user_pe_data_on_peamu_login(sender, **kwargs)

--- a/itou/external_data/tasks.py
+++ b/itou/external_data/tasks.py
@@ -1,8 +1,8 @@
 from huey.contrib.djhuey import db_task
 
-from .apis.pe_connect import import_user_data
+from .apis.pe_connect import import_user_pe_data
 
 
 @db_task()
-def import_pe_data(user_pk, token):
-    import_user_data(user_pk, token)
+def huey_import_user_pe_data(user, token, pe_data_import):
+    import_user_pe_data(user, token, pe_data_import)

--- a/itou/external_data/tests.py
+++ b/itou/external_data/tests.py
@@ -6,12 +6,12 @@ from django.test import TestCase
 import itou.external_data.apis.pe_connect as pec
 from itou.users.factories import JobSeekerFactory
 
-from .apis.pe_connect import import_user_data
+from .apis.pe_connect import import_user_pe_data
 from .models import ExternalDataImport
 
 
 # Test data import status (All ok, failed, partial)
-# Tests are SYNCHRONOUS (because calls to `import_user_data` are)
+# Tests are SYNCHRONOUS (because calls to `import_user_pe_data` are)
 
 FOO_TOKEN = "kreacher_token"
 
@@ -96,8 +96,8 @@ class ExternalDataImportTest(TestCase):
         # Mock all PE APIs
         _status_ok(m)
 
-        result = import_user_data(user.pk, FOO_TOKEN)
-        self.assertEqual(result.status, ExternalDataImport.STATUS_OK)
+        result = import_user_pe_data(user, FOO_TOKEN)
+        self.assertEquals(result.status, ExternalDataImport.STATUS_OK)
 
         report = result.report
 
@@ -112,8 +112,8 @@ class ExternalDataImportTest(TestCase):
         user = JobSeekerFactory()
         _status_partial(m)
 
-        result = import_user_data(user.pk, FOO_TOKEN)
-        self.assertEqual(result.status, ExternalDataImport.STATUS_PARTIAL)
+        result = import_user_pe_data(user, FOO_TOKEN)
+        self.assertEquals(result.status, ExternalDataImport.STATUS_PARTIAL)
 
         report = result.report
         self.assertTrue(user.has_external_data)
@@ -130,8 +130,8 @@ class ExternalDataImportTest(TestCase):
         user = JobSeekerFactory()
         _status_failed(m)
 
-        result = import_user_data(user.pk, FOO_TOKEN)
-        self.assertEqual(result.status, ExternalDataImport.STATUS_FAILED)
+        result = import_user_pe_data(user, FOO_TOKEN)
+        self.assertEquals(result.status, ExternalDataImport.STATUS_FAILED)
 
         report = result.report
         self.assertEqual(0, len(report.get("fields_updated")))
@@ -150,7 +150,7 @@ class JobSeekerExternalDataTest(TestCase):
         user.birthdate = None
         user.save()
 
-        result = import_user_data(user.pk, FOO_TOKEN)
+        result = import_user_pe_data(user, FOO_TOKEN)
         user.refresh_from_db()
         self.assertTrue(user.has_external_data)
 
@@ -172,7 +172,7 @@ class JobSeekerExternalDataTest(TestCase):
         user = JobSeekerFactory()
         birthdate = user.birthdate
 
-        report = import_user_data(user.pk, FOO_TOKEN).report
+        report = import_user_pe_data(user, FOO_TOKEN).report
 
         user.refresh_from_db()
 
@@ -184,7 +184,7 @@ class JobSeekerExternalDataTest(TestCase):
         _status_partial(m)
 
         user = JobSeekerFactory()
-        import_user_data(user.pk, FOO_TOKEN)
+        import_user_pe_data(user, FOO_TOKEN)
         user.refresh_from_db()
         self.assertTrue(user.has_external_data)
 
@@ -202,7 +202,7 @@ class JobSeekerExternalDataTest(TestCase):
         _status_failed(m)
 
         user = JobSeekerFactory()
-        import_user_data(user.pk, FOO_TOKEN)
+        import_user_pe_data(user, FOO_TOKEN)
         user.refresh_from_db()
         self.assertTrue(user.has_external_data)
 
@@ -217,7 +217,7 @@ class JobSeekerExternalDataTest(TestCase):
         user1 = JobSeekerFactory()
         user2 = JobSeekerFactory()
 
-        import_user_data(user1.pk, FOO_TOKEN)
+        import_user_pe_data(user1, FOO_TOKEN)
         user1.refresh_from_db()
 
         self.assertTrue(user1.has_external_data)

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -122,7 +122,7 @@ def edit_user_info(request, template_name="dashboard/edit_user_info.html"):
     dashboard_url = reverse_lazy("dashboard:index")
     prev_url = get_safe_url(request, "prev_url", fallback_url=dashboard_url)
     form = EditUserInfoForm(instance=request.user, data=request.POST or None)
-    extra_data = request.user.externaldataimport_set.pe_imports().first()
+    extra_data = request.user.externaldataimport_set.pe_sources().first()
     job_seeker_signed_pk = resume_signer.sign(request.user.pk)
 
     if request.method == "POST" and form.is_valid():


### PR DESCRIPTION
### Quoi ?

Réduction du nombre de requêtes SQL à l'import PE.

### Pourquoi ?

Parce que moins de requêtes c'est mieux, pardi !

### Comment ?

En passant l'instance de l'ORM en argument ou en utilisant la même query pour 2 tests, etc.
Au passage, quelques modifications concernant des remarques de pylint :
- les appels du logger doivent être lazy (pas de formatage des args sinon les loggers ne peuvent pas regrouper les messages)
- j'ai essayé de clarifier les noms de variables/fonctions, pas sûr d'y être vraiment parvenu, avec une table nommée ExternalDataImport, je ne suis pas aidé !

Seul le dernier commit de cette PR est intéressant (cette PR est dépendante d'une autre).

