### PR TITLE
Ajout d’un bouton de déploiment vers la production

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,18 @@
+name: Deploy to production
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  merge-master-into-master_clever:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Merge master into master_clever
+        uses: devmasx/merge-branch@v1.3.1
+        with:
+          type: now
+          from_branch: master
+          target_branch: master_clever
+          github_token: ${{ github.token }}


### PR DESCRIPTION
Mise en place d’un bouton pour déployer en production depuis Github.

### Pourquoi ?

Pour éviter de faire les choses:
 - à la main depuis une console, ce qui peut être source d’erreur
 - depuis son environnement local, qui peut être dans un état incohérent

### Comment ?

Ajout d’une github action dédiée.

On peut déployer en production:
 - en allant dans les [github actions du projet](https://github.com/betagouv/itou/actions).
 - en choisissant "Deploy to production" -> "Run workflow" -> "Run"

La branche source n’a pas d’importance (pas trouvé comment le virer, pa).

Les utilisateurs de [Github CLI](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-using-github-cli) peuvent également déployer depuis un terminal via `gh workflow run deploy.yml`

![Sélection_011](https://user-images.githubusercontent.com/1223316/115895331-96dcd980-a45a-11eb-942f-2f364aa3af01.png)

Note:
dans mon test, j’ai un second workflow qui se déclenche à la fin de celui-ci, mais dans notre cas le déploiement se fait via un hook sur le push donc il y a encore un peu de travail pour faire cohabiter les différentes manière de faire. En l’état, pas sur que la notif soit envoyée.

```yaml
# hello.yml
name: Automatic hello word

on:
 # Only trigger when the merge workflow succeeded
  workflow_run:
    workflows: ["Deploy to production"]
    types:
      - completed

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - name: Hello
        run: echo Hello, world!
```