### PR TITLE
Modification de la classe de base des notifications 

### DIFF
--- a/itou/approvals/notifications.py
+++ b/itou/approvals/notifications.py
@@ -1,5 +1,6 @@
 from itou.utils.emails import get_email_message
 from itou.utils.notifications.base_class import BaseNotification
+from itou.siaes.models import SiaeMembershipQuerySet
 
 
 class NewProlongationToAuthorizedPrescriberNotification(BaseNotification):
@@ -11,6 +12,7 @@ class NewProlongationToAuthorizedPrescriberNotification(BaseNotification):
 
     def __init__(self, prolongation):
         self.prolongation = prolongation
+        super().__init__(recipients_qs=SiaeMembershipQuerySet)
 
     @property
     def email(self):

--- a/itou/approvals/notifications.py
+++ b/itou/approvals/notifications.py
@@ -1,4 +1,3 @@
-from itou.siaes.models import SiaeMembershipQuerySet
 from itou.utils.emails import get_email_message
 from itou.utils.notifications.base_class import BaseNotification
 
@@ -12,7 +11,6 @@ class NewProlongationToAuthorizedPrescriberNotification(BaseNotification):
 
     def __init__(self, prolongation):
         self.prolongation = prolongation
-        super().__init__(recipients_qs=SiaeMembershipQuerySet)
 
     @property
     def email(self):

--- a/itou/approvals/notifications.py
+++ b/itou/approvals/notifications.py
@@ -1,6 +1,6 @@
+from itou.siaes.models import SiaeMembershipQuerySet
 from itou.utils.emails import get_email_message
 from itou.utils.notifications.base_class import BaseNotification
-from itou.siaes.models import SiaeMembershipQuerySet
 
 
 class NewProlongationToAuthorizedPrescriberNotification(BaseNotification):

--- a/itou/utils/notifications/base_class.py
+++ b/itou/utils/notifications/base_class.py
@@ -46,7 +46,7 @@ class BaseNotification:
         self.email.send()
 
     def get_recipients(self):
-        return self.recipients_qs.filter(self.subscribed_lookup)
+        return self.recipients_qs.active().filter(self.subscribed_lookup)
 
     @property
     def email(self):

--- a/itou/utils/notifications/base_class.py
+++ b/itou/utils/notifications/base_class.py
@@ -1,7 +1,5 @@
 from django.db.models import Q
 
-from itou.siaes.models import SiaeMembershipQuerySet
-
 
 class BaseNotification:
     """
@@ -30,14 +28,9 @@ class BaseNotification:
     NAME = None  # Notification name as well as key used to store notification preference in the database.
     SEND_TO_UNSET_RECIPIENTS = True  # If recipients didn't express any preference, do we send it anyway?
 
-    def __init__(
-        self,
-        recipients_qs: [
-            SiaeMembershipQuerySet,
-        ],
-    ):
+    def __init__(self, recipients_qs):
         """
-        `recipients_qs`: Django QuerySet leading to this notification recipients.
+        `recipients_qs`: Django QuerySet leading to this notification recipients (Ex: itou.siaes.models.SiaeMembershipQuerySet).
         We should be able to perform a `filter()` with it.
         """
         self.recipients_qs = recipients_qs
@@ -46,7 +39,7 @@ class BaseNotification:
         self.email.send()
 
     def get_recipients(self):
-        return self.recipients_qs.active().filter(self.subscribed_lookup)
+        return self.recipients_qs.filter(self.subscribed_lookup)
 
     @property
     def email(self):

--- a/itou/utils/notifications/base_class.py
+++ b/itou/utils/notifications/base_class.py
@@ -1,5 +1,7 @@
 from django.db.models import Q
 
+from itou.siaes.models import SiaeMembershipQuerySet
+
 
 class BaseNotification:
     """
@@ -28,11 +30,11 @@ class BaseNotification:
     NAME = None  # Notification name as well as key used to store notification preference in the database.
     SEND_TO_UNSET_RECIPIENTS = True  # If recipients didn't express any preference, do we send it anyway?
 
-    def __init__(self, recipients_qs):
+    def __init__(self, recipients_qs: SiaeMembershipQuerySet):
         """
         `recipients_qs`: Django QuerySet leading to this notification recipients
         We should be able to perform a `filter()` with it.
-        Ex: itou.siaes.models.SiaeMembershipQuerySet
+        e.g. itou.siaes.models.SiaeMembershipQuerySet
         """
         self.recipients_qs = recipients_qs
 

--- a/itou/utils/notifications/base_class.py
+++ b/itou/utils/notifications/base_class.py
@@ -30,8 +30,9 @@ class BaseNotification:
 
     def __init__(self, recipients_qs):
         """
-        `recipients_qs`: Django QuerySet leading to this notification recipients (Ex: itou.siaes.models.SiaeMembershipQuerySet).
+        `recipients_qs`: Django QuerySet leading to this notification recipients
         We should be able to perform a `filter()` with it.
+        Ex: itou.siaes.models.SiaeMembershipQuerySet
         """
         self.recipients_qs = recipients_qs
 

--- a/itou/utils/notifications/tests.py
+++ b/itou/utils/notifications/tests.py
@@ -54,7 +54,7 @@ class NotificationsBaseClassTest(TestCase):
             self.siaemembership_set.filter(user__email__in=recipients_emails).count(), len(recipients_emails)
         )
 
-    def test_desactivate_user_not_in_recipients_email(self):
+    def test_inactive_user_not_in_recipients(self):
         SiaeMembershipFactory(siae=self.siae, user__is_active=False, is_siae_admin=False)
         self.assertEqual(self.siaemembership_set.count(), 2)
 

--- a/itou/utils/notifications/tests.py
+++ b/itou/utils/notifications/tests.py
@@ -57,7 +57,7 @@ class NotificationsBaseClassTest(TestCase):
             self.siaemembership_set.filter(user__email__in=recipients_emails).count(), len(recipients_emails)
         )
 
-    def test_deasctivate_user_not_in_recipients_email(self):
+    def test_desactivate_user_not_in_recipients_email(self):
         recipients_emails = self.notification.recipients_emails
         self.assertEqual(
             self.siaemembership_set.filter(user__is_active=False, user__email__in=recipients_emails).count(), 0


### PR DESCRIPTION
### Quoi ?
Supprimer la liste des destinataires par défaut

### Pourquoi ?
Pour que la liste des destinataires soit mieux maîtrisée par les utilisateurs de la classe BaseNotification (notamment pour bien cibler les utilisateurs actifs). 

### Comment ?
Suppression de la valeur par défaut du paramètre type QuerySet + ajustement des tests unitaires

