### PR TITLE
Publication des notes de version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Le format est basé sur [Tenez un Changelog](https://keepachangelog.com/en/1.0.0
  - Ajout de la colonne "date de création" pour permettre au support de voir les structures créés lors des imports.
 
 ### Modifié
-    
+
  - Nouvelle version majeure de Django v3.2
  - Changement du code de tracking Hotjar
  - Amélioration des performances de l'enregistrement de la session utilisateur
@@ -623,7 +623,6 @@ du Fonds Départemental d'Insertion (FDI)](http://fdi.inclusion.beta.gouv.fr/)
 - Correction d'un bug de code postal lors de l'ajout d'une structure en Corse
 - Correction d'un bug de lien non cliquable à cause du widget "Je donne mon avis"
 
-### Supprimé
 
 ## [1.0.0] - 2020-04-13
 
@@ -647,5 +646,3 @@ du Fonds Départemental d'Insertion (FDI)](http://fdi.inclusion.beta.gouv.fr/)
 - Restriction d'embauche temporaire pour les ETTI hors 62-67-93 (jusqu'au 10/04/2020)
 - Les fiches des employeurs solidaires sont publiques ("Opération ETTI")
 - Fix page stats erreur 403 à cause du token CSRF
-
-### Supprimé

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,8 +5,9 @@ from django.views.generic import TemplateView
 
 from itou.utils.urls import SiretConverter
 from itou.www.dashboard import views as dashboard_views
-from itou.www.signup import views as signup_views
 from itou.www.login import views as login_views
+from itou.www.signup import views as signup_views
+
 
 register_converter(SiretConverter, "siret")
 
@@ -59,6 +60,7 @@ urlpatterns = [
     path("search/", include("itou.www.search.urls")),
     path("siae/", include("itou.www.siaes_views.urls")),
     path("prescribers/", include("itou.www.prescribers_views.urls")),
+    path("releases/", include("itou.www.releases.urls")),
     path("signup/", include("itou.www.signup.urls")),
     path("stats/", include("itou.www.stats.urls")),
     path("welcoming_tour/", include("itou.www.welcoming_tour.urls")),

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -279,6 +279,9 @@
                                         {% include "includes/icon.html" with icon="external-link" %}
                                     </a>
                                 </li>
+                                <li>
+                                    <a href="{% url 'releases:list' %}">Journal des modifications</a>
+                                </li>
                             </ul>
                         </div>
 

--- a/itou/templates/releases/list.html
+++ b/itou/templates/releases/list.html
@@ -1,0 +1,7 @@
+{% extends "layout/content.html" %}
+
+{% block title %}Notes de publication{{ block.super }}{% endblock %}
+
+{% block content %}
+  {{ changelog_html }}
+{% endblock %}

--- a/itou/www/releases/tests.py
+++ b/itou/www/releases/tests.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class ReleaseTest(TestCase):
+    def test_list(self):
+        url = reverse("releases:list")
+        response = self.client.get(url)
+        self.assertContains(response, "Journal des modifications")

--- a/itou/www/releases/urls.py
+++ b/itou/www/releases/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from itou.www.releases import views
+
+
+app_name = "releases"
+
+
+urlpatterns = [
+    path("", views.releases, name="releases"),
+]

--- a/itou/www/releases/urls.py
+++ b/itou/www/releases/urls.py
@@ -7,5 +7,5 @@ app_name = "releases"
 
 
 urlpatterns = [
-    path("", views.releases, name="releases"),
+    path("", views.releases, name="list"),
 ]

--- a/itou/www/releases/views.py
+++ b/itou/www/releases/views.py
@@ -4,8 +4,10 @@ import markdown
 from django.conf import settings
 from django.shortcuts import render
 from django.utils.html import mark_safe
+from django.views.decorators.cache import cache_page
 
 
+@cache_page(60 * 60)  # 1 hour
 def releases(request, template_name="releases/list.html"):
     """
     Render our CHANGELOG.md file in HTML

--- a/itou/www/releases/views.py
+++ b/itou/www/releases/views.py
@@ -1,0 +1,18 @@
+import os
+
+import markdown
+from django.conf import settings
+from django.shortcuts import render
+from django.utils.html import mark_safe
+
+
+def releases(request, template_name="releases/list.html"):
+    """
+    Render our CHANGELOG.md file in HTML
+    """
+    changelog_filename = os.path.join(settings.ROOT_DIR, "CHANGELOG.md")
+    with open(changelog_filename, "r", encoding="utf-8") as f:
+        changelog_html = markdown.markdown(f.read())
+
+    context = {"changelog_html": mark_safe(changelog_html)}
+    return render(request, template_name, context)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,6 +38,9 @@ django-bootstrap-datepicker-plus==3.0.5  # https://github.com/monim67/django-boo
 # Enhance select fields in forms with jQuery Select plugin
 django_select2==7.6.2  # https://github.com/codingjoe/django-select2
 
+# Render Markdown in HTML
+markdown==3.3.4  # https://github.com/Python-Markdown/markdown
+
 # Data management
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
https://trello.com/c/7LF4V9oE/1581-c1-cr%C3%A9er-la-page-%C3%A9volutions-et-y-mettre-le-changelog-github

### Quoi ?

Nouvelle vue qui affiche le markdown de CHANGELOG.md en HTML.

### Pourquoi ?

Pour que le monde entier soit informé des changements effectués sur notre base de code dans un langage non technique.

### Comment ?

En mettant un lien qui donne envie de cliquer dessus dans le pied de page.
Avec un petit cache pour tenir la charge sur hackernews.

### Captures d'écran

![Capture d’écran de 2021-04-29 17-59-11](https://user-images.githubusercontent.com/1815/116581538-b8cfd380-a914-11eb-96cf-888a16b9ccf7.png)
