### PR TITLE
Des agréments Pôle emploi sont expirés alors qu'ils devraient bénéficier de la prolongation COVID

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -105,7 +105,7 @@ class ApprovalAdmin(admin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
     def is_valid(self, obj):
-        return obj.is_valid
+        return obj.is_valid()
 
     is_valid.boolean = True
     is_valid.short_description = _("En cours de validité")
@@ -263,7 +263,7 @@ class PoleEmploiApprovalAdmin(admin.ModelAdmin):
     date_hierarchy = "birthdate"
 
     def is_valid(self, obj):
-        return obj.is_valid
+        return obj.is_valid()
 
     is_valid.boolean = True
     is_valid.short_description = _("En cours de validité")

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -50,10 +50,10 @@ class CommonApprovalMixin(models.Model):
     class Meta:
         abstract = True
 
-    @property
-    def is_valid(self):
+    def is_valid(self, end_at=None):
+        end_at = end_at or self.end_at
         now = timezone.now().date()
-        return (self.start_at <= now <= self.end_at) or (self.start_at >= now)
+        return (self.start_at <= now <= end_at) or (self.start_at >= now)
 
     @property
     def is_in_progress(self):
@@ -327,7 +327,7 @@ class Approval(CommonApprovalMixin):
         a pre-existing valid PoleEmploiApproval by copying its data.
         """
         approval = approvals_wrapper.latest_approval
-        if not approval.is_valid or not isinstance(approval, (cls, PoleEmploiApproval)):
+        if not approval.is_valid() or not isinstance(approval, (cls, PoleEmploiApproval)):
             raise RuntimeError(_("Invalid approval."))
         if isinstance(approval, cls):
             return approval
@@ -937,6 +937,12 @@ class PoleEmploiApproval(CommonApprovalMixin):
     def __str__(self):
         return self.number
 
+    def is_valid(self):
+        end_at = self.end_at
+        if self.overlaps_covid_lockdown:
+            end_at = end_at + relativedelta(months=self.LOCKDOWN_EXTENSION_DELAY_MONTHS)
+        return super().is_valid(end_at=end_at)
+
     @staticmethod
     def format_name_as_pole_emploi(name):
         """
@@ -1012,7 +1018,7 @@ class ApprovalsWrapper:
             self.status = self.NONE_FOUND
         else:
             self.latest_approval = self.merged_approvals[0]
-            if self.latest_approval.is_valid:
+            if self.latest_approval.is_valid():
                 self.status = self.VALID
             elif self.latest_approval.waiting_period_has_elapsed:
                 # The `Période de carence` is over. A job seeker can get a new Approval.
@@ -1033,7 +1039,7 @@ class ApprovalsWrapper:
 
         # If an ongoing PASS IAE exists, consider it's the latest valid approval
         # even if a PoleEmploiApproval is more recent.
-        if any(approval.is_valid for approval in approvals):
+        if any(approval.is_valid() for approval in approvals):
             return approvals
 
         approvals_numbers = [approval.number for approval in approvals]

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -94,6 +94,10 @@ class CommonApprovalMixin(models.Model):
         starts_after_lockdown = self.start_at > self.LOCKDOWN_END_AT
         return not (ends_before_lockdown or starts_after_lockdown)
 
+    @property
+    def display_end_at(self):
+        return self.end_at
+
 
 class CommonApprovalQuerySet(models.QuerySet):
     """
@@ -950,6 +954,13 @@ class PoleEmploiApproval(CommonApprovalMixin):
         Upper-case ASCII transliterations of Unicode text.
         """
         return unidecode(name.strip()).upper()
+
+    @property
+    def display_end_at(self):
+        end_at = self.end_at
+        if self.overlaps_covid_lockdown:
+            end_at = end_at + relativedelta(months=self.LOCKDOWN_EXTENSION_DELAY_MONTHS)
+        return end_at
 
     @property
     def number_with_spaces(self):

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -962,16 +962,20 @@ class PoleEmploiApproval(CommonApprovalMixin):
     @property
     def display_end_at(self):
         """
-        When importing Pôle emploi approvals from a file, the COVID prolongation is not integrated to the set we receive and we decided not to apply it at this moment to preserve data integrity.
+        When importing Pôle emploi approvals from a file, the COVID prolongation is not integrated
+        to the set we receive and we decided not to apply it at this moment to preserve data integrity.
         We set it when transforming an approval into a PASS IAE (concretely PoleEmploiApproval => Approval).
-        But a beforehand step is distorting the process: the fetching of valid approvals (see ApprovalsWrapper). In fact, an expired approval that could benefit from the COVID prolongation is still considered invalid as its end date has not been updated yet.
+        But a beforehand step is distorting the process: the fetching of valid approvals (see
+        ApprovalsWrapper). In fact, an expired approval that could benefit from the COVID prolongation
+        is still considered invalid as its end date has not been updated yet.
 
         Steps:
         - Fetching of the last available approval: Approval.get_or_create_from_valid(approvals_wrapper)
         - If a PoleEmploiApproval is found and is valid, continue to the save()
         - In Approval > save(), apply the COVID prolongation.
 
-        To apply this prolongation without reflecting it into the database, we override two parent methods:
+        To apply this prolongation without reflecting it into the database,
+        we override two parent methods:
         - self.is_valid()
         - self.display_end_at: extended end_at
         """

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import Permission
@@ -119,26 +120,6 @@ class CommonApprovalMixinTest(TestCase):
         expected = datetime.date(2002, 1, 1)
         self.assertEqual(approval.waiting_period_end, expected)
 
-    def test_is_valid(self):
-
-        # End today.
-        end_at = datetime.date.today()
-        start_at = end_at - relativedelta(years=2)
-        approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertTrue(approval.is_valid)
-
-        # Ended yesterday.
-        end_at = datetime.date.today() - relativedelta(days=1)
-        start_at = end_at - relativedelta(years=2)
-        approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertFalse(approval.is_valid)
-
-        # Start tomorrow.
-        start_at = datetime.date.today() + relativedelta(days=1)
-        end_at = start_at + relativedelta(years=2)
-        approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertTrue(approval.is_valid)
-
     def test_is_in_progress(self):
         start_at = datetime.date.today() - relativedelta(days=10)
         approval = ApprovalFactory(start_at=start_at)
@@ -150,28 +131,28 @@ class CommonApprovalMixinTest(TestCase):
         end_at = datetime.date.today() + relativedelta(days=1)
         start_at = end_at - relativedelta(years=2)
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertTrue(approval.is_valid)
+        self.assertTrue(approval.is_valid())
         self.assertFalse(approval.is_in_waiting_period)
 
         # End is today.
         end_at = datetime.date.today()
         start_at = end_at - relativedelta(years=2)
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertTrue(approval.is_valid)
+        self.assertTrue(approval.is_valid())
         self.assertFalse(approval.is_in_waiting_period)
 
         # End is yesterday.
         end_at = datetime.date.today() - relativedelta(days=1)
         start_at = end_at - relativedelta(years=2)
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertFalse(approval.is_valid)
+        self.assertFalse(approval.is_valid())
         self.assertTrue(approval.is_in_waiting_period)
 
         # Ended since more than WAITING_PERIOD_YEARS.
         end_at = datetime.date.today() - relativedelta(years=Approval.WAITING_PERIOD_YEARS, days=1)
         start_at = end_at - relativedelta(years=2)
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertFalse(approval.is_valid)
+        self.assertFalse(approval.is_valid())
         self.assertFalse(approval.is_in_waiting_period)
 
     def test_originates_from_itou(self):
@@ -288,25 +269,25 @@ class ApprovalModelTest(TestCase):
         start_at = datetime.date.today()
         end_at = start_at + relativedelta(years=2)
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertTrue(approval.is_valid)
+        self.assertTrue(approval.is_valid())
 
         # End today.
         end_at = datetime.date.today()
         start_at = end_at - relativedelta(years=2)
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertTrue(approval.is_valid)
+        self.assertTrue(approval.is_valid())
 
         # Ended 1 year ago.
         end_at = datetime.date.today() - relativedelta(years=1)
         start_at = end_at - relativedelta(years=2)
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertFalse(approval.is_valid)
+        self.assertFalse(approval.is_valid())
 
         # Ended yesterday.
         end_at = datetime.date.today() - relativedelta(days=1)
         start_at = end_at - relativedelta(years=2)
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
-        self.assertFalse(approval.is_valid)
+        self.assertFalse(approval.is_valid())
 
     def test_number_with_spaces(self):
 
@@ -433,6 +414,54 @@ class PoleEmploiApprovalModelTest(TestCase):
         pole_emploi_approval = PoleEmploiApprovalFactory(number="010331610106A01")
         expected = "01033 16 10106 A01"
         self.assertEqual(pole_emploi_approval.number_with_spaces, expected)
+
+    def test_is_valid(self):
+        # Avoid COVID lockdown specific cases
+        now_date = PoleEmploiApproval.LOCKDOWN_START_AT - relativedelta(months=1)
+        now = datetime.datetime(year=now_date.year, month=now_date.month, day=now_date.day)
+
+        with mock.patch("django.utils.timezone.now", side_effect=lambda: now):
+            # End today.
+            end_at = now_date
+            start_at = end_at - relativedelta(years=2)
+            approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
+            self.assertTrue(approval.is_valid())
+
+            # Ended yesterday.
+            end_at = now_date - relativedelta(days=1)
+            start_at = end_at - relativedelta(years=2)
+            approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
+            self.assertFalse(approval.is_valid())
+
+            # Start tomorrow.
+            start_at = now_date + relativedelta(days=1)
+            end_at = start_at + relativedelta(years=2)
+            approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
+            self.assertTrue(approval.is_valid())
+
+    def test_is_valid_overlaps_covid_lockdown(self):
+        now_date = PoleEmploiApproval.LOCKDOWN_END_AT + relativedelta(months=6)
+        now = datetime.datetime(year=now_date.year, month=now_date.month, day=now_date.day)
+
+        # Overlaps COVID lockdown: should be prolonged
+        with mock.patch("django.utils.timezone.now", side_effect=lambda: now):
+            end_at = now_date - relativedelta(days=1)
+            start_at = end_at - relativedelta(years=2)
+            approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
+            self.assertTrue(approval.is_valid())
+
+        # Overlaps COVID lockdown but is expired even with the prolongation
+        with mock.patch("django.utils.timezone.now", side_effect=lambda: now):
+            end_at = now_date - relativedelta(months=PoleEmploiApproval.LOCKDOWN_EXTENSION_DELAY_MONTHS, days=1)
+            start_at = end_at - relativedelta(years=2)
+            approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
+            self.assertFalse(approval.is_valid())
+
+        # Does not overlap COVID lockdown: should not be prolonged
+        end_at = PoleEmploiApproval.LOCKDOWN_START_AT - relativedelta(days=1)
+        start_at = end_at - relativedelta(years=2)
+        approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
+        self.assertFalse(approval.is_valid())
 
 
 class PoleEmploiApprovalManagerTest(TestCase):

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -421,7 +421,7 @@ class PoleEmploiApprovalModelTest(TestCase):
         now = datetime.datetime(year=now_date.year, month=now_date.month, day=now_date.day)
 
         with mock.patch("django.utils.timezone.now", side_effect=lambda: now):
-            # End today.
+            # Ends today.
             end_at = now_date
             start_at = end_at - relativedelta(years=2)
             approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
@@ -433,7 +433,7 @@ class PoleEmploiApprovalModelTest(TestCase):
             approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
             self.assertFalse(approval.is_valid())
 
-            # Start tomorrow.
+            # Starts tomorrow.
             start_at = now_date + relativedelta(days=1)
             end_at = start_at + relativedelta(years=2)
             approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)

--- a/itou/eligibility/models.py
+++ b/itou/eligibility/models.py
@@ -205,7 +205,7 @@ class EligibilityDiagnosis(models.Model):
     @property
     def considered_to_expire_at(self):
         if self.job_seeker.approvals_wrapper.has_valid:
-            return self.job_seeker.approvals_wrapper.latest_approval.end_at
+            return self.job_seeker.approvals_wrapper.latest_approval.display_end_at
         return self.expires_at
 
     @classmethod

--- a/itou/fixtures/django/12_pe_approvals.json
+++ b/itou/fixtures/django/12_pe_approvals.json
@@ -1,0 +1,18 @@
+[
+{
+   "model": "approvals.poleemploiapproval",
+   "pk": 1,
+   "fields": {
+      "start_at": "2020-02-02",
+      "end_at": "2022-02-01",
+      "created_at": "2020-02-02T10:34:22Z",
+      "pe_structure_code": "13150",
+      "number": "490052010146P01",
+      "pole_emploi_id": "7654321A",
+      "first_name": "Jacques",
+      "last_name": "Henry",
+      "birth_name": "Henry",
+      "birthdate": "1990-03-13"
+   }
+}
+]

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -36,7 +36,7 @@
 
         {# Validity. #}
         <li{% if not approval.is_suspended %} class="text-success"{% endif %}>
-            {% blocktranslate with start=approval.start_at|date:"d/m/Y" end=approval.end_at|date:"d/m/Y" %}
+            {% blocktranslate with start=approval.start_at|date:"d/m/Y" end=approval.display_end_at|date:"d/m/Y" %}
                 Valide du {{ start }} au {{ end }}
             {% endblocktranslate %}
         </li>
@@ -128,7 +128,7 @@
     {% else %}
 
         <p class="text-danger">
-            {% blocktranslate with end=approval.end_at|date:"d/m/Y" since=approval.end_at|timesince %}
+            {% blocktranslate with end=approval.display_end_at|date:"d/m/Y" since=approval.display_end_at|timesince %}
                 <b>Expiré</b> le {{ end }} (depuis {{ since }})
             {% endblocktranslate %}
         </p>


### PR DESCRIPTION
### Pourquoi ?

Lors de l'import des agréments en provenance de Pôle emploi, nous n'appliquons pas la prolongation COVID et celle-ci n'est pas intégrée aux données que nous recevons. Nous l'appliquons lors de la transformation d'un agrément en PASS IAE.
Mais une étape en amont fausse le processus : la récupération des agréments valides. En effet, un agrément expiré mais qui pourrait bénéficier de la prolongation COVID est considéré comme invalide car sa date de fin n'a pas encore été mise à jour. 

Le processus dans le code :
- Récupération du dernier agrément à prendre en compte : `Approval.get_or_create_from_valid(approvals_wrapper)`
- Dans `get_or_create_from_valid`, le système transforme un agrément existant s'il est considéré valide. Il n'est pas valide, car il est expiré.
- S'il n'était pas expiré, on passerait à l'étape suivante, le `save()`, où la prolongation serait bien accordée avant l'enregistrement.

### Quoi ?

- Mise à jour de la méthode `Approval.is_valid` pour prendre en compte la prolongation COVID
- Ajout d'un jeu de données pour avoir un agrément Pôle emploi en recette et en démo
- Affichage de la date de fin **avec la prolongation COVID** dans le gabarit
- Prise en compte de la prolongation COVID lors du calcul de l'expiration d'un diagnostic

### Captures d'écran

La date de fin affichée inclut la prolongation.

![image](https://user-images.githubusercontent.com/6150920/112160251-461f5a00-8bea-11eb-8303-a64b1663f80c.png)

