### PR TITLE
Boost design

### DIFF
--- a/itou/templates/apply/submit_base.html
+++ b/itou/templates/apply/submit_base.html
@@ -8,7 +8,9 @@
         {% if request.user.is_siae_staff %}
             <span class="text-muted">{{ siae.display_name }}</span>
         {% else %}
-            Postuler pour <span class="text-muted">{{ job_seeker.get_full_name|title }}</span> chez <span class="text-muted">{{ siae.display_name }}</span>
+            Postuler
+            {% if job_seeker %}pour <span class="text-muted">{{ job_seeker.get_full_name|title }}</span>{% endif %}
+            chez <span class="text-muted">{{ siae.display_name }}</span>
         {% endif %}
     </h1>
 

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -20,14 +20,27 @@
     </p>
 {% endif %}
 
-<p>
+<p class="mb-0">
     {% if approval.is_pass_iae %}
-        Numéro de PASS IAE (agrément) :
+        PASS IAE (agrément) disponible :
     {% else %}
         Agrément existant :
     {% endif %}
-    <b>{{ approval.number_with_spaces }}</b>
 </p>
+
+{% if job_application.is_pending %}
+    {% comment %}
+    Si on affiche le numéro du PASS IAE à ce moment là, certains employeurs pensent qu'il
+    n'y a pas besoin de valider la candidature car un numéro est déjà attribué.
+    {% endcomment %}
+    <p>
+        <b>Pour obtenir son numéro, vous devez valider l'embauche et demander l'obtention d'un PASS IAE.</b>
+    </p>
+{% else %}
+    <p>
+        <b>{{ approval.number_with_spaces }}</b>
+    </p>
+{% endif %}
 
 {% if approval.is_valid %}
 

--- a/itou/templates/signup/prescriber_signup.html
+++ b/itou/templates/signup/prescriber_signup.html
@@ -27,7 +27,7 @@
         <div class="alert alert-secondary pb-0" role="alert">
             <p>
                 <b>{{ prescriber_org_data.name }}</b> - {{ prescriber_org_data.siret }}<br>
-                {{ prescriber_org_data.address_line_1 }}<br>
+                {% if prescriber_org_data.address_line_1 %}{{ prescriber_org_data.address_line_1 }}<br>{% endif %}
                 {% if prescriber_org_data.address_line_2 %}{{ prescriber_org_data.address_line_2 }}<br>{% endif %}
                 {{ prescriber_org_data.post_code }} {{ prescriber_org_data.city }}
             </p>

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -414,7 +414,7 @@ class PrescriberUserSignupForm(FullnameFormMixin, SignupForm):
             prescriber_org = PrescriberOrganization()
             prescriber_org.siret = self.prescriber_org_data["siret"]
             prescriber_org.name = self.prescriber_org_data["name"]
-            prescriber_org.address_line_1 = self.prescriber_org_data["address_line_1"]
+            prescriber_org.address_line_1 = self.prescriber_org_data["address_line_1"] or ""
             prescriber_org.address_line_2 = self.prescriber_org_data["address_line_2"] or ""
             prescriber_org.post_code = self.prescriber_org_data["post_code"]
             prescriber_org.city = self.prescriber_org_data["city"]


### PR DESCRIPTION
### Quoi ?

- Correctif pour l'erreur Sentry `null value in column "address_line_1" violates not-null constraint`
- Correctif pour un titre incorrect lorsque l'on postule pour un candidat en tant que prescripteur
- Le numéro de PASS IAE est masqué pour les candidatures en cours

![Capture d’écran 2021-05-04 à 16 28 54](https://user-images.githubusercontent.com/281139/117020691-f8246880-acf6-11eb-9bb0-6754ee8a5582.png)
