### PR TITLE
Modification de la notice pour ouvrir les exports CSV

### DIFF
--- a/itou/templates/apply/includes/info_csv.html
+++ b/itou/templates/apply/includes/info_csv.html
@@ -1,13 +1,10 @@
 <div class="card my-4">
     <div class="card-body">
         <p class="card-text">
-                {% include "includes/icon.html" with icon="info" %}
-                Les exports sont au <a href="https://fr.wikipedia.org/wiki/Comma-separated_values" target="_blank" rel="noreferrer noopener">format CSV</a>: il s’agit d’un format texte lisible dans Excel et LibreOffice, où chaque valeur est séparée par une virgule. Lorsque vous ouvrez un fichier d’export, pour qu’il s’affiche correctement merci de choisir&nbsp;:
-                <ul>
-                    <li>Type de séparateur&nbsp;: Virgule (Comma en anglais)</li>
-                    <li>Jeu de caractères&nbsp;: Unicode (UTF-8)</li>
-                    <li>S’il manque le zéro initial des numéros de téléphone : indiquer que cette colonne est de type « texte » avant l’import.</li>
-                </ul>
+            {% include "includes/icon.html" with icon="info" %}
+            <a href="{{ ITOU_DOC_URL }}/mon-mode-demploi-prescripteur/exporter-mes-candidatures-sur-excel">
+            Consultez le mode d'emploi pour lire le fichier
+            </a>
         </p>
     </div>
 </div>


### PR DESCRIPTION
# Quoi
Changement de texte + redirection vers la doc

# Pourquoi
Le texte est à la fois pas assez détaillé pour des gens qui ne connaissent pas, et un peu long, il alourdit l’écran.

![Sélection_015](https://user-images.githubusercontent.com/1223316/116406805-58b43100-a831-11eb-8b72-46dcc49e922f.png)

