### PR TITLE
Bugfix : "Unable to find a unique username"

### DIFF
--- a/itou/www/invitations_views/forms.py
+++ b/itou/www/invitations_views/forms.py
@@ -232,6 +232,9 @@ class NewUserInvitationForm(SignupForm):
 
     def save(self, request):
         self.cleaned_data["email"] = self.email
+        # Avoid django-allauth to call its own often failing `generate_unique_username`
+        # function by forcing a username.
+        self.cleaned_data["username"] = User.generate_unique_username()
         get_adapter().stash_verified_email(request, self.email)
         # Possible problem: this causes the user to be saved twice.
         # If we want to save it once, we should override the Allauth method.

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.core import mail
 from django.shortcuts import reverse
 from django.test import TestCase
@@ -51,6 +53,8 @@ class TestAcceptInvitation(TestCase):
 
         user = User.objects.get(email=invitation.email)
         self.assertTrue(user.emailaddress_set.first().verified)
+        # `username` should be a valid UUID, see `User.generate_unique_username()`.
+        self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assert_accepted_invitation(invitation, user)
 
     def test_accept_invitation_logged_in_user(self):

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -115,7 +115,7 @@ class SiaeSignupTest(TestCase):
             self.assertTrue(user.is_active)
             self.assertTrue(siae.has_admin(user))
             self.assertEqual(1, siae.members.count())
-            # Check that `username` is not overriden by django-allauth.
+            # `username` should be a valid UUID, see `User.generate_unique_username()`.
             self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
             self.assertEqual(user.first_name, user_first_name)
             self.assertEqual(user.last_name, post_data["last_name"])
@@ -198,7 +198,7 @@ class JobSeekerSignupTest(TestCase):
 
         # Check `User` state.
         user = User.objects.get(email=post_data["email"])
-        # Check that `username` is not overriden by django-allauth.
+        # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertTrue(user.is_job_seeker)
         self.assertFalse(user.is_prescriber)
@@ -402,7 +402,7 @@ class PrescriberSignupTest(TestCase):
 
         # Check `User` state.
         user = User.objects.get(email=post_data["email"])
-        # Check that `username` is not overriden by django-allauth.
+        # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertFalse(user.is_job_seeker)
         self.assertTrue(user.is_prescriber)
@@ -538,7 +538,7 @@ class PrescriberSignupTest(TestCase):
 
         # Check `User` state.
         user = User.objects.get(email=post_data["email"])
-        # Check that `username` is not overriden by django-allauth.
+        # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertFalse(user.is_job_seeker)
         self.assertTrue(user.is_prescriber)
@@ -640,7 +640,7 @@ class PrescriberSignupTest(TestCase):
 
         # Check `User` state.
         user = User.objects.get(email=post_data["email"])
-        # Check that `username` is not overriden by django-allauth.
+        # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertFalse(user.is_job_seeker)
         self.assertTrue(user.is_prescriber)
@@ -721,7 +721,7 @@ class PrescriberSignupTest(TestCase):
 
         # Check `User` state.
         user = User.objects.get(email=post_data["email"])
-        # Check that `username` is not overriden by django-allauth.
+        # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertFalse(user.is_job_seeker)
         self.assertTrue(user.is_prescriber)


### PR DESCRIPTION
### Quoi ?

Bugfix : "Unable to find a unique username".

### Pourquoi ?

Toujours le même bug dans Allauth qui n'était pas adressé dans la partie "Invitations".

Au passage j'ajoute un commentaire que je trouve plus clair.