### PR TITLE
Ajustements des réglages pour coverage.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+  source = itou
+  omit = */migrations/*

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ pylint:
 	docker exec -ti itou_django pylint itou
 
 coverage:
-	docker exec -ti itou_django coverage run --source=itou ./manage.py test itou --settings=config.settings.test
+	docker exec -ti itou_django coverage run ./manage.py test itou --settings=config.settings.test
 	docker exec -ti itou_django coverage html
 
 coverage_venv:
-	coverage run --source=itou ./manage.py test itou --settings=config.settings.test && coverage html
+	coverage run ./manage.py test itou --settings=config.settings.test && coverage html
 
 setup_git_pre_commit_hook:
 	touch .git/hooks/pre-commit


### PR DESCRIPTION
### Quoi ?

Exclus les migrations du coverage.

### Pourquoi ?

Car cela génère du bruit dans les rapports.

### Comment ?

Ajout d'un fichier .coverage.rc et suppression du paramètre explicite dans le Makefile.


