### PR TITLE
Investigation PDFShift

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -354,6 +354,7 @@ SOCIALACCOUNT_ADAPTER = "itou.allauth_adapters.peamu.adapter.PEAMUSocialAccountA
 # PDFShift
 # ------------------------------------------------------------------------------
 
+PDFSHIFT_API_BASE_URL = "https://api.pdfshift.io/v3"
 PDFSHIFT_API_KEY = os.environ.get("PDFSHIFT_API_KEY")
 PDFSHIFT_SANDBOX_MODE = os.environ.get("DJANGO_DEBUG")
 

--- a/itou/utils/pdf.py
+++ b/itou/utils/pdf.py
@@ -1,7 +1,11 @@
 import io
+import logging
 
 import httpx
 from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
 
 
 class HtmlToPdf:
@@ -36,7 +40,9 @@ class HtmlToPdf:
             "auth": ("api", settings.PDFSHIFT_API_KEY),
             "json": {"source": html, "sandbox": settings.PDFSHIFT_SANDBOX_MODE},
         }
-        with httpx.stream("POST", "https://api.pdfshift.io/v3/convert/pdf", **kwargs) as response:
+        url = f"{settings.PDFSHIFT_API_BASE_URL}/convert/pdf"
+        logger.info("POST request to `%s`", url)
+        with httpx.stream("POST", url, **kwargs) as response:
             response.raise_for_status()
             result = io.BytesIO()
             for chunk in response.iter_bytes(1024):
@@ -61,3 +67,48 @@ class HtmlToPdf:
         if self.autoclose:
             self.file.close()
         return self
+
+
+class PDFShiftCreditsUsageAPI:
+    """
+    For internal usage: retrieve PDFShift credits usage.
+    A credit is counted per 5Mb chunks.
+
+    Doc:
+        https://docs.pdfshift.io/#credits-usage
+
+    Usage:
+        from itou.utils.pdf import PDFShiftCreditsUsageAPI
+        credits = PDFShiftCreditsUsageAPI()
+        credits.number_of_approval_pdf_delivered
+    """
+
+    def __init__(self):
+        self.data = self.get()
+
+    def get(self):
+        r = httpx.get(f"{settings.PDFSHIFT_API_BASE_URL}/credits/usage", auth=("api", settings.PDFSHIFT_API_KEY))
+        r.raise_for_status()
+        return r.json()
+
+    @property
+    def base(self):
+        return self.data["credits"]["base"]
+
+    @property
+    def remaining(self):
+        return self.data["credits"]["remaining"]
+
+    @property
+    def total(self):
+        return self.data["credits"]["total"]
+
+    @property
+    def used(self):
+        return self.data["credits"]["used"]
+
+    @property
+    def number_of_approval_pdf_delivered(self):
+        # A credit is counted per 5Mb chunks.
+        # 1 PDF == 150K
+        return (self.used * 5000) // 150


### PR DESCRIPTION
### Quoi ?

Investigation sur le nombre de PDF générés.

### Pourquoi ?

Difficile de trouver l'information exacte sur le site de PDFShift.

### Comment ?

- Ajout d'un log sur les appels à l'API de génération de PDF pour compter les appels
- Ajout d'un _wrapper_ sur le endpoint `/credits/usage`

### Autre

Il semble que : **A credit is counted per 5Mb chunks.**

![num](https://user-images.githubusercontent.com/281139/121531198-7cf15900-c9fe-11eb-9417-a20a52877d67.png)

Or les résultats me paraissent gros :

```shell
In [1]: from itou.utils.pdf import PDFShiftCreditsUsageAPI

In [2]: credits = PDFShiftCreditsUsageAPI()

In [3]: credits.used
Out[3]: 5876

In [4]: credits.number_of_approval_pdf_delivered
Out[4]: 195866
```


