### PR TITLE
Amélioration du script import_siae.py pour Supportix

### DIFF
--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -158,15 +158,12 @@ def check_convention_data_consistency(dry_run):
     for convention in SiaeConvention.objects.prefetch_related("siaes").all():
         # Check that each convention has exactly one siae of ASP source.
         asp_siaes = [siae for siae in convention.siaes.all() if siae.source == Siae.SOURCE_ASP]
-        if dry_run:
-            # During a dry run we might have some zero-siae conventions
-            # which have not been deleted for real.
-            assert len(asp_siaes) in [0, 1]
-        else:
+
+        if not dry_run:
             assert len(asp_siaes) == 1
 
-        # Check that each inactive convention has a grace period start date.
         if not convention.is_active:
+            # Check that each inactive convention has a grace period start date.
             assert convention.deactivated_at is not None
 
         # Additional data consistency checks.
@@ -177,7 +174,7 @@ def check_convention_data_consistency(dry_run):
     asp_siaes_without_convention = Siae.objects.filter(
         kind__in=Siae.ASP_MANAGED_KINDS, source=Siae.SOURCE_ASP, convention__isnull=True
     ).count()
-    print(f"{asp_siaes_without_convention} siaes of ASP source have no convention (no solution)")
+    assert asp_siaes_without_convention == 0
 
     user_created_siaes_without_convention = Siae.objects.filter(
         kind__in=Siae.ASP_MANAGED_KINDS,

--- a/itou/siaes/management/commands/import_siae.py
+++ b/itou/siaes/management/commands/import_siae.py
@@ -17,7 +17,6 @@ name instead of hardcoding column numbers as in `field = row[42]`.
 import logging
 
 from django.core.management.base import BaseCommand
-from django.db.models import Q
 
 from itou.siaes.management.commands._import_siae.convention import (
     check_convention_data_consistency,
@@ -87,9 +86,10 @@ class Command(BaseCommand):
                     self.delete_siae(siae)
                 else:
                     self.log(
-                        f"siae.id={siae.id} is user created and "
+                        f"FATAL ERROR: siae.id={siae.id} is user created and "
                         f"has no member but has job applications thus cannot be deleted"
                     )
+                    self.fatal_errors += 1
 
     def update_siae_auth_email(self, siae, new_auth_email):
         assert siae.auth_email != new_auth_email
@@ -134,42 +134,36 @@ class Command(BaseCommand):
                 self.update_siae_siret(siae, new_siret)
                 continue
 
-            # A siae already exists with the new siret.
-            # Let's see if one of the two siaes can be safely deleted.
-            if could_siae_be_deleted(siae):
-                self.log(f"siae.id={siae.id} ghost will be deleted")
-                self.delete_siae(siae)
-            elif could_siae_be_deleted(existing_siae):
-                self.log(f"siae.id={existing_siae.id} ghost will be deleted")
-                self.delete_siae(existing_siae)
-                self.update_siae_siret(siae, new_siret)
-            else:
-                self.log(
-                    f"siae.id={siae.id} has changed siret from "
-                    f"{siae.siret} to {new_siret} but siret "
-                    f"already exists (siae.id={existing_siae.id}) "
-                    f"and both siaes have data (will *not* be fixed)"
-                )
+            def fmt(siae):
+                return f"{siae.source} {siae.siret} convention.id={siae.convention.id} asp_id={siae.convention.asp_id}"
+
+            self.log(
+                f"FATAL ERROR: siae.id={siae.id} ({fmt(siae)}) has changed siret from "
+                f"{siae.siret} to {new_siret} but new siret is already used by "
+                f"siae.id={existing_siae.id} ({fmt(existing_siae)}) "
+            )
+            self.fatal_errors += 1
 
         self.log(f"{auth_email_updates} siae.auth_email fields will be updated")
 
     @timeit
-    def delete_inactive_siaes_when_possible(self):
+    def cleanup_siaes_after_grace_period(self):
         blocked_deletions = 0
         deletions = 0
-        for siae in Siae.objects.filter(source=Siae.SOURCE_ASP).filter(
-            Q(convention__isnull=True) | Q(convention__is_active=False)
-        ):
+
+        for siae in Siae.objects.select_related("convention").all():
+            if not siae.grace_period_has_expired:
+                continue
             if could_siae_be_deleted(siae):
-                self.log(f"siae.id={siae.id} is inactive and without data thus will be deleted")
+                self.log(f"siae.id={siae.id} is past grace period thus will be deleted")
                 self.delete_siae(siae)
                 deletions += 1
                 continue
-
+            self.log(f"siae.id={siae.id} is past grace period but cannot be deleted")
             blocked_deletions += 1
 
-        self.log(f"{deletions} siaes will be deleted as inactive and without data")
-        self.log(f"{blocked_deletions} siaes are inactive but cannot be deleted")
+        self.log(f"{deletions} siaes past their grace period will be deleted")
+        self.log(f"{blocked_deletions} siaes past their grace period cannot be deleted")
 
     @timeit
     def create_new_siaes(self):
@@ -187,19 +181,22 @@ class Command(BaseCommand):
             )
             if existing_siae_query.exists():
                 # Siaes with this asp_id already exist, no need to create one more.
-                total_existing_siae_with_asp_source = 0
+                total_existing_siaes_with_asp_source = 0
                 for existing_siae in existing_siae_query.all():
                     assert existing_siae.is_asp_managed
                     if existing_siae.source == Siae.SOURCE_ASP:
-                        total_existing_siae_with_asp_source += 1
+                        total_existing_siaes_with_asp_source += 1
                         if not self.dry_run:
                             # Siret should have been fixed by
                             # update_siret_and_auth_email_of_existing_siaes()
-                            # except in a dry-run.
+                            # except in a dry run.
                             assert existing_siae.siret == siret
                     else:
                         assert existing_siae.source == Siae.SOURCE_USER_CREATED
-                assert total_existing_siae_with_asp_source == 1
+
+                if not self.dry_run:
+                    # Duplicate siaes should have been deleted except in a dry run.
+                    assert total_existing_siaes_with_asp_source == 1
                 continue
 
             existing_siae_query = Siae.objects.filter(siret=siret, kind=kind)
@@ -263,13 +260,16 @@ class Command(BaseCommand):
                     convention = convention_query.get()
                 else:
                     convention.save()
+                assert convention.siaes.filter(source=Siae.SOURCE_ASP).count() == 0
                 siae.convention = convention
                 siae.save()
+                assert convention.siaes.filter(source=Siae.SOURCE_ASP).count() == 1
 
         deletable_conventions = get_deletable_conventions()
         self.log(f"will delete {len(deletable_conventions)} conventions")
         for convention in deletable_conventions:
             if not self.dry_run:
+                assert convention.siaes.count() == 0
                 # This will delete the related financial annexes as well.
                 convention.delete()
 
@@ -301,10 +301,15 @@ class Command(BaseCommand):
         self.dry_run = dry_run
         self.set_logger(options.get("verbosity"))
 
+        self.fatal_errors = 0
+
         self.delete_user_created_siaes_without_members()
         self.update_siret_and_auth_email_of_existing_siaes()
         self.create_new_siaes()
         self.manage_conventions()
         self.manage_financial_annexes()
-        self.delete_inactive_siaes_when_possible()
+        self.cleanup_siaes_after_grace_period()
         self.check_whether_signup_is_possible_for_all_siaes()
+
+        if self.fatal_errors >= 1:
+            raise RuntimeError("At least one fatal error above needs manual resolution")


### PR DESCRIPTION
### Quoi ?

- ajout d'erreurs fatales cassantes pour forcer supportix à resoudre manuellement certains edge cases
- résolution de edge cases variés rencontrés sur les dernières semaines
- ajout d'assertions variées pour détecter le plus en amont possible certains problèmes de données

### Pourquoi ?

Maintenant que c'est supportix qui fait tourner le script, il convient que certains warnings deviennent cassants pour une résolution manuelle par supportix.