### PR TITLE
Ajoute un outil d'analyse de couverture de code par les tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ style:
 pylint:
 	docker exec -ti itou_django pylint itou
 
+coverage:
+  # Use .coveragerc
+	docker exec -ti itou_django coverage run --source=itou django-admin test project && coverage html
+
+coverage_venv:
+	coverage run --source=itou ./manage.py test itou.www --settings=config.settings.test && coverage html
+
 setup_git_pre_commit_hook:
 	touch .git/hooks/pre-commit
 	chmod +x .git/hooks/pre-commit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,6 +22,7 @@ isort==5.8.0  # https://github.com/timothycrosley/isort
 pylint==2.7.2  # https://github.com/PyCQA/pylint
 pylint-django==2.4.2  # https://github.com/PyCQA/pylint-django
 pre-commit==2.11.1  # https://github.com/pre-commit/pre-commit
+coverage==5.5  # https://github.com/nedbat/coveragepy
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
### Quoi ?

Nouvelle dépendance de dev sur `coverage` et nouvelles règles pour le Makefile.
J'ai aussi testé vite fait le plugin de coverage pour les templates Django mais le projet n'est pas très actif et je ne suis pas sûr de l'utilité donc je ne l'ai pas inclus.

### Pourquoi ?

Pour savoir ce que l'on ne teste pas.

### Comment ?

L'outil fournit une jolie sortie HTML/JS pour consulter tout cela.

### Captures d'écran (optionnel)

![Capture d’écran de 2021-03-25 14-50-46](https://user-images.githubusercontent.com/1815/112483674-8bbe5d00-8d79-11eb-88c4-0e8a308baeda.png)


