### PR TITLE
Les prescripteurs peuvent voir le message de refus des candidatures suivies

### DIFF
--- a/itou/templates/apply/process_details_prescriber.html
+++ b/itou/templates/apply/process_details_prescriber.html
@@ -65,6 +65,7 @@
 
     {% endif %}
 
+    <hr>
     <p>
         <a href="{{ back_url }}">Retour</a>
     </p>

--- a/itou/templates/apply/process_details_prescriber.html
+++ b/itou/templates/apply/process_details_prescriber.html
@@ -30,11 +30,35 @@
 
     {% include "apply/includes/job_application_sender_info.html" with job_application=job_application %}
 
-    <hr>
+    {# Answer ------------------------------------------------------------------------- #}
+
+    {% if job_application.refusal_reason or job_application.answer %}
+
+        <hr>
+
+        <h3 class="font-weight-normal text-muted">Réponse</h3>
+
+        {% if job_application.refusal_reason %}
+            <p>
+                <b>Motif du refus :</b><br>
+                {{ job_application.get_refusal_reason_display }}
+            </p>
+        {% endif %}
+
+        {% if job_application.answer %}
+            <div class="alert alert-secondary">
+                <p><b>Message :</b></p>
+                {{ job_application.answer|linebreaks }}
+            </div>
+        {% endif %}
+
+    {% endif %}
 
     {# History ------------------------------------------------------ #}
 
     {% if transition_logs %}
+
+        <hr>
 
         <h3 class="font-weight-normal text-muted">Historique des modifications</h3>
         {% include "apply/includes/transition_logs.html" with job_application=job_application transition_logs=transition_logs %}

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -88,7 +88,7 @@ class ProcessViewsTest(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_details_for_prescriber(self):
-        """As a prescriber, I cannot access the job_applications details for prescribers."""
+        """As a prescriber, I can access the job_applications details for prescribers."""
 
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory()
         prescriber = job_application.sender_prescriber_organization.members.first()


### PR DESCRIPTION
### Quoi ?

Ajout des éléments suivants dans la page de suivi d'une candidature côté prescripteur : 
- raison du refus,
- message associé.

### Pourquoi ?

Avant, les utilisateurs avaient cette information dans la liste de leurs candidatures. Nous avons omis de la remettre dans la page de détails.

### Captures d'écran

![image](https://user-images.githubusercontent.com/6150920/121161827-a74fe480-c84d-11eb-83cd-8003d7dce8c1.png)