### PR TITLE
Mise à jour vers Django 3.2

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -176,6 +176,9 @@ DATABASES = {
 
 ATOMIC_REQUESTS = True
 
+# https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 # Password validation.
 # ------------------------------------------------------------------------------
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -71,10 +71,10 @@ LOCAL_APPS = [
     "itou.approvals",
     "itou.eligibility",
     "itou.invitations",
-    "itou.external_data.apps.ExternalDataConfig",
+    "itou.external_data",
     "itou.metabase",
     "itou.asp",
-    "itou.employee_record.apps.EmployeeRecordConfig",
+    "itou.employee_record",
     # www.
     "itou.www.apply",
     "itou.www.approvals_views",

--- a/itou/allauth_adapters/peamu/urls.py
+++ b/itou/allauth_adapters/peamu/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path
+from django.urls import include, re_path
 
 from itou.allauth_adapters.peamu.provider import PEAMUProvider
 from itou.allauth_adapters.peamu.views import oauth2_callback as callback_view, oauth2_login as login_view
@@ -6,11 +6,11 @@ from itou.allauth_adapters.peamu.views import oauth2_callback as callback_view, 
 
 def default_urlpatterns(provider):
     urlpatterns = [
-        path("login", login_view, name=provider.id + "_login"),
-        path("login/callback", callback_view, name=provider.id + "_callback"),
+        re_path(r"^login/$", login_view, name=provider.id + "_login"),
+        re_path(r"^login/callback/$", callback_view, name=provider.id + "_callback"),
     ]
 
-    return [path(provider.get_slug(), include(urlpatterns))]
+    return [re_path(r"^" + provider.get_slug() + r"/", include(urlpatterns))]
 
 
 urlpatterns = default_urlpatterns(PEAMUProvider)

--- a/itou/allauth_adapters/peamu/urls.py
+++ b/itou/allauth_adapters/peamu/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from itou.allauth_adapters.peamu.provider import PEAMUProvider
 from itou.allauth_adapters.peamu.views import oauth2_callback as callback_view, oauth2_login as login_view
@@ -6,11 +6,11 @@ from itou.allauth_adapters.peamu.views import oauth2_callback as callback_view, 
 
 def default_urlpatterns(provider):
     urlpatterns = [
-        url("^login/$", login_view, name=provider.id + "_login"),
-        url("^login/callback/$", callback_view, name=provider.id + "_callback"),
+        path("login", login_view, name=provider.id + "_login"),
+        path("login/callback", callback_view, name=provider.id + "_callback"),
     ]
 
-    return [url("^" + provider.get_slug() + "/", include(urlpatterns))]
+    return [path(provider.get_slug(), include(urlpatterns))]
 
 
 urlpatterns = default_urlpatterns(PEAMUProvider)

--- a/itou/api/apps.py
+++ b/itou/api/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class ApiConfig(AppConfig):
-    name = "api"

--- a/itou/approvals/apps.py
+++ b/itou/approvals/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class ApprovalsConfig(AppConfig):
-    name = "approvals"

--- a/itou/asp/__init__.py
+++ b/itou/asp/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "itou.asp.apps.AspConfig"

--- a/itou/cities/apps.py
+++ b/itou/cities/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class CitiesConfig(AppConfig):
-    name = "cities"

--- a/itou/eligibility/apps.py
+++ b/itou/eligibility/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class EligibilityConfig(AppConfig):
-    name = "eligibility"

--- a/itou/external_data/tests.py
+++ b/itou/external_data/tests.py
@@ -97,7 +97,7 @@ class ExternalDataImportTest(TestCase):
         _status_ok(m)
 
         result = import_user_pe_data(user, FOO_TOKEN)
-        self.assertEquals(result.status, ExternalDataImport.STATUS_OK)
+        self.assertEqual(result.status, ExternalDataImport.STATUS_OK)
 
         report = result.report
 
@@ -113,7 +113,7 @@ class ExternalDataImportTest(TestCase):
         _status_partial(m)
 
         result = import_user_pe_data(user, FOO_TOKEN)
-        self.assertEquals(result.status, ExternalDataImport.STATUS_PARTIAL)
+        self.assertEqual(result.status, ExternalDataImport.STATUS_PARTIAL)
 
         report = result.report
         self.assertTrue(user.has_external_data)
@@ -131,7 +131,7 @@ class ExternalDataImportTest(TestCase):
         _status_failed(m)
 
         result = import_user_pe_data(user, FOO_TOKEN)
-        self.assertEquals(result.status, ExternalDataImport.STATUS_FAILED)
+        self.assertEqual(result.status, ExternalDataImport.STATUS_FAILED)
 
         report = result.report
         self.assertEqual(0, len(report.get("fields_updated")))
@@ -195,7 +195,7 @@ class JobSeekerExternalDataTest(TestCase):
 
         self.assertEqual(user.address_line_1, "4, Privet Drive")
         self.assertEqual(user.address_line_2, "The cupboard under the stairs")
-        self.assertNotEquals(str(user.birthdate), "1970-01-01")
+        self.assertNotEqual(str(user.birthdate), "1970-01-01")
 
     @requests_mock.Mocker()
     def test_import_failed(self, m):

--- a/itou/invitations/apps.py
+++ b/itou/invitations/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class InvitationsConfig(AppConfig):
-    name = "invitations"

--- a/itou/job_applications/apps.py
+++ b/itou/job_applications/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class JobApplicationsConfig(AppConfig):
-    name = "job_applications"

--- a/itou/jobs/apps.py
+++ b/itou/jobs/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class JobsConfig(AppConfig):
-    name = "jobs"

--- a/itou/prescribers/apps.py
+++ b/itou/prescribers/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class PrescribersConfig(AppConfig):
-    name = "prescribers"

--- a/itou/siaes/apps.py
+++ b/itou/siaes/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class SiaesConfig(AppConfig):
-    name = "siaes"

--- a/itou/users/apps.py
+++ b/itou/users/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class UsersConfig(AppConfig):
-    name = "users"

--- a/itou/www/apply/apps.py
+++ b/itou/www/apply/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class ApplyConfig(AppConfig):
-    name = "apply"

--- a/itou/www/approvals_views/apps.py
+++ b/itou/www/approvals_views/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class ApprovalsViewsConfig(AppConfig):
-    name = "approvals_views"

--- a/itou/www/autocomplete/apps.py
+++ b/itou/www/autocomplete/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class AutocompleteConfig(AppConfig):
-    name = "autocomplete"

--- a/itou/www/dashboard/apps.py
+++ b/itou/www/dashboard/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class DashboardConfig(AppConfig):
-    name = "dashboard"

--- a/itou/www/eligibility_views/apps.py
+++ b/itou/www/eligibility_views/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class EligibilityViewsConfig(AppConfig):
-    name = "eligibility_views"

--- a/itou/www/home/apps.py
+++ b/itou/www/home/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class HomeConfig(AppConfig):
-    name = "home"

--- a/itou/www/invitations_views/apps.py
+++ b/itou/www/invitations_views/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class InvitationsViewsConfig(AppConfig):
-    name = "invitations_views"

--- a/itou/www/prescribers_views/apps.py
+++ b/itou/www/prescribers_views/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class PrescribersViewsConfig(AppConfig):
-    name = "prescribers_views"

--- a/itou/www/search/apps.py
+++ b/itou/www/search/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class SearchConfig(AppConfig):
-    name = "search"

--- a/itou/www/siaes_views/apps.py
+++ b/itou/www/siaes_views/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class SiaesViewsConfig(AppConfig):
-    name = "siaes_views"

--- a/itou/www/signup/apps.py
+++ b/itou/www/signup/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class SignupConfig(AppConfig):
-    name = "signup"

--- a/itou/www/stats/apps.py
+++ b/itou/www/stats/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class StatsConfig(AppConfig):
-    name = "stats"

--- a/itou/www/welcoming_tour/apps.py
+++ b/itou/www/welcoming_tour/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class WelcomingTourConfig(AppConfig):
-    name = "welcoming_tour"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.2.0  # https://github.com/avian2/unidecode
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.1.8  # pyup: < 4.0  # https://www.djangoproject.com/
+django==3.2  # pyup: < 4.0  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.43.0  # https://github.com/pennersr/django-allauth

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ coverage==5.5  # https://github.com/nedbat/coveragepy
 # ------------------------------------------------------------------------------
 factory-boy==2.12.0  # https://github.com/FactoryBoy/factory_boy
 
-django-debug-toolbar==3.2  # https://github.com/jazzband/django-debug-toolbar
+django-debug-toolbar==3.2.1  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.1.1  # https://github.com/django-extensions/django-extensions
 django-admin-logs==1.0.1  # https://pypi.org/project/django-admin-logs/
 


### PR DESCRIPTION
### Quoi ?

Mise à jour vers [Django 3.2](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys).

Et en même temps de la [Django Debug Toolbar](https://www.djangoproject.com/weblog/2021/apr/14/debug-toolbar-security-releases/).

### Pourquoi ?

- de nouvelles fonctionnalités et améliorations sont ajoutées
- des bogues sont corrigés
- les anciennes versions de Django finiront par ne plus recevoir de mises à jour de sécurité
- la mise à jour de chaque nouvelle version de Django rend les mises à jour futures moins pénibles

### Comment ?

> https://docs.djangoproject.com/en/3.2/howto/upgrade-version/

### Autre

Il reste un _warning_ un tout petit peu inquiétant :

```
/usr/local/lib/python3.9/site-packages/xworkflows/compat.py:26: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
  return isinstance(var, collections.Callable)
```