### PR TITLE
Ajout d'une validation des données POST de la vue `configure_jobs`

### DIFF
--- a/itou/templates/siaes/configure_jobs.html
+++ b/itou/templates/siaes/configure_jobs.html
@@ -13,7 +13,18 @@
 
         {% csrf_token %}
 
-        <table class="js-jobs-table table table-bordered table-striped table-responsive-sm text-center{% if not siae.job_description_through.exists %} d-none{% endif %}">
+        {% if errors %}
+            <div class="alert alert-danger alert-dismissible alert-link" role="alert">
+                <button class="close" type="button" data-dismiss="alert" aria-label="close">×</button>
+                <ul>
+                    {% for error in errors.values %}
+                        <li>{{ error }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
+
+        <table class="js-jobs-table table table-bordered table-striped table-responsive-sm text-center{% if not job_descriptions %} d-none{% endif %}">
             <thead>
                 <tr>
                     <th scope="col">ROME</th>
@@ -23,7 +34,7 @@
                 </tr>
             </thead>
             <tbody class="js-jobs-tbody">
-                {% for job in siae.job_description_through.all %}
+                {% for job in job_descriptions %}
                 {# Important: keep the JavaScript template in sync if you edit the row markup. #}
                 <tr>
                     <td>{{ job.appellation.rome.code }}</td>

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 
-from itou.siaes.models import Siae, SiaeMembership
+from itou.siaes.models import Siae, SiaeJobDescription, SiaeMembership
 from itou.utils.address.departments import DEPARTMENTS
 from itou.utils.urls import get_external_link_markup
 
@@ -208,3 +208,17 @@ class FinancialAnnexSelectForm(forms.Form):
         widget=forms.Select,
         help_text="Veuillez sélectionner un numéro existant.",
     )
+
+
+class ValidateSiaeJobDescriptionForm(forms.ModelForm):
+    """
+    Validate a job description.
+    """
+
+    class Meta:
+        model = SiaeJobDescription
+        fields = [
+            "custom_name",
+            "description",
+            "is_active",
+        ]

--- a/itou/www/siaes_views/tests.py
+++ b/itou/www/siaes_views/tests.py
@@ -183,6 +183,8 @@ class ConfigureJobsViewTest(TestCase):
         response = self.client.post(self.url, data=post_data)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context["errors"])
+        # No proper Django form is used in the view and we use a custom `errors` dict.
+        # See the `configure_jobs` view.
         self.assertIn("10357", response.context["errors"])
         self.assertNotIn("10579", response.context["errors"])
 

--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -5,7 +5,7 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse
 
 from itou.jobs.models import Appellation
 from itou.siaes.models import Siae, SiaeFinancialAnnex, SiaeJobDescription
@@ -126,7 +126,7 @@ def configure_jobs(request, template_name="siaes/configure_jobs.html"):
                             job_through.save()
 
                 messages.success(request, "Mise à jour effectuée !")
-                return HttpResponseRedirect(reverse_lazy("dashboard:index"))
+                return HttpResponseRedirect(reverse("dashboard:index"))
 
     context = {"errors": errors, "job_descriptions": job_descriptions, "siae": siae}
     return render(request, template_name, context)
@@ -236,7 +236,7 @@ def create_siae(request, template_name="siaes/create_siae.html"):
             siae = form.save(request)
 
         request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = siae.pk
-        return HttpResponseRedirect(reverse_lazy("dashboard:index"))
+        return HttpResponseRedirect(reverse("dashboard:index"))
 
     context = {"form": form}
     return render(request, template_name, context)
@@ -254,7 +254,7 @@ def edit_siae(request, template_name="siaes/edit_siae.html"):
     if request.method == "POST" and form.is_valid():
         form.save()
         messages.success(request, "Mise à jour effectuée !")
-        return HttpResponseRedirect(reverse_lazy("dashboard:index"))
+        return HttpResponseRedirect(reverse("dashboard:index"))
 
     context = {"form": form, "siae": siae}
     return render(request, template_name, context)
@@ -308,7 +308,7 @@ def deactivate_member(request, user_id, template_name="siaes/deactivate_member.h
                 siae.member_deactivation_email(membership.user).send()
         else:
             raise PermissionDenied
-        return HttpResponseRedirect(reverse_lazy("siaes_views:members"))
+        return HttpResponseRedirect(reverse("siaes_views:members"))
 
     context = {
         "structure": siae,
@@ -354,7 +354,7 @@ def update_admin_role(request, action, user_id, template_name="siaes/update_admi
             membership.save()
         else:
             raise PermissionDenied
-        return HttpResponseRedirect(reverse_lazy("siaes_views:members"))
+        return HttpResponseRedirect(reverse("siaes_views:members"))
 
     context = {
         "action": action,
@@ -377,7 +377,7 @@ def block_job_applications(request, template_name="siaes/block_job_applications.
     if request.method == "POST" and form.is_valid():
         form.save()
         messages.success(request, "Mise à jour du blocage des candidatures effectuée !")
-        return HttpResponseRedirect(reverse_lazy("dashboard:index"))
+        return HttpResponseRedirect(reverse("dashboard:index"))
 
     context = {"siae": siae, "form": form}
 

--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -53,7 +53,7 @@ def configure_jobs(request, template_name="siaes/configure_jobs.html"):
     Configure an SIAE's jobs.
 
     Time was limited during the prototyping phase and this view is based on
-    JavaScript to generate a dynamic form. No proper Django form is uded.
+    JavaScript to generate a dynamic form. No proper Django form is used.
     """
     siae = get_current_siae_or_404(request)
     job_descriptions = siae.job_description_through.select_related("appellation__rome").all()


### PR DESCRIPTION
### Quoi ?

Ajout d'une validation des données POST de la vue `configure_jobs`.

### Pourquoi ?

Sans cette validation, on peut passer à la requête un `custom_name` de taille supérieure à 255 caractères lever une erreur d'intégrité au niveau du champ de la base de données.

### Comment ?

Avec un compromis appuyé par le fait que cette erreur n'est jamais remontée dans Sentry pour le moment.

La vue a été réalisée rapidement pendant la fabrication du prototype en se reposant sur JavaScript pour construire un formulaire dynamique. Du coup ça rend plus compliqué de valider les données et d'afficher les erreurs au bon endroit dans l'UI.

En attendant la refonte de cette UI (`ModelFormSet` ou validation JSON) on affiche les éventuelles erreurs en haut de la page.