### PR TITLE
Seul le créateur d'un compte peut en modifier l'e-mail

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -182,9 +182,7 @@ class User(AbstractUser, AddressMixin):
             return True
 
         is_account_creator = bool(user.created_by and user.created_by == self)
-        if user.has_verified_email or not user.is_handled_by_proxy or not is_account_creator:
-            return False
-        return True
+        return user.is_handled_by_proxy and is_account_creator and not user.has_verified_email
 
     @cached_property
     def has_verified_email(self):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1,6 +1,5 @@
 import uuid
 
-from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.contrib.postgres.fields import CIEmailField
@@ -181,12 +180,14 @@ class User(AbstractUser, AddressMixin):
         if self == user:
             return True
 
-        is_account_creator = bool(user.created_by and user.created_by == self)
-        return user.is_handled_by_proxy and is_account_creator and not user.has_verified_email
+        return user.is_handled_by_proxy and user.is_created_by(self) and not user.has_verified_email
 
-    @cached_property
+    def is_created_by(self, user):
+        return bool(self.created_by_id and self.created_by_id == user.pk)
+
+    @property
     def has_verified_email(self):
-        return EmailAddress.objects.filter(email=self.email, verified=True)
+        return self.emailaddress_set.filter(email=self.email, verified=True).exists()
 
     @cached_property
     def approvals_wrapper(self):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -178,8 +178,7 @@ class User(AbstractUser, AddressMixin):
         super().save(*args, **kwargs)
 
     def can_edit_email(self, user):
-        is_proxy = self.pk != user.pk
-        if not is_proxy:
+        if self == user:
             return True
 
         is_account_creator = bool(user.created_by and user.created_by == self)

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -44,7 +44,7 @@ class ProcessViewsTest(TestCase):
         self.assertContains(response, "Modifier les informations")
 
     def test_details_for_siae_hidden(self):
-        """An hiden job_application is not displayed."""
+        """A hidden job_application is not displayed."""
 
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(
             job_seeker__is_job_seeker=True, hidden_for_siae=True

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -1,4 +1,3 @@
-from allauth.account.models import EmailAddress
 from django import forms
 from django.core.exceptions import ValidationError
 
@@ -20,12 +19,12 @@ class EditUserInfoForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
     email = forms.EmailField(label="Adresse électronique", widget=forms.TextInput(attrs={"autocomplete": "off"}))
 
     def __init__(self, *args, **kwargs):
+        editor = kwargs.pop("editor")
         super().__init__(*args, **kwargs)
-        has_verified_email = EmailAddress.objects.filter(email=self.instance.email, verified=True)
-        if has_verified_email or not self.instance.is_job_seeker:
-            # We want the possibility to edit the email of job seekers
-            # until they validate their email
+
+        if not self.instance.is_job_seeker or not editor.can_edit_email(self.instance):
             del self.fields["email"]
+
         if not self.instance.is_job_seeker:
             del self.fields["birthdate"]
             del self.fields["pole_emploi_id"]

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -21,7 +21,7 @@ from itou.siaes.factories import (
 )
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory, SiaeStaffFactory
 from itou.users.models import User
-from itou.www.dashboard.forms import EditUserEmailForm, EditUserInfoForm
+from itou.www.dashboard.forms import EditUserEmailForm
 
 
 class DashboardViewTest(TestCase):

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -123,38 +123,6 @@ class EditJobSeekerInfo(TestCase):
         self.assertEqual(job_seeker.birthdate.strftime("%d/%m/%Y"), post_data["birthdate"])
         self.assertEqual(job_seeker.phone, post_data["phone"])
 
-    def test_edit_email(self):
-        editor = PrescriberFactory()
-        job_seeker = JobSeekerFactory(created_by=editor)
-        data = {
-            "email": "bob@saintclar.net",
-            "first_name": "Bob",
-            "last_name": "Saint Clar",
-            "birthdate": "20/12/1978",
-            "phone": "0610203050",
-            "lack_of_pole_emploi_id_reason": job_seeker.REASON_NOT_REGISTERED,
-        }
-        form = EditUserInfoForm(instance=job_seeker, editor=editor)
-        self.assertTrue(form.fields.get("email"))
-        form = EditUserInfoForm(instance=job_seeker, editor=editor, data=data)
-        self.assertTrue(form.fields.get("email"))
-
-    def test_edit_email_not_allowed(self):
-        job_seeker = JobSeekerFactory()
-        editor = PrescriberFactory()
-        data = {
-            "email": "bob@saintclar.net",
-            "first_name": "Bob",
-            "last_name": "Saint Clar",
-            "birthdate": "20/12/1978",
-            "phone": "0610203050",
-            "lack_of_pole_emploi_id_reason": job_seeker.REASON_NOT_REGISTERED,
-        }
-        form = EditUserInfoForm(instance=job_seeker, editor=editor)
-        self.assertFalse(form.fields.get("email"))
-        form = EditUserInfoForm(instance=job_seeker, editor=editor, data=data)
-        self.assertFalse(form.fields.get("email"))
-
     def test_edit_by_prescriber(self):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory()
         user = job_application.sender

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -128,7 +128,7 @@ def edit_user_info(request, template_name="dashboard/edit_user_info.html"):
     """
     dashboard_url = reverse_lazy("dashboard:index")
     prev_url = get_safe_url(request, "prev_url", fallback_url=dashboard_url)
-    form = EditUserInfoForm(instance=request.user, data=request.POST or None)
+    form = EditUserInfoForm(instance=request.user, editor=request.user, data=request.POST or None)
     extra_data = request.user.externaldataimport_set.pe_sources().first()
     job_seeker_signed_pk = resume_signer.sign(request.user.pk)
 
@@ -172,7 +172,7 @@ def edit_job_seeker_info(request, job_application_id, template_name="dashboard/e
 
     dashboard_url = reverse_lazy("dashboard:index")
     back_url = get_safe_url(request, "back_url", fallback_url=dashboard_url)
-    form = EditUserInfoForm(instance=job_application.job_seeker, data=request.POST or None)
+    form = EditUserInfoForm(instance=job_application.job_seeker, editor=request.user, data=request.POST or None)
 
     if request.method == "POST" and form.is_valid():
         form.save()


### PR DESCRIPTION
### Quoi ?

On serre la vis ! Seule la personne ayant créé le compte candidat peut en modifier le courriel.

### Pourquoi ?

Actuellement, le courriel d'un candidat peut être modifié pendant le processus de candidature par l'employeur ou le prescripteur. Cela pose plusieurs soucis.

### Comment ?

- Ajout de deux méthodes dans la classe `User` : `has_verified_email` et `can_edit_email`. 
- Modification du formulaire `EditUserInfoForm`.
- Ajout de quelques tests.

### Des commentaires ?

Je n'ai pas ajouté de test au niveau du modèle pour `has_verified_email` et `can_edit_email` car `coverage` m'indique que ces méthodes sont déjà testées. Je me dis que ça fera doublon. Qu'en pensez-vous ?
