### PR TITLE
Simplification du script d'import des SIAE (abandon du "dry run")

### DIFF
--- a/itou/siaes/management/commands/_import_siae/financial_annex.py
+++ b/itou/siaes/management/commands/_import_siae/financial_annex.py
@@ -7,7 +7,7 @@ from itou.siaes.management.commands._import_siae.vue_af import AF_NUMBER_TO_ROW
 from itou.siaes.models import SiaeConvention, SiaeFinancialAnnex
 
 
-def get_creatable_and_deletable_afs(dry_run):
+def get_creatable_and_deletable_afs():
     """
     Get AFs which should be created / deleted.
 
@@ -34,20 +34,17 @@ def get_creatable_and_deletable_afs(dry_run):
         # Sometimes an AF start date changes.
         if af.start_at != row.start_at:
             af.start_at = row.start_at
-            if not dry_run:
-                af.save()
+            af.save()
 
         # Sometimes an AF end date changes.
         if af.end_at != row.end_date:
             af.end_at = row.end_date
-            if not dry_run:
-                af.save()
+            af.save()
 
         # Sometimes an AF state changes.
         if af.state != row.state:
             af.state = row.state
-            if not dry_run:
-                af.save()
+            af.save()
 
         # Sometimes an AF migrates from one convention to another.
         if af.convention.asp_id != row.asp_id:
@@ -55,8 +52,7 @@ def get_creatable_and_deletable_afs(dry_run):
             if convention_query.exists():
                 convention = convention_query.get()
                 af.convention = convention
-                if not dry_run:
-                    af.save()
+                af.save()
             else:
                 deletable_afs.append(af)
                 continue

--- a/itou/siaes/management/commands/import_siae.py
+++ b/itou/siaes/management/commands/import_siae.py
@@ -36,16 +36,11 @@ class Command(BaseCommand):
     """
     Update and sync SIAE data based on latest ASP exports.
 
-    No dry run is available.
-
-    When ready:
+    Run the following command:
         django-admin import_siae --verbosity=2
     """
 
     help = "Update and sync SIAE data based on latest ASP exports."
-
-    def add_arguments(self, parser):
-        parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="Only print data to import")
 
     def set_logger(self, verbosity):
         """
@@ -272,11 +267,8 @@ class Command(BaseCommand):
             af.delete()
 
     @timeit
-    def handle(self, dry_run=False, **options):
+    def handle(self, **options):
         self.set_logger(options.get("verbosity"))
-        if dry_run:
-            self.log("This script does not have a dry run, please run a wet run directly instead.")
-            return
 
         self.fatal_errors = 0
 

--- a/itou/siaes/management/commands/import_siae.py
+++ b/itou/siaes/management/commands/import_siae.py
@@ -36,8 +36,7 @@ class Command(BaseCommand):
     """
     Update and sync SIAE data based on latest ASP exports.
 
-    To debug:
-        django-admin import_siae --verbosity=2 --dry-run
+    No dry run is available.
 
     When ready:
         django-admin import_siae --verbosity=2
@@ -67,8 +66,7 @@ class Command(BaseCommand):
 
     def delete_siae(self, siae):
         assert could_siae_be_deleted(siae)
-        if not self.dry_run:
-            siae.delete()
+        siae.delete()
 
     @timeit
     def delete_user_created_siaes_without_members(self):
@@ -93,16 +91,14 @@ class Command(BaseCommand):
 
     def update_siae_auth_email(self, siae, new_auth_email):
         assert siae.auth_email != new_auth_email
-        if not self.dry_run:
-            siae.auth_email = new_auth_email
-            siae.save()
+        siae.auth_email = new_auth_email
+        siae.save()
 
     def update_siae_siret(self, siae, new_siret):
         assert siae.siret != new_siret
         self.log(f"siae.id={siae.id} has changed siret from {siae.siret} to {new_siret} (will be updated)")
-        if not self.dry_run:
-            siae.siret = new_siret
-            siae.save()
+        siae.siret = new_siret
+        siae.save()
 
     @timeit
     def update_siret_and_auth_email_of_existing_siaes(self):
@@ -188,26 +184,19 @@ class Command(BaseCommand):
                     assert existing_siae.is_asp_managed
                     if existing_siae.source == Siae.SOURCE_ASP:
                         total_existing_siaes_with_asp_source += 1
-                        if not self.dry_run:
-                            # Siret should have been fixed by
-                            # update_siret_and_auth_email_of_existing_siaes()
-                            # except in a dry run.
-                            assert existing_siae.siret == siret
+                        # Siret should have been fixed by update_siret_and_auth_email_of_existing_siaes().
+                        assert existing_siae.siret == siret
                     else:
                         assert existing_siae.source == Siae.SOURCE_USER_CREATED
 
-                if not self.dry_run:
-                    # Duplicate siaes should have been deleted except in a dry run.
-                    assert total_existing_siaes_with_asp_source == 1
+                # Duplicate siaes should have been deleted.
+                assert total_existing_siaes_with_asp_source == 1
                 continue
 
             existing_siae_query = Siae.objects.filter(siret=siret, kind=kind)
             if existing_siae_query.exists():
                 # Siae with this siret+kind already exists but with wrong source.
                 existing_siae = existing_siae_query.get()
-                if existing_siae.source == Siae.SOURCE_ASP:
-                    assert self.dry_run
-                    continue
                 assert existing_siae.source in [Siae.SOURCE_USER_CREATED, Siae.SOURCE_STAFF_CREATED]
                 assert existing_siae.is_asp_managed
                 self.log(
@@ -215,10 +204,9 @@ class Command(BaseCommand):
                     f"with wrong source={existing_siae.source} "
                     f"(source will be fixed to ASP)"
                 )
-                if not self.dry_run:
-                    existing_siae.source = Siae.SOURCE_ASP
-                    existing_siae.convention = None
-                    existing_siae.save()
+                existing_siae.source = Siae.SOURCE_ASP
+                existing_siae.convention = None
+                existing_siae.save()
                 continue
 
             assert not SiaeConvention.objects.filter(asp_id=asp_id, kind=kind).exists()
@@ -233,8 +221,7 @@ class Command(BaseCommand):
         self.log("siret;kind;department;name;address")
         for siae in creatable_siaes:
             self.log(f"{siae.siret};{siae.kind};{siae.department};{siae.name};{siae.address_on_one_line}")
-            if not self.dry_run:
-                siae.save()
+            siae.save()
         self.log("--- end of CSV output of all creatable_siaes ---")
 
         self.log(f"{len(creatable_siaes)} structures will be created")
@@ -256,47 +243,45 @@ class Command(BaseCommand):
         creatable_conventions = get_creatable_conventions()
         self.log(f"will create {len(creatable_conventions)} conventions")
         for (convention, siae) in creatable_conventions:
-            if not self.dry_run:
-                assert not SiaeConvention.objects.filter(asp_id=convention.asp_id, kind=convention.kind).exists()
-                convention.save()
-                assert convention.siaes.count() == 0
-                siae.convention = convention
-                siae.save()
-                assert convention.siaes.filter(source=Siae.SOURCE_ASP).count() == 1
+            assert not SiaeConvention.objects.filter(asp_id=convention.asp_id, kind=convention.kind).exists()
+            convention.save()
+            assert convention.siaes.count() == 0
+            siae.convention = convention
+            siae.save()
+            assert convention.siaes.filter(source=Siae.SOURCE_ASP).count() == 1
 
     @timeit
     def delete_conventions(self):
         deletable_conventions = get_deletable_conventions()
         self.log(f"will delete {len(deletable_conventions)} conventions")
         for convention in deletable_conventions:
-            if not self.dry_run:
-                assert convention.siaes.count() == 0
-                # This will delete the related financial annexes as well.
-                convention.delete()
+            assert convention.siaes.count() == 0
+            # This will delete the related financial annexes as well.
+            convention.delete()
 
     @timeit
     def manage_financial_annexes(self):
-        creatable_afs, deletable_afs = get_creatable_and_deletable_afs(dry_run=self.dry_run)
+        creatable_afs, deletable_afs = get_creatable_and_deletable_afs()
 
         self.log(f"will create {len(creatable_afs)} financial annexes")
         for af in creatable_afs:
-            if not self.dry_run:
-                af.save()
+            af.save()
 
         self.log(f"will delete {len(deletable_afs)} financial annexes")
         for af in deletable_afs:
-            if not self.dry_run:
-                af.delete()
+            af.delete()
 
     @timeit
     def handle(self, dry_run=False, **options):
-        self.dry_run = dry_run
         self.set_logger(options.get("verbosity"))
+        if dry_run:
+            self.log("This script does not have a dry run, please run a wet run directly instead.")
+            return
 
         self.fatal_errors = 0
 
         self.delete_user_created_siaes_without_members()
-        update_existing_conventions(dry_run=self.dry_run)
+        update_existing_conventions()
         self.update_siret_and_auth_email_of_existing_siaes()
         self.create_new_siaes()
         self.create_conventions()
@@ -305,11 +290,11 @@ class Command(BaseCommand):
         self.cleanup_siaes_after_grace_period()
 
         # Run some updates a second time.
-        update_existing_conventions(dry_run=self.dry_run)
+        update_existing_conventions()
         self.update_siret_and_auth_email_of_existing_siaes()
 
         # Final checks.
-        check_convention_data_consistency(dry_run=self.dry_run)
+        check_convention_data_consistency()
         self.check_whether_signup_is_possible_for_all_siaes()
 
         if self.fatal_errors >= 1:


### PR DESCRIPTION
### Quoi ?

Abandon du dry run du script import_siae.

En deux parties :
- une PR publique https://github.com/betagouv/itou/pull/684 : suppression du dry run
- une PR privée https://github.com/betagouv/itou-private/pull/38 : mise à jour de la documentation

### Pourquoi ?

Maintenir ce dry run ajoutait trop de complexité pour pas assez de bénéfices.

Trop de complexité car dans de nombreux edge cases il fallait réagir différement selon dry ou wet run.

L'import SIAE étant constitué de plusieurs étapes successives dont chacune dépend des actions de la précédente, le dry run était de toute façon infaisable pour les dernières étapes.

Le dry run était au final partiel, donc donnait une fausse assurance que le wet run se déroulerait sans erreur. Si le dry run n'est pas capable d'assurer que le wet run se déroulera sans erreur, son intérêt est réduit.

