### PR TITLE
Bugfix : un ACI ne peut pas utiliser le motif de prolongation "difficultés particulières"

### DIFF
--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -26,9 +26,7 @@
 
             {% csrf_token %}
 
-            {% bootstrap_form_errors form %}
-
-            {% bootstrap_form form %}
+            {% bootstrap_form form alert_error_type="all" %}
 
             <p>
                 <a href="{% url 'search:prescribers_home' %}" rel="noopener" target="_blank">

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -21,6 +21,7 @@ class DeclareProlongationForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         if not self.instance.pk:
+            self.instance.declared_by_siae = self.siae
             # `start_at` should begin just after the approval. It cannot be set by the user.
             self.instance.start_at = Prolongation.get_start_at(self.approval)
             # `approval` must be set before model validation to avoid violating a not-null constraint.


### PR DESCRIPTION
### Quoi ?

Bugfix : un ACI ne peut pas utiliser le motif de prolongation "difficultés particulières".

### Pourquoi ?

La validation de Model (`Model.full_clean()`) est déclenchée à l’intérieur de l’étape de validation de formulaire, juste après l’appel à la méthode `clean()` du formulaire.

La majeure partie de la logique de validation des prolongations est implémentée et testée dans `Prolongation.clean()`.

Or il manquait une propriété dans le form `declared_by_siae` pour dérouler la validation proprement.

Cette erreur est couverte par un test.

