### PR TITLE
FIX: Configuration de Huey / Redis

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -469,11 +469,12 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
 
 # Huey instance
 # If any performance issue, increasing the number of workers *can* be a good idea
-# Parameter `immediate` means `synchronous` (async here)
-# Now using `huey.RedisExpireHuey` with default TTL of results (1 day)
-# => Will avoid OOM errors
+# Parameters:
+# - `immediate` means `synchronous` (async here)
+# - `results` is False => do not store huey operations result (Redis instance memory issues)
 HUEY = {
-    "huey_class": "huey.RedisExpireHuey",
+    "huey_class": "huey.RedisHuey",
+    "results": False,
     "name": "ITOU",
     "url": REDIS_URL + f"/?db={REDIS_DB}",
     "consumer": {

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -470,7 +470,10 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
 # Huey instance
 # If any performance issue, increasing the number of workers *can* be a good idea
 # Parameter `immediate` means `synchronous` (async here)
+# Now using `huey.RedisExpireHuey` with default TTL of results (1 day)
+# => Will avoid OOM errors
 HUEY = {
+    "huey_class": "huey.RedisExpireHuey",
     "name": "ITOU",
     "url": REDIS_URL + f"/?db={REDIS_DB}",
     "consumer": {


### PR DESCRIPTION
### Quoi ?

Une modification de la configuration de Huey.

### Pourquoi ?

Suite au problème survenu sur l'instance Redis le 12.06.2021 (OOM), il est nécessaire de modifier 
la configuration de Huey dans Django.

### Comment ?

Huey dispose d'une classe `huey.RedisExpireHuey` permettant de gérer l'expiration des résultats de traitements (contenus dans la clé `huey.results`).

La commande `FLUSHALL` utilisée en mode manuel à complètement effacé les résultats de traitements, libérant ainsi la quasi intégralité de la RAM de l'instance Redis.

Avec l'utilisation de cette classe, les résultats sont éliminés au bout d'une journée (valeur par défaut).

Il est également possible de les supprimer immédiatement, mais cela rendrait un éventuel dépannage en cas d'incident plus difficile

Liens intéressant :

- https://github.com/coleifer/huey/blob/345857dd01293af70a3a72dcb8052e34b38574b1/huey/api.py#L1077
- https://huey.readthedocs.io/en/latest/api.html#RedisExpireHuey
