### PR TITLE
Prise en compte d'un changement de date de fin d'annexe financière

### DIFF
--- a/itou/siaes/management/commands/_import_siae/financial_annex.py
+++ b/itou/siaes/management/commands/_import_siae/financial_annex.py
@@ -36,7 +36,12 @@ def get_creatable_and_deletable_afs(dry_run):
             af.start_at = row.start_at
             if not dry_run:
                 af.save()
-        assert af.end_at == row.end_date
+
+        # Sometimes an AF end date changes.
+        if af.end_at != row.end_date:
+            af.end_at = row.end_date
+            if not dry_run:
+                af.save()
 
         # Sometimes an AF state changes.
         if af.state != row.state:


### PR DESCRIPTION
### Quoi ?

Prise en compte d'un changement de date de fin d'annexe financière.

### Pourquoi ?

Lors de l'import des données ASP, la date de fin d'une annexe financière peut changer. Nous devons prendre en compte ce changement.
