### PR TITLE
Ajout d'une table de laison candidatures <-> fiches de poste dans metabase

### DIFF
--- a/itou/metabase/management/commands/_dataframes.py
+++ b/itou/metabase/management/commands/_dataframes.py
@@ -1,0 +1,76 @@
+"""
+Helper methods for manipulating dataframes used by both populate_metabase and populate_metabase_fluxiae scripts.
+"""
+
+import pandas as pd
+from psycopg2 import sql
+from tqdm import tqdm
+
+from itou.metabase.management.commands._database_psycopg2 import MetabaseDatabaseCursor
+from itou.metabase.management.commands._database_sqlalchemy import get_pg_engine
+
+
+def switch_table_atomically(table_name):
+    with MetabaseDatabaseCursor() as (cur, conn):
+        cur.execute(
+            sql.SQL("ALTER TABLE IF EXISTS {} RENAME TO {}").format(
+                sql.Identifier(table_name), sql.Identifier(f"{table_name}_old")
+            )
+        )
+        cur.execute(
+            sql.SQL("ALTER TABLE {} RENAME TO {}").format(
+                sql.Identifier(f"{table_name}_new"), sql.Identifier(table_name)
+            )
+        )
+        conn.commit()
+        cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(f"{table_name}_old")))
+        conn.commit()
+
+
+def store_df(df, table_name, dry_run):
+    """
+    Store dataframe in database.
+
+    Do this chunk by chunk to solve
+    psycopg2.OperationalError "server closed the connection unexpectedly" error.
+    """
+    if dry_run:
+        table_name += "_dry_run"
+        df = df.head(1000)
+
+    # Recipe from https://stackoverflow.com/questions/44729727/pandas-slice-large-dataframe-in-chunks
+    rows_per_chunk = 10 * 1000
+    df_chunks = [df[i : i + rows_per_chunk] for i in range(0, df.shape[0], rows_per_chunk)]
+
+    print(f"Storing {table_name} in {len(df_chunks)} chunks of (max) {rows_per_chunk} rows each ...")
+    if_exists = "replace"  # For the 1st chunk, drop old existing table if needed.
+    for df_chunk in tqdm(df_chunks):
+        pg_engine = get_pg_engine()
+        df_chunk.to_sql(
+            name=f"{table_name}_new",
+            # Use a new connection for each chunk to avoid random disconnections.
+            con=pg_engine,
+            if_exists=if_exists,
+            index=False,
+            chunksize=1000,
+            # INSERT by batch and not one by one. Increases speed x100.
+            method="multi",
+        )
+        pg_engine.dispose()
+        if_exists = "append"  # For all other chunks, append to table in progress.
+
+    switch_table_atomically(table_name=table_name)
+    print(f"Stored {table_name} in database ({len(df)} rows).")
+    print("")
+
+
+def get_df_from_rows(rows):
+    """
+    Helper method converting rows into a dataframe.
+
+    Rows should be a list of rows, each row being a Dict (or an OrderedDict to ensure column order) like this one:
+    `{"field1": value1, "field2": value2}`
+    """
+    # `columns=rows[0].keys()` trick is necessary to preserve the order of columns.
+    df = pd.DataFrame(rows, columns=rows[0].keys())
+    return df

--- a/itou/metabase/management/commands/_job_applications.py
+++ b/itou/metabase/management/commands/_job_applications.py
@@ -2,6 +2,9 @@ from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.metabase.management.commands._utils import anonymize, get_choice, get_department_and_region_columns
 
 
+JOB_APPLICATION_PK_ANONYMIZATION_SALT = "job_application.id"
+
+
 # Reword the original JobApplication.SENDER_KIND_CHOICES
 SENDER_KIND_CHOICES = (
     (JobApplication.SENDER_KIND_JOB_SEEKER, "Candidat"),
@@ -101,7 +104,7 @@ TABLE_COLUMNS = [
         "name": "id_anonymisé",
         "type": "varchar",
         "comment": "ID anonymisé de la candidature",
-        "fn": lambda o: anonymize(o.id, salt="job_application.id"),
+        "fn": lambda o: anonymize(o.pk, salt=JOB_APPLICATION_PK_ANONYMIZATION_SALT),
     },
     {
         "name": "date_candidature",

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -62,16 +62,13 @@ An EMI does not necessarily have a mission.
 """
 import logging
 import os
-from collections import OrderedDict
 
-import pandas as pd
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from psycopg2 import sql
-from tqdm import tqdm
 
 from itou.metabase.management.commands._database_psycopg2 import MetabaseDatabaseCursor
-from itou.metabase.management.commands._database_sqlalchemy import get_pg_engine
+from itou.metabase.management.commands._dataframes import store_df, switch_table_atomically
 from itou.siaes.management.commands._import_siae.utils import get_fluxiae_df, get_fluxiae_referential_filenames, timeit
 from itou.siaes.models import Siae
 from itou.utils.address.departments import DEPARTMENT_TO_REGION, DEPARTMENTS
@@ -126,41 +123,6 @@ class Command(BaseCommand):
     def log(self, message):
         self.logger.debug(message)
 
-    def store_df(self, df, vue_name):
-        """
-        Store dataframe in database.
-
-        Do this dataframe chunk by dataframe chunk to solve
-        psycopg2.OperationalError "server closed the connection unexpectedly" error.
-        """
-        if self.dry_run:
-            vue_name += "_dry_run"
-
-        # Recipe from https://stackoverflow.com/questions/44729727/pandas-slice-large-dataframe-in-chunks
-        rows_per_chunk = 10 * 1000
-        df_chunks = [df[i : i + rows_per_chunk] for i in range(0, df.shape[0], rows_per_chunk)]
-
-        self.log(f"Storing {len(df_chunks)} chunks of (max) {rows_per_chunk} rows each ...")
-        if_exists = "replace"  # For the 1st chunk, drop old existing table if needed.
-        for df_chunk in tqdm(df_chunks):
-            pg_engine = get_pg_engine()
-            df_chunk.to_sql(
-                name=f"{vue_name}_new",
-                # Use a new connection for each chunk to avoid random disconnections.
-                con=pg_engine,
-                if_exists=if_exists,
-                index=False,
-                chunksize=1000,
-                # INSERT by batch and not one by one. Increases speed x100.
-                method="multi",
-            )
-            pg_engine.dispose()
-            if_exists = "append"  # For all other chunks, append to table in progress.
-
-        self.switch_table_atomically(table_name=vue_name)
-        self.log(f"Stored {vue_name} in database ({len(df)} rows).")
-        self.log("")
-
     @timeit
     def populate_fluxiae_structures(self):
         """
@@ -203,53 +165,16 @@ class Command(BaseCommand):
                 df.loc[index, "itou_latitude"] = siae.latitude
                 df.loc[index, "itou_longitude"] = siae.longitude
 
-        self.store_df(df=df, vue_name=vue_name)
+        store_df(df=df, table_name=vue_name, dry_run=self.dry_run)
 
     @timeit
     def populate_fluxiae_view(self, vue_name, skip_first_row=True):
         df = get_fluxiae_df(vue_name=vue_name, skip_first_row=skip_first_row, dry_run=self.dry_run)
-        self.store_df(df=df, vue_name=vue_name)
+        store_df(df=df, table_name=vue_name, dry_run=self.dry_run)
 
     def populate_fluxiae_referentials(self):
         for filename in get_fluxiae_referential_filenames():
             self.populate_fluxiae_view(vue_name=filename)
-
-    def populate_departments(self):
-        """
-        Populate department codes, department names and region names.
-        """
-        rows = []
-
-        for dpt_code, dpt_name in DEPARTMENTS.items():
-            # We want to preserve the order of columns.
-            row = OrderedDict()
-
-            row["code_departement"] = dpt_code
-            row["nom_departement"] = dpt_name
-            row["nom_region"] = DEPARTMENT_TO_REGION[dpt_code]
-
-            rows.append(row)
-
-        # `columns=rows[0].keys()` trick is necessary to preserve the order of columns.
-        df = pd.DataFrame(rows, columns=rows[0].keys())
-
-        self.store_df(df=df, vue_name="departements")
-
-    def switch_table_atomically(self, table_name):
-        with MetabaseDatabaseCursor() as (cur, conn):
-            cur.execute(
-                sql.SQL("ALTER TABLE IF EXISTS {} RENAME TO {}").format(
-                    sql.Identifier(table_name), sql.Identifier(f"{table_name}_old")
-                )
-            )
-            cur.execute(
-                sql.SQL("ALTER TABLE {} RENAME TO {}").format(
-                    sql.Identifier(f"{table_name}_new"), sql.Identifier(table_name)
-                )
-            )
-            conn.commit()
-            cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(f"{table_name}_old")))
-            conn.commit()
 
     def build_custom_table(self, table_name, sql_request):
         """
@@ -269,7 +194,7 @@ class Command(BaseCommand):
             )
             conn.commit()
 
-        self.switch_table_atomically(table_name=table_name)
+        switch_table_atomically(table_name=table_name)
         self.log("Done.")
 
     @timeit
@@ -317,9 +242,6 @@ class Command(BaseCommand):
         self.populate_fluxiae_view(vue_name="fluxIAE_MissionsEtatMensuelIndiv")
         self.populate_fluxiae_view(vue_name="fluxIAE_PMSMP")
         self.populate_fluxiae_view(vue_name="fluxIAE_Salarie", skip_first_row=False)
-
-        # Custom views for our needs (no fluxIAE data involved).
-        self.populate_departments()
 
         # Build custom tables by running raw SQL queries on existing tables.
         self.build_custom_tables()


### PR DESCRIPTION
### Quoi ?

- Refactorings préparatifs, notamment déplacement de la méthode `store_df` dans une librairie commune aux deux scripts metabase (populate_metabase vs populate_metabase_fluxiae).
- Ajout d'une table de laison candidatures <-> fiches de poste dans metabase.

### Pourquoi ?

A la demande de Soumia.

### Comment faire la revue ?

Ne surtout pas regarder le diff global, illisible en raisons des refactorings préparatifs.

A la place, regarder commit par commit.