### PR TITLE
Répare la page /stats

### DIFF
--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -10,7 +10,7 @@ from django.conf import settings
 # * https://github.com/jpadilla/pyjwt
 # * https://github.com/metabase/embedding-reference-apps/blob/master/django/embedded_analytics/user_stats/views.py
 def _get_token(payload):
-    return jwt.encode(payload, settings.METABASE_SECRET_KEY, algorithm="HS256").decode("utf8")
+    return jwt.encode(payload, settings.METABASE_SECRET_KEY, algorithm="HS256")
 
 
 def metabase_embedded_url(dashboard_id):


### PR DESCRIPTION
### Quoi ?

Répare la page /stats

### Pourquoi ?

Suite à la mise à jour de PyJWT en version 2.0.1, les tokens retournés par `jwt.encode()` sont au format `string` VS `byte string`.

### Comment ?

Suppression de `.decode("utf8")`.