### PR TITLE
Possibilité de modifier un PASS IAE existant dans l'admin

### DIFF
--- a/itou/approvals/admin_forms.py
+++ b/itou/approvals/admin_forms.py
@@ -5,15 +5,24 @@ from itou.approvals.models import Approval
 
 class ApprovalFormMixin:
 
+    ADDITIONAL_HELP_TEXT_NUMBER = " Laissez le champ vide pour générer automatiquement un numéro de PASS IAE."
     ERROR_NUMBER = (
         f"Les numéros préfixés par {Approval.ASP_ITOU_PREFIX} sont attribués automatiquement. "
         "Laissez le champ vide pour une génération automatique."
     )
+    ERROR_NUMBER_CANNOT_BE_CHANGED = "Vous ne pouvez pas modifier le numéro existant du PASS IAE %s."
 
     def clean_number(self):
         number = self.cleaned_data["number"]
-        if number and number.startswith(Approval.ASP_ITOU_PREFIX):
+        is_new = self.instance.pk is None
+        if is_new and number and number.startswith(Approval.ASP_ITOU_PREFIX):
+            # On ne laisse pas saisir un numéro qui commencerait par `ASP_ITOU_PREFIX`
+            # car ça risquerait de créer des trous dans la séquence des numéros.
             raise forms.ValidationError(self.ERROR_NUMBER)
+        elif number != self.instance.number:
+            # On laisse la possibilité de modifier un PASS IAE existant afin
+            # de pouvoir modifier ses dates, mais pas son numéro.
+            raise forms.ValidationError(self.ERROR_NUMBER_CANNOT_BE_CHANGED % self.instance.number)
         return number
 
 
@@ -26,7 +35,7 @@ class ApprovalAdminForm(ApprovalFormMixin, forms.ModelForm):
         # trous dans les agréments transmis par PE et nous avons des
         # réclamations côté support.
         self.fields["number"].required = False
-        self.fields["number"].help_text += " Laissez le champ vide pour générer automatiquement un numéro de PASS IAE."
+        self.fields["number"].help_text += self.ADDITIONAL_HELP_TEXT_NUMBER
 
 
 class ManuallyAddApprovalForm(ApprovalFormMixin, forms.ModelForm):
@@ -43,7 +52,7 @@ class ManuallyAddApprovalForm(ApprovalFormMixin, forms.ModelForm):
         # The `number` field can be filled in manually by an admin when a Pôle emploi
         # approval already exists and needs to be re-issued by Itou.
         self.fields["number"].required = False
-        self.fields["number"].help_text += " Laissez le champ vide pour générer automatiquement un numéro de PASS IAE."
+        self.fields["number"].help_text += self.ADDITIONAL_HELP_TEXT_NUMBER
 
     class Meta:
         model = Approval

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -623,7 +623,11 @@ class AutomaticApprovalAdminViewsTest(TestCase):
     Test Approval automatic admin views.
     """
 
-    def test_edit_approval(self):
+    def test_edit_approval_with_a_wrong_number(self):
+        """
+        Given an existing approval, when setting a different number,
+        then the save is rejected.
+        """
         user = UserFactory()
         user.is_staff = True
         user.save()


### PR DESCRIPTION
### Quoi ?

On laisse la possibilité de modifier un PASS IAE existant dans l'admin.

### Pourquoi ?

Pour pouvoir modifier ses dates, mais sans donner la possibilité de modifier le numéro déjà attribué.

Sans ça, le support ne peut plus faire de rétroactivité ou prendre en comptes les régulations demandées par les utilisateurs.