### PR TITLE
Possibilité d’éditer l’email d’un demandeur (tant que l’email n’est pas confirmé)

### DIFF
--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -17,6 +17,8 @@ class EditUserInfoForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
     Edit a user profile.
     """
 
+    email = forms.EmailField(label="Adresse électronique", widget=forms.TextInput(attrs={"autocomplete": "off"}))
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         has_verified_email = EmailAddress.objects.filter(email=self.instance.email, verified=True)

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -1,3 +1,4 @@
+from allauth.account.models import EmailAddress
 from django import forms
 from django.core.exceptions import ValidationError
 
@@ -18,6 +19,11 @@ class EditUserInfoForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        has_verified_email = EmailAddress.objects.filter(email=self.instance.email, verified=True)
+        if has_verified_email or not self.instance.is_job_seeker:
+            # We want the possibility to edit the email of job seekers
+            # until they validate their email
+            del self.fields["email"]
         if not self.instance.is_job_seeker:
             del self.fields["birthdate"]
             del self.fields["pole_emploi_id"]
@@ -40,6 +46,7 @@ class EditUserInfoForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
     class Meta:
         model = User
         fields = [
+            "email",
             "first_name",
             "last_name",
             "birthdate",

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -177,6 +177,76 @@ class EditJobSeekerInfo(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
+    def test_edit_email_when_unconfirmed(self):
+        """
+        The SIAE can edit the email of a jobseeker it works with, provided he did not confirm its email.
+        """
+        new_email = "bidou@yopmail.com"
+        job_application = JobApplicationSentByPrescriberFactory()
+        user = job_application.to_siae.members.first()
+
+        # Ensure that the job seeker is not autonomous (i.e. he did not register by himself).
+        job_application.job_seeker.created_by = user
+        job_application.job_seeker.save()
+
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = job_application.to_siae.pk
+
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+
+        response = self.client.get(url)
+        self.assertContains(response, "Adresse électronique")
+
+        post_data = {
+            "email": new_email,
+            "birthdate": "20/12/1978",
+            "phone": "0610203050",
+            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+        }
+        response = self.client.post(url, data=post_data)
+
+        job_seeker = get_user_model().objects.get(id=job_application.job_seeker.id)
+        self.assertEqual(job_seeker.email, new_email)
+
+    def test_edit_email_when_confirmed(self):
+        new_email = "bidou@yopmail.com"
+        job_application = JobApplicationSentByPrescriberFactory()
+        user = job_application.to_siae.members.first()
+
+        # Ensure that the job seeker is not autonomous (i.e. he did not register by himself).
+        job_application.job_seeker.created_by = user
+        job_application.job_seeker.save()
+
+        # Confirm job seeker email
+        job_seeker = get_user_model().objects.get(id=job_application.job_seeker.id)
+        post_data = {"login": job_seeker.email, "password": DEFAULT_PASSWORD}
+        url = reverse("account_login")
+        response = self.client.post(url, data=post_data)
+        job_seeker.refresh_from_db()
+        confirmation_token = EmailConfirmationHMAC(job_seeker.emailaddress_set.first()).key
+        confirm_email_url = reverse("account_confirm_email", kwargs={"key": confirmation_token})
+        response = self.client.post(confirm_email_url)
+
+        # Now the SIAE wants to edit the jobseeker email. The field is not available, and it cannot be bypassed
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = job_application.to_siae.pk
+
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+
+        response = self.client.get(url)
+        self.assertNotContains(response, "Adresse électronique")
+
+        post_data = {
+            "email": new_email,
+            "birthdate": "20/12/1978",
+            "phone": "0610203050",
+            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+        }
+        response = self.client.post(url, data=post_data)
+
+        job_seeker = get_user_model().objects.get(id=job_application.job_seeker.id)
+        self.assertNotEqual(job_seeker.email, new_email)
+
 
 class ChangeEmailViewTest(TestCase):
     def test_update_email(self):

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -1,5 +1,4 @@
 from allauth.account.models import EmailAddress, EmailConfirmationHMAC
-from django.conf import settings
 from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
@@ -245,7 +244,7 @@ class EditJobSeekerInfo(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, back_url)
 
-        job_seeker = get_user_model().objects.get(id=job_application.job_seeker.id)
+        job_seeker = User.objects.get(id=job_application.job_seeker.id)
         # The email is not changed, but other fields are taken into account
         self.assertNotEqual(job_seeker.email, new_email)
         self.assertEqual(job_seeker.phone, post_data["phone"])

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -96,7 +96,6 @@ class EditJobSeekerInfo(TestCase):
         job_application.job_seeker.save()
 
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
-        self.client.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = job_application.to_siae.pk
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
@@ -190,7 +189,6 @@ class EditJobSeekerInfo(TestCase):
         user = job_application.to_siae.members.first()
 
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
-        self.client.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = job_application.to_siae.pk
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
@@ -228,7 +226,6 @@ class EditJobSeekerInfo(TestCase):
 
         # Now the SIAE wants to edit the jobseeker email. The field is not available, and it cannot be bypassed
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
-        self.client.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = job_application.to_siae.pk
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -69,6 +69,7 @@ class EditUserInfoViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
         post_data = {
+            "email": "bob@saintclar.net",
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
@@ -104,6 +105,7 @@ class EditJobSeekerInfo(TestCase):
         self.assertEqual(response.status_code, 200)
 
         post_data = {
+            "email": "bob@saintclar.net",
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -223,14 +223,8 @@ class EditJobSeekerInfo(TestCase):
         job_application.job_seeker.save()
 
         # Confirm job seeker email
-        job_seeker = get_user_model().objects.get(id=job_application.job_seeker.id)
-        post_data = {"login": job_seeker.email, "password": DEFAULT_PASSWORD}
-        url = reverse("account_login")
-        response = self.client.post(url, data=post_data)
-        job_seeker.refresh_from_db()
-        confirmation_token = EmailConfirmationHMAC(job_seeker.emailaddress_set.first()).key
-        confirm_email_url = reverse("account_confirm_email", kwargs={"key": confirmation_token})
-        response = self.client.post(confirm_email_url)
+        job_seeker = User.objects.get(id=job_application.job_seeker.id)
+        EmailAddress.objects.create(user=job_seeker, email=job_seeker.email, verified=True)
 
         # Now the SIAE wants to edit the jobseeker email. The field is not available, and it cannot be bypassed
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)


### PR DESCRIPTION
### Quoi ?

Possibilité, pour les professionnels, d’éditer l’email d’un demandeur (tant que l’email n’est pas confirmé).

### Pourquoi ?

Les professionnels ne peuvent pas modifier l'adresse email du candidat

### Comment ?

Ajout de l’email dans le formulaire d’édition d’un utilisateur, dans les cas concernés.

### Captures d'écran (optionnel)

![Capture d’écran de 2021-04-13 15-03-02](https://user-images.githubusercontent.com/1223316/114556871-6b433d80-9c69-11eb-839c-c49511cae1a4.png)

