### PR TITLE
Correctif pour l'erreur "Cette ville n'existe pas"

### DIFF
--- a/itou/static/js/city_autocomplete_field.js
+++ b/itou/static/js/city_autocomplete_field.js
@@ -6,6 +6,8 @@ $(document).ready(() => {
   let loading = $('.js-city-autocomplete-loading')
   let noLoading = $('.js-city-autocomplete-no-loading')
 
+  let autoSubmitOnEnterPressed = citySearchInput.data('autosubmit-on-enter-pressed')
+
   function clearInput() {
     citySearchInput.val('')
     hiddenCityInput.val('')
@@ -42,7 +44,9 @@ $(document).ready(() => {
         if (event.keyCode === 13) {
           let value = hiddenCityInput.data('title')
           citySearchInput.val(value)
-          citySearchInput.parents('form:first').submit()
+          if (autoSubmitOnEnterPressed) {
+            citySearchInput.parents('form:first').submit()
+          }
         }
       },
       search: (event, ui) => {

--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -21,8 +21,7 @@
 
     {% csrf_token %}
 
-    {% bootstrap_form_errors form %}
-    {% bootstrap_form form exclude="resume_link" %}
+    {% bootstrap_form form alert_error_type="all" %}
 
     {% if ITOU_ENVIRONMENT == "PROD" %}
         {% if request.user.is_job_seeker %}

--- a/itou/utils/address/forms.py
+++ b/itou/utils/address/forms.py
@@ -47,9 +47,13 @@ class AddressFormMixin(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Needed for proper auto-completion when existing in DB
-        # Reverted back on clean
-        self.initial["city_name"] = self.initial.get("city")
+        # Needed for proper auto-completion when existing in DB.
+        if self.instance and hasattr(self.instance, "city") and hasattr(self.instance, "department"):
+            self.initial["city_name"] = self.instance.city
+            # Populate the hidden `city` field.
+            city = City.objects.filter(name=self.instance.city, department=self.instance.department).first()
+            if city:
+                self.initial["city"] = city.slug
 
     def clean(self):
         cleaned_data = super().clean()

--- a/itou/utils/address/forms.py
+++ b/itou/utils/address/forms.py
@@ -43,6 +43,12 @@ class AddressFormMixin(forms.Form):
         label="Code postal",
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Needed for proper auto-completion when existing in DB
+        # Reverted back on clean
+        self.initial["city_name"] = self.initial.get("city")
+
     def clean(self):
         cleaned_data = super().clean()
 
@@ -70,9 +76,3 @@ class AddressFormMixin(forms.Form):
 
         if not valid:
             raise ValidationError("Adresse incomplète")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Needed for proper auto-completion when existing in DB
-        # Reverted back on clean
-        self.initial["city_name"] = self.initial.get("city")

--- a/itou/utils/address/forms.py
+++ b/itou/utils/address/forms.py
@@ -1,5 +1,4 @@
 import django.forms as forms
-from django.core.exceptions import ValidationError
 from django.urls import reverse_lazy
 
 from itou.cities.models import City
@@ -21,6 +20,7 @@ class AddressFormMixin(forms.Form):
             attrs={
                 "class": "js-city-autocomplete-input form-control",
                 "data-autocomplete-source-url": ALL_CITY_AUTOCOMPLETE_SOURCE_URL,
+                "data-autosubmit-on-enter-pressed": 0,
                 "placeholder": "Nom de la ville",
                 "autocomplete": "off",
             }

--- a/itou/utils/address/forms.py
+++ b/itou/utils/address/forms.py
@@ -10,6 +10,8 @@ class AddressFormMixin(forms.Form):
 
     ALL_CITY_AUTOCOMPLETE_SOURCE_URL = reverse_lazy("autocomplete:cities")
 
+    # The hidden `city` field is populated by the autocomplete JavaScript mechanism,
+    # see `city_autocomplete_field.js`.
     city = forms.CharField(required=False, widget=forms.HiddenInput(attrs={"class": "js-city-autocomplete-hidden"}))
 
     city_name = forms.CharField(

--- a/itou/www/search/forms.py
+++ b/itou/www/search/forms.py
@@ -32,6 +32,7 @@ class SiaeSearchForm(forms.Form):
             attrs={
                 "class": "js-city-autocomplete-input form-control",
                 "data-autocomplete-source-url": CITY_AUTOCOMPLETE_SOURCE_URL,
+                "data-autosubmit-on-enter-pressed": 1,
                 "placeholder": "Autour de (Arras, Bobigny, Strasbourg…)",
                 "autocomplete": "off",
             }
@@ -77,6 +78,7 @@ class PrescriberSearchForm(forms.Form):
             attrs={
                 "class": "js-city-autocomplete-input form-control",
                 "data-autocomplete-source-url": CITY_AUTOCOMPLETE_SOURCE_URL,
+                "data-autosubmit-on-enter-pressed": 1,
                 "placeholder": "Autour de (Arras, Bobigny, Strasbourg…)",
                 "autocomplete": "off",
             }


### PR DESCRIPTION
### Quoi ?

Correctif pour l'erreur "Cette ville n'existe pas".

### Pourquoi ?

Pour soulager le support.

### Comment ?

`AddressFormMixin` permet d'ajouter une adresse avec un mécanisme d'auto-complétion pour la ville.

Ce mécanisme est basé sur `js-city-autocomplete-input` qui travaille avec deux champs :

- `city` un champ masqué contenant un slug de la ville
- `city_name` le nom de la ville en toutes lettres

**Problème** : si une adresse existait déjà pour une instance de modèle, le champ caché `city` n'était pas pré-rempli.

Du coup au moment de la validation on tombait systématiquement sur l'erreur "Cette ville n'existe pas", quand bien même la ville était déjà renseignée en toutes lettres.

### Captures d'écran (optionnel)

### Autre

- déplacement de `AddressFormMixin.__init__()`
- affichage des erreurs une seule fois dans le template avec `alert_error_type="all"`
- affichage des erreurs dans le formulaire au niveau des champs correspondants
- possibilité de désactiver la soumission automatique du formulaire quand on clique sur une ville du menu d'auto-complétion : c'est parfait pour la recherche mais hyper pénible dans les autres interfaces