### PR TITLE
Replacement de l’email d’assistance par le portail assistance

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -383,7 +383,6 @@ ITOU_ENVIRONMENT = "PROD"
 ITOU_PROTOCOL = "https"
 ITOU_FQDN = "emplois.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact@inclusion.beta.gouv.fr"
-ITOU_EMAIL_ASSISTANCE = "assistance@inclusion.beta.gouv.fr"
 ITOU_ASSISTANCE_URL = "https://assistance.inclusion.beta.gouv.fr"
 
 DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -384,6 +384,7 @@ ITOU_PROTOCOL = "https"
 ITOU_FQDN = "emplois.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact@inclusion.beta.gouv.fr"
 ITOU_EMAIL_ASSISTANCE = "assistance@inclusion.beta.gouv.fr"
+ITOU_ASSISTANCE_URL = "https://assistance.inclusion.beta.gouv.fr"
 
 DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"
 

--- a/itou/templates/approvals/approval_as_pdf.html
+++ b/itou/templates/approvals/approval_as_pdf.html
@@ -22,7 +22,7 @@
 
         <section class="mt-5">
             <span class="d-block font-weight-bold">{% translate "Votre contact en direct :" %}</span>
-            <span class="d-block text-decoration">{{ contact_email }}</span>
+            <span class="d-block text-decoration">{{ itou_assistance_url }}</span>
         </section>
 
         <section class="mt-5">

--- a/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
+++ b/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
@@ -17,7 +17,7 @@ Bonjour,
 
 Si vous avez autorisé cette prolongation, vous n'avez aucune démarche à faire.
 
-Si vous n'avez pas autorisé cette prolongation, merci de contacter notre assistance technique : {{ itou_email_assistance }}
+Si vous n'avez pas autorisé cette prolongation, merci de contacter notre assistance technique : {{ itou_assistance_url }}
 
 {% endblocktranslate %}
 

--- a/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
+++ b/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
@@ -13,9 +13,9 @@ Si vous êtes bien un prescripteur habilité, nous avons besoin d'une preuve de 
 
 - si votre organisation appartient à la liste des organisations habilitées au national ({{ itou_doc_url }}/pourquoi-une-plateforme-de-linclusion/qui-sont-les-differents-prescripteurs/prescripteur-habilite#liste-des-prescripteurs-habilites-en-national) : merci de nous communiquer par retour de mail le type de structure et l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
 
-- si vous êtes une organisation conventionnée par un Conseil départemental pour le suivi des BRSA : vous devez demander au Conseil départemental de nous adresser un mail à {{ itou_email_assistance }} afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail). Communiquez à cette personne l'ID de votre structure en lui demandant de le mentionner dans l'e-mail attestant de votre habilitation pour que nous fassions le rapprochement
+- si vous êtes une organisation conventionnée par un Conseil départemental pour le suivi des BRSA : vous devez demander au Conseil départemental de nous contacter via {{ itou_assistance_url }} afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail). Communiquez à cette personne l'ID de votre structure en lui demandant de le mentionner dans l'e-mail attestant de votre habilitation pour que nous fassions le rapprochement
 
-- si vous êtes une organisation conventionnée par un PLIE : vous devez demander à l'organisme gestionnaire du PLIE de nous adresser un mail à {{ itou_email_assistance }} afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail)
+- si vous êtes une organisation conventionnée par un PLIE : vous devez demander à l'organisme gestionnaire du PLIE de nous contacter via {{ itou_assistance_url }} afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail)
 
 Nous restons à votre disposition pour tout renseignement complémentaire.{% endblocktranslate %}
 

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -38,12 +38,12 @@
                 <b>Si votre conventionnement est récent</b>, nous vous invitons à renouveler votre inscription dans une semaine.
             </p>
             <p>
-                <b>Si votre conventionnement a plus d’un mois</b>, prenez contact avec votre DIRECCTE en lui demandant de nous envoyer la confirmation de votre conventionnement via <a href="{{ ITOU_ASSISTANCE_URL }}">{{ ITOU_ASSISTANCE_URL }}</a>.
+                <b>Si votre conventionnement a plus d’un mois</b>, prenez contact avec votre DIRECCTE en lui demandant de nous envoyer la confirmation de votre conventionnement via <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener">{{ ITOU_ASSISTANCE_URL }}</a>.
                 <br>
                 La DIRECCTE doit nous indiquer si le conventionnement de votre structure est en cours en précisant le numéro de SIRET, le type de structure, l’adresse postale et l’adresse e-mail du correspondant technique ASP.<br>
             </p>
             <p>
-                <b>Si vous tentez d'inscrire une Entreprise Adaptée ou un GEIQ</b>, merci d'utiliser <a href="https://itou.typeform.com/to/RYfNLR79" target="_blank">ce formulaire</a>.
+                <b>Si vous tentez d'inscrire une Entreprise Adaptée ou un GEIQ</b>, merci d'utiliser <a href="https://itou.typeform.com/to/RYfNLR79" target="_blank" rel="noopener">ce formulaire</a>.
             </p>
         {% endblocktranslate %}
     </div>
@@ -152,7 +152,7 @@
 {% if siaes_without_members or siaes_with_members %}
     <div class="mt-5">
         <p>
-            {% blocktranslate %}En cas de problème contactez-nous : <a href="{{ ITOU_ASSISTANCE_URL }}">{{ ITOU_ASSISTANCE_URL }}</a>{% endblocktranslate %}
+            {% blocktranslate %}En cas de problème contactez-nous : <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener">{{ ITOU_ASSISTANCE_URL }}</a>{% endblocktranslate %}
         </p>
     </div>
 {% endif %}

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -152,7 +152,7 @@
 {% if siaes_without_members or siaes_with_members %}
     <div class="mt-5">
         <p>
-            {% blocktranslate %}En cas de problème contactez-nous : <a href="mailto:{{ ITOU_EMAIL_ASSISTANCE }}">{{ ITOU_EMAIL_ASSISTANCE }}</a>{% endblocktranslate %}
+            {% blocktranslate %}En cas de problème contactez-nous : <a href="{{ ITOU_ASSISTANCE_URL }}">{{ ITOU_ASSISTANCE_URL }}</a>{% endblocktranslate %}
         </p>
     </div>
 {% endif %}

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -38,7 +38,7 @@
                 <b>Si votre conventionnement est récent</b>, nous vous invitons à renouveler votre inscription dans une semaine.
             </p>
             <p>
-                <b>Si votre conventionnement a plus d’un mois</b>, prenez contact avec votre DIRECCTE en lui demandant de nous envoyer la confirmation de votre conventionnement par e-mail à l’adresse <a href="mailto:{{ ITOU_EMAIL_ASSISTANCE }}">{{ ITOU_EMAIL_ASSISTANCE }}</a>.
+                <b>Si votre conventionnement a plus d’un mois</b>, prenez contact avec votre DIRECCTE en lui demandant de nous envoyer la confirmation de votre conventionnement via <a href="{{ ITOU_ASSISTANCE_URL }}">{{ ITOU_ASSISTANCE_URL }}</a>.
                 <br>
                 La DIRECCTE doit nous indiquer si le conventionnement de votre structure est en cours en précisant le numéro de SIRET, le type de structure, l’adresse postale et l’adresse e-mail du correspondant technique ASP.<br>
             </p>

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -29,6 +29,7 @@ def get_email_text_template(template, context):
     context.update(
         {
             "itou_doc_url": settings.ITOU_DOC_URL,
+            "itou_assistance_url": settings.ITOU_ASSISTANCE_URL,
             "itou_protocol": settings.ITOU_PROTOCOL,
             "itou_fqdn": settings.ITOU_FQDN,
             "itou_email_assistance": settings.ITOU_EMAIL_ASSISTANCE,

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -32,7 +32,6 @@ def get_email_text_template(template, context):
             "itou_assistance_url": settings.ITOU_ASSISTANCE_URL,
             "itou_protocol": settings.ITOU_PROTOCOL,
             "itou_fqdn": settings.ITOU_FQDN,
-            "itou_email_assistance": settings.ITOU_EMAIL_ASSISTANCE,
             "itou_email_contact": settings.ITOU_EMAIL_CONTACT,
             "itou_environment": settings.ITOU_ENVIRONMENT,
         }

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -11,6 +11,7 @@ def expose_settings(request):
         "ALLOWED_HOSTS": settings.ALLOWED_HOSTS,
         "ITOU_DOC_URL": settings.ITOU_DOC_URL,
         "ITOU_EMAIL_ASSISTANCE": settings.ITOU_EMAIL_ASSISTANCE,
+        "ITOU_ASSISTANCE_URL": settings.ITOU_ASSISTANCE_URL,
         "ITOU_EMAIL_CONTACT": settings.ITOU_EMAIL_CONTACT,
         "ITOU_ENVIRONMENT": settings.ITOU_ENVIRONMENT,
         "ITOU_FQDN": settings.ITOU_FQDN,

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -10,7 +10,6 @@ def expose_settings(request):
     return {
         "ALLOWED_HOSTS": settings.ALLOWED_HOSTS,
         "ITOU_DOC_URL": settings.ITOU_DOC_URL,
-        "ITOU_EMAIL_ASSISTANCE": settings.ITOU_EMAIL_ASSISTANCE,
         "ITOU_ASSISTANCE_URL": settings.ITOU_ASSISTANCE_URL,
         "ITOU_EMAIL_CONTACT": settings.ITOU_EMAIL_CONTACT,
         "ITOU_ENVIRONMENT": settings.ITOU_ENVIRONMENT,

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -74,7 +74,7 @@ def approval_as_pdf(request, job_application_id, template_name="approvals/approv
     context = {
         "approval": job_application.approval,
         "base_url": base_url,
-        "contact_email": settings.ITOU_EMAIL_CONTACT,
+        "assistance_url": settings.ITOU_ASSISTANCE_URL,
         "diagnosis_author": diagnosis_author,
         "diagnosis_author_org_name": diagnosis_author_org_name,
         "siae": job_application.to_siae,

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -71,7 +71,9 @@ class CreateSiaeForm(forms.ModelForm):
             )
 
             assistance_url = settings.ITOU_ASSISTANCE_URL
-            assistance_html = f'<a href="{assistance_url}" target="_blank" class="alert-link">{assistance_url}</a>'
+            assistance_html = (
+                f'<a href="{assistance_url}" target="_blank" rel="noopener" class="alert-link">{assistance_url}</a>'
+            )
 
             error_message_siret = _(
                 "en précisant votre numéro de SIRET (si existant),"

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -63,8 +63,6 @@ class CreateSiaeForm(forms.ModelForm):
         existing_siae_query = Siae.objects.filter(siret=siret, kind=kind)
 
         if existing_siae_query.exists():
-            existing_siae = existing_siae_query.get()
-            user = self.current_user
             error_message = _(
                 """
                 La structure à laquelle vous souhaitez vous rattacher est déjà
@@ -72,32 +70,15 @@ class CreateSiaeForm(forms.ModelForm):
                 """
             )
 
+            assistance_url = settings.ITOU_ASSISTANCE_URL
+            assistance_html = f'<a href="{assistance_url}" target="_blank" class="alert-link">{assistance_url}</a>'
+
             error_message_siret = _(
                 "en précisant votre numéro de SIRET (si existant),"
                 " le type et l’adresse de cette structure, ainsi que votre numéro de téléphone"
                 " pour être contacté(e) si nécessaire."
             )
-            mail_to = settings.ITOU_EMAIL_ASSISTANCE
-            mail_subject = _("Se rattacher à une structure existante - Les emplois de l'inclusion")
-
-            mail_body = _(
-                "Veuillez rattacher mon compte (%(first_name)s %(last_name)s %(email)s)"
-                " à la structure existante (%(kind)s %(siret)s ID=%(id)s)"
-                " sur les emplois de l'inclusion."
-            ) % {
-                "first_name": user.first_name,
-                "last_name": user.last_name,
-                "email": user.email,
-                "kind": existing_siae.kind,
-                "siret": existing_siae.siret,
-                "id": existing_siae.id,
-            }
-
-            mailto_html = (
-                f'<a href="mailto:{mail_to}?subject={mail_subject}&body={mail_body}"'
-                f' target="_blank" class="alert-link">{mail_to}</a>'
-            )
-            error_message = mark_safe(f"{error_message} {mailto_html} {error_message_siret}")
+            error_message = mark_safe(f"{error_message} {assistance_html} {error_message_siret}")
             raise forms.ValidationError(error_message)
 
         if not siret.startswith(self.current_siae.siren):

--- a/itou/www/siaes_views/tests.py
+++ b/itou/www/siaes_views/tests.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from django.conf import settings
 from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
@@ -268,6 +269,7 @@ class CreateSiaeViewTest(TestCase):
         self.assertNotContains(response, escape(expected_message))
         expected_message = "La structure à laquelle vous souhaitez vous rattacher est déjà"
         self.assertContains(response, escape(expected_message))
+        self.assertContains(response, escape(settings.ITOU_ASSISTANCE_URL))
 
         self.assertEqual(Siae.objects.filter(siret=post_data["siret"]).count(), 1)
 


### PR DESCRIPTION
### Quoi ?

Replacement de l’email direct d’assistance par [le portail assistance](https://assistance.inclusion.beta.gouv.fr) dans toute l’application.

### Pourquoi ?

Pour favoriser l’utilisation du portail et ainsi simplifier la gestion des tickets support.

### Comment ?

J’ai remplacé l’email direct d’assistance par [le portail assistance](https://assistance.inclusion.beta.gouv.fr) dans toute l’application :
 - emails
 - PDF du Pass
 - formulaires siae (siret incorrect au signup et à la création)

### Captures d'écran
Le signup, mais c’est pareil partout :

![Capture d’écran de 2021-03-26 11-37-03](https://user-images.githubusercontent.com/1223316/112619676-e31b0680-8e27-11eb-9619-601a846c114b.png)

