### PR TITLE
Correctif pour un settings manquant

### DIFF
--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -231,7 +231,10 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
                 )
             elif not job_application.hiring_without_approval:
                 external_link = get_external_link_markup(
-                    url=settings.ITOU_DOC_PASS_VERIFICATION_URL,
+                    url=(
+                        f"{settings.ITOU_DOC_URL}/pourquoi-une-plateforme-de-linclusion/"
+                        "pass-iae-agrement-plus-simple-cest-a-dire#verification-des-demandes-de-pass-iae"
+                    ),
                     text="consulter notre espace documentation",
                 )
                 messages.success(


### PR DESCRIPTION
### Quoi ?

Correctif pour un settings manquant

### Pourquoi ?

Fix de l'erreur Sentry :

> 'Settings' object has no attribute 'ITOU_DOC_PASS_VERIFICATION_URL'