### PR TITLE
Réparation du cronjob metabase quotidien

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -53,6 +53,9 @@ tqdm==4.59.0  # https://github.com/tqdm/tqdm
 # Read Excel files with Pandas
 xlrd==1.2.0  # https://pypi.org/project/xlrd/
 
+# sqlalchemy.create_engine is required for pandas.to_sql used in populate_metabase_fluxiae and populate_metabase_itou
+sqlalchemy==1.3.20  # https://github.com/sqlalchemy/sqlalchemy
+
 # Third-party applications
 # ------------------------------------------------------------------------------
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -36,11 +36,6 @@ django-admin-logs==1.0.1  # https://pypi.org/project/django-admin-logs/
 # ------------------------------------------------------------------------------
 requests-mock==1.8.0  # https://github.com/jamielennox/requests-mock
 
-# Metabase
-# ------------------------------------------------------------------------------
-# sqlalchemy.create_engine is required for pandas.to_sql used in populate_metabase_fluxiae.py
-sqlalchemy==1.3.20  # https://github.com/sqlalchemy/sqlalchemy
-
 # Data extracts
 # ------------------------------------------------------------------------------
 # xlwt is required for pandas.to_excel used in dgefp_control.py script (see private repo)


### PR DESCRIPTION
### Quoi ?

La dépendance `sqlalchemy` doit être installée dans tous les environnements et non plus uniquement le dev local.

### Pourquoi ?

Jusqu'à vendredi dernier (10 juin 2021) `sqlalchemy` était uniquement utilisé par le script `populate_metabase_fluxiae` qui tourne seulement en local dev, une fois par semaine par supportix, donc jamais en prod.

Depuis vendredi dernier, suite à la MEP de https://github.com/betagouv/itou/pull/682, la nouvelle méthode `populate_selected_jobs` de `populate_metabase_itou` fait appel à `sqlalchemy` (via la méthode `store_df`). Hors `populate_metabase_itou` tourne non seulement en local dev mais aussi en prod chaque nuit via un cronjob, d'où la nécessité d'avoir `sqlalchemy` en production.