### PR TITLE
Correctifs pour les imports SAIE+EA du 6 juin 2021

### DIFF
--- a/itou/siaes/management/commands/_import_siae/utils.py
+++ b/itou/siaes/management/commands/_import_siae/utils.py
@@ -3,10 +3,13 @@
 Various helpers shared by the import_siae, import_geiq and import_ea_eatt scripts.
 
 """
+import csv
+import gzip
 import os
 from functools import wraps
 from time import time
 
+import pandas as pd
 from django.utils import timezone
 
 from itou.siaes.models import Siae
@@ -220,3 +223,109 @@ def sync_structures(df, source, kinds, build_structure, dry_run):
 
     print(f"{deleted_count} {source} can and will be deleted.")
     print(f"{undeletable_count} {source} cannot be deleted as they have data.")
+
+
+def anonymize_fluxiae_df(df):
+    """
+    Drop and/or anonymize sensitive data in fluxIAE dataframe.
+    """
+    if "salarie_date_naissance" in df.columns.tolist():
+        df["salarie_annee_naissance"] = df.salarie_date_naissance.str[-4:].astype(int)
+
+    deletable_columns = [
+        "nom_usage",
+        "nom_naissance",
+        "prenom",
+        "date_naissance",
+        "telephone",
+        "adr_mail",
+        "salarie_agrement",
+        "salarie_adr_point_remise",
+        "salarie_adr_cplt_point_geo",
+        "salarie_adr_numero_voie",
+        "salarie_codeextensionvoie",
+        "salarie_codetypevoie",
+        "salarie_adr_libelle_voie",
+        "salarie_adr_cplt_distribution",
+        "salarie_adr_qpv_nom",
+    ]
+
+    for deletable_column in deletable_columns:
+        for column_name in df.columns.tolist():
+            if deletable_column in column_name:
+                del df[column_name]
+
+    # Better safe than sorry when dealing with sensitive data!
+    for column_name in df.columns.tolist():
+        for deletable_column in deletable_columns:
+            assert deletable_column not in column_name
+
+    return df
+
+
+def get_fluxiae_df(vue_name, converters=None, description=None, parse_dates=None, skip_first_row=True, dry_run=False):
+    """
+    Load fluxIAE CSV file as a dataframe.
+    Any sensitive data will be dropped and/or anonymized.
+    """
+    filename = get_filename(
+        filename_prefix=vue_name,
+        filename_extension=".csv",
+        description=description,
+    )
+
+    # Prepare parameters for pandas.read_csv method.
+    kwargs = {}
+
+    if skip_first_row:
+        # Some fluxIAE exports have a leading "DEB***" row, some don't.
+        kwargs["skiprows"] = 1
+
+    # All fluxIAE exports have a final "FIN***" row which should be ignored. The most obvious way to do this is
+    # to use `skipfooter=1` option in `pd.read_csv` however this causes several issues:
+    # - it forces the use of the 'python' engine instead of the default 'c' engine
+    # - the 'python' engine is much slower than the 'c' engine
+    # - the 'python' engine does not play well when faced with special characters (e.g. `"`) inside a row value,
+    #   it will break or require the `error_bad_lines=False` option to ignore all those rows
+
+    # Thus we decide to always use the 'c' engine and implement the `skipfooter=1` option ourselves by counting
+    # the rows in the CSV file beforehands instead. Always using the 'c' engine is proven to significantly reduce
+    # the duration and frequency of the developer's headaches.
+
+    with gzip.open(filename) as f:
+        # Ignore 3 rows: the `DEB*` first row, the headers row, and the `FIN*` last row.
+        nrows = -3
+        for line in f:
+            nrows += 1
+            if dry_run and nrows == 100:
+                break
+
+    print(f"Loading {nrows} rows for {vue_name} ...")
+
+    if converters:
+        kwargs["converters"] = converters
+
+    if parse_dates:
+        kwargs["parse_dates"] = parse_dates
+
+    df = pd.read_csv(
+        filename,
+        sep="|",
+        # Some rows have a single `"` in a field, for example in fluxIAE_Mission the mission_descriptif field of
+        # the mission id 1003399237 is `"AIEHPAD` (no closing double quote). This screws CSV parsing big time
+        # as the parser will read many rows until the next `"` and consider all of them as part of the
+        # initial mission_descriptif field value o_O. Let's just disable quoting alltogether to avoid that.
+        quoting=csv.QUOTE_NONE,
+        nrows=nrows,
+        **kwargs,
+    )
+
+    # If there is only one column, something went wrong, let's break early.
+    # Most likely an incorrect skip_first_row value.
+    assert len(df.columns.tolist()) >= 2
+
+    assert len(df) == nrows
+
+    df = anonymize_fluxiae_df(df)
+
+    return df

--- a/itou/siaes/management/commands/_import_siae/utils.py
+++ b/itou/siaes/management/commands/_import_siae/utils.py
@@ -263,7 +263,15 @@ def anonymize_fluxiae_df(df):
     return df
 
 
-def get_fluxiae_df(vue_name, converters=None, description=None, parse_dates=None, skip_first_row=True, dry_run=False):
+def get_fluxiae_df(
+    vue_name,
+    converters=None,
+    description=None,
+    parse_dates=None,
+    skip_first_row=True,
+    anonymize_sensitive_data=True,
+    dry_run=False,
+):
     """
     Load fluxIAE CSV file as a dataframe.
     Any sensitive data will be dropped and/or anonymized.
@@ -326,6 +334,7 @@ def get_fluxiae_df(vue_name, converters=None, description=None, parse_dates=None
 
     assert len(df) == nrows
 
-    df = anonymize_fluxiae_df(df)
+    if anonymize_sensitive_data:
+        df = anonymize_fluxiae_df(df)
 
     return df

--- a/itou/siaes/management/commands/_import_siae/vue_af.py
+++ b/itou/siaes/management/commands/_import_siae/vue_af.py
@@ -17,10 +17,9 @@ For convenience we systematically call such an (asp_id, kind) identifier
 an "siae_key" throughout the import_siae.py script code.
 
 """
-import pandas as pd
 from django.utils import timezone
 
-from itou.siaes.management.commands._import_siae.utils import get_filename, remap_columns, timeit
+from itou.siaes.management.commands._import_siae.utils import get_fluxiae_df, remap_columns, timeit
 from itou.siaes.models import Siae, SiaeFinancialAnnex
 from itou.utils.validators import validate_af_number
 
@@ -38,23 +37,12 @@ def get_vue_af_df():
     - end_date
     - state
     """
-    filename = get_filename(
-        filename_prefix="fluxIAE_AnnexeFinanciere", filename_extension=".csv", description="Vue AF"
-    )
-
-    df = pd.read_csv(
-        filename,
-        sep="|",
+    df = get_fluxiae_df(
+        vue_name="fluxIAE_AnnexeFinanciere",
         converters={"af_id_structure": int},
         parse_dates=["af_date_debut_effet", "af_date_fin_effet"],
-        # First and last rows of CSV are weird markers.
-        # Example of first row: `DEBAnnexeFinanciere31082020_063002`
-        # Example of last row: `FIN34003|||||||||||||||`
-        # Let's ignore them.
-        skiprows=1,
-        skipfooter=1,
-        # Fix warning caused by using `skipfooter`.
-        engine="python",
+        description="Vue AF",
+        skip_first_row=True,
     )
 
     column_mapping = {


### PR DESCRIPTION
### Quoi et pourquoi ?

- import SIAE : nouvelle donnée pourrie dans le dernier export faisant planter l'engine `python` de `pd.read_csv`. La solution est de passer à l'engine `c`, solution déjà implémentée pour l'import fluxIAE. Du coup cette PR fait un refactoring pour partager cette solution `get_fluxiae_df` entre tous les scripts.
- import EA : gros changement de données dans le dernier export, les colonnes ont changé de nom, nouvelle logique de déduplication et seulement 2% des EA ont un email (problème remonté à la DGEFP). Cette PR fait des correctifs préparatoires mais l'import est impossible tant que la DGEFP ne nous aura pas envoyé un nouveau fichier avec les emails.

### Comment faire la revue

Commit par commit sinon le diff est imbitable.