### PR TITLE
Correctif pour l'erreur GEOSException

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -14,8 +14,8 @@
     {# Alerte pour les employeurs en cas d'absence ou de mauvais score de geocoding. #}
     {% if current_siae and not current_siae.has_reliable_coords %}
         <div class="alert alert-warning mb-0" role="alert">
-            Nous n'avons pu géolocaliser votre établissement.<br>
-            Cela pourrait affecter votre présence ou votre position dans les résultats de recherche.<br>
+            Nous n'avons pas pu géolocaliser votre établissement.<br>
+            Cela peut affecter sa position dans les résultats de recherche.<br>
             <a href="{% url 'siaes_views:edit_siae' %}">Indiquez une autre adresse</a> ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener">contactez-nous</a> en cas de problème.
         </div>
     {% endif %}
@@ -24,8 +24,8 @@
     {# Seuls les prescripteurs habilités apparaissent dans le moteur de recherche. #}
     {% if current_prescriber_organization and current_prescriber_organization.is_authorized and not current_prescriber_organization.has_reliable_coords %}
         <div class="alert alert-warning mb-0" role="alert">
-            Nous n'avons pu géolocaliser votre établissement.<br>
-            Cela pourrait affecter votre présence ou votre position dans les résultats de recherche.<br>
+            Nous n'avons pas pu géolocaliser votre établissement.<br>
+            Cela peut affecter sa position dans les résultats de recherche.<br>
             <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a> ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener">contactez-nous</a> en cas de problème.
         </div>
     {% endif %}
@@ -34,7 +34,7 @@
         <div class="alert alert-warning mb-0" role="alert">
             La DGEFP nous indique que votre structure n'est plus conventionnée.<br>
             Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.<br>
-            A compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
+            À compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
 
             {% if user_is_siae_admin %}
                 Veuillez dès que possible régulariser votre situation

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -11,25 +11,34 @@
         </div>
     {% endif %}
 
+    {# Alerte pour les employeurs en cas d'absence ou de mauvais score de geocoding. #}
     {% if current_siae and not current_siae.has_reliable_coords %}
-        <div class="alert alert-warning" role="alert">
-            {% url 'siaes_views:edit_siae' as edit_siae_url %}
-            Nous n'avons pu géolocaliser votre établissement avec l'adresse <b>{{ current_siae.address_on_one_line }}</b> :
-            cela pourrait affecter votre position dans les résultats de recherche.
-            Vous pouvez nous <a href="{{ edit_siae_url }}">indiquer une autre adresse</a> ou
-            <a href="mailto:{{ ITOU_EMAIL_CONTACT }}">nous contacter</a> en cas de problème.
+        <div class="alert alert-warning mb-0" role="alert">
+            Nous n'avons pu géolocaliser votre établissement.<br>
+            Cela pourrait affecter votre présence ou votre position dans les résultats de recherche.<br>
+            <a href="{% url 'siaes_views:edit_siae' %}">Indiquez une autre adresse</a> ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener">contactez-nous</a> en cas de problème.
+        </div>
+    {% endif %}
+
+    {# Alerte pour les prescripteurs en cas d'absence ou de mauvais score de geocoding. #}
+    {# Seuls les prescripteurs habilités apparaissent dans le moteur de recherche. #}
+    {% if current_prescriber_organization and current_prescriber_organization.is_authorized and not current_prescriber_organization.has_reliable_coords %}
+        <div class="alert alert-warning mb-0" role="alert">
+            Nous n'avons pu géolocaliser votre établissement.<br>
+            Cela pourrait affecter votre présence ou votre position dans les résultats de recherche.<br>
+            <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a> ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener">contactez-nous</a> en cas de problème.
         </div>
     {% endif %}
 
     {% if current_siae and not current_siae.is_active %}
-        <div class="alert alert-warning" role="alert">
-            La DGEFP nous indique que votre structure n'est plus conventionnée.
-            Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.
-            A compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.
+        <div class="alert alert-warning mb-0" role="alert">
+            La DGEFP nous indique que votre structure n'est plus conventionnée.<br>
+            Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.<br>
+            A compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
 
             {% if user_is_siae_admin %}
                 Veuillez dès que possible régulariser votre situation
-                <a href="{% url 'siaes_views:show_financial_annexes' %}">en sélectionnant une annexe financière valide}</a>.
+                <a href="{% url 'siaes_views:show_financial_annexes' %}">en sélectionnant une annexe financière valide}</a>.<br>
             {% else %}
                 {% with current_siae.active_admin_members.first as admin %}
                     Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle régularise la situation de votre structure.

--- a/itou/utils/apis/geocoding.py
+++ b/itou/utils/apis/geocoding.py
@@ -25,13 +25,13 @@ def call_ban_geocoding_api(address, post_code=None, limit=1):
     try:
         r = httpx.get(url)
     except httpx.RequestError as e:
-        logger.error("Error while fetching `%s`: %s", url, e)
+        logger.info("Error while fetching `%s`: %s", url, e)
         return None
 
     try:
         return r.json()["features"][0]
     except IndexError:
-        logger.error("Geocoding error, no result found for `%s`", url)
+        logger.info("Geocoding error, no result found for `%s`", url)
         return None
 
 

--- a/itou/utils/apis/geocoding.py
+++ b/itou/utils/apis/geocoding.py
@@ -68,6 +68,9 @@ def process_geocoding_data(data):
 
 
 def get_geocoding_data(address, post_code=None, limit=1):
+    """
+    Return a dict containing info about the given `address` or None if no result found.
+    """
 
     geocoding_data = call_ban_geocoding_api(address, post_code=post_code, limit=limit)
 

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -425,7 +425,8 @@ class PrescriberUserSignupForm(FullnameFormMixin, SignupForm):
             prescriber_org.department = self.prescriber_org_data["department"]
             longitude = self.prescriber_org_data["longitude"]
             latitude = self.prescriber_org_data["latitude"]
-            prescriber_org.coords = GEOSGeometry(f"POINT({longitude} {latitude})")
+            if longitude and latitude:
+                prescriber_org.coords = GEOSGeometry(f"POINT({longitude} {latitude})")
             prescriber_org.geocoding_score = self.prescriber_org_data["geocoding_score"]
             prescriber_org.kind = self.kind
             prescriber_org.authorization_status = self.authorization_status


### PR DESCRIPTION
### Quoi ?

Correctif pour l'erreur `GEOSException` qui empêche des prescripteurs de pouvoir s'inscrire.

### Pourquoi ?

Dans le tunnel d'inscription des prescripteurs, on tente de récupérer automatiquement des informations de geocoding. Quand il n'y en a pas, PostGIS déclenche une erreur `GEOSException` car il manque les informations de latitude et de longitude.

### Comment ?

On rend les informations de latitude et de longitude optionnelles et on affiche un message d'alerte sur le tableau de bord quand leur absence peut avoir des conséquences dans les résultats de recherche.

### Autre

- ajout de doc
- changement de niveau du logging des erreurs de geocoding