### PR TITLE
Remplacement de `generate_unique_username`

### DIFF
--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest import mock
 
 from allauth.account.forms import default_token_generator
@@ -115,6 +116,8 @@ class SiaeSignupTest(TestCase):
             self.assertTrue(user.is_active)
             self.assertTrue(siae.has_admin(user))
             self.assertEqual(1, siae.members.count())
+            # Check that `username` is not overriden by django-allauth.
+            self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
             self.assertEqual(user.first_name, user_first_name)
             self.assertEqual(user.last_name, post_data["last_name"])
             self.assertEqual(user.email, user_secondary_email)
@@ -196,6 +199,8 @@ class JobSeekerSignupTest(TestCase):
 
         # Check `User` state.
         user = get_user_model().objects.get(email=post_data["email"])
+        # Check that `username` is not overriden by django-allauth.
+        self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertTrue(user.is_job_seeker)
         self.assertFalse(user.is_prescriber)
         self.assertFalse(user.is_siae_staff)
@@ -398,6 +403,8 @@ class PrescriberSignupTest(TestCase):
 
         # Check `User` state.
         user = get_user_model().objects.get(email=post_data["email"])
+        # Check that `username` is not overriden by django-allauth.
+        self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertFalse(user.is_job_seeker)
         self.assertTrue(user.is_prescriber)
         self.assertFalse(user.is_siae_staff)
@@ -532,6 +539,8 @@ class PrescriberSignupTest(TestCase):
 
         # Check `User` state.
         user = get_user_model().objects.get(email=post_data["email"])
+        # Check that `username` is not overriden by django-allauth.
+        self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertFalse(user.is_job_seeker)
         self.assertTrue(user.is_prescriber)
         self.assertFalse(user.is_siae_staff)
@@ -632,6 +641,8 @@ class PrescriberSignupTest(TestCase):
 
         # Check `User` state.
         user = get_user_model().objects.get(email=post_data["email"])
+        # Check that `username` is not overriden by django-allauth.
+        self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertFalse(user.is_job_seeker)
         self.assertTrue(user.is_prescriber)
         self.assertFalse(user.is_siae_staff)
@@ -711,6 +722,8 @@ class PrescriberSignupTest(TestCase):
 
         # Check `User` state.
         user = get_user_model().objects.get(email=post_data["email"])
+        # Check that `username` is not overriden by django-allauth.
+        self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertFalse(user.is_job_seeker)
         self.assertTrue(user.is_prescriber)
         self.assertFalse(user.is_siae_staff)


### PR DESCRIPTION
### Quoi ?

Remplacement de `allauth.utils.generate_unique_username()` par `uuid4()`.

### Pourquoi ?

Le champ [`User.username`](https://docs.djangoproject.com/fr/3.1/ref/contrib/auth/#django.contrib.auth.models.User.username) fait partie du modèle de base de `django.contrib.auth`. Il n'est pas utilisé dans Itou mais il reste nécessaire dans certaines méthodes comme [`create_user`](https://docs.djangoproject.com/fr/3.1/ref/contrib/auth/#django.contrib.auth.models.UserManager.create_user) utilisé [par ici](https://github.com/betagouv/itou/blob/2c1ff02aa379165de6e2b3cc47f602df0e9e0662/itou/users/models.py#L274)…

On utilise `allauth.utils.generate_unique_username()` pour générer une valeur _human-readable_.

Mais ça génère masse d'erreurs sur Sentry :

> https://sentry.io/organizations/itou/issues/2291675609/events/3cd6060532134b1b8dc2460debb44157/events/?project=5671910

J'ai [regardé le code de `allauth`](https://github.com/pennersr/django-allauth/blob/da5ccd/allauth/utils.py#L118-L119)… j'ai pas eu envie de patcher.

Du coup je propose qu'on s'en passe et qu'on utilise `uuid4()` pour avoir une valeur aléatoire et unique.

### Captures d'écran

<img width="1087" alt="username" src="https://user-images.githubusercontent.com/281139/112674351-19777680-8e66-11eb-8872-44cd57cc9925.png">
