### PR TITLE
Boost dev

### DIFF
--- a/itou/templates/apply/includes/list_card_header.html
+++ b/itou/templates/apply/includes/list_card_header.html
@@ -4,7 +4,11 @@
 
     <small>chez</small>
 
-    <b>{{ job_application.to_siae.display_name }}</b>
+    <b>
+        <a href="{{ job_application.to_siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
+            {{ job_application.to_siae.display_name }}
+        </a>
+    </b>
 
     {% if job_application.to_siae.grace_period_has_expired %}
         <span class="badge badge-danger">
@@ -15,14 +19,13 @@
 
     <br>
 
+    <small class="text-muted">{{ job_application.created_at|date:"d F Y à H:i" }}</small>
 
-        <small class="text-muted">{{ job_application.created_at|date:"d F Y à H:i" }}</small>
-
-        {% if job_application.is_pending_for_too_long and not request.user_is_job_seeker %}
-            <br>
-            <small class="text-danger font-weight-bold">
-                En attente de réponse depuis plus de {{ job_application.WEEKS_BEFORE_CONSIDERED_OLD }} semaines.
-            </small>
-        {% endif %}
+    {% if job_application.is_pending_for_too_long and not request.user_is_job_seeker %}
+        <br>
+        <small class="text-danger font-weight-bold">
+            En attente de réponse depuis plus de {{ job_application.WEEKS_BEFORE_CONSIDERED_OLD }} semaines.
+        </small>
+    {% endif %}
 
 </div>

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -65,24 +65,40 @@ class ModelTest(TestCase):
 
     def test_clean_pole_emploi_fields(self):
 
-        job_seeker = JobSeekerFactory(pole_emploi_id="", lack_of_pole_emploi_id_reason="")
-
         # Both fields cannot be empty.
+        job_seeker = JobSeekerFactory(pole_emploi_id="", lack_of_pole_emploi_id_reason="")
+        cleaned_data = {
+            "pole_emploi_id": job_seeker.pole_emploi_id,
+            "lack_of_pole_emploi_id_reason": job_seeker.lack_of_pole_emploi_id_reason,
+        }
         with self.assertRaises(ValidationError):
-            User.clean_pole_emploi_fields(job_seeker.pole_emploi_id, job_seeker.lack_of_pole_emploi_id_reason)
+            User.clean_pole_emploi_fields(cleaned_data)
 
-        # Both fields cannot be present at the same time.
+        # If both fields are present at the same time, `pole_emploi_id` takes precedence.
         job_seeker = JobSeekerFactory(pole_emploi_id="69970749", lack_of_pole_emploi_id_reason=User.REASON_FORGOTTEN)
-        with self.assertRaises(ValidationError):
-            User.clean_pole_emploi_fields(job_seeker.pole_emploi_id, job_seeker.lack_of_pole_emploi_id_reason)
+        cleaned_data = {
+            "pole_emploi_id": job_seeker.pole_emploi_id,
+            "lack_of_pole_emploi_id_reason": job_seeker.lack_of_pole_emploi_id_reason,
+        }
+        User.clean_pole_emploi_fields(cleaned_data)
+        self.assertEqual(cleaned_data["pole_emploi_id"], job_seeker.pole_emploi_id)
+        self.assertEqual(cleaned_data["lack_of_pole_emploi_id_reason"], "")
 
         # No exception should be raised for the following cases.
 
         job_seeker = JobSeekerFactory(pole_emploi_id="62723349", lack_of_pole_emploi_id_reason="")
-        User.clean_pole_emploi_fields(job_seeker.pole_emploi_id, job_seeker.lack_of_pole_emploi_id_reason)
+        cleaned_data = {
+            "pole_emploi_id": job_seeker.pole_emploi_id,
+            "lack_of_pole_emploi_id_reason": job_seeker.lack_of_pole_emploi_id_reason,
+        }
+        User.clean_pole_emploi_fields(cleaned_data)
 
         job_seeker = JobSeekerFactory(pole_emploi_id="", lack_of_pole_emploi_id_reason=User.REASON_FORGOTTEN)
-        User.clean_pole_emploi_fields(job_seeker.pole_emploi_id, job_seeker.lack_of_pole_emploi_id_reason)
+        cleaned_data = {
+            "pole_emploi_id": job_seeker.pole_emploi_id,
+            "lack_of_pole_emploi_id_reason": job_seeker.lack_of_pole_emploi_id_reason,
+        }
+        User.clean_pole_emploi_fields(cleaned_data)
 
     def test_email_already_exists(self):
         JobSeekerFactory(email="foo@bar.com")

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -64,9 +64,7 @@ class CheckJobSeekerInfoForm(forms.ModelForm):
 
     def clean(self):
         super().clean()
-        self._meta.model.clean_pole_emploi_fields(
-            self.cleaned_data["pole_emploi_id"], self.cleaned_data["lack_of_pole_emploi_id_reason"]
-        )
+        self._meta.model.clean_pole_emploi_fields(self.cleaned_data)
 
 
 class CreateJobSeekerForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
@@ -120,9 +118,7 @@ class CreateJobSeekerForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
 
     def clean(self):
         super().clean()
-        self._meta.model.clean_pole_emploi_fields(
-            self.cleaned_data["pole_emploi_id"], self.cleaned_data["lack_of_pole_emploi_id_reason"]
-        )
+        self._meta.model.clean_pole_emploi_fields(self.cleaned_data)
 
     def save(self, commit=True):
         # Exclude 'city_name' form field (not mapped to model)
@@ -352,9 +348,7 @@ class JobSeekerPoleEmploiStatusForm(forms.ModelForm):
 
     def clean(self):
         super().clean()
-        self._meta.model.clean_pole_emploi_fields(
-            self.cleaned_data["pole_emploi_id"], self.cleaned_data["lack_of_pole_emploi_id_reason"]
-        )
+        self._meta.model.clean_pole_emploi_fields(self.cleaned_data)
 
 
 class UserAddressForm(AddressFormMixin, forms.ModelForm):

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -221,9 +221,12 @@ class AcceptForm(forms.ModelForm):
         model = JobApplication
         fields = ["hiring_start_at", "hiring_end_at", "answer", "hiring_without_approval"]
         help_texts = {
+            # Make it clear to employers that `hiring_start_at` has an impact on the start of the
+            # "parcours IAE" and the payment of the "aide au poste".
             "hiring_start_at": (
                 "Au format JJ/MM/AAAA, par exemple  %(date)s. Il n'est pas possible d'antidater un contrat. "
-                "Indiquez une date dans le futur."
+                "La date est modifiable jusqu'à la veille de la date saisie. En cas de premier PASS IAE pour "
+                "la personne, cette date déclenche le début de son parcours."
             )
             % {"date": datetime.date.today().strftime("%d/%m/%Y")},
             "hiring_end_at": (

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -69,9 +69,7 @@ class EditUserInfoForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
     def clean(self):
         super().clean()
         if self.instance.is_job_seeker:
-            self._meta.model.clean_pole_emploi_fields(
-                self.cleaned_data["pole_emploi_id"], self.cleaned_data["lack_of_pole_emploi_id_reason"]
-            )
+            self._meta.model.clean_pole_emploi_fields(self.cleaned_data)
 
 
 class EditUserEmailForm(forms.Form):

--- a/itou/www/eligibility_views/forms.py
+++ b/itou/www/eligibility_views/forms.py
@@ -10,8 +10,8 @@ class ConfirmEligibilityForm(forms.Form):
 
     confirm = forms.BooleanField(
         label=(
-            "Je confirme que le candidat remplit les critères d'éligibilité à l'IAE et "
-            "m'engage à fournir les justificatifs correspondants en cas de contrôle a posteriori."
+            "Le candidat étant éligible à l'IAE, je m'engage à conserver les justificatifs "
+            "correspondants aux critères d'éligibilité sélectionnés pour 24 mois, en cas de contrôle."
         )
     )
 


### PR DESCRIPTION
### Quoi ?

- _Wording_ : bien faire comprendre aux employeurs que la date de début d'embauche a une incidence sur le début du parcours et du versement de l'aide au poste
- _Wording_ :  ajout d'un avertissement au sujet de la conservation des pièces justificatives en cas de contrôle
- Dans les listes des candidatures, le nom de l'employeur devient un lien qui pointe vers la fiche publique de la structure afin de pouvoir accéder à ses coordonnées
- Si un ID PE est renseigné il prend la priorité et on ne tient pas compte du motif de son absence