### PR TITLE
Affichage spécifique des critères d’éligibilité pour les candidatures envoyées par des prescripteurs habilités

### DIFF
--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -44,54 +44,101 @@
     {% if job_application.to_siae.is_subject_to_eligibility_rules %}
 
             {% if eligibility_diagnosis and eligibility_diagnosis.is_considered_valid %}
+                {% if job_application.is_sent_by_authorized_prescriber %}
+                    {#
+                        Les candidatures envoyées par des prescripteurs habilités ne sont pas affichés de manière 
+                        hiérarchisée afin de ne pas induire les employeurs en erreur.
+                        Avec des critères hiérarchisés, ils ont tendance à penser que le candidat n'est pas éligible car pas suffisamment de critère de niveau 2 par exemple
+                    #}
+                    <hr>
+                    <h3 class="font-weight-normal text-muted">
+                        {% translate "Éligibilité IAE" %}
+                    </h3>
+                    <p>
+                        Confirmé par
+                        <b>{{ eligibility_diagnosis.author.get_full_name }}</b>
+                        {% if eligibility_diagnosis.author_siae %}
+                            ({{ eligibility_diagnosis.author_siae.display_name }})
+                        {% endif %}
+                        {% if eligibility_diagnosis.author_prescriber_organization %}
+                            ({{ eligibility_diagnosis.author_prescriber_organization.display_name }})
+                        {% endif %}
+                    </p>
 
-                <hr>
-                <h3 class="font-weight-normal text-muted">
-                    {% translate "Critères d'éligibilité" %}
-                </h3>
-                <p>
-                    {% translate "Validés par" %}
-                    <b>{{ eligibility_diagnosis.author.get_full_name }}</b>
-                    {% if eligibility_diagnosis.author_siae %}
-                        ({{ eligibility_diagnosis.author_siae.display_name }})
-                    {% endif %}
-                    {% if eligibility_diagnosis.author_prescriber_organization %}
-                        ({{ eligibility_diagnosis.author_prescriber_organization.display_name }})
-                    {% endif %}
-                    {% translate "le" %}
-                    <b>{{ eligibility_diagnosis.created_at|date:"d/m/Y" }}</b>.
-                </p>
+                    {% with eligibility_diagnosis.administrative_criteria.all as administrative_criteria %}
+                        {% if administrative_criteria %}
+                            <p>
+                                <span class="badge badge-secondary">
+                                    Situation administrative du candidat
+                                </span>
+                            </p>
+                            {# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#regroup #}
+                            {% regroup administrative_criteria|dictsort:"level" by get_level_display as levels %}
+                            <ul>
+                                {% for level in levels %}
+                                    {% for criteria in level.list %}
+                                        <li>{{ criteria.name }}</li>
+                                    {% endfor %}
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                    {% endwith %}
 
-                {% with eligibility_diagnosis.administrative_criteria.all as administrative_criteria %}
-                    {% if administrative_criteria %}
-                        <p>
-                            <span class="badge badge-secondary">
-                                {% translate "Critères administratifs" %}
-                            </span>
-                        </p>
-                        {# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#regroup #}
-                        {% regroup administrative_criteria|dictsort:"level" by get_level_display as levels %}
-                        <ul>
-                            {% for level in levels %}
-                                <li>
-                                    <span class="badge badge-secondary">{{ level.grouper }}</span>
-                                    <ul>
-                                        {% for criteria in level.list %}
-                                            <li>{{ criteria.name }}</li>
-                                        {% endfor %}
-                                    </ul>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    {% endif %}
-                {% endwith %}
+                    <p>
+                        <i>
+                            Ce diagnostic est valide du {{ eligibility_diagnosis.created_at|date:"d/m/Y" }} au 
+                            {{ eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}.
+                        </i>
+                    </p>
+                {% else %}
+                    <hr>
+                    <h3 class="font-weight-normal text-muted">
+                        {% translate "Critères d'éligibilité" %}
+                    </h3>
+                    <p>
+                        {% translate "Validés par" %}
+                        <b>{{ eligibility_diagnosis.author.get_full_name }}</b>
+                        {% if eligibility_diagnosis.author_siae %}
+                            ({{ eligibility_diagnosis.author_siae.display_name }})
+                        {% endif %}
+                        {% if eligibility_diagnosis.author_prescriber_organization %}
+                            ({{ eligibility_diagnosis.author_prescriber_organization.display_name }})
+                        {% endif %}
+                        {% translate "le" %}
+                        <b>{{ eligibility_diagnosis.created_at|date:"d/m/Y" }}</b>.
+                    </p>
 
-                <p>
-                    <i>
-                        {% translate "Ce diagnostic expire le " %}
-                        {{ eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}.
-                    </i>
-                </p>
+                    {% with eligibility_diagnosis.administrative_criteria.all as administrative_criteria %}
+                        {% if administrative_criteria %}
+                            <p>
+                                <span class="badge badge-secondary">
+                                    {% translate "Critères administratifs" %}
+                                </span>
+                            </p>
+                            {# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#regroup #}
+                            {% regroup administrative_criteria|dictsort:"level" by get_level_display as levels %}
+                            <ul>
+                                {% for level in levels %}
+                                    <li>
+                                        <span class="badge badge-secondary">{{ level.grouper }}</span>
+                                        <ul>
+                                            {% for criteria in level.list %}
+                                                <li>{{ criteria.name }}</li>
+                                            {% endfor %}
+                                        </ul>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                    {% endwith %}
+
+                    <p>
+                        <i>
+                            {% translate "Ce diagnostic expire le " %}
+                            {{ eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}.
+                        </i>
+                    </p>
+                    {% endif %}
 
             {% elif approvals_wrapper.has_valid_pole_emploi_eligibility_diagnosis %}
 


### PR DESCRIPTION
### Quoi ?

Les critères des candidatures envoyées par des **prescripteurs habilités** ne sont pas affichés de manière hiérarchisée afin de ne pas induire les employeurs en erreur au sujet des critères.
On ne touche pas à l'affichage des autres candidatures.        

### Pourquoi ?

Avec des critères hiérarchisés, ils ont tendance à penser que le candidat n'est pas éligible car pas suffisamment de critère de niveau 2 par exemple

### Comment ?

Affichage spécifique dans ce cas précis.
J’ai hésité à extraire le code dans un include, car `itou/templates/apply/process_details.html` commence à devenir bien touffu. Je ne l’ai pas fait car j’ai l’impression que ce n’est ni réutilisable, ni trop la pratique dans l’équipe de découper les gros templates.

### Captures d'écran (optionnel)

![Sélection_008](https://user-images.githubusercontent.com/1223316/114524085-345b3080-9c45-11eb-9f06-2b177d42eb14.png)


