### PR TITLE
Amélioration des erreurs S3 envoyées à Sentry

### DIFF
--- a/itou/static/js/s3_upload.js
+++ b/itou/static/js/s3_upload.js
@@ -112,14 +112,13 @@ window.s3UploadInit = function s3UploadInit({
 
   dropzone.on("error", function (file, errorMessage, xhr) {
     let statusCode = 500;
+    errorMessage = JSON.stringify(errorMessage);
 
     if (xhr != null) {
       if (xhr.responseText != null) {
         statusCode = xhr.status;
         let responseJson = JSON.parse(xhr.responseText);
         errorMessage = responseJson["Message"];
-
-        // Override strange [object Object] error message.
         file.previewElement.querySelectorAll('[data-dz-errormessage]')[0].textContent = "Erreur technique. Merci de recommencer.";
       }
 
@@ -133,7 +132,6 @@ window.s3UploadInit = function s3UploadInit({
         error_message: sentryErrorMessage,
         csrfmiddlewaretoken: sentryCsrfToken,
       });
-
     }
   });
 };

--- a/itou/static/js/s3_upload.js
+++ b/itou/static/js/s3_upload.js
@@ -48,7 +48,7 @@ window.s3UploadInit = function s3UploadInit({
     dictFallbackMessage: "Ce navigateur n'est pas compatible",
     dictFileTooBig: "Fichier trop volumineux",
     dictInvalidFileType: "Type de fichier non pris en charge",
-    dictResponseError: "Erreur technique",
+    dictResponseError: "Erreur technique {{statusCode}}. Merci de recommencer.",
     dictCancelUpload: "Annuler",
     dictUploadCanceled: "Annulé",
     dictCancelUploadConfirmation: "Voulez-vous vraiment annuler le transfert ?",
@@ -111,17 +111,29 @@ window.s3UploadInit = function s3UploadInit({
   });
 
   dropzone.on("error", function (file, errorMessage, xhr) {
+    let statusCode = 500;
+
     if (xhr != null) {
+      if (xhr.responseText != null) {
+        statusCode = xhr.status;
+        let responseJson = JSON.parse(xhr.responseText);
+        errorMessage = responseJson["Message"];
+
+        // Override strange [object Object] error message.
+        file.previewElement.querySelectorAll('[data-dz-errormessage]')[0].textContent = "Erreur technique. Merci de recommencer.";
+      }
+
       // An error occurred with the request.
       // Send it to Sentry to avoid silent bugs.
       const sentryErrorMessage =
         `Unable to upload "${file.upload.filename}" ` +
         `(${file.upload.progress} of ${file.upload.total}) to S3 ${formUrl}: ${errorMessage}`;
       $.post(sentryInternalUrl, {
-        status_code: 500,
+        status_code: statusCode,
         error_message: sentryErrorMessage,
         csrfmiddlewaretoken: sentryCsrfToken,
       });
+
     }
   });
 };


### PR DESCRIPTION
### Quoi ?
Modification du message d'erreur envoyé à Sentry et de celui affiché à l'utilisateur. 
Cela me permettra de vérifier l'hypothèse suivante : plusieurs utilisateurs envoient le CV plus d'une heure après l'affichage du formulaire. Cela génère une erreur 403 `Expired Policy`.

### Pourquoi ?
Sentry reçoit des erreurs lorsqu'un CV ne peut être ajouté à une candidature. Actuellement, elles manquent de détail et ne nous permettent pas de résoudre parfaitement les problèmes.

### Comment ?

- Ajout d'informations dans le message envoyé à Sentry
- Modification du message d'erreur affiché à l'utilisateur si celle-ci vient d'une requête qui a échoué. 

### Captures d'écran (optionnel)

Avant : 
![image](https://user-images.githubusercontent.com/6150920/120215924-a2c87200-c236-11eb-9e08-a90866daa041.png)

Après : 
![image](https://user-images.githubusercontent.com/6150920/120215972-b1af2480-c236-11eb-9b7a-5a223657aac0.png)
