### PR TITLE
Correctif pour 'CreateJobSeekerForm' has no field named 'addr1'

### DIFF
--- a/itou/templates/apply/submit_step_job_seeker_create.html
+++ b/itou/templates/apply/submit_step_job_seeker_create.html
@@ -26,7 +26,7 @@
 
         <div class="form-group row">
             {% bootstrap_field form.post_code form_group_class="col-md-3 col-sm-12 form-group"%}
-            {% bootstrap_field form.city_name form_group_class="col form-group"%}
+            {% bootstrap_field form.city_slug form_group_class="col form-group"%}
             {% bootstrap_field form.city %}
         </div>
 

--- a/itou/templates/apply/submit_step_job_seeker_create.html
+++ b/itou/templates/apply/submit_step_job_seeker_create.html
@@ -25,9 +25,11 @@
         {% bootstrap_field form.address_line_2 %}
 
         <div class="form-group row">
-            {% bootstrap_field form.post_code form_group_class="col-md-3 col-sm-12 form-group"%}
-            {% bootstrap_field form.city_slug form_group_class="col form-group"%}
-            {% bootstrap_field form.city %}
+            {# Use Bootstrap's grid system of 12 columns to put `post_code` and `city` on the same line. #}
+            {% bootstrap_field form.post_code form_group_class="form-group col-md-5"%}
+            {% bootstrap_field form.city form_group_class="form-group col-md-7"%}
+            {# Add the hidden field `city_slug`. #}
+            {% bootstrap_field form.city_slug %}
         </div>
 
         {% bootstrap_field form.pole_emploi_id %}

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -1,47 +1,55 @@
-<div class="card mb-2">
-    
+<div class="card my-4">
+
     <div class="card-header">
         <b>{{ item.job_seeker.get_full_name|title }}</b>
     </div>
 
     <div class="card-body">
+
         <div class="row">
+
             <div class="col-md-7">
                 <p class="m-0">Début de contrat : <b>{{ item.hiring_start_at }}</b></p>
                 <p class="m-0">Fin de contrat : <b>{{ item.hiring_end_at }}</b></p>
                 <p class="m-0">Numéro de PASS IAE (agrément) : <b>{{ item.approval.number_with_spaces }}</b></p>
             </div>
-       
-    {% if form.status.value == "NEW" %}
+
+            {# Statuses. #}
+            {% if form.status.value == "SENT" %}
+                <div class="col-md-5 text-right">
+                    <p class="m-0 pt-1 badge badge-warning">Transmise à l'ASP le : <b>{{ item.updated_at }}</b></p>
+                </div>
+            {% elif form.status.value == "REJECTED" %}
+                <div class="col-md-5 text-right">
+                    <p class="m-0 pt-1 badge badge-danger">Rejetée par l'ASP le : <b>{{ item.updated_at }}</b></p>
+                </div>
+            {% elif form.status.value == "PROCESSED" %}
+                <div class="col-md-5 text-right">
+                    <p class="m-0 pt-1 badge badge-success">Validée par l'ASP le : <b>{{ item.updated_at }}</b></p>
+                </div>
+            {% endif %}
+
         </div>
-        <div>
-            <a href="#" class="btn btn-outline-primary float-right">Créer la fiche salarié</a>
-        </div>
-            
-    {% elif form.status.value == "SENT" %}
-            <div class="col-md-5 text-right">
-                <p class="m-0 pt-1 badge badge-warning">Transmise à l'ASP le : <b>{{ item.updated_at }}</b></p> 
+
+        {# Actions. #}
+        {% if form.status.value == "NEW" %}
+            <div>
+                <a href="#" class="btn btn-outline-primary float-right">Créer la fiche salarié</a>
             </div>
-        </div>
-        <div>
-            <a href="#" class="btn btn-outline-primary float-right">Voir le détail de la fiche salarié</a>
-        </div>
-    {% elif form.status.value == "REJECTED" %}
-        <div class="col-md-5 text-right">
-                <p class="m-0 pt-1 badge badge-danger">Rejetée par l'ASP le : <b>{{ item.updated_at }}</b></p> 
+        {% elif form.status.value == "SENT" %}
+            <div>
+                <a href="#" class="btn btn-outline-primary float-right">Voir le détail de la fiche salarié</a>
             </div>
-        </div>
-        <div>
-            <a href="#" class="btn btn-outline-primary float-right">Modifier la fiche salarié</a>
-        </div>
-    {% elif form.status.value == "PROCESSED" %}
-            <div class="col-md-5 text-right">
-                <p class="m-0 pt-1 badge badge-success">Validée par l'ASP le : <b>{{ item.updated_at }}</b></p> 
+        {% elif form.status.value == "REJECTED" %}
+            <div>
+                <a href="#" class="btn btn-outline-primary float-right">Modifier la fiche salarié</a>
             </div>
-        </div>
-        <div>
-            <a href="#" class="btn btn-outline-primary float-right">Voir le détail de la fiche salarié</a>
-        </div>
-    {% endif %}
+        {% elif form.status.value == "PROCESSED" %}
+            <div>
+                <a href="#" class="btn btn-outline-primary float-right">Voir le détail de la fiche salarié</a>
+            </div>
+        {% endif %}
+
     </div>
+
 </div>

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -11,7 +11,7 @@
 <h1>Fiches salarié ASP - <span class="text-muted">{{ current_siae.display_name }}</span></h1>
 
 <div class="ml-0 mt-3">
-    <form method="GET" class="form">
+    <form method="get" class="form">
         <div class="row">
             <div class="col-sm-3">
                 <div class="card-deck">

--- a/itou/utils/address/forms.py
+++ b/itou/utils/address/forms.py
@@ -78,7 +78,7 @@ class AddressFormMixin(forms.Form):
         empty_address = not any([addr1, addr2, post_code, city_slug])
         if not empty_address and not valid_address:
             if not addr1:
-                self.add_error("addr1", "Adresse : ce champ est obligatoire.")
+                self.add_error("address_line_1", "Adresse : ce champ est obligatoire.")
             if not post_code:
                 self.add_error("post_code", "Code postal : ce champ est obligatoire.")
             if not city_slug:

--- a/itou/utils/address/forms.py
+++ b/itou/utils/address/forms.py
@@ -9,11 +9,13 @@ class AddressFormMixin(forms.Form):
 
     ALL_CITY_AUTOCOMPLETE_SOURCE_URL = reverse_lazy("autocomplete:cities")
 
-    # The hidden `city` field is populated by the autocomplete JavaScript mechanism,
-    # see `city_autocomplete_field.js`.
-    city = forms.CharField(required=False, widget=forms.HiddenInput(attrs={"class": "js-city-autocomplete-hidden"}))
+    # The hidden `city_slug` field is populated by the autocomplete JavaScript
+    # mechanism, see `city_autocomplete_field.js`.
+    city_slug = forms.CharField(
+        required=False, widget=forms.HiddenInput(attrs={"class": "js-city-autocomplete-hidden"})
+    )
 
-    city_name = forms.CharField(
+    city = forms.CharField(
         label="Ville",
         required=False,
         widget=forms.TextInput(
@@ -50,25 +52,23 @@ class AddressFormMixin(forms.Form):
         # Needed for proper auto-completion when `AddressFormMixin` is used with
         # a ModelForm which has an instance existing in DB.
         if hasattr(self, "instance") and hasattr(self.instance, "city") and hasattr(self.instance, "department"):
-            self.initial["city_name"] = self.instance.city
+            self.initial["city"] = self.instance.city
             # Populate the hidden `city` field.
             city = City.objects.filter(name=self.instance.city, department=self.instance.department).first()
             if city:
-                self.initial["city"] = city.slug
+                self.initial["city_slug"] = city.slug
 
     def clean(self):
         cleaned_data = super().clean()
 
-        city_slug = cleaned_data["city"]
+        city_slug = cleaned_data["city_slug"]
 
         if city_slug:
             try:
-                # TODO: use more intuitive field names.
-                # Override the `city` field in `cleaned_data` with the real city name
-                # because the value will be stored in `AddressMixin.city`.
+                # Override the `city` field with the real city name.
                 cleaned_data["city"] = City.objects.get(slug=city_slug).name
             except City.DoesNotExist:
-                raise forms.ValidationError({"city_name": "Cette ville n'existe pas."})
+                raise forms.ValidationError({"city": "Cette ville n'existe pas."})
 
         # Basic check of address fields.
         addr1, addr2, post_code, city = (
@@ -86,4 +86,4 @@ class AddressFormMixin(forms.Form):
             if not post_code:
                 self.add_error("post_code", "Code postal : ce champ est obligatoire.")
             if not city_slug:
-                self.add_error("city_name", "Ville : ce champ est obligatoire.")
+                self.add_error("city", "Ville : ce champ est obligatoire.")

--- a/itou/utils/address/tests.py
+++ b/itou/utils/address/tests.py
@@ -1,0 +1,101 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from itou.prescribers.models import PrescriberOrganization
+from itou.utils.address.departments import department_from_postcode
+from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
+
+
+class UtilsAddressMixinTest(TestCase):
+    @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
+    def test_set_coords(self, mock_call_ban_geocoding_api):
+        """
+        Test `AddressMixin.set_coords()`.
+        Use `PrescriberOrganization` which inherits from abstract `AddressMixin`.
+        """
+        prescriber = PrescriberOrganization.objects.create(siret="12000015300011")
+
+        self.assertEqual(prescriber.address_line_1, "")
+        self.assertEqual(prescriber.address_line_2, "")
+        self.assertEqual(prescriber.post_code, "")
+        self.assertEqual(prescriber.city, "")
+        self.assertEqual(prescriber.coords, None)
+        self.assertEqual(prescriber.geocoding_score, None)
+        self.assertEqual(prescriber.latitude, None)
+        self.assertEqual(prescriber.longitude, None)
+
+        prescriber.set_coords("10 PL 5 MARTYRS LYCEE BUFFON", post_code="75015")
+        prescriber.save()
+
+        # Expected data comes from BAN_GEOCODING_API_RESULT_MOCK.
+        expected_coords = "SRID=4326;POINT (2.316754 48.838411)"
+        expected_latitude = 48.838411
+        expected_longitude = 2.316754
+        expected_geocoding_score = 0.587663373207207
+
+        self.assertEqual(prescriber.coords, expected_coords)
+        self.assertEqual(prescriber.geocoding_score, expected_geocoding_score)
+        self.assertEqual(prescriber.latitude, expected_latitude)
+        self.assertEqual(prescriber.longitude, expected_longitude)
+
+    @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
+    def test_set_coords_and_address(self, mock_call_ban_geocoding_api):
+        """
+        Test `AddressMixin.set_coords_and_address()`.
+        Use `PrescriberOrganization` which inherits from abstract `AddressMixin`.
+        """
+        prescriber = PrescriberOrganization.objects.create(siret="12000015300011")
+
+        self.assertEqual(prescriber.address_line_1, "")
+        self.assertEqual(prescriber.address_line_2, "")
+        self.assertEqual(prescriber.post_code, "")
+        self.assertEqual(prescriber.city, "")
+        self.assertEqual(prescriber.coords, None)
+        self.assertEqual(prescriber.geocoding_score, None)
+        self.assertEqual(prescriber.latitude, None)
+        self.assertEqual(prescriber.longitude, None)
+
+        prescriber.set_coords_and_address("10 PL 5 MARTYRS LYCEE BUFFON", post_code="75015")
+        prescriber.save()
+
+        # Expected data comes from BAN_GEOCODING_API_RESULT_MOCK.
+        expected_address_line_1 = "10 Pl des Cinq Martyrs du Lycee Buffon"
+        expected_post_code = "75015"
+        expected_city = "Paris"
+        expected_coords = "SRID=4326;POINT (2.316754 48.838411)"
+        expected_latitude = 48.838411
+        expected_longitude = 2.316754
+        expected_geocoding_score = 0.587663373207207
+
+        self.assertEqual(prescriber.address_line_1, expected_address_line_1)
+        self.assertEqual(prescriber.address_line_2, "")
+        self.assertEqual(prescriber.post_code, expected_post_code)
+        self.assertEqual(prescriber.city, expected_city)
+        self.assertEqual(prescriber.coords, expected_coords)
+        self.assertEqual(prescriber.geocoding_score, expected_geocoding_score)
+        self.assertEqual(prescriber.latitude, expected_latitude)
+        self.assertEqual(prescriber.longitude, expected_longitude)
+
+
+class UtilsDepartmentsTest(TestCase):
+    def test_department_from_postcode(self):
+        # Corsica south == 2A
+        post_codes = ["20000", "20137", "20700"]
+        for post_code in post_codes:
+            self.assertEqual(department_from_postcode(post_code), "2A")
+
+        # Corsica north == 2B
+        post_codes = ["20240", "20220", "20407", "20660"]
+        for post_code in post_codes:
+            self.assertEqual(department_from_postcode(post_code), "2B")
+
+        # DOM
+        post_codes = ["97500", "97000", "98800", "98000"]
+        for post_code in post_codes:
+            self.assertEqual(department_from_postcode(post_code), post_code[:3])
+
+        # Any other city
+        post_codes = ["13150", "30210", "17000"]
+        for post_code in post_codes:
+            self.assertEqual(department_from_postcode(post_code), post_code[:2])

--- a/itou/utils/address/tests.py
+++ b/itou/utils/address/tests.py
@@ -118,8 +118,8 @@ class DummyUserModelForm(AddressFormMixin, forms.ModelForm):
             "address_line_1",
             "address_line_2",
             "post_code",
-            "city_name",
             "city",
+            "department",
         ]
 
 
@@ -136,8 +136,8 @@ class UtilsAddressFormMixinTest(TestCase):
         form = AddressFormMixin(data=form_data)
         self.assertTrue(form.is_valid())
         expected_cleaned_data = {
+            "city_slug": "",
             "city": "",
-            "city_name": "",
             "address_line_1": "",
             "address_line_2": "",
             "post_code": "",
@@ -149,8 +149,8 @@ class UtilsAddressFormMixinTest(TestCase):
         `address_line_1` is missing but `address_line_2` exists.
         """
         form_data = {
+            "city_slug": "",
             "city": "",
-            "city_name": "",
             "address_line_1": "",
             "address_line_2": "11 rue des pixels cassés",
             "post_code": "",
@@ -159,7 +159,7 @@ class UtilsAddressFormMixinTest(TestCase):
         self.assertFalse(form.is_valid())
         self.assertEqual(form.errors["address_line_1"][0], "Adresse : ce champ est obligatoire.")
         self.assertEqual(form.errors["post_code"][0], "Code postal : ce champ est obligatoire.")
-        self.assertEqual(form.errors["city_name"][0], "Ville : ce champ est obligatoire.")
+        self.assertEqual(form.errors["city"][0], "Ville : ce champ est obligatoire.")
 
     def test_fecth_city(self):
         """
@@ -170,8 +170,8 @@ class UtilsAddressFormMixinTest(TestCase):
         city = City.objects.first()
 
         form_data = {
-            "city": city.slug,
-            "city_name": "",
+            "city_slug": city.slug,
+            "city": "",
             "address_line_1": "11 rue des pixels cassés",
             "address_line_2": "",
             "post_code": "67000",
@@ -182,8 +182,8 @@ class UtilsAddressFormMixinTest(TestCase):
         with self.assertNumQueries(1):
             self.assertTrue(form.is_valid())
             expected_cleaned_data = {
-                "city": city.name,  # should have been replaced in `AddressFormMixin.clean()`.
-                "city_name": "",
+                "city_slug": city.slug,
+                "city": city.name,
                 "address_line_1": form_data["address_line_1"],
                 "address_line_2": form_data["address_line_2"],
                 "post_code": form_data["post_code"],
@@ -192,7 +192,7 @@ class UtilsAddressFormMixinTest(TestCase):
 
     def test_with_instance(self):
         """
-        If an instance is passed, `city` and `city_name` should be prepopulated.
+        If an instance is passed, `city` and `city_slug` should be prepopulated.
         """
 
         create_test_cities(["57"], num_per_department=1)
@@ -209,5 +209,5 @@ class UtilsAddressFormMixinTest(TestCase):
 
             form = DummyUserModelForm(data={}, instance=user)
 
-            self.assertEqual(form.initial["city"], city.slug)
-            self.assertEqual(form.initial["city_name"], city.name)
+            self.assertEqual(form.initial["city_slug"], city.slug)
+            self.assertEqual(form.initial["city"], city.name)

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -13,12 +13,10 @@ from django.test import RequestFactory, SimpleTestCase, TestCase
 from factory import Faker
 
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
-from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
 from itou.siaes.models import Siae, SiaeMembership
 from itou.users.factories import JobSeekerFactory, PrescriberFactory
 from itou.users.models import User
-from itou.utils.address.departments import department_from_postcode
 from itou.utils.apis.api_entreprise import EtablissementAPI
 from itou.utils.apis.geocoding import process_geocoding_data
 from itou.utils.emails import sanitize_mailjet_recipients
@@ -187,77 +185,6 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
             self.assertDictEqual(expected, result)
 
 
-class UtilsAddressMixinTest(TestCase):
-    @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
-    def test_set_coords(self, mock_call_ban_geocoding_api):
-        """
-        Test `AddressMixin.set_coords()`.
-        Use `PrescriberOrganization` which inherits from abstract `AddressMixin`.
-        """
-        prescriber = PrescriberOrganization.objects.create(siret="12000015300011")
-
-        self.assertEqual(prescriber.address_line_1, "")
-        self.assertEqual(prescriber.address_line_2, "")
-        self.assertEqual(prescriber.post_code, "")
-        self.assertEqual(prescriber.city, "")
-        self.assertEqual(prescriber.coords, None)
-        self.assertEqual(prescriber.geocoding_score, None)
-        self.assertEqual(prescriber.latitude, None)
-        self.assertEqual(prescriber.longitude, None)
-
-        prescriber.set_coords("10 PL 5 MARTYRS LYCEE BUFFON", post_code="75015")
-        prescriber.save()
-
-        # Expected data comes from BAN_GEOCODING_API_RESULT_MOCK.
-        expected_coords = "SRID=4326;POINT (2.316754 48.838411)"
-        expected_latitude = 48.838411
-        expected_longitude = 2.316754
-        expected_geocoding_score = 0.587663373207207
-
-        self.assertEqual(prescriber.coords, expected_coords)
-        self.assertEqual(prescriber.geocoding_score, expected_geocoding_score)
-        self.assertEqual(prescriber.latitude, expected_latitude)
-        self.assertEqual(prescriber.longitude, expected_longitude)
-
-    @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
-    def test_set_coords_and_address(self, mock_call_ban_geocoding_api):
-        """
-        Test `AddressMixin.set_coords_and_address()`.
-        Use `PrescriberOrganization` which inherits from abstract `AddressMixin`.
-        """
-        prescriber = PrescriberOrganization.objects.create(siret="12000015300011")
-
-        self.assertEqual(prescriber.address_line_1, "")
-        self.assertEqual(prescriber.address_line_2, "")
-        self.assertEqual(prescriber.post_code, "")
-        self.assertEqual(prescriber.city, "")
-        self.assertEqual(prescriber.coords, None)
-        self.assertEqual(prescriber.geocoding_score, None)
-        self.assertEqual(prescriber.latitude, None)
-        self.assertEqual(prescriber.longitude, None)
-
-        prescriber.set_coords_and_address("10 PL 5 MARTYRS LYCEE BUFFON", post_code="75015")
-        prescriber.save()
-
-        # Expected data comes from BAN_GEOCODING_API_RESULT_MOCK.
-        expected_address_line_1 = "10 Pl des Cinq Martyrs du Lycee Buffon"
-        expected_post_code = "75015"
-        expected_city = "Paris"
-        expected_coords = "SRID=4326;POINT (2.316754 48.838411)"
-        expected_latitude = 48.838411
-        expected_longitude = 2.316754
-        expected_geocoding_score = 0.587663373207207
-
-        self.assertEqual(prescriber.address_line_1, expected_address_line_1)
-        self.assertEqual(prescriber.address_line_2, "")
-        self.assertEqual(prescriber.post_code, expected_post_code)
-        self.assertEqual(prescriber.city, expected_city)
-        self.assertEqual(prescriber.coords, expected_coords)
-        self.assertEqual(prescriber.geocoding_score, expected_geocoding_score)
-        self.assertEqual(prescriber.latitude, expected_latitude)
-        self.assertEqual(prescriber.longitude, expected_longitude)
-
-
 class UtilsGeocodingTest(TestCase):
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
     def test_process_geocoding_data(self, mock_call_ban_geocoding_api):
@@ -278,29 +205,6 @@ class UtilsGeocodingTest(TestCase):
             "coords": GEOSGeometry("POINT(2.316754 48.838411)"),
         }
         self.assertEqual(result, expected)
-
-
-class UtilsDepartmentsTest(TestCase):
-    def test_department_from_postcode(self):
-        # Corsica south == 2A
-        post_codes = ["20000", "20137", "20700"]
-        for post_code in post_codes:
-            self.assertEqual(department_from_postcode(post_code), "2A")
-
-        # Corsica north == 2B
-        post_codes = ["20240", "20220", "20407", "20660"]
-        for post_code in post_codes:
-            self.assertEqual(department_from_postcode(post_code), "2B")
-
-        # DOM
-        post_codes = ["97500", "97000", "98800", "98000"]
-        for post_code in post_codes:
-            self.assertEqual(department_from_postcode(post_code), post_code[:3])
-
-        # Any other city
-        post_codes = ["13150", "30210", "17000"]
-        for post_code in post_codes:
-            self.assertEqual(department_from_postcode(post_code), post_code[:2])
 
 
 class UtilsValidatorsTest(TestCase):

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -100,7 +100,7 @@ class CreateJobSeekerForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
             "address_line_1",
             "address_line_2",
             "post_code",
-            "city_name",
+            "city_slug",
             "city",
             "pole_emploi_id",
             "lack_of_pole_emploi_id_reason",
@@ -121,9 +121,9 @@ class CreateJobSeekerForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
         self._meta.model.clean_pole_emploi_fields(self.cleaned_data)
 
     def save(self, commit=True):
-        # Exclude 'city_name' form field (not mapped to model)
+        # Exclude 'city_slug' form field (not mapped to model)
         partial_fields = self.cleaned_data
-        del partial_fields["city_name"]
+        del partial_fields["city_slug"]
 
         if commit:
             return self._meta.model.create_job_seeker_by_proxy(self.proxy_user, **partial_fields)
@@ -359,12 +359,12 @@ class UserAddressForm(AddressFormMixin, forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        for field in ["address_line_1", "post_code", "city_name"]:
+        for field in ["address_line_1", "post_code", "city"]:
             self.fields[field].required = True
 
     class Meta:
         model = User
-        fields = ["address_line_1", "address_line_2", "post_code", "city_name", "city"]
+        fields = ["address_line_1", "address_line_2", "post_code", "city_slug", "city"]
 
 
 class FilterJobApplicationsForm(forms.Form):

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -173,8 +173,8 @@ class ProcessViewsTest(TestCase):
         address = {
             "address_line_1": job_seeker.address_line_1,
             "post_code": job_seeker.post_code,
-            "city_name": city.name,
-            "city": city.slug,
+            "city": city.name,
+            "city_slug": city.slug,
         }
 
         for state in [JobApplicationWorkflow.STATE_PROCESSING, JobApplicationWorkflow.STATE_OBSOLETE]:
@@ -298,8 +298,8 @@ class ProcessViewsTest(TestCase):
             # Data for `UserAddressForm`.
             "address_line_1": "11 rue des Lilas",
             "post_code": "57000",
-            "city_name": city.name,
-            "city": city.slug,
+            "city": city.name,
+            "city_slug": city.slug,
             # Data for `AcceptForm`.
             "hiring_start_at": datetime.date.today().strftime("%d/%m/%Y"),
             "hiring_end_at": (datetime.date.today() + datetime.timedelta(days=360)).strftime("%d/%m/%Y"),
@@ -335,8 +335,8 @@ class ProcessViewsTest(TestCase):
             "answer": "",
             "address_line_1": job_application.job_seeker.address_line_1,
             "post_code": job_application.job_seeker.post_code,
-            "city_name": "Metz",
-            "city": "metz",
+            "city": "Metz",
+            "city_slug": "metz",
         }
         response = self.client.post(url, data=post_data)
         self.assertFormError(
@@ -350,8 +350,8 @@ class ProcessViewsTest(TestCase):
         base_for_post_data = {
             "address_line_1": job_seeker.address_line_1,
             "post_code": job_seeker.post_code,
-            "city_name": city.name,
-            "city": city.slug,
+            "city": city.name,
+            "city_slug": city.slug,
             "pole_emploi_id": job_seeker.pole_emploi_id,
             "answer": "",
         }

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -607,8 +607,8 @@ class ApplyAsPrescriberTest(TestCase):
             "address_line_1": "55, avenue de la Rose",
             "address_line_2": "7e étage",
             "post_code": "67200",
-            "city_name": "Sommerau (67)",
-            "city": "sommerau-67",
+            "city": "Sommerau (67)",
+            "city_slug": "sommerau-67",
         }
 
         response = self.client.post(next_url, data=post_data)

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -57,7 +57,7 @@ class EditUserInfoForm(AddressFormMixin, ResumeFormMixin, forms.ModelForm):
             "address_line_2",
             "post_code",
             "city",
-            "city_name",
+            "city_slug",
             "pole_emploi_id",
             "lack_of_pole_emploi_id_reason",
         ] + ResumeFormMixin.Meta.fields

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -187,8 +187,8 @@ class JobSeekerSignupTest(TestCase):
             "address_line_1": address_line_1,
             "address_line_2": address_line_2,
             "post_code": post_code,
-            "city_name": city.name,
-            "city": city.slug,
+            "city": city.name,
+            "city_slug": city.slug,
             "resume_link": resume_link,
         }
 


### PR DESCRIPTION
### Quoi ?

Correctif pour `'CreateJobSeekerForm' has no field named 'addr1'`.

### Pourquoi ?

Je me suis trompé de nom de champ et `AddressFormMixin` n'était pas couvert par des tests.

### Comment ?

Ajout de tests pour `AddressFormMixin`.

### Autre

Déplacement des tests qui concernent `itou.utils.address` dans `itou.utils.address.tests` plutôt que de venir gonfler le fichier des tests à la racine du dossier `utils` : `itou.utils.tests`.

Ça sera probablement plus simple à revoir commit par commit.