### PR TITLE
Ajout du setting SECURE_HSTS_SECONDS

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -227,6 +227,11 @@ SECURE_BROWSER_XSS_FILTER = True
 
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
+# Load the site over HTTPS only.
+# TODO: use a small value for testing, once confirmed that HSTS didn't break anything increase it.
+# https://docs.djangoproject.com/en/dev/ref/middleware/#http-strict-transport-security
+SECURE_HSTS_SECONDS = 30
+
 SESSION_COOKIE_HTTPONLY = True
 
 SESSION_COOKIE_SECURE = True

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -219,21 +219,21 @@ STATICFILES_DIRS = (os.path.join(APPS_DIR, "static"),)
 # Security.
 # ------------------------------------------------------------------------------
 
-SESSION_EXPIRE_AT_BROWSER_CLOSE = True
-
-SESSION_COOKIE_SECURE = True
-
-SESSION_COOKIE_HTTPONLY = True
-
 CSRF_COOKIE_HTTPONLY = True
 
 CSRF_COOKIE_SECURE = True
 
 SECURE_BROWSER_XSS_FILTER = True
 
-X_FRAME_OPTIONS = "DENY"
-
 SECURE_CONTENT_TYPE_NOSNIFF = True
+
+SESSION_COOKIE_HTTPONLY = True
+
+SESSION_COOKIE_SECURE = True
+
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+
+X_FRAME_OPTIONS = "DENY"
 
 # Logging.
 # https://docs.djangoproject.com/en/dev/topics/logging


### PR DESCRIPTION
### Quoi ?

Ajout du setting `SECURE_HSTS_SECONDS` pour ajouter un en-tête HTTP Strict Transport Security (HSTS).

### Pourquoi ?

Pour forcer les navigateurs à charger le site en HTTPS.

![hsts](https://user-images.githubusercontent.com/281139/121542486-7831a280-ca08-11eb-915a-519198cc76a7.png)

[Vu dans l'audit dashlord](https://dashlord.incubateur.net/#/url/https://emplois.inclusion.beta.gouv.fr).