### PR TITLE
Ajout d'un lien vers la doc

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -405,11 +405,10 @@ LEMARCHE_OPEN_REGIONS = ["Hauts-de-France", "Grand Est", "Île-de-France"]
 
 POLE_EMPLOI_EMAIL_SUFFIX = "@pole-emploi.fr"
 
-# Documentation links
+# Documentation link.
 ITOU_DOC_URL = "https://doc.inclusion.beta.gouv.fr"
-ITOU_DOC_PASS_VERIFICATION_URL = f"{ITOU_DOC_URL}/pourquoi-une-plateforme-de-linclusion/pass-iae-agrement-plus-simple-cest-a-dire#verification-des-demandes-de-pass-iae"
 
-# Communauté links.
+# Communauté link.
 ITOU_COMMUNITY_URL = "https://communaute.inclusion.beta.gouv.fr"
 
 # Approvals

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -18,6 +18,7 @@ from unidecode import unidecode
 
 from itou.approvals.notifications import NewProlongationToAuthorizedPrescriberNotification
 from itou.utils.models import DateRange
+from itou.utils.urls import get_external_link_markup
 from itou.utils.validators import alphanumeric
 
 
@@ -1037,12 +1038,9 @@ class ApprovalsWrapper:
     IN_WAITING_PERIOD = "IN_WAITING_PERIOD"
 
     # Error messages.
-    WAITING_PERIOD_DOC_URL = (
-        f"{settings.ITOU_DOC_URL}/qui-est-eligible-iae-criteres-eligibilite/derogation-au-delai-de-carence"
-    )
-    WAITING_PERIOD_DOC_LINK = (
-        f'<a href="{WAITING_PERIOD_DOC_URL}" rel="noopener" target="_blank">'
-        "En savoir plus sur la dérogation du délai de carence (ouverture dans un nouvel onglet)</a>."
+    WAITING_PERIOD_DOC_LINK = get_external_link_markup(
+        url=f"{settings.ITOU_DOC_URL}/qui-est-eligible-iae-criteres-eligibilite/derogation-au-delai-de-carence",
+        text="En savoir plus sur la dérogation du délai de carence",
     )
     ERROR_CANNOT_OBTAIN_NEW_FOR_USER = mark_safe(
         (

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -13,6 +13,7 @@ from django.db.models import Count, Q
 from django.db.models.functions import TruncDate
 from django.utils import timezone
 from django.utils.functional import cached_property
+from django.utils.safestring import mark_safe
 from unidecode import unidecode
 
 from itou.approvals.notifications import NewProlongationToAuthorizedPrescriberNotification
@@ -1036,17 +1037,29 @@ class ApprovalsWrapper:
     IN_WAITING_PERIOD = "IN_WAITING_PERIOD"
 
     # Error messages.
-    ERROR_CANNOT_OBTAIN_NEW_FOR_USER = (
-        "Vous avez terminé un parcours il y a moins de deux ans. "
-        "Pour prétendre à nouveau à un parcours en structure d'insertion "
-        "par l'activité économique vous devez rencontrer un prescripteur "
-        "habilité : Pôle emploi, Mission Locale, CAP Emploi, etc."
+    WAITING_PERIOD_DOC_URL = (
+        f"{settings.ITOU_DOC_URL}/qui-est-eligible-iae-criteres-eligibilite/derogation-au-delai-de-carence"
     )
-    ERROR_CANNOT_OBTAIN_NEW_FOR_PROXY = (
-        "Le candidat a terminé un parcours il y a moins de deux ans. "
-        "Pour prétendre à nouveau à un parcours en structure d'insertion "
-        "par l'activité économique il doit rencontrer un prescripteur "
-        "habilité : Pôle emploi, Mission Locale, CAP Emploi, etc."
+    WAITING_PERIOD_DOC_LINK = (
+        f'<a href="{WAITING_PERIOD_DOC_URL}" rel="noopener" target="_blank">'
+        "En savoir plus sur la dérogation du délai de carence (ouverture dans un nouvel onglet)</a>."
+    )
+    ERROR_CANNOT_OBTAIN_NEW_FOR_USER = mark_safe(
+        (
+            "Vous avez terminé un parcours il y a moins de deux ans.<br>"
+            "Pour prétendre à nouveau à un parcours en structure d'insertion "
+            "par l'activité économique vous devez rencontrer un prescripteur "
+            "habilité : Pôle emploi, Mission Locale, CAP Emploi, etc."
+        )
+    )
+    ERROR_CANNOT_OBTAIN_NEW_FOR_PROXY = mark_safe(
+        (
+            "Le candidat a terminé un parcours il y a moins de deux ans.<br>"
+            "Pour prétendre à nouveau à un parcours en structure d'insertion "
+            "par l'activité économique il doit rencontrer un prescripteur "
+            "habilité : Pôle emploi, Mission Locale, CAP Emploi, etc."
+            f"<br>{WAITING_PERIOD_DOC_LINK}"  # Display doc link only for proxies.
+        )
     )
 
     def __init__(self, user):

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -30,7 +30,7 @@ from itou.utils.perms.user import KIND_JOB_SEEKER, KIND_PRESCRIBER, KIND_SIAE_ST
 from itou.utils.resume.forms import ResumeFormMixin
 from itou.utils.templatetags import dict_filters, format_filters
 from itou.utils.tokens import SIAE_SIGNUP_MAGIC_LINK_TIMEOUT, SiaeSignupTokenGenerator
-from itou.utils.urls import get_absolute_url, get_safe_url
+from itou.utils.urls import get_absolute_url, get_external_link_markup, get_safe_url
 from itou.utils.validators import (
     alphanumeric,
     validate_af_number,
@@ -471,6 +471,14 @@ class UtilsEmailsTestCase(TestCase):
         path = "/awesome/team/"
         url = get_absolute_url(path)
         self.assertEqual(f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/awesome/team/", url)
+
+    def test_get_external_link_markup(self):
+        url = "https://emplois.inclusion.beta.gouv.fr"
+        text = "Lien vers une ressource externe"
+        expected = (
+            f'<a href="{url}" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet">{text}</a>'
+        )
+        self.assertEqual(get_external_link_markup(url=url, text=text), expected)
 
 
 class PermsUserTest(TestCase):

--- a/itou/utils/urls.py
+++ b/itou/utils/urls.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.safestring import mark_safe
 
 
 def get_safe_url(request, param_name, fallback_url=None):
@@ -42,6 +43,12 @@ def get_absolute_url(path=""):
     if path.startswith("/"):
         path = path[1:]
     return f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/{path}"
+
+
+def get_external_link_markup(url, text):
+    return mark_safe(
+        f'<a href="{url}" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet">{text}</a>'
+    )
 
 
 class SiretConverter:

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -14,6 +14,7 @@ from django_xworkflows import models as xwf_models
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.utils.perms.user import get_user_info
+from itou.utils.urls import get_external_link_markup
 from itou.www.apply.forms import AcceptForm, AnswerForm, JobSeekerPoleEmploiStatusForm, RefusalForm, UserAddressForm
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm, ConfirmEligibilityForm
 
@@ -204,20 +205,19 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
 
         if job_application.to_siae.is_subject_to_eligibility_rules:
             if job_application.approval:
-                PRO_CONTRACT_URL = (
-                    "https://www.pole-emploi.fr/employeur/aides-aux-recrutements/"
-                    "les-aides-a-lembauche/insertion-par-lactivite-economiq.html"
+                external_link = get_external_link_markup(
+                    url=(
+                        "https://www.pole-emploi.fr/employeur/aides-aux-recrutements/"
+                        "les-aides-a-lembauche/insertion-par-lactivite-economiq.html"
+                    ),
+                    text="demander l’aide spécifique de Pôle emploi ici",
                 )
                 messages.success(
                     request,
                     mark_safe(
                         (
-                            "Embauche acceptée ! "
-                            "(Pour un contrat de professionnalisation vous pouvez soit introduire une "
-                            "demande d’aide au poste ou demander l’aide spécifique de Pôle emploi "
-                            f'<a href="{PRO_CONTRACT_URL}" rel="noopener" target="_blank">'
-                            "ici"
-                            "</a>)."
+                            "Embauche acceptée ! (Pour un contrat de professionnalisation vous pouvez "
+                            f"soit introduire une demande d’aide au poste ou {external_link}."
                         )
                     ),
                 )
@@ -229,26 +229,25 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
                     ),
                 )
             elif not job_application.hiring_without_approval:
-                link = settings.ITOU_DOC_PASS_VERIFICATION_URL
+                external_link = get_external_link_markup(
+                    url=settings.ITOU_DOC_PASS_VERIFICATION_URL,
+                    text="consulter notre espace documentation",
+                )
                 messages.success(
                     request,
                     mark_safe(
                         (
                             "Votre demande de Pass IAE est en cours de vérification auprès de nos équipes.<br>"
                             "Si vous souhaitez en savoir plus sur le processus de vérification, n’hésitez pas à "
-                            "<a href='" + link + "'>consulter notre espace documentation</a>."
+                            f"{external_link}."
                         )
                     ),
                 )
 
+        external_link = get_external_link_markup(url=settings.ITOU_EMAIL_APPROVAL_SURVEY_URL, text="Je donne mon avis")
         messages.warning(
             request,
-            mark_safe(
-                "Êtes-vous satisfait des emplois de l'inclusion ? "
-                + f"<a href='{settings.ITOU_EMAIL_APPROVAL_SURVEY_URL}' rel='noopener' target='_blank'>"
-                + "Je donne mon avis"
-                + "</a>"
-            ),
+            mark_safe(f"Êtes-vous satisfait des emplois de l'inclusion ? {external_link}"),
         )
 
         return HttpResponseRedirect(next_url)

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -5,6 +5,7 @@ from django.utils.safestring import mark_safe
 
 from itou.siaes.models import Siae, SiaeMembership
 from itou.utils.address.departments import DEPARTMENTS
+from itou.utils.urls import get_external_link_markup
 
 
 class CreateSiaeForm(forms.ModelForm):
@@ -64,18 +65,16 @@ class CreateSiaeForm(forms.ModelForm):
                 La structure à laquelle vous souhaitez vous rattacher est déjà
                 connue de nos services. Merci de nous contacter à l'adresse
                 """
-
-            assistance_url = settings.ITOU_ASSISTANCE_URL
-            assistance_html = (
-                f'<a href="{assistance_url}" target="_blank" rel="noopener" class="alert-link">{assistance_url}</a>'
+            external_link = get_external_link_markup(
+                url=settings.ITOU_ASSISTANCE_URL,
+                text=settings.ITOU_ASSISTANCE_URL,
             )
-
             error_message_siret = (
                 "en précisant votre numéro de SIRET (si existant),"
                 " le type et l’adresse de cette structure, ainsi que votre numéro de téléphone"
                 " pour être contacté(e) si nécessaire."
             )
-            error_message = mark_safe(f"{error_message} {assistance_html} {error_message_siret}")
+            error_message = mark_safe(f"{error_message} {external_link} {error_message_siret}")
             raise forms.ValidationError(error_message)
 
         if not siret.startswith(self.current_siae.siren):


### PR DESCRIPTION
### Quoi ?

Ajout d'un  lien vers la documentation quand un candidat est en période de carence dans le message affiché aux orienteurs et aux employeurs.

### Pourquoi ?

Demande du métier pour être plus explicite.

### Comment ?

Proposition de factorisation de la génération du HTML des liens utilisés dans le code Python pour viser l'homogénéité et l'accessibilité.

### Captures d'écran

![screen](https://user-images.githubusercontent.com/281139/117801024-1ab50500-b254-11eb-9bc9-f5c7d5f96ef7.png)
