### PR TITLE
Ajout d’un lien vers le Typeform "secteur d’activité employeurs"

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -329,6 +329,18 @@
 
     </div>
 
+    {% if user.is_siae_staff %}
+    <div class="layout layout-column-full border-top bg-light text-center p-4 mt-5 card">
+        <p class="h5 mb-3"><span class="badge badge-warning">Nouveau</span>&nbsp;Améliorez la visibilité de votre structure en précisant les secteurs d'activités sur lesquels vous intervenez</p>
+        <p class="mb-1">
+            <a href="https://itou.typeform.com/to/xGF5FMel#structure=xxxxx&type=xxxxx&ville=xxxxx&siret=xxxxx" rel="noopener" target="_blank" class="btn btn-primary">
+                C'est parti !
+                {% include "includes/icon.html" with icon="external-link" %}
+            </a>
+        </p>
+    </div>
+    {% endif %}
+
     {% if current_siae and current_siae.region in lemarche_regions %}
         <div class="layout layout-column-full border-top bg-light text-center p-4 mt-5 card">
             <p class="h5 mb-3">Développez votre clientèle avec le marché de l'inclusion</p>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "layout/content.html" %}
-
+{% load url_add_query %}
 {% block title %}Tableau de bord{{ block.super }}{% endblock %}
 
 {% block messages %}
@@ -333,7 +333,7 @@
     <div class="layout layout-column-full border-top bg-light text-center p-4 mt-5 card">
         <p class="h5 mb-3"><span class="badge badge-warning">Nouveau</span>&nbsp;Améliorez la visibilité de votre structure en précisant les secteurs d'activités sur lesquels vous intervenez</p>
         <p class="mb-1">
-            <a href="https://itou.typeform.com/to/xGF5FMel#structure={{ current_siae.name|urlencode }}&type={{ current_siae.kind|urlencode }}&ville={{ current_siae.city|urlencode }}&siret={{ current_siae.siret|urlencode }}" rel="noopener" target="_blank" class="btn btn-primary">
+            <a href="{% url_add_query 'https://itou.typeform.com/to/xGF5FMel' structure=current_siae.name type=current_siae.kind ville=current_siae.city siret=current_siae.siret %}" rel="noopener" target="_blank" class="btn btn-primary">
                 C'est parti !
                 {% include "includes/icon.html" with icon="external-link" %}
             </a>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -333,7 +333,7 @@
     <div class="layout layout-column-full border-top bg-light text-center p-4 mt-5 card">
         <p class="h5 mb-3"><span class="badge badge-warning">Nouveau</span>&nbsp;Améliorez la visibilité de votre structure en précisant les secteurs d'activités sur lesquels vous intervenez</p>
         <p class="mb-1">
-            <a href="https://itou.typeform.com/to/xGF5FMel#structure=xxxxx&type=xxxxx&ville=xxxxx&siret=xxxxx" rel="noopener" target="_blank" class="btn btn-primary">
+            <a href="https://itou.typeform.com/to/xGF5FMel#structure={{ current_siae.name|urlencode }}&type={{ current_siae.kind|urlencode }}&ville={{ current_siae.city|urlencode }}&siret={{ current_siae.siret|urlencode }}" rel="noopener" target="_blank" class="btn btn-primary">
                 C'est parti !
                 {% include "includes/icon.html" with icon="external-link" %}
             </a>


### PR DESCRIPTION
Le titre et la description sont en français et au format texte.

### Quoi ?

Ajout d’un lien dans le dashboard des utilisateurs de type "employeur" vers une invitation à remplir un typeform dans lequel on demande à la structure d'indiquer les secteurs d'activité sur lesquelles elle intervient.

### Pourquoi ?

Pour connaître l'activité commerciale des employeurs pour le c4

### Comment ?

Un encart dédié, cf capture d’écran.

### Captures d'écran (optionnel)

![Capture d’écran de 2021-04-22 15-13-02](https://user-images.githubusercontent.com/1223316/115726376-f8ca1000-a382-11eb-9001-cf53cbde5eac.png)

