### PR TITLE
Ajout d'un contrôle de la date de début d'une prolongation dans l'admin

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -734,8 +734,8 @@ class Prolongation(models.Model):
             raise ValidationError(
                 {
                     "end_at": (
-                        f'La durée totale est trop longue pour le motif "{self.get_reason_display()}". '
-                        f"Date de fin maximum: {max_end_at.strftime('%d/%m/%Y')}."
+                        f"La durée totale est trop longue pour le motif « {self.get_reason_display()} ». "
+                        f"Date de fin maximum : {max_end_at.strftime('%d/%m/%Y')}."
                     )
                 }
             )
@@ -745,7 +745,7 @@ class Prolongation(models.Model):
                 self.declared_by_siae.KIND_AI,
                 self.declared_by_siae.KIND_ACI,
             ]:
-                raise ValidationError(f'Le motif "{self.get_reason_display()}" est réservé aux AI et ACI.')
+                raise ValidationError(f"Le motif « {self.get_reason_display()} » est réservé aux AI et ACI.")
 
         if (
             hasattr(self, "validated_by")
@@ -758,8 +758,8 @@ class Prolongation(models.Model):
 
             if self.start_at != self.get_start_at(self.approval):
                 raise ValidationError(
-                    "La date de début ne peut pas être différente de la date de fin du PASS IAE : "
-                    f"{self.approval.end_at.strftime('%d/%m/%Y')}."
+                    "La date de début ne peut pas être différente de la date de fin du PASS IAE "
+                    f"« {self.approval.end_at.strftime('%d/%m/%Y')} »."
                 )
 
             # A prolongation cannot overlap another one for the same SIAE.

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -756,6 +756,12 @@ class Prolongation(models.Model):
 
         if hasattr(self, "approval"):
 
+            if self.start_at != self.get_start_at(self.approval):
+                raise ValidationError(
+                    "La date de début ne peut pas être différente de la date de fin du PASS IAE : "
+                    f"{self.approval.end_at.strftime('%d/%m/%Y')}."
+                )
+
             # A prolongation cannot overlap another one for the same SIAE.
             # This check is enforced by a constraint at the database level but
             # still required here to avoid a 500 server error "IntegrityError"

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -1109,6 +1109,22 @@ class ProlongationModelTest(TestCase):
     Test Prolongation model.
     """
 
+    def test_clean_with_wrong_start_at(self):
+        """
+        Given an existing prolongation, when setting a wrong `start_at`
+        then a call to `clean()` is rejected.
+        """
+        start_at = datetime.date.today()
+        end_at = start_at + relativedelta(months=1)
+        prolongation = ProlongationFactory(start_at=start_at, end_at=end_at)
+        # Set a `prolongation.start_at` different from `prolongation.approval.start_at`.
+        prolongation.start_at -= relativedelta(days=2)
+        with self.assertRaises(ValidationError) as error:
+            prolongation.clean()
+        self.assertIn(
+            "La date de début ne peut pas être différente de la date de fin du PASS IAE", error.exception.message
+        )
+
     def test_get_start_at(self):
 
         end_at = datetime.date(2021, 2, 1)


### PR DESCRIPTION
### Quoi ?

Ajout d'un contrôle de la date de début d'une prolongation dans l'admin.

### Pourquoi ?

Ce contrôle existe côté interface SIAE. Or il n'est pas présent dans l'admin.

### Comment ?

Ajout du contrôle dans `Prolongation.clean()` de sorte qu'il soit toujours appelé en sortie d'un `ModelForm` (front ou admin).