### PR TITLE
Ajout de 4 nouvelles tables fluxIAE dans metabase

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -303,18 +303,22 @@ class Command(BaseCommand):
 
         self.populate_fluxiae_referentials()
 
-        # Specific views with specific needs.
+        # Specific fluxIAE views requiring some mixing with itou data.
         self.populate_fluxiae_structures()
 
-        # Regular views with no special treatment.
-        self.populate_fluxiae_view(vue_name="fluxIAE_Missions")
-        self.populate_fluxiae_view(vue_name="fluxIAE_EtatMensuelIndiv")
-        self.populate_fluxiae_view(vue_name="fluxIAE_MissionsEtatMensuelIndiv")
-        self.populate_fluxiae_view(vue_name="fluxIAE_ContratMission", skip_first_row=False)
+        # Regular fluxIAE views not mixed with any itou data.
         self.populate_fluxiae_view(vue_name="fluxIAE_AnnexeFinanciere")
+        self.populate_fluxiae_view(vue_name="fluxIAE_ContratMission", skip_first_row=False)
+        self.populate_fluxiae_view(vue_name="fluxIAE_Encadrement")
+        self.populate_fluxiae_view(vue_name="fluxIAE_EtatMensuelAgregat")
+        self.populate_fluxiae_view(vue_name="fluxIAE_EtatMensuelIndiv")
+        self.populate_fluxiae_view(vue_name="fluxIAE_Formations")
+        self.populate_fluxiae_view(vue_name="fluxIAE_Missions")
+        self.populate_fluxiae_view(vue_name="fluxIAE_MissionsEtatMensuelIndiv")
+        self.populate_fluxiae_view(vue_name="fluxIAE_PMSMP")
         self.populate_fluxiae_view(vue_name="fluxIAE_Salarie", skip_first_row=False)
 
-        # Custom views for our needs.
+        # Custom views for our needs (no fluxIAE data involved).
         self.populate_departments()
 
         # Build custom tables by running raw SQL queries on existing tables.

--- a/itou/siaes/management/commands/_import_siae/utils.py
+++ b/itou/siaes/management/commands/_import_siae/utils.py
@@ -232,13 +232,24 @@ def anonymize_fluxiae_df(df):
     if "salarie_date_naissance" in df.columns.tolist():
         df["salarie_annee_naissance"] = df.salarie_date_naissance.str[-4:].astype(int)
 
-    deletable_columns = [
+    # Any column having any of these keywords inside its name will be dropped.
+    # E.g. if `courriel` is a deletable keyword, then columns named `referent_courriel`,
+    # `representant_courriel` etc will all be dropped.
+    deletable_keywords = [
+        "courriel",
+        "telephone",
+        "prenom",
         "nom_usage",
         "nom_naissance",
-        "prenom",
+        "responsable_nom",
+        "urgence_nom",
+        "referent_nom",
+        "representant_nom",
         "date_naissance",
-        "telephone",
         "adr_mail",
+        "nationalite",
+        "titre_sejour",
+        "observations",
         "salarie_agrement",
         "salarie_adr_point_remise",
         "salarie_adr_cplt_point_geo",
@@ -250,15 +261,15 @@ def anonymize_fluxiae_df(df):
         "salarie_adr_qpv_nom",
     ]
 
-    for deletable_column in deletable_columns:
-        for column_name in df.columns.tolist():
-            if deletable_column in column_name:
+    for column_name in df.columns.tolist():
+        for deletable_keyword in deletable_keywords:
+            if deletable_keyword in column_name:
                 del df[column_name]
 
     # Better safe than sorry when dealing with sensitive data!
     for column_name in df.columns.tolist():
-        for deletable_column in deletable_columns:
-            assert deletable_column not in column_name
+        for deletable_keyword in deletable_keywords:
+            assert deletable_keyword not in column_name
 
     return df
 


### PR DESCRIPTION
### Quoi ?

Ajout de 4 nouvelles tables fluxIAE dans metabase.

En deux parties :
- une PR publique https://github.com/betagouv/itou/pull/679 => ajout des 4 nouvelles vues en question
- une PR privée https://github.com/betagouv/itou-private/pull/37 => mise à jour de la documentation. Vu qu'on injecte un nombre toujours grandissant des 17 vues fluxIAE, autant simplifier et déplacer toutes les vues dans le bon dossier plutôt que s'embêter à choisir quelles vues déplacer

### Pourquoi ?

Pour que Soumia puisse faire encore plus de tableaux de bord intéressants dans metabase.
