### PR TITLE
Ouverture de l'interface "Mes AF" à tous les employeurs

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -23,7 +23,6 @@
 
     {% if current_siae and not current_siae.is_active %}
         <div class="alert alert-warning" role="alert">
-
             La DGEFP nous indique que votre structure n'est plus conventionnée.
             Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.
             A compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.
@@ -36,8 +35,6 @@
                     Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle régularise la situation de votre structure.
                 {% endwith %}
             {% endif %}
-            Pour toute question, veuillez contacter notre support.
-
         </div>
     {% endif %}
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -236,23 +236,18 @@
                         </a>
                     </p>
                     {% if can_show_financial_annexes %}
-                        {# step 1 : (April 19th 2021) : show dashboard link only to inactive siaes #}
-                        {# step 2 : (April 22th 2021 most likely) : show dashboard link to everyone #}
-                        {# these 2 steps are designed to prevent potential support overload #}
-                        {% if not current_siae.is_active %}
-                            <p class="card-text">
-                                {% include "includes/icon.html" with icon="check-circle" %}
-                                <a href="{% url 'siaes_views:show_financial_annexes' %}">
-                                    Mes annexes financières
-                                </a>
-                                <span class="badge badge-info">Nouveau</span>
-                                {% if not current_siae.is_active %}
-                                    <span class="badge badge-danger">
-                                        Action requise
-                                    </span>
-                                {% endif %}
-                            </p>
-                        {% endif %}
+                        <p class="card-text">
+                            {% include "includes/icon.html" with icon="check-circle" %}
+                            <a href="{% url 'siaes_views:show_financial_annexes' %}">
+                                Mes annexes financières
+                            </a>
+                            <span class="badge badge-info">Nouveau</span>
+                            {% if not current_siae.is_active %}
+                                <span class="badge badge-danger">
+                                    Action requise
+                                </span>
+                            {% endif %}
+                        </p>
                     {% endif %}
                     {% if current_siae.is_active and user_is_siae_admin %}
                         <p class="card-text">


### PR DESCRIPTION
### Quoi ?

Ouverture de l'interface "Mes AF" à tous les employeurs.

### Pourquoi ?

La première MEP ce lundi ne montrait cette interface qu'à la minorité de structures inactives, pour mitiger le risque d'une surcharge du support. Ce jeudi Sarah affirme qu'il n'y pas eu de surcharge, donc go on peut passer à cette seconde étape d'ouvrir à tous les employeurs.
