### PR TITLE
Autoriser le super utilisateur à modifier l'état d'une habilitation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,10 @@ pylint:
 	docker exec -ti itou_django pylint itou
 
 coverage:
-  # Use .coveragerc
-	docker exec -ti itou_django coverage run --source=itou django-admin test project && coverage html
+	docker exec -ti itou_django coverage run --source=itou django-admin test itou --settings=config.settings.test && coverage html
 
 coverage_venv:
-	coverage run --source=itou ./manage.py test itou.www --settings=config.settings.test && coverage html
+	coverage run --source=itou ./manage.py test itou --settings=config.settings.test && coverage html
 
 setup_git_pre_commit_hook:
 	touch .git/hooks/pre-commit

--- a/itou/templates/admin/prescribers/change_form.html
+++ b/itou/templates/admin/prescribers/change_form.html
@@ -5,7 +5,8 @@
 
     {% translate "Êtes vous certain ?" as confirm %}
 
-    {% if original.has_pending_authorization %}
+    {# Whatever the state, the super user has access to refuse and validate actions #}
+    {% if original.has_pending_authorization or user.is_superuser %}
 
         <div class="submit-row">
             <input class="danger" type="submit" value="{% translate "Refuser l'habilitation" %}"
@@ -16,8 +17,7 @@
                    onclick="return confirm('{{ confirm }}')">
         </div>
 
-    {% elif original.has_refused_authorization %}
-
+    {% elif original.has_refused_authorization and not user.is_superuser %}
         {# Allow to validate an authorization after an error in a refusal. #}
 
         <div class="submit-row">

--- a/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
+++ b/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
@@ -7,15 +7,17 @@
 
 Nous n'avons pas pu vérifier l'habilitation de votre structure, par conséquent nous vous avons attribué le statut d'orienteur. Vous pourrez envoyer des candidatures aux employeurs solidaires sans valider l'éligibilité IAE des candidats, c'est l'employeur qui se chargera de valider cette éligibilité sur la base de critères administratifs, et donc qui en portera la responsabilité juridique.
 
-Si vous êtes bien un prescripteur habilité, nous avons besoin d'une preuve de votre habilitation :
+Si vous êtes bien un prescripteur habilité, nous avons besoin d'une preuve de votre habilitation, toute preuve d'habilitation doit être envoyée via {{ itou_assistance_url }}, rubrique « Habilitation / Prescripteur » :
 
 - si vous êtes une organisation habilitée par le préfet : merci de nous communiquer par retour de mail l'arrêté préfectoral portant mention de votre habilitation à valider l'éligibilité IAE des candidats. Pensez à nous communiquer l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
 
 - si votre organisation appartient à la liste des organisations habilitées au national ({{ itou_doc_url }}/pourquoi-une-plateforme-de-linclusion/qui-sont-les-differents-prescripteurs/prescripteur-habilite#liste-des-prescripteurs-habilites-en-national) : merci de nous communiquer par retour de mail le type de structure et l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
 
-- si vous êtes une organisation conventionnée par un Conseil départemental pour le suivi des BRSA : vous devez demander au Conseil départemental de nous contacter via {{ itou_assistance_url }} afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail). Communiquez à cette personne l'ID de votre structure en lui demandant de le mentionner dans l'e-mail attestant de votre habilitation pour que nous fassions le rapprochement
+- si vous êtes une organisation conventionnée par un Conseil départemental pour le suivi des BRSA : vous devez demander au Conseil départemental de nous contacter via {{ itou_assistance_url }}, rubrique « Habilitation / Prescripteur » afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail). Communiquez à cette personne l'ID de votre structure en lui demandant de le mentionner dans l'e-mail attestant de votre habilitation pour que nous fassions le rapprochement
 
-- si vous êtes une organisation conventionnée par un PLIE : vous devez demander à l'organisme gestionnaire du PLIE de nous contacter via {{ itou_assistance_url }} afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail)
+- si vous êtes une organisation conventionnée par un PLIE : vous devez demander à l'organisme gestionnaire du PLIE de nous contacter via {{ itou_assistance_url }}, rubrique « Habilitation / Prescripteur » afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail)
+
+Pour les autres cas, utilisez également le portail {{ itou_assistance_url }}, rubrique « Habilitation / Prescripteur » pour nous faire part du motif et justificatif de demande d’habilitation.
 
 Nous restons à votre disposition pour tout renseignement complémentaire.{% endblocktranslate %}
 


### PR DESCRIPTION
Dans l'interface d'administration, il est uniquement possible de modifier l'habilitation 
d'un organisation quand l'état est soit `pending` ou `refused` mais nous avons des
demandes du support (https://trello.com/c/vDyFd00M/1622-accorder-habilitation-%C3%A0-une-orga, https://trello.com/c/DR0IRF4Z/1621-retirer-habilitation-%C3%A0-une-orga) en dehors de ces cas.

### Quoi ?

Accès à ses actions dans tous les cas pour les super utilisateurs.

### Pourquoi ?

Pour éviter d'avoir à faire la manip depuis le shell Django de la prod.

### Comment ?

En vérifiant le rôle de l'utilisateur dans le template de l'admin.

Au passage, **il était et il est** encore possible d'effectuer l'action sans être super utilisateur car il n'y a pas de check au niveau de `response_change` :
https://github.com/betagouv/itou/blob/master/itou/prescribers/admin.py#L205

### Captures d'écran (optionnel)

Oh les jolis boutons qui sont traduits EN CAPS LOCK !

![Capture d’écran de 2021-03-31 14-49-47](https://user-images.githubusercontent.com/1815/113148662-66769680-9232-11eb-8aee-f9b7c57fd94e.png)
