### PR TITLE
Correctif pour `test_is_open_to_prolongation`

### DIFF
--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -314,7 +314,7 @@ class ApprovalModelTest(TestCase):
         end_at = (
             today
             + relativedelta(months=Approval.PROLONGATION_PERIOD_BEFORE_APPROVAL_END_MONTHS)
-            + relativedelta(days=1)
+            + relativedelta(days=5)
         )
         start_at = end_at - relativedelta(years=2)
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
@@ -324,7 +324,7 @@ class ApprovalModelTest(TestCase):
         end_at = (
             today
             + relativedelta(months=Approval.PROLONGATION_PERIOD_BEFORE_APPROVAL_END_MONTHS)
-            - relativedelta(days=1)
+            - relativedelta(days=5)
         )
         start_at = end_at - relativedelta(years=2)
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -310,7 +310,8 @@ class ApprovalModelTest(TestCase):
 
         today = datetime.date.today()
 
-        # Set "now" to be "before" the day approval is open to prolongation.
+        # Ensure "now" is "before" the period of time during which it
+        # is possible to prolong a PASS IAE.
         end_at = (
             today
             + relativedelta(months=Approval.PROLONGATION_PERIOD_BEFORE_APPROVAL_END_MONTHS)
@@ -320,7 +321,8 @@ class ApprovalModelTest(TestCase):
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
         self.assertFalse(approval.is_open_to_prolongation)
 
-        # Set "now" to be "after" the day approval is open to prolongation.
+        # Ensure "now" is "after" the period of time during which it
+        # is possible to prolong a PASS IAE.
         end_at = (
             today
             + relativedelta(months=Approval.PROLONGATION_PERIOD_BEFORE_APPROVAL_END_MONTHS)

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -308,9 +308,11 @@ class ApprovalModelTest(TestCase):
 
     def test_is_open_to_prolongation(self):
 
+        today = datetime.date.today()
+
         # Set "now" to be "before" the day approval is open to prolongation.
         end_at = (
-            datetime.date.today()
+            today
             + relativedelta(months=Approval.PROLONGATION_PERIOD_BEFORE_APPROVAL_END_MONTHS)
             + relativedelta(days=1)
         )
@@ -320,7 +322,7 @@ class ApprovalModelTest(TestCase):
 
         # Set "now" to be "after" the day approval is open to prolongation.
         end_at = (
-            datetime.date.today()
+            today
             + relativedelta(months=Approval.PROLONGATION_PERIOD_BEFORE_APPROVAL_END_MONTHS)
             - relativedelta(days=1)
         )


### PR DESCRIPTION
### Quoi ?

Correctif pour `test_is_open_to_prolongation`.

### Pourquoi ?

Le test casse quand on est le dernier jour du mois. Exemple : 30 avril 2021.

### Comment ?

Le test casse de temps en temps car on fait des calculs sur la base de 3 mois plus ou moins 1 jour pour s'assurer qu'on est dans la période ou en dehors.

Or 1 jour n'est pas suffisant pour éviter les périodes ambiguës. Quid des mois qui ont 28, 29, 30 ou 31 jours ?

Pour fixer le problème, on ajoute ou retranche une durée de 5 jours permettant d'éviter les cas ambigus.

> https://github.com/dateutil/dateutil/issues/1134