### PR TITLE
Mise en avant du forum sur le tableau de bord

### DIFF
--- a/itou/approvals/admin_forms.py
+++ b/itou/approvals/admin_forms.py
@@ -15,14 +15,17 @@ class ApprovalFormMixin:
     def clean_number(self):
         number = self.cleaned_data["number"]
         is_new = self.instance.pk is None
+
         if is_new and number and number.startswith(Approval.ASP_ITOU_PREFIX):
             # On ne laisse pas saisir un numéro qui commencerait par `ASP_ITOU_PREFIX`
             # car ça risquerait de créer des trous dans la séquence des numéros.
             raise forms.ValidationError(self.ERROR_NUMBER)
-        elif number != self.instance.number:
+
+        if not is_new and number != self.instance.number:
             # On laisse la possibilité de modifier un PASS IAE existant afin
             # de pouvoir modifier ses dates, mais pas son numéro.
             raise forms.ValidationError(self.ERROR_NUMBER_CANNOT_BE_CHANGED % self.instance.number)
+
         return number
 
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -71,6 +71,24 @@
 
 {% block content %}
 
+    {# Mise en avant temporaire du forum. #}
+    {% if user.is_prescriber or user.is_siae_staff %}
+        <div class="card mb-5 bg-light text-center">
+            <div class="card-body">
+                <p class="h5 mb-3">
+                    <span class="badge badge-warning">Nouveau</span>
+                    Bénéficiez des bonnes pratiques et actualités de la 1ère communauté des professionnels de l'inclusion !
+                </p>
+                <p class="mb-0">
+                    <a href="{{ ITOU_COMMUNITY_URL }}" rel="noopener" target="_blank" class="btn btn-primary">
+                        Partagez et découvrez les outils qui facilitent votre quotidien
+                        {% include "includes/icon.html" with icon="external-link" %}
+                    </a>
+                </p>
+            </div>
+        </div>
+    {% endif %}
+
     <h1>
         Tableau de bord
         {% if current_siae %} - <span class="text-muted">{{ current_siae.display_name }}</span>{% endif %}
@@ -351,14 +369,19 @@
     </div>
 
     {% if user.is_siae_staff %}
-        <div class="layout layout-column-full border-top bg-light text-center p-4 mt-5 card">
-            <p class="h5 mb-3"><span class="badge badge-warning">Nouveau</span>&nbsp;Améliorez la visibilité de votre structure en précisant les secteurs d'activités sur lesquels vous intervenez</p>
-            <p class="mb-1">
-                <a href="{% url_add_query 'https://itou.typeform.com/to/xGF5FMel' structure=current_siae.name type=current_siae.kind ville=current_siae.city siret=current_siae.siret %}" rel="noopener" target="_blank" class="btn btn-primary">
-                    C'est parti !
-                    {% include "includes/icon.html" with icon="external-link" %}
-                </a>
-            </p>
+        <div class="card mt-5 bg-light text-center">
+            <div class="card-body">
+                <p class="h5 mb-3">
+                    <span class="badge badge-warning">Nouveau</span>
+                    Améliorez la visibilité de votre structure en précisant les secteurs d'activités sur lesquels vous intervenez
+                </p>
+                <p class="mb-0">
+                    <a href="{% url_add_query 'https://itou.typeform.com/to/xGF5FMel' structure=current_siae.name type=current_siae.kind ville=current_siae.city siret=current_siae.siret %}" rel="noopener" target="_blank" class="btn btn-primary">
+                        C'est parti !
+                        {% include "includes/icon.html" with icon="external-link" %}
+                    </a>
+                </p>
+            </div>
         </div>
     {% endif %}
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -71,8 +71,8 @@
 
 {% block content %}
 
-    {# Mise en avant temporaire du forum. #}
-    {% if user.is_prescriber or user.is_siae_staff %}
+    {# Mise en avant temporaire du forum pour les prescripteurs. #}
+    {% if user.is_prescriber %}
         <div class="card mb-5 bg-light text-center">
             <div class="card-body">
                 <p class="h5 mb-3">
@@ -82,6 +82,24 @@
                 <p class="mb-0">
                     <a href="{{ ITOU_COMMUNITY_URL }}" rel="noopener" target="_blank" class="btn btn-primary">
                         Partagez et découvrez les outils qui facilitent votre quotidien
+                        {% include "includes/icon.html" with icon="external-link" %}
+                    </a>
+                </p>
+            </div>
+        </div>
+    {% endif %}
+
+    {# Mise en avant temporaire du marché pour les employeurs. #}
+    {% if user.is_siae_staff %}
+        <div class="card mb-5 bg-light text-center">
+            <div class="card-body">
+                <p class="h5 mb-3">
+                    <span class="badge badge-warning">Nouveau</span>
+                    Améliorer la visibilité de votre structure
+                </p>
+                <p class="mb-0">
+                    <a href="{% url_add_query 'https://itou.typeform.com/to/xGF5FMel' structure=current_siae.name type=current_siae.kind ville=current_siae.city siret=current_siae.siret %}" rel="noopener" target="_blank" class="btn btn-primary">
+                        C'est parti !
                         {% include "includes/icon.html" with icon="external-link" %}
                     </a>
                 </p>
@@ -367,22 +385,5 @@
         {% endif %}
 
     </div>
-
-    {% if user.is_siae_staff %}
-        <div class="card mt-5 bg-light text-center">
-            <div class="card-body">
-                <p class="h5 mb-3">
-                    <span class="badge badge-warning">Nouveau</span>
-                    Améliorez la visibilité de votre structure en précisant les secteurs d'activités sur lesquels vous intervenez
-                </p>
-                <p class="mb-0">
-                    <a href="{% url_add_query 'https://itou.typeform.com/to/xGF5FMel' structure=current_siae.name type=current_siae.kind ville=current_siae.city siret=current_siae.siret %}" rel="noopener" target="_blank" class="btn btn-primary">
-                        C'est parti !
-                        {% include "includes/icon.html" with icon="external-link" %}
-                    </a>
-                </p>
-            </div>
-        </div>
-    {% endif %}
 
 {% endblock %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -15,24 +15,6 @@
         {% include "search/includes/siaes_search_form.html" with form=form %}
     </form>
 
-    {# Lien temporaire vers le forum pour un sondage à propos du moteur de recherche. #}
-    {% if siaes_page %}
-        <div class="card mb-5 bg-light text-center">
-            <div class="card-body">
-                <p class="h5 mb-3">
-                    <span class="badge badge-warning">Nouveau</span>
-                    Vous souhaitez améliorer le moteur de recherche des entreprises ?
-                </p>
-                <p class="mb-0">
-                    <a href="{{ ITOU_COMMUNITY_URL }}/t/un-nouveau-moteur-de-recherche-de-siae/3807" rel="noopener" target="_blank" class="btn btn-primary">
-                        Répondez à nos 3 questions !
-                        {% include "includes/icon.html" with icon="external-link" %}
-                    </a>
-                </p>
-            </div>
-        </div>
-    {% endif %}
-
     <h3>
         {% with request.GET.city_name as city and request.GET.distance as distance %}
             Employeurs solidaires à <b>{{ distance }} km</b> du centre de <b>{{ city }}</b>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.2.0  # https://github.com/avian2/unidecode
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.2  # pyup: < 4.0  # https://www.djangoproject.com/
+django==3.2.1  # pyup: < 4.0  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.43.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
### Quoi ?

Mise en avant du forum sur le tableau de bord.

### Pourquoi ?

Pour donner un coup de boost à l'acquisition du chantier de la communauté.

### Comment ?

Ajout d'une mise en avant visuelle en haut du tableau de bord (ça fait un peu CDiscount mais c'est validé).

### Autre

- la mise en avant du C4 passe en haut aussi
- homogénéisation du balisage HTML des mises en avant
- retrait de lien vers le sondage sur la page des résultats de recherche SIAE
- correctif d'une condition moisie de mon fait
- mise à jour de [sécurité de Django 3.2.1](https://www.djangoproject.com/weblog/2021/may/04/security-releases/)

