### PR TITLE
Fix email content

### DIFF
--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -356,6 +356,7 @@ class PrescriberOrganization(AddressMixin):  # Do not forget the mixin!
     def member_activation_email(self, user):
         """
         Send email when an admin of the structure activates the membership of a given user.
+        TODO: I am never called, am I useless ?
         """
         to = [user.email]
         context = {"structure": self}

--- a/itou/templates/common/emails/add_admin_email_body.txt
+++ b/itou/templates/common/emails/add_admin_email_body.txt
@@ -1,22 +1,19 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% load format_filters %}
-{% load i18n %}
 {% block body %}
 
-{% translate "Vous êtes administrateur d'une structure sur les emplois de l'inclusion" %}
+Vous êtes administrateur d'une structure sur les emplois de l'inclusion
 
-{% blocktranslate %}
 Un administrateur peut ajouter ou retirer :
 - des collaborateurs 
 - des administrateurs
-{% endblocktranslate %}
 
-{% translate "Structure :" %}
+Structure :
 
-- {% translate "Nom" %} : {{ structure.display_name }}
-- {% translate "Type" %} : {{ structure.kind }}
-- {% translate "Email de contact" %} : {{ structure.email }}
+- Nom : {{ structure.display_name }}
+- Type : {{ structure.kind }}
+- Email de contact : {{ structure.email }}
 
-{% translate "Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs de cette structure sur les emplois de l'inclusion." %}
+Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs de cette structure sur les emplois de l'inclusion.
 
 {% endblock body %}

--- a/itou/templates/common/emails/add_admin_email_subject.txt
+++ b/itou/templates/common/emails/add_admin_email_subject.txt
@@ -1,5 +1,5 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% load i18n %}
 {% block subject %}
-{% blocktranslate %}[Activation] Vous êtes désormais administrateur de {{ structure.display_name }}{% endblocktranslate %}
+[Activation] Vous êtes désormais administrateur de {{ structure.display_name }}
 {% endblock %}

--- a/itou/templates/common/emails/member_deactivation_email_body.txt
+++ b/itou/templates/common/emails/member_deactivation_email_body.txt
@@ -1,16 +1,15 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% load format_filters %}
-{% load i18n %}
 {% block body %}
 
-{% translate "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" %}
+Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion
 
-{% translate "Structure :" %}
+Structure :
 
-- {% translate "Nom" %} : {{ structure.display_name }}
-- {% translate "Type" %} : {{ structure.kind }}
-- {% translate "Email de contact" %} : {{ structure.email }}
+- Nom : {{ structure.display_name }}
+- Type : {{ structure.kind }}
+- Email de contact : {{ structure.email }}
 
-{% translate "Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion." %}
+Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
 
 {% endblock body %}

--- a/itou/templates/common/emails/member_deactivation_email_subject.txt
+++ b/itou/templates/common/emails/member_deactivation_email_subject.txt
@@ -1,5 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
-{% load i18n %}
 {% block subject %}
-{% blocktranslate %}[Désactivation] Vous n'êtes plus membre de {{ structure.display_name }}{% endblocktranslate %}
+[Désactivation] Vous n'êtes plus membre de {{ structure.display_name }}
 {% endblock %}

--- a/itou/templates/common/emails/remove_admin_email_body.txt
+++ b/itou/templates/common/emails/remove_admin_email_body.txt
@@ -1,16 +1,15 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% load format_filters %}
-{% load i18n %}
 {% block body %}
 
-{% translate "Un administrateur vous a retiré les droits d'administrateur d'une structure sur les emplois de l'inclusion" %}
+Un administrateur vous a retiré les droits d'administrateur d'une structure sur les emplois de l'inclusion
 
-{% translate "Structure :" %}
+Structure :
 
-- {% translate "Nom" %} : {{ structure.display_name }}
-- {% translate "Type" %} : {{ structure.kind }}
-- {% translate "Email de contact" %} : {{ structure.email }}
+- Nom : {{ structure.display_name }}
+- Type : {{ structure.kind }}
+- Email de contact : {{ structure.email }}
 
-{% translate "Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion." %}
+Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
 
 {% endblock body %}

--- a/itou/templates/common/emails/remove_admin_email_subject.txt
+++ b/itou/templates/common/emails/remove_admin_email_subject.txt
@@ -1,5 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
-{% load i18n %}
 {% block subject %}
-{% blocktranslate %}[Désactivation] Vous n'êtes plus administrateur de {{ structure.display_name }}{% endblocktranslate %}
+[Désactivation] Vous n'êtes plus administrateur de {{ structure.display_name }}
 {% endblock %}

--- a/itou/www/prescribers_views/tests.py
+++ b/itou/www/prescribers_views/tests.py
@@ -178,7 +178,7 @@ class UserMembershipDeactivationTest(TestCase):
         # User must have been notified of deactivation (we're human after all)
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]
-        self.assertIn("[Désactivation] Vous n'êtes plus membre de", email.subject)
+        self.assertEqual(f"[Désactivation] Vous n'êtes plus membre de {organization.display_name}", email.subject)
         self.assertIn("Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion", email.body)
         self.assertEqual(email.to[0], guest.email)
 

--- a/itou/www/prescribers_views/tests.py
+++ b/itou/www/prescribers_views/tests.py
@@ -273,6 +273,15 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         organization.refresh_from_db()
         self.assertTrue(guest in organization.active_admin_members)
 
+        # The admin should receive a valid email
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertEqual(
+            f"[Activation] Vous êtes désormais administrateur de {organization.display_name}", email.subject
+        )
+        self.assertIn("Vous êtes administrateur d'une structure sur les emplois de l'inclusion", email.body)
+        self.assertEqual(email.to[0], guest.email)
+
     def test_remove_admin(self):
         """
         Check the ability for an admin to remove another admin
@@ -299,6 +308,18 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
 
         organization.refresh_from_db()
         self.assertFalse(guest in organization.active_admin_members)
+
+        # The admin should receive a valid email
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertEqual(
+            f"[Désactivation] Vous n'êtes plus administrateur de {organization.display_name}", email.subject
+        )
+        self.assertIn(
+            "Un administrateur vous a retiré les droits d'administrateur d'une structure",
+            email.body,
+        )
+        self.assertEqual(email.to[0], guest.email)
 
     def test_admin_management_permissions(self):
         """

--- a/itou/www/siaes_views/tests.py
+++ b/itou/www/siaes_views/tests.py
@@ -670,6 +670,13 @@ class SIAEAdminMembersManagementTest(TestCase):
         siae.refresh_from_db()
         self.assertTrue(guest in siae.active_admin_members)
 
+        # The admin should receive a valid email
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertEqual(f"[Activation] Vous êtes désormais administrateur de {siae.display_name}", email.subject)
+        self.assertIn("Vous êtes administrateur d'une structure sur les emplois de l'inclusion", email.body)
+        self.assertEqual(email.to[0], guest.email)
+
     def test_remove_admin(self):
         """
         Check the ability for an admin to remove another admin
@@ -696,6 +703,16 @@ class SIAEAdminMembersManagementTest(TestCase):
 
         siae.refresh_from_db()
         self.assertFalse(guest in siae.active_admin_members)
+
+        # The admin should receive a valid email
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertEqual(f"[Désactivation] Vous n'êtes plus administrateur de {siae.display_name}", email.subject)
+        self.assertIn(
+            "Un administrateur vous a retiré les droits d'administrateur d'une structure",
+            email.body,
+        )
+        self.assertEqual(email.to[0], guest.email)
 
     def test_admin_management_permissions(self):
         """

--- a/itou/www/siaes_views/tests.py
+++ b/itou/www/siaes_views/tests.py
@@ -573,7 +573,7 @@ class UserMembershipDeactivationTest(TestCase):
         # User must have been notified of deactivation (we're human after all)
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]
-        self.assertIn("[Désactivation] Vous n'êtes plus membre de", email.subject)
+        self.assertEqual(f"[Désactivation] Vous n'êtes plus membre de {siae.display_name}", email.subject)
         self.assertIn("Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion", email.body)
         self.assertEqual(email.to[0], guest.email)
 


### PR DESCRIPTION
### Quoi ?

Les sujets d’emails ne contiennent pas les noms des siae et prescripteurs.

### Pourquoi ?

Excellente question ! Je n’ai pas trouvé à 100%, mais:
 - les tests automatisés ne testaient pas suffisament les chaines à vérifier, et donc il ne détectaient pas l’erreur
 - pour une raison qui m’échappe, dans `translate` et `blocktranslate`, les `@property` sont mal remplacées (chaine vide, pas d’exception levée). L’objet est pourtant bien transmis, les attributs sont eux, bien affichés : on affiche correctement `siae.kind`, mais `siae.display_name` est une chaine vide.
 - On peut tricher. Ainsi:
 ```jinja
{# chaine vide #}
{% blocktranslate %}
organization.display_name
{% endblocktranslate %}
```
mais 
```jinja
{# remplacement correct #}
{% blocktranslate with org_name=organization.display_name %}
org_name
{% endblocktranslate %}
```
- Il se trouve que sans traduction, les `properties` sont correctement remplacées. Ça tombe bien, on veut enlever les traductions.
```jinja
{# pas de traduction, remplacement correct #}
organization.display_name
```


### Comment ?

 - Ajout et amélioration de tests (plus de monde est touché que ce qu’on avait détecté).
 - J’ai supprimé les traductions dans les emails concernés.