### PR TITLE
Pouvoir supprimer le geocoding dans l'admin

### DIFF
--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -152,6 +152,7 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
         "authorization_status",
         "authorization_updated_at",
         "authorization_updated_by",
+        "geocoding_score",
     )
     search_fields = (
         "pk",

--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.contrib.gis import forms as gis_forms
+from django.contrib.gis.db import models as gis_models
 from django.db.models import Count
 from django.utils.timezone import now
 from django.utils.translation import gettext as _
@@ -143,7 +145,6 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
     raw_id_fields = ("created_by",)
     readonly_fields = (
         "pk",
-        "coords",  # Quick tip to disable GeoDjango's Openlayers map.
         "created_by",
         "created_at",
         "updated_at",
@@ -162,6 +163,10 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
         "post_code",
         "address_line_1",
     )
+    formfield_overrides = {
+        # https://docs.djangoproject.com/en/2.2/ref/contrib/gis/forms-api/#widget-classes
+        gis_models.PointField: {"widget": gis_forms.OSMWidget(attrs={"map_width": 800, "map_height": 500})}
+    }
 
     def member_count(self, obj):
         return obj._member_count

--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -6,6 +6,7 @@ from django.utils.timezone import now
 from django.utils.translation import gettext as _
 
 from itou.prescribers import models
+from itou.prescribers.admin_forms import PrescriberOrganizationAdminForm
 
 
 class TmpMissingSiretFilter(admin.SimpleListFilter):
@@ -96,6 +97,7 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
     class Media:
         css = {"all": ("css/itou-admin.css",)}
 
+    form = PrescriberOrganizationAdminForm
     change_form_template = "admin/prescribers/change_form.html"
     fieldsets = (
         (
@@ -111,6 +113,7 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
                     "post_code",
                     "city",
                     "department",
+                    "extra_field_refresh_geocoding",
                     "coords",
                     "geocoding_score",
                 )
@@ -187,11 +190,9 @@ class PrescriberOrganizationAdmin(admin.ModelAdmin):
                 # Set geocoding.
                 obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
 
-        if change and obj.geocoding_address:
-            old_obj = self.model.objects.get(id=obj.id)
-            if obj.geocoding_address != old_obj.geocoding_address:
-                # Refresh geocoding.
-                obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
+        if change and form.cleaned_data.get("extra_field_refresh_geocoding") and obj.geocoding_address:
+            # Refresh geocoding.
+            obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
 
         super().save_model(request, obj, form, change)
 

--- a/itou/prescribers/admin_forms.py
+++ b/itou/prescribers/admin_forms.py
@@ -1,0 +1,21 @@
+from django import forms
+from django.utils.translation import gettext_lazy
+
+from itou.prescribers.models import PrescriberOrganization
+
+
+class PrescriberOrganizationAdminForm(forms.ModelForm):
+
+    # Add a custom form field that is not part of the model in the admin.
+    extra_field_refresh_geocoding = forms.BooleanField(
+        label=gettext_lazy("Recalculer le geocoding"),
+        help_text=gettext_lazy(
+            "Si cette case est cochée, les coordonnées géographiques seront mises à "
+            "jour si l'adresse est correctement renseignée."
+        ),
+        required=False,
+    )
+
+    class Meta:
+        model = PrescriberOrganization
+        fields = "__all__"

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -9,6 +9,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
 from itou.siaes import models
+from itou.siaes.admin_forms import SiaeAdminForm
 
 
 class MembersInline(admin.TabularInline):
@@ -82,6 +83,7 @@ class SiaeHasMembersFilter(admin.SimpleListFilter):
 
 @admin.register(models.Siae)
 class SiaeAdmin(admin.ModelAdmin):
+    form = SiaeAdminForm
     list_display = ("pk", "siret", "kind", "name", "department", "geocoding_score", "member_count")
     list_filter = (SiaeHasMembersFilter, "kind", "block_job_applications", "source", "department")
     raw_id_fields = ("created_by", "convention")
@@ -129,6 +131,7 @@ class SiaeAdmin(admin.ModelAdmin):
                     "post_code",
                     "city",
                     "department",
+                    "extra_field_refresh_geocoding",
                     "coords",
                     "geocoding_score",
                 )
@@ -160,11 +163,9 @@ class SiaeAdmin(admin.ModelAdmin):
                 # Set geocoding.
                 obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
 
-        if change and obj.geocoding_address:
-            old_obj = self.model.objects.get(id=obj.id)
-            if obj.geocoding_address != old_obj.geocoding_address:
-                # Refresh geocoding.
-                obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
+        if change and form.cleaned_data.get("extra_field_refresh_geocoding") and obj.geocoding_address:
+            # Refresh geocoding.
+            obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
 
         # Pulled-up the save action:
         # many-to-many relationships / cross-tables references

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -1,6 +1,8 @@
 import datetime
 
 from django.contrib import admin, messages
+from django.contrib.gis import forms as gis_forms
+from django.contrib.gis.db import models as gis_models
 from django.db.models import Count
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -85,7 +87,6 @@ class SiaeAdmin(admin.ModelAdmin):
     raw_id_fields = ("created_by", "convention")
     readonly_fields = (
         "pk",
-        "coords",  # Quick tip to disable GeoDjango's Openlayers map.
         "source",
         "created_by",
         "created_at",
@@ -135,6 +136,10 @@ class SiaeAdmin(admin.ModelAdmin):
     )
     search_fields = ("pk", "siret", "name", "city", "department", "post_code", "address_line_1")
     inlines = (MembersInline, JobsInline)
+    formfield_overrides = {
+        # https://docs.djangoproject.com/en/2.2/ref/contrib/gis/forms-api/#widget-classes
+        gis_models.PointField: {"widget": gis_forms.OSMWidget(attrs={"map_width": 800, "map_height": 500})}
+    }
 
     def member_count(self, obj):
         return obj._member_count

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -92,6 +92,7 @@ class SiaeAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
         "job_applications_blocked_at",
+        "geocoding_score",
     )
     fieldsets = (
         (

--- a/itou/siaes/admin_forms.py
+++ b/itou/siaes/admin_forms.py
@@ -1,0 +1,21 @@
+from django import forms
+from django.utils.translation import gettext_lazy
+
+from itou.siaes.models import Siae
+
+
+class SiaeAdminForm(forms.ModelForm):
+
+    # Add a custom form field that is not part of the model in the admin.
+    extra_field_refresh_geocoding = forms.BooleanField(
+        label=gettext_lazy("Recalculer le geocoding"),
+        help_text=gettext_lazy(
+            "Si cette case est cochée, les coordonnées géographiques seront mises à "
+            "jour si l'adresse est correctement renseignée."
+        ),
+        required=False,
+    )
+
+    class Meta:
+        model = Siae
+        fields = "__all__"


### PR DESCRIPTION
### Quoi ?

Pouvoir supprimer le _geocoding_ dans l'admin des SIAE et des organisations de prescripteurs.

### Pourquoi ?

Le support se sert de cette fonctionnalité pour supprimer une organisation de la liste des résultats de recherche.

### Comment ?

J'en profite au passage pour couvrir tous les cas d'usage possible dans l'admin :

- pouvoir explicitement demander un re-calcul du _geocoding_ (ou changer une adresse sans le modifier)
- pouvoir déplacer à la main la localisation pour du _fine tuning_ en affichant une carte
- pouvoir supprimer les coordonnées

_Bonus track_: le score du _geocoding_ passe en read-only

### Captures d'écran

![geocoding](https://user-images.githubusercontent.com/281139/111981524-16982100-8b08-11eb-8e03-2fe8043967a2.png)
