### PR TITLE
Ignorer la période de carence pour les non SIAE

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1117,3 +1117,17 @@ class ApprovalsWrapper:
         has been made outside of Itou.
         """
         return self.has_valid and not self.latest_approval.originates_from_itou
+
+    def cannot_bypass_waiting_period(self, siae, sender_prescriber_organization):
+        """
+        An approval in waiting period can only be bypassed if the prescriber is authorized
+        or if the structure is not a SIAE.
+        """
+        is_sent_by_authorized_prescriber = (
+            sender_prescriber_organization is not None and sender_prescriber_organization.is_authorized
+        )
+        return (
+            self.has_in_waiting_period
+            and siae.is_subject_to_eligibility_rules
+            and not is_sent_by_authorized_prescriber
+        )

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -192,47 +192,6 @@ class ApplyAsJobSeekerTest(TestCase):
             last_url = response.redirect_chain[-1][0]
             self.assertEqual(last_url, reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": siae.pk}))
 
-    def test_apply_as_jobseeker_to_geiq_with_approval_in_waiting_period(self):
-        """
-        Apply as jobseeker to a GEIQ with an approval in waiting period.
-        Waiting period is bypassed.
-        """
-
-        # Avoid COVID lockdown specific cases
-        now_date = PoleEmploiApproval.LOCKDOWN_START_AT - relativedelta(months=1)
-        now = timezone.datetime(year=now_date.year, month=now_date.month, day=now_date.day, tzinfo=pytz.utc)
-
-        with mock.patch("django.utils.timezone.now", side_effect=lambda: now):
-            siae = SiaeWithMembershipAndJobsFactory(kind=Siae.KIND_GEIQ, romes=("N1101", "N1105"))
-            user = JobSeekerFactory()
-            end_at = now_date - relativedelta(days=30)
-            start_at = end_at - relativedelta(years=2)
-            PoleEmploiApprovalFactory(
-                pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate, start_at=start_at, end_at=end_at
-            )
-            self.client.login(username=user.email, password=DEFAULT_PASSWORD)
-
-            url = reverse("apply:start", kwargs={"siae_pk": siae.pk})
-            response = self.client.get(url)
-
-            self.assertEqual(response.status_code, 302)
-
-            session = self.client.session
-            session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
-            expected_session_data = {
-                "job_seeker_pk": None,
-                "to_siae_pk": siae.pk,
-                "sender_pk": None,
-                "sender_kind": None,
-                "sender_siae_pk": None,
-                "sender_prescriber_organization_pk": None,
-                "job_description_id": None,
-            }
-            self.assertDictEqual(session_data, expected_session_data)
-
-            next_url = reverse("apply:step_sender", kwargs={"siae_pk": siae.pk})
-            self.assertEqual(response.url, next_url)
-
 
 class ApplyAsAuthorizedPrescriberTest(TestCase):
     def test_apply_as_authorized_prescriber(self):

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -24,9 +24,10 @@ def check_waiting_period(approvals_wrapper, job_application):
     This should be an edge case.
     An approval may expire between the time an application is sent and
     the time it is accepted.
-    Only "authorized prescribers" can bypass an approval in waiting period.
     """
-    if approvals_wrapper.has_in_waiting_period and not job_application.is_sent_by_authorized_prescriber:
+    if approvals_wrapper.cannot_bypass_waiting_period(
+        siae=job_application.to_siae, sender_prescriber_organization=job_application.sender_prescriber_organization
+    ):
         error = approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_PROXY
         raise PermissionDenied(error)
 


### PR DESCRIPTION
### Quoi ?

Ignorer la période de carence pour les non SIAE.

### Pourquoi ?

Ce blocage n'a pas de sens pour les GEIQ/EA.

Cf https://trello.com/c/GeUSbdub/1679-un-orienteur-ne-peut-pas-candidater-en-ea-ou-geiq-si-son-candidat-a-un-parcours-iae-dans-le-d%C3%A9lai-de-carence

### Comment ?

En étendant l'exception existante accordée aux prescripteurs habilités à toutes les structures non SIAE.