### PR TITLE
Suppression de `SESSION_SAVE_EVERY_REQUEST`

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -120,11 +120,6 @@ ROOT_URLCONF = "config.urls"
 
 WSGI_APPLICATION = "config.wsgi.application"
 
-# Session.
-# ------------------------------------------------------------------------------
-
-SESSION_SAVE_EVERY_REQUEST = True
-
 # Templates.
 # ------------------------------------------------------------------------------
 

--- a/itou/utils/nav_history.py
+++ b/itou/utils/nav_history.py
@@ -37,6 +37,7 @@ def push_url_in_history(session_key):
                 url_history = url_history[: current_url_index + 1]
 
             session_data["url_history"] = url_history
+            request.session.modified = True
 
             return view(request, *args, **kwargs)
 

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -110,6 +110,8 @@ def step_sender(request, siae_pk):
     if user_info.siae:
         session_data["sender_siae_pk"] = user_info.siae.pk
 
+    request.session.modified = True
+
     next_url = reverse("apply:step_job_seeker", kwargs={"siae_pk": siae_pk})
     return HttpResponseRedirect(next_url)
 
@@ -126,6 +128,7 @@ def step_job_seeker(request, siae_pk, template_name="apply/submit_step_job_seeke
     # The user submit an application for himself.
     if request.user.is_job_seeker:
         session_data["job_seeker_pk"] = request.user.pk
+        request.session.modified = True
         return HttpResponseRedirect(next_url)
 
     siae = get_object_or_404(Siae, pk=session_data["to_siae_pk"])
@@ -138,6 +141,7 @@ def step_job_seeker(request, siae_pk, template_name="apply/submit_step_job_seeke
 
         if job_seeker:
             session_data["job_seeker_pk"] = job_seeker.pk
+            request.session.modified = True
             return HttpResponseRedirect(next_url)
 
         args = urlencode({"email": form.cleaned_data["email"]})
@@ -195,6 +199,7 @@ def step_create_job_seeker(request, siae_pk, template_name="apply/submit_step_jo
     if request.method == "POST" and form.is_valid():
         job_seeker = form.save()
         session_data["job_seeker_pk"] = job_seeker.pk
+        request.session.modified = True
         next_url = reverse("apply:step_eligibility", kwargs={"siae_pk": siae.pk})
         if request.GET.get("resume"):
             next_url = reverse("apply:step_send_resume", kwargs={"siae_pk": siae.pk})

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -242,6 +242,7 @@ def prescriber_choose_org(request, template_name="signup/prescriber_choose_org.h
                 "safir_code": None,
             }
         )
+        request.session.modified = True
         return HttpResponseRedirect(next_url)
 
     context = {
@@ -289,6 +290,7 @@ def prescriber_choose_kind(request, template_name="signup/prescriber_choose_kind
                 "safir_code": None,
             }
         )
+        request.session.modified = True
         return HttpResponseRedirect(next_url)
 
     context = {
@@ -322,6 +324,7 @@ def prescriber_confirm_authorization(request, template_name="signup/prescriber_c
                 "safir_code": None,
             }
         )
+        request.session.modified = True
         next_url = reverse("signup:prescriber_siret")
         return HttpResponseRedirect(next_url)
 
@@ -353,6 +356,7 @@ def prescriber_pole_emploi_safir_code(request, template_name="signup/prescriber_
                 "safir_code": form.cleaned_data["safir_code"],
             }
         )
+        request.session.modified = True
         next_url = reverse("signup:prescriber_pole_emploi_user")
         return HttpResponseRedirect(next_url)
 
@@ -381,6 +385,7 @@ def prescriber_siret(request, template_name="signup/prescriber_siret.html"):
 
     if request.method == "POST" and form.is_valid():
         session_data["prescriber_org_data"] = form.org_data
+        request.session.modified = True
         next_url = reverse("signup:prescriber_user")
         return HttpResponseRedirect(next_url)
 


### PR DESCRIPTION
### Quoi ?

Suppression de `SESSION_SAVE_EVERY_REQUEST`.

### Pourquoi ?

Le setting a été installé pendant la phase de réalisation du prototype pour gagner du temps.

Mais il force Django à enregistrer la session dans la base de données lors de chaque requête, même quand la session n'est pas manipulée.

Ça génère beaucoup d'écritures inutiles en base de données.

### Comment ?

Avec `request.session.modified = True` quand c'est nécessaire pour gérer le dernier cas de la doc :

> https://docs.djangoproject.com/en/3.1/topics/http/sessions/#when-sessions-are-saved

```python
# Session is modified.
request.session['foo'] = 'bar'

# Session is modified.
del request.session['foo']

# Session is modified.
request.session['foo'] = {}

# Gotcha: Session is NOT modified, because this alters
# request.session['foo'] instead of request.session.
request.session['foo']['bar'] = 'baz'
```
