### PR TITLE
Correction d'une erreur Javascript dans le script d'envoi S3

### DIFF
--- a/itou/static/js/s3_upload.js
+++ b/itou/static/js/s3_upload.js
@@ -114,8 +114,8 @@ window.s3UploadInit = function s3UploadInit({
     let statusCode = 500;
     errorMessage = JSON.stringify(errorMessage);
 
-    if (xhr != null) {
-      if (xhr.responseText != null) {
+    if (xhr) {
+      if (xhr.responseText) {
         statusCode = xhr.status;
         let responseJson = JSON.parse(xhr.responseText);
         errorMessage = responseJson["Message"];


### PR DESCRIPTION
Une erreur Javascript empêche l'envoi d'erreur vers Sentry.
