### PR TITLE
Ajout de la redirection forum.inclusion -> communaute.inclusion

### DIFF
--- a/itou/utils/new_dns/middleware.py
+++ b/itou/utils/new_dns/middleware.py
@@ -23,6 +23,9 @@ class NewDnsRedirectMiddleware:
         elif host == "staging.inclusion.beta.gouv.fr":
             new_host = "staging.emplois.inclusion.beta.gouv.fr"
 
+        elif host == "forum.inclusion.beta.gouv.fr":
+            new_host = "communaute.inclusion.beta.gouv.fr"
+
         if new_host:
             return HttpResponsePermanentRedirect(f"https://{new_host}{request.get_full_path()}")
 


### PR DESCRIPTION
### Quoi ?

Ajout de la redirection forum.inclusion.beta.gouv.fr -> communaute.inclusion.beta.gouv.fr

### Pourquoi ?

Cette redirection est actuellement gérée par une instance ruby/discourse [qui ne fait plus que cela](https://github.com/betagouv/itou-discourse/pull/77). Il continue d’y avoir un peu de traffic dessus, mais nous pouvons mutualiser les redirections permanentes sur ce projet et enlever une instance.

