### PR TITLE
Résolution d'une erreur Sentry

### DIFF
--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -40,7 +40,7 @@ class EtablissementAPI:
             r = httpx.get(url, headers=headers)
             r.raise_for_status()
             data = r.json()
-        except httpx.HTTPError as e:
+        except httpx.HTTPStatusError as e:
             if e.response.status_code == 422:
                 error = "SIRET non reconnu."
             else:


### PR DESCRIPTION
### Quoi ?

Des erreurs ne sont pas levées dans Sentry car elles sont [masquées par d'autres exceptions](https://sentry.io/organizations/itou/issues/2417913606/?environment=production&project=5671910&query=is%3Aunresolved).

### Pourquoi ?
L'exception `HTTPError` de HTTPx ne contient pas l'attribut `response`, or une ligne dans notre code le suppose. Pour avoir l'attribut `response`, il faut `HTTPStatusError`.

### Comment ?

Remplacement de `HTTPError` par `HTTPStatusError`.