### PR TITLE
Hotfix des ACIPHC créées par le support

### DIFF
--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -169,8 +169,16 @@ def check_convention_data_consistency(dry_run):
 
         # Additional data consistency checks.
         for siae in convention.siaes.all():
-            assert siae.kind == convention.kind
             assert siae.siren == convention.siren_signature
+            if siae.is_kind_aciphc and convention.is_kind_aci:
+                assert siae.is_source_user_created
+                # Sometimes our staff manually changes an existing ACI antenna's kind from ACI to ACIPHC and forgets
+                # to detach the ACI convention.
+                if not dry_run:
+                    siae.convention = None
+                    siae.save()
+            else:
+                assert siae.kind == convention.kind
 
     asp_siaes_without_convention = Siae.objects.filter(
         kind__in=Siae.ASP_MANAGED_KINDS, source=Siae.SOURCE_ASP, convention__isnull=True

--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -170,8 +170,8 @@ def check_convention_data_consistency(dry_run):
         # Additional data consistency checks.
         for siae in convention.siaes.all():
             assert siae.siren == convention.siren_signature
-            if siae.is_kind_aciphc and convention.is_kind_aci:
-                assert siae.is_source_user_created
+            if siae.kind == Siae.KIND_ACIPHC and convention.kind == SiaeConvention.KIND_ACI:
+                assert siae.source == Siae.SOURCE_USER_CREATED
                 # Sometimes our staff manually changes an existing ACI antenna's kind from ACI to ACIPHC and forgets
                 # to detach the ACI convention.
                 if not dry_run:

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -226,17 +226,6 @@ class Siae(AddressMixin):  # Do not forget the mixin!
         verbose_name_plural = "Structures d'insertion par l'activité économique"
         unique_together = ("siret", "kind")
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Add `kind` attributes, e.g.: `self.is_kind_etti`.
-        for kind, _description in self.KIND_CHOICES:
-            setattr(self, f"is_kind_{kind.lower()}", kind == self.kind)
-
-        # Add `source` attributes, e.g.: `self.is_source_user_created`.
-        for source, _description in self.SOURCE_CHOICES:
-            setattr(self, f"is_source_{source.lower()}", source == self.source)
-
     def __str__(self):
         return f"{self.siret} {self.display_name}"
 
@@ -741,13 +730,6 @@ class SiaeConvention(models.Model):
             # It is the only exception. Both structures are active.
             # ("siret_signature", "kind"),
         )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Add `kind` attributes, e.g.: `self.is_kind_etti`.
-        for kind, _description in self.KIND_CHOICES:
-            setattr(self, f"is_kind_{kind.lower()}", kind == self.kind)
 
     def save(self, *args, **kwargs):
         if self.pk:

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -233,6 +233,10 @@ class Siae(AddressMixin):  # Do not forget the mixin!
         for kind, _description in self.KIND_CHOICES:
             setattr(self, f"is_kind_{kind.lower()}", kind == self.kind)
 
+        # Add `source` attributes, e.g.: `self.is_source_user_created`.
+        for source, _description in self.SOURCE_CHOICES:
+            setattr(self, f"is_source_{source.lower()}", source == self.source)
+
     def __str__(self):
         return f"{self.siret} {self.display_name}"
 
@@ -737,6 +741,13 @@ class SiaeConvention(models.Model):
             # It is the only exception. Both structures are active.
             # ("siret_signature", "kind"),
         )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Add `kind` attributes, e.g.: `self.is_kind_etti`.
+        for kind, _description in self.KIND_CHOICES:
+            setattr(self, f"is_kind_{kind.lower()}", kind == self.kind)
 
     def save(self, *args, **kwargs):
         if self.pk:

--- a/itou/siaes/tests.py
+++ b/itou/siaes/tests.py
@@ -52,13 +52,6 @@ class SiaeFactoriesTest(TestCase):
 
 
 class SiaeModelTest(TestCase):
-    def test_is_kind(self):
-        siae = SiaeFactory(kind=Siae.KIND_GEIQ)
-        self.assertTrue(siae.is_kind_geiq)
-        self.assertFalse(siae.is_kind_etti)
-        self.assertFalse(siae.is_kind_ea)
-        self.assertFalse(siae.is_kind_aci)
-
     def test_siren_and_nic(self):
         siae = SiaeFactory(siret="12345678900001")
         self.assertEqual(siae.siren, "123456789")

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -61,7 +61,7 @@
                         {% if siae.brand %}<small class="text-muted">({{ siae.name|title }})</small>{% endif %}
                     </h5>
                     <h6 class="card-subtitle mb-2 text-muted">{{ siae.address_on_one_line }}</h6>
-                    {% if siae.is_kind_ea or siae.is_kind_eatt %}
+                    {% if siae.kind in ea_eatt_kinds %}
                         <p class="card-text">
                             <span class="badge badge-dark">Priorité aux bénéficiaires de RQTH</span>
                         </p>

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -62,7 +62,7 @@ def search_siaes_results(request, template_name="search/siaes_search_results.htm
             siaes = siaes.filter(kind=kind)
         siaes_page = pager(siaes, request.GET.get("page"), items_per_page=10)
 
-    context = {"form": form, "siaes_page": siaes_page}
+    context = {"form": form, "siaes_page": siaes_page, "ea_eatt_kinds": [Siae.KIND_EA, Siae.KIND_EATT]}
     return render(request, template_name, context)
 
 


### PR DESCRIPTION
### Quoi ?

Hotfix des ACIPHC créees par le support.

### Pourquoi ?

Normalement le support devrait créer les ACIPHC from scratch, donc pas de convention et pas de problème.

Mais en pratique le support convertit parfois le type d'une antenne ACI existante en ACIPHC et du coup on a une incohérence de données pas critique pour la prod, mais problématique pour la cohérence des données.

L'incohérence est que la siae ACIPHC se retrouve attachée à une convention ACI. Ca ne devrait pas arriver car les ACIPHC sont supposées ne *pas* avoir de convention. Et de toute façon, une structure et sa convention devraient *toujours* avoir le même type.

### Comment ?

En aval dans l'import SIAE, on corrige a posteriori les ACIPHC en question en détachant la convention ACI.

### Voir aussi

https://itou-inclusion.slack.com/archives/C01181Y04LT/p1620812621056500