### PR TITLE
Ajout des transactions aux enregistrements interdépendants

### DIFF
--- a/itou/approvals/admin_views.py
+++ b/itou/approvals/admin_views.py
@@ -21,7 +21,6 @@ from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.utils.emails import get_email_text_template
 
 
-@transaction.atomic
 def manually_add_approval(
     request, model_admin, job_application_id, template_name="admin/approvals/manually_add_approval.html"
 ):
@@ -62,10 +61,10 @@ def manually_add_approval(
     adminForm = admin.helpers.AdminForm(form, fieldsets, {})
 
     if request.method == "POST" and form.is_valid():
-        approval = form.save()
-        job_application.approval = approval
-        job_application.save()
-        job_application.manually_deliver_approval(delivered_by=request.user)
+        with transaction.atomic():
+            approval = form.save()
+            job_application.approval = approval
+            job_application.manually_deliver_approval(delivered_by=request.user)
         messages.success(request, f"Le PASS IAE {approval.number_with_spaces} a bien été créé et envoyé par e-mail.")
         return HttpResponseRedirect(reverse("admin:approvals_approval_changelist"))
 

--- a/itou/approvals/admin_views.py
+++ b/itou/approvals/admin_views.py
@@ -83,7 +83,6 @@ def manually_add_approval(
     return render(request, template_name, context)
 
 
-@transaction.atomic
 def manually_refuse_approval(
     request, model_admin, job_application_id, template_name="admin/approvals/manually_refuse_approval.html"
 ):
@@ -113,7 +112,9 @@ def manually_refuse_approval(
     )
 
     if request.method == "POST" and request.POST.get("confirm") == "yes":
-        job_application.manually_refuse_approval(refused_by=request.user)
+        with transaction.atomic():
+            # Rollback on failure of email delivery
+            job_application.manually_refuse_approval(refused_by=request.user)
         messages.success(request, "Délivrance du PASS IAE refusée.")
         return HttpResponseRedirect(reverse("admin:approvals_approval_changelist"))
 

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -253,7 +253,9 @@ def import_user_pe_data(
     Returns a valid ExternalDataImport object when result is PARTIAL or OK.
     """
     if not pe_data_import:
-        pe_data_import = ExternalDataImport.objects.create(source=ExternalDataImport.DATA_SOURCE_PE_CONNECT, user=user)
+        pe_data_import = ExternalDataImport.objects.create(
+            source=ExternalDataImport.DATA_SOURCE_PE_CONNECT, user=user, status=ExternalDataImport.STATUS_PENDING
+        )
 
     # Save pending status if updating record (transitive state)
     if pe_data_import != ExternalDataImport.STATUS_PENDING:

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -257,11 +257,6 @@ def import_user_pe_data(
             source=ExternalDataImport.DATA_SOURCE_PE_CONNECT, user=user, status=ExternalDataImport.STATUS_PENDING
         )
 
-    # Save pending status if updating record (transitive state)
-    if pe_data_import != ExternalDataImport.STATUS_PENDING:
-        pe_data_import.status = ExternalDataImport.STATUS_PENDING
-        pe_data_import.save()
-
     try:
         status, user_data = _get_aggregated_user_data(token)
         set_pe_data_import_from_user_data(pe_data_import, user, status, user_data)

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -138,7 +138,7 @@ def _get_compensations(token):
     return _fields_or_failed(_call_api(ESD_COMPENSATION_API, token), keys)
 
 
-def _get_aggregated_user_data(token):
+def get_aggregated_user_data(token):
     """
     Aggregates all needed user data before formatting and storage.
     Returns a pair status and a "flat" dict.
@@ -258,11 +258,10 @@ def import_user_pe_data(
         )
 
     try:
-        status, user_data = _get_aggregated_user_data(token)
+        status, user_data = get_aggregated_user_data(token)
         set_pe_data_import_from_user_data(pe_data_import, user, status, user_data)
         pe_data_import.save()
 
-        # At the moment, results are stored only if OK
         if status == ExternalDataImport.STATUS_OK:
             logger.info("Stored external data for user %s", user)
         elif status == ExternalDataImport.STATUS_PARTIAL:

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -662,12 +662,13 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         """
         Manually deliver an approval.
         """
-        email = self.email_deliver_approval(self.accepted_by)
-        email.send()
         self.approval_number_sent_by_email = True
         self.approval_number_sent_at = timezone.now()
         self.approval_manually_delivered_by = delivered_by
         self.save()
+        # Send email at the end because we can't rollback this operation
+        email = self.email_deliver_approval(self.accepted_by)
+        email.send()
 
     def manually_refuse_approval(self, refused_by):
         """
@@ -676,6 +677,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         self.approval_manually_refused_by = refused_by
         self.approval_manually_refused_at = timezone.now()
         self.save()
+        # Send email at the end because we can't rollback this operation
         email = self.email_manually_refuse_approval
         email.send()
 

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import AbstractUser
 from django.contrib.postgres.fields import CIEmailField
 from django.core.exceptions import ValidationError
 from django.core.validators import MinLengthValidator
-from django.db import models, transaction
+from django.db import models
 from django.utils import timezone
 from django.utils.crypto import salted_hmac
 from django.utils.functional import cached_property
@@ -326,15 +326,6 @@ class User(AbstractUser, AddressMixin):
             not pole_emploi_id and not lack_of_pole_emploi_id_reason
         ):
             raise ValidationError("Renseignez soit un identifiant Pôle emploi, soit la raison de son absence.")
-
-    @transaction.atomic
-    def get_or_create_job_seeker_profile(self):
-        if hasattr(self, "jobseeker_profile"):
-            return self.jobseeker_profile
-
-        profile = JobSeekerProfile(user=self)
-
-        return profile
 
 
 def get_allauth_account_user_display(user):

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -175,17 +175,6 @@ class ModelTest(TestCase):
         with self.assertRaises(ValidationError):
             job_seeker.clean()
 
-    def test_create_job_seeker_profile(self):
-        """
-        User title is not needed for validation of a User objects
-
-        It is mandatory for validation of JobSeekerProfile objects
-        """
-        job_seeker = JobSeekerFactory()
-        job_seeker.get_or_create_job_seeker_profile()
-
-        self.assertIsNotNone(job_seeker.jobseeker_profile)
-
 
 def mock_get_geocoding_data(address, post_code=None, limit=1):
     return RESULTS_BY_ADDRESS.get(address)

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -156,7 +156,6 @@ def postpone(request, job_application_id, template_name="apply/process_postpone.
 
 
 @login_required
-@transaction.atomic
 def accept(request, job_application_id, template_name="apply/process_accept.html"):
     """
     Trigger the `accept` transition.
@@ -186,17 +185,17 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
     forms.append(form_accept)
 
     if request.method == "POST" and all([form.is_valid() for form in forms]):
-
-        if form_pe_status:
-            form_pe_status.save()
-
-        if form_user_address:
-            form_user_address.save()
-
         try:
-            # After each successful transition, a save() is performed by django-xworkflows.
-            job_application = form_accept.save(commit=False)
-            job_application.accept(user=request.user)
+            with transaction.atomic():
+                if form_pe_status:
+                    form_pe_status.save()
+
+                if form_user_address:
+                    form_user_address.save()
+
+                # After each successful transition, a save() is performed by django-xworkflows.
+                job_application = form_accept.save(commit=False)
+                job_application.accept(user=request.user)
         except xwf_models.InvalidTransitionError:
             messages.error(request, "Action déjà effectuée.")
             return HttpResponseRedirect(next_url)

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -242,7 +242,7 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
         messages.warning(
             request,
             mark_safe(
-                "Etes-vous satisfait des emplois de l'inclusion ? "
+                "Êtes-vous satisfait des emplois de l'inclusion ? "
                 + f"<a href='{settings.ITOU_EMAIL_APPROVAL_SURVEY_URL}' rel='noopener' target='_blank'>"
                 + "Je donne mon avis"
                 + "</a>"

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -120,6 +120,7 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
             preview = True
         elif request.POST.get("save"):
             prolongation.save()
+            # Send an email w/o DB changes
             prolongation.notify_authorized_prescriber()
             messages.success(request, "Déclaration de prolongation enregistrée.")
             return HttpResponseRedirect(back_url)

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.contrib import auth, messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse, reverse_lazy
@@ -103,9 +104,10 @@ logout = login_required(ItouLogoutView.as_view())
 def edit_user_email(request, template_name="dashboard/edit_user_email.html"):
     form = EditUserEmailForm(data=request.POST or None, user_email=request.user.email)
     if request.method == "POST" and form.is_valid():
-        request.user.email = form.cleaned_data["email"]
-        request.user.save()
-        request.user.emailaddress_set.first().delete()
+        with transaction.atomic():
+            request.user.email = form.cleaned_data["email"]
+            request.user.save()
+            request.user.emailaddress_set.first().delete()
         auth.logout(request)
         return HttpResponseRedirect("/")
 

--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -171,8 +171,9 @@ def join_siae(request, invitation_id):
     if not invitation.siae.is_active:
         messages.error(request, "Cette structure n'est plus active.")
     elif invitation.can_be_accepted:
-        invitation.add_invited_user_to_siae()
-        invitation.accept()
+        with transaction.atomic():
+            invitation.add_invited_user_to_siae()
+            invitation.accept()
         messages.success(request, f"Vous êtes désormais membre de la structure {invitation.siae.display_name}.")
     else:
         messages.error(request, "Cette invitation n'est plus valide.")

--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect, render, reverse
 from django.utils import formats, safestring
 
@@ -108,8 +109,10 @@ def join_prescriber_organization(request, invitation_id):
         raise PermissionDenied()
 
     if invitation.can_be_accepted:
-        invitation.add_invited_user_to_organization()
-        invitation.accept()
+        with transaction.atomic():
+            invitation.add_invited_user_to_organization()
+            # Send an email after the model changes
+            invitation.accept()
         messages.success(
             request, f"Vous êtes désormais membre de l'organisation {invitation.organization.display_name}."
         )

--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -69,6 +69,7 @@ def invite_prescriber_with_org(request, template_name="invitations_views/create.
     formset = PrescriberWithOrgInvitationFormSet(data=request.POST or None, form_kwargs=form_kwargs)
     if request.POST:
         if formset.is_valid():
+            # We don't need atomicity here (invitations are independent)
             invitations = formset.save()
 
             for invitation in invitations:
@@ -129,6 +130,7 @@ def invite_siae_staff(request, template_name="invitations_views/create.html"):
     formset = SiaeStaffInvitationFormSet(data=request.POST or None, form_kwargs=form_kwargs)
     if request.POST:
         if formset.is_valid():
+            # We don't need atomicity here (invitations are independent)
             invitations = formset.save()
 
             for invitation in invitations:

--- a/itou/www/prescribers_views/views.py
+++ b/itou/www/prescribers_views/views.py
@@ -81,6 +81,7 @@ def deactivate_member(request, user_id, template_name="prescribers/deactivate_me
     if request.method == "POST":
         if user != target_member and user_is_admin:
             if membership.is_active:
+                # Only membership is modified
                 membership.deactivate_membership_by_user(user)
                 membership.save()
                 messages.success(

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -83,19 +83,16 @@ class CreateSiaeForm(forms.ModelForm):
 
         return self.cleaned_data
 
-    def save(self, request, commit=True):
-        siae = super().save(commit=commit)
-        if commit:
-            siae.set_coords(siae.geocoding_address, post_code=siae.post_code)
-            siae.created_by = request.user
-            siae.source = Siae.SOURCE_USER_CREATED
-            siae.convention = self.current_siae.convention
-            siae.save()
-            membership = SiaeMembership()
-            membership.user = request.user
-            membership.siae = siae
-            membership.is_siae_admin = True
-            membership.save()
+    def save(self, request):
+        siae = super().save(commit=False)
+        siae.set_coords(siae.geocoding_address, post_code=siae.post_code)
+        siae.created_by = request.user
+        siae.source = Siae.SOURCE_USER_CREATED
+        siae.convention = self.current_siae.convention
+        siae.save()
+
+        SiaeMembership.objects.create(siae=siae, is_siae_admin=True, user=request.user)
+
         return siae
 
 

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -154,11 +154,10 @@ class EditSiaeForm(forms.ModelForm):
             "website": "Votre site web doit commencer par http:// ou https://",
         }
 
-    def save(self, commit=True):
-        siae = super().save(commit=commit)
-        if commit:
-            siae.set_coords(siae.geocoding_address, post_code=siae.post_code)
-            siae.save()
+    def save(self):
+        siae = super().save(commit=False)
+        siae.set_coords(siae.geocoding_address, post_code=siae.post_code)
+        siae.save()
         return siae
 
 

--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -198,7 +198,10 @@ def create_siae(request, template_name="siaes/create_siae.html"):
     )
 
     if request.method == "POST" and form.is_valid():
-        siae = form.save(request)
+        with transaction.atomic():
+            # The form creates multiple objects
+            siae = form.save(request)
+
         request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = siae.pk
         return HttpResponseRedirect(reverse_lazy("dashboard:index"))
 

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -46,16 +46,14 @@ class JobSeekerSignupForm(FullnameFormMixin, SignupForm):
         return email
 
     def save(self, request):
-
         # Avoid django-allauth to call its own often failing `generate_unique_username`
         # function by forcing a username.
         self.cleaned_data["username"] = User.generate_unique_username()
         # Create the user.
-        user = super().save(request)
 
+        user = super().save(request)
         user.first_name = self.cleaned_data["first_name"]
         user.last_name = self.cleaned_data["last_name"]
-
         user.is_job_seeker = True
         user.save()
 
@@ -365,7 +363,6 @@ class PrescriberPoleEmploiUserSignupForm(FullnameFormMixin, SignupForm):
         return email
 
     def save(self, request):
-
         # Avoid django-allauth to call its own often failing `generate_unique_username`
         # function by forcing a username.
         self.cleaned_data["username"] = User.generate_unique_username()
@@ -401,7 +398,6 @@ class PrescriberUserSignupForm(FullnameFormMixin, SignupForm):
         self.fields["email"].help_text = "Utilisez une adresse e-mail professionnelle."
 
     def save(self, request):
-
         # Avoid django-allauth to call its own often failing `generate_unique_username`
         # function by forcing a username.
         self.cleaned_data["username"] = User.generate_unique_username()


### PR DESCRIPTION
### Quoi ?

Ouvre des contextes transactions dans les vues ou les *management commands* quand
plusieurs objets liés doivent être enregistrés de manière atomique.

### Pourquoi ?

Pour conserver la cohérence des données métiers si une erreur survient durant le traitement de la requête (vue).

### Comment ?

En utilisant `with transaction.atomic()` avec une granularité fine mais toujours au niveau de la vue.

