### PR TITLE
Tarte au citron - Désactivation de l'icône présent en bas à droite

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -316,6 +316,7 @@
             "orientation": "top",  /* Put the banner at the top to help visually impaired people */
             "showAlertSmall": false,  /* Show the small banner on bottom right */
             "cookieslist": false,  /* Show the cookie list */
+            "showIcon": false, /* Show cookie icon to manage cookies */
             "adblocker": false,  /* Show a Warning if an adblocker is detected */
             "DenyAllCta" : true, /* Show the deny all button */
             "AcceptAllCta" : true,  /* Show the accept all button when highPrivacy on */


### PR DESCRIPTION
### Quoi ?

Masquage de l'icône Tarte au citron

### Pourquoi ?

L’icône apparaît au dessus de contenu et n'est pas demandé. 

### Comment ?

Ajout des options disponibles dans la dernière version de Tarte au citron et modification de la valeur par défaut
 (optionnel)

Avant :
![screenshot-staging emplois inclusion beta gouv fr-2021 06 07-12_18_16](https://user-images.githubusercontent.com/17601807/121014710-909c8580-c79a-11eb-887c-b501ce02ae3a.png)
Après :
![screenshot-127 0 0 1_8080-2021 06 07-14_13_15](https://user-images.githubusercontent.com/17601807/121014738-972afd00-c79a-11eb-9b04-472e917535f7.png)

