### PR TITLE
Rendre visible les infos du PASS IAE lorsqu'il est expiré

### DIFF
--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -108,18 +108,31 @@
 
 {% elif approval.is_in_waiting_period %}
 
-    {% comment %}
-    Hide the "expired" status when a job application is sent by an authorized prescriber
-    for a job seeker with an approval in waiting period. The "expired" status suggests to
-    employers that they cannot hire the job seeker. But authorized prescribers can bypass
-    approvals in waiting period.
-    {% endcomment %}
-    {% if not job_application.is_sent_by_authorized_prescriber %}
+    {% if job_application.is_pending and job_application.is_sent_by_authorized_prescriber %}
+
+        {% comment %}
+        Display nothing about the status.
+
+        When an authorized prescriber bypasses the waiting period and sends a candidate
+        with an "expired" approval, the employer receives the application with the mention
+        "expired". He thinks that the hiring is impossible when he just has to validate
+        the job application to get a new PASS IAE.
+
+        The mention "expired" is removed if the job application is sent by an authorized
+        prescriber and is still waiting to be processed.
+
+        Otherwise the employer could decline the job application thinking that the hiring
+        is impossible.
+        {% endcomment %}
+
+    {% else %}
+
         <p class="text-danger">
             {% blocktranslate with end=approval.end_at|date:"d/m/Y" since=approval.end_at|timesince %}
                 <b>Expiré</b> le {{ end }} (depuis {{ since }})
             {% endblocktranslate %}
         </p>
+
     {% endif %}
 
 {% endif %}


### PR DESCRIPTION
### Quoi ?

Rendre visible les infos du PASS IAE lorsqu'il est expiré.

### Pourquoi ?

Dès que le PASS est expiré, l'employeur ne peut plus voir les dates et informations liées à ce PASS. 

### Comment ?

Ce comportement date de la PR #530 dans laquelle on a décidé de faire disparaitre la mention "agrément expiré" si la candidature est envoyée par un prescripteur habilité pour ne pas semer le doute dans la tête de l'employeur.

Il manquait une condition : que la candidature soit toujours en attente de traitement.

Dans tous les autres cas, il faut afficher la mention "expiré" avec les dates de début et de fin du PASS IAE.

### Captures d'écran

![expired](https://user-images.githubusercontent.com/281139/112126083-63413200-8bc4-11eb-99c0-2260d95a5da0.png)
