### PR TITLE
Renommage du script metabase "populate_metabase" en "populate_metabase_itou" pour éviter la confusion avec l'autre script "populate_metabase_fluxiae"

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,3 +1,3 @@
 [
-    "0 0 * * * $ROOT/clevercloud/populate_metabase.sh"
+    "0 0 * * * $ROOT/clevercloud/populate_metabase_itou.sh"
 ]

--- a/clevercloud/populate_metabase_itou.sh
+++ b/clevercloud/populate_metabase_itou.sh
@@ -15,4 +15,4 @@ fi
 # $APP_HOME is set by default by clever cloud.
 cd $APP_HOME
 
-django-admin populate_metabase --verbosity 2
+django-admin populate_metabase_itou --verbosity 2

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -1,7 +1,7 @@
 """
 Populate metabase with fluxIAE data and some custom tables for our needs (mainly `missions_ai_ehpad`).
 
-For itou data, see the other script `populate_metabase.py`.
+For itou data, see the other script `populate_metabase_itou.py`.
 
 At this time this script is only supposed to run manually on your local dev, not in production.
 

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -65,10 +65,10 @@ class Command(BaseCommand):
     touching any real table, and injects only a sample of data.
 
     To populate alternate tables with sample data:
-        django-admin populate_metabase --verbosity=2 --dry-run
+        django-admin populate_metabase_itou --verbosity=2 --dry-run
 
     When ready:
-        django-admin populate_metabase --verbosity=2
+        django-admin populate_metabase_itou --verbosity=2
     """
 
     help = "Populate metabase database."
@@ -335,7 +335,7 @@ class Command(BaseCommand):
 
         self.populate_table(table_name="communes", table_columns=_insee_codes.TABLE_COLUMNS, queryset=queryset)
 
-    def populate_metabase(self):
+    def populate_metabase_itou(self):
         if not settings.ALLOW_POPULATING_METABASE:
             self.log("Populating metabase is not allowed in this environment.")
             return
@@ -354,6 +354,6 @@ class Command(BaseCommand):
     def handle(self, dry_run=False, **options):
         self.set_logger(options.get("verbosity"))
         self.dry_run = dry_run
-        self.populate_metabase()
+        self.populate_metabase_itou()
         self.log("-" * 80)
         self.log("Done.")


### PR DESCRIPTION
### Quoi ?

Renommage du script metabase "populate_metabase" en "populate_metabase_itou" pour éviter la confusion avec l'autre script "populate_metabase_fluxiae".

En deux parties :
- une PR publique https://github.com/betagouv/itou/pull/685
- une PR privée https://github.com/betagouv/itou-private/pull/39

### Pourquoi ?

Suite à discussion avec Stéphane.
