### PR TITLE
Suppression de la fenêtre surgissante sur le formulaire d'embauche

### DIFF
--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -39,54 +39,38 @@
         </div>
 
         {% buttons %}
-            <a class="btn btn-secondary"
-               href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Annuler</a>
             {% if job_application.to_siae.is_subject_to_eligibility_rules %}
-                <a href="#" class="btn btn-success" data-toggle="modal" data-target="#confirmModal">Je l'embauche</a>
+                <h4 class="text-center mt-5">
+                    Obtention d'un PASS IAE
+                </h4>
+                <p class="text-center pt-2">
+                    Dans le cadre de cette embauche, souhaitez-vous obtenir un PASS IAE ?
+                </p>
+                <div class="form-group">
+                    <button type="submit" class="btn btn-success btn-block">
+                        je l'embauche et j'obtiens un PASS IAE
+                    </button>
+                    <button
+                        type="submit"
+                        class="btn btn-outline-success btn-block"
+                        onClick="$(&quot;input[name='hiring_without_approval']&quot;).val('True')">
+                            je l'embauche sans besoin d'un PASS IAE
+                    </button>
+                </div>
+                <div class="my-4 mx-5 justify-content-center">
+                    <p class="text-center">
+                        <b>Contrat de professionnalisation ?</b>
+                        Demande d'aide une fois le PASS IAE délivré !
+                    </p>
+                </div>
+                <hr class="my-4">
             {% else %}
-                <button class="btn btn-success" type="submit">Je l'embauche</button>
+                <button class="btn btn-success btn-block mt-5 mb-3" type="submit">Je l'embauche</button>
             {% endif %}
 
+            <a class="btn btn-outline-secondary btn-block"
+               href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Annuler</a>
         {% endbuttons %}
-
-        {% if job_application.to_siae.is_subject_to_eligibility_rules %}
-            <div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-labelledby="confirmModal" aria-hidden="true">
-                <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
-                    <div class="modal-content">
-                        <div class="modal-body text-center">
-                            <h4 class="modal-title">
-                                Obtention d'un PASS IAE
-                            </h4>
-                            <p class="pt-2">
-                                Dans le cadre de cette embauche, souhaitez-vous obtenir un PASS IAE ?
-                            </p>
-                            <div class="row">
-                                <div class="col pr-2">
-                                    <button type="submit" class="btn btn-success w-100">
-                                        J'obtiens un PASS IAE
-                                    </button>
-                                </div>
-                                <div class="col pl-2">
-                                    <button
-                                        type="submit"
-                                        class="btn btn-secondary w-100"
-                                        onClick="$(&quot;input[name='hiring_without_approval']&quot;).val('True')">
-                                            Je n'ai pas besoin d'un PASS IAE
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="modal-footer justify-content-center">
-                            <p class="m-0">
-                                <b>Contrat de professionnalisation ?</b>
-                                Demande d'aide une fois le PASS IAE délivré !
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        {% endif %}
-
     </form>
 
 {% endblock %}

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -50,10 +50,7 @@
                     <button type="submit" class="btn btn-success btn-block">
                         je l'embauche et j'obtiens un PASS IAE
                     </button>
-                    <button
-                        type="submit"
-                        class="btn btn-outline-success btn-block"
-                        onClick="$(&quot;input[name='hiring_without_approval']&quot;).val('True')">
+                    <button type="submit" name="without_approval" class="btn btn-outline-success btn-block">
                             je l'embauche sans besoin d'un PASS IAE
                     </button>
                 </div>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -252,6 +252,10 @@ class AcceptForm(forms.ModelForm):
         if self.errors:
             return cleaned_data
 
+        # is it the second button that submitted the form
+        if "without_approval" in self.data:
+            self.cleaned_data["hiring_without_approval"] = True
+
         hiring_start_at = self.cleaned_data["hiring_start_at"]
         hiring_end_at = self.cleaned_data["hiring_end_at"]
 


### PR DESCRIPTION
### Quoi ?

Suppression de la fenêtre surgissante

### Pourquoi ?

Parce que la fenêtre surgissante ne permet pas de voir quand il y a des erreurs sur un champs du formulaire.

### Comment ?

Le contenu de la fenêtre surgissante est déplacé en lieu et place du bouton qui déclenchait son apparition. 

### Captures d'écran

Avant :
![screenshot-localhost_8080-2021 06 08-11_03_32](https://user-images.githubusercontent.com/17601807/121201146-98305d00-c874-11eb-9bd9-67727789939b.png)

Maintenant pour un employeur éligible IAE : 
![capture-employeur-eligible](https://user-images.githubusercontent.com/17601807/121201203-a1b9c500-c874-11eb-85b2-369acf13708c.png)

Maintenant pour un employeur non éligible IAE : 

![capture-employeur-non-eligible](https://user-images.githubusercontent.com/17601807/121201217-a3838880-c874-11eb-82de-5cb77be5c11a.png)