### PR TITLE
Affichage complet des mois

### DIFF
--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -30,7 +30,7 @@
                 <tbody>
                     {% for month in job_applications_by_month %}
                     <tr>
-                        <td>{{ month.month|date:"F Y" }}</td>
+                        <td>{{ month.month|date:"F Y"|capfirst }}</td>
                         <td>{{ month.c }}</td>
                         <td>
                         {% if export_for == "siae" %}

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -30,7 +30,7 @@
                 <tbody>
                     {% for month in job_applications_by_month %}
                     <tr>
-                        <td>{{ month.month|date:"M Y" }}</td>
+                        <td>{{ month.month|date:"F Y" }}</td>
                         <td>{{ month.c }}</td>
                         <td>
                         {% if export_for == "siae" %}


### PR DESCRIPTION
### Quoi ?

Changement de l'affichage des noms de mois.

### Pourquoi ?

Clarté.

### Comment ?

Je trouve bancale le formatage « M » pour les noms courts, je trouve que « N » est meilleur.
