### PR TITLE
Prise en compte de l'extension COVID dans les vérifications de date de fin d'embauche

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -97,8 +97,14 @@ class CommonApprovalMixin(models.Model):
 
     @property
     def display_end_at(self):
-        # See `PoleEmploiApproval.display_end_at`.
+        """
+        See `PoleEmploiApproval.display_end_at`.
+        """
         return self.end_at
+
+    @staticmethod
+    def get_extended_covid_end_at(end_at):
+        return end_at + relativedelta(months=CommonApprovalMixin.LOCKDOWN_EXTENSION_DELAY_MONTHS)
 
 
 class CommonApprovalQuerySet(models.QuerySet):
@@ -185,7 +191,7 @@ class Approval(CommonApprovalMixin):
             # Handle COVID extensions for approvals originally issued by Pôle emploi.
             # Approvals issued by Itou have already been extended through SQL.
             if not self.originates_from_itou and self.overlaps_covid_lockdown:
-                self.end_at = self.end_at + relativedelta(months=self.LOCKDOWN_EXTENSION_DELAY_MONTHS)
+                self.end_at = self.get_extended_covid_end_at(self.end_at)
 
         super().save(*args, **kwargs)
 
@@ -988,7 +994,7 @@ class PoleEmploiApproval(CommonApprovalMixin):
         """
         end_at = self.end_at
         if self.overlaps_covid_lockdown:
-            end_at = end_at + relativedelta(months=self.LOCKDOWN_EXTENSION_DELAY_MONTHS)
+            end_at = self.get_extended_covid_end_at(end_at)
         return end_at
 
     @property

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -97,7 +97,7 @@ class CommonApprovalMixin(models.Model):
 
     @property
     def display_end_at(self):
-        # See PoleEmploiApproval > display_end_at
+        # See `PoleEmploiApproval.display_end_at`.
         return self.end_at
 
 
@@ -954,7 +954,7 @@ class PoleEmploiApproval(CommonApprovalMixin):
 
     def is_valid(self):
         """
-        See self.display_end_at
+        See `self.display_end_at`.
         """
         end_at = self.end_at
         if self.overlaps_covid_lockdown:

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -96,9 +96,9 @@ class CommonApprovalMixin(models.Model):
         return not (ends_before_lockdown or starts_after_lockdown)
 
     @property
-    def display_end_at(self):
+    def extended_end_at(self):
         """
-        See `PoleEmploiApproval.display_end_at`.
+        See `PoleEmploiApproval.extended_end_at`.
         """
         return self.end_at
 
@@ -960,9 +960,9 @@ class PoleEmploiApproval(CommonApprovalMixin):
 
     def is_valid(self):
         """
-        See `self.display_end_at`.
+        See `self.extended_end_at`.
         """
-        return super().is_valid(end_at=self.display_end_at)
+        return super().is_valid(end_at=self.extended_end_at)
 
     @staticmethod
     def format_name_as_pole_emploi(name):
@@ -973,7 +973,7 @@ class PoleEmploiApproval(CommonApprovalMixin):
         return unidecode(name.strip()).upper()
 
     @property
-    def display_end_at(self):
+    def extended_end_at(self):
         """
         When importing Pôle emploi approvals from a file, the COVID prolongation is not integrated
         to the set we receive and we decided not to apply it at this moment to preserve data integrity.
@@ -990,7 +990,7 @@ class PoleEmploiApproval(CommonApprovalMixin):
         To apply this prolongation without reflecting it into the database,
         we override two parent methods:
         - self.is_valid()
-        - self.display_end_at: extended end_at
+        - self.extended_end_at: extended end_at
         """
         end_at = self.end_at
         if self.overlaps_covid_lockdown:

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -956,10 +956,7 @@ class PoleEmploiApproval(CommonApprovalMixin):
         """
         See `self.display_end_at`.
         """
-        end_at = self.end_at
-        if self.overlaps_covid_lockdown:
-            end_at = end_at + relativedelta(months=self.LOCKDOWN_EXTENSION_DELAY_MONTHS)
-        return super().is_valid(end_at=end_at)
+        return super().is_valid(end_at=self.display_end_at)
 
     @staticmethod
     def format_name_as_pole_emploi(name):

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -174,7 +174,7 @@ class CommonApprovalMixinTest(TestCase):
         approval = ApprovalFactory(user=user)
         self.assertTrue(approval.is_pass_iae)
 
-    def overlaps_covid_lockdown(self):
+    def test_overlaps_covid_lockdown(self):
 
         # Overlaps: start before lockdown.
         start_at = Approval.LOCKDOWN_START_AT - relativedelta(years=1)

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -14,7 +14,14 @@ from django.utils import timezone
 
 from itou.approvals.admin_forms import ApprovalAdminForm
 from itou.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory, ProlongationFactory, SuspensionFactory
-from itou.approvals.models import Approval, ApprovalsWrapper, PoleEmploiApproval, Prolongation, Suspension
+from itou.approvals.models import (
+    Approval,
+    ApprovalsWrapper,
+    CommonApprovalMixin,
+    PoleEmploiApproval,
+    Prolongation,
+    Suspension,
+)
 from itou.approvals.notifications import NewProlongationToAuthorizedPrescriberNotification
 from itou.job_applications.factories import JobApplicationSentByJobSeekerFactory, JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
@@ -205,6 +212,12 @@ class CommonApprovalMixinTest(TestCase):
         end_at = start_at + relativedelta(years=Approval.DEFAULT_APPROVAL_YEARS)
         approval = ApprovalFactory(number="625741810185", start_at=start_at, end_at=end_at)
         self.assertFalse(approval.overlaps_covid_lockdown)
+
+    def test_get_extended_covid_end_at(self):
+        end_at = datetime.date(2021, 5, 18)
+        covid_end_at = CommonApprovalMixin.get_extended_covid_end_at(end_at)
+        expected_end_at = datetime.date(2021, 8, 18)
+        self.assertEqual(covid_end_at, expected_end_at)
 
 
 class ApprovalModelTest(TestCase):

--- a/itou/eligibility/models.py
+++ b/itou/eligibility/models.py
@@ -204,7 +204,7 @@ class EligibilityDiagnosis(models.Model):
     @property
     def considered_to_expire_at(self):
         if self.job_seeker.approvals_wrapper.has_valid:
-            return self.job_seeker.approvals_wrapper.latest_approval.display_end_at
+            return self.job_seeker.approvals_wrapper.latest_approval.extended_end_at
         return self.expires_at
 
     @classmethod

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -48,7 +48,7 @@
 
         {# Validity. #}
         <li{% if not approval.is_suspended %} class="text-success"{% endif %}>
-            Valide du {{ approval.start_at|date:"d/m/Y" }} au {{ approval.display_end_at|date:"d/m/Y" }}
+            Valide du {{ approval.start_at|date:"d/m/Y" }} au {{ approval.extended_end_at|date:"d/m/Y" }}
         </li>
 
         {# Delivery date. #}
@@ -113,7 +113,7 @@
 {% elif approval.is_in_waiting_period %}
 
     <p class="text-danger">
-        <b>Expiré</b> le {{ approval.display_end_at|date:"d/m/Y" }} (depuis {{ approval.display_end_at|timesince }})
+        <b>Expiré</b> le {{ approval.extended_end_at|date:"d/m/Y" }} (depuis {{ approval.extended_end_at|timesince }})
     </p>
 
     {% if job_application.is_pending and job_application.is_sent_by_authorized_prescriber %}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -261,7 +261,9 @@ class AcceptForm(forms.ModelForm):
             max_end_at = Approval.get_default_end_date(hiring_start_at)
 
             if self.instance.job_seeker.approvals_wrapper.has_valid:
-                in_progress_approval_end_at = self.instance.job_seeker.approvals_wrapper.latest_approval.display_end_at
+                in_progress_approval_end_at = (
+                    self.instance.job_seeker.approvals_wrapper.latest_approval.extended_end_at
+                )
                 max_end_at = min(max_end_at, in_progress_approval_end_at)
 
             if hiring_end_at > max_end_at:

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -261,7 +261,7 @@ class AcceptForm(forms.ModelForm):
             max_end_at = Approval.get_default_end_date(hiring_start_at)
 
             if self.instance.job_seeker.approvals_wrapper.has_valid:
-                in_progress_approval_end_at = self.instance.job_seeker.approvals_wrapper.latest_approval.end_at
+                in_progress_approval_end_at = self.instance.job_seeker.approvals_wrapper.latest_approval.display_end_at
                 max_end_at = min(max_end_at, in_progress_approval_end_at)
 
             if hiring_end_at > max_end_at:


### PR DESCRIPTION
### Quoi ?

Prise en compte de l'extension COVID dans les vérifications de date de fin d'embauche.

### Pourquoi ?

On a borné la date de fin d'embauche à la durée maximum d'un PASS IAE ou le temps restant d'un PASS IAE déjà existant dans la PR #666.

Or, si un agrément PE est éligible à l'extension COVID, la date de fin avec extension n'était pas prise en compte dans le contrôle.

### Comment ?

Utilisation de `extended_end_at` à la place de `end_at`.

Au passage : factorisation du calcul de la durée de l'extension.