### PR TITLE
Ajout du formulaire de situation avant l'inscription d'un demandeur d'emploi

### DIFF
--- a/itou/templates/signup/job_seeker_situation.html
+++ b/itou/templates/signup/job_seeker_situation.html
@@ -17,7 +17,7 @@
             <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
         {% endif %}
 
-        {% bootstrap_form form %}
+        {% bootstrap_form form alert_error_type="all" %}
 
         {% buttons %}
             <button type="submit" class="btn btn-primary">Continuer</button>

--- a/itou/templates/signup/job_seeker_situation.html
+++ b/itou/templates/signup/job_seeker_situation.html
@@ -1,0 +1,27 @@
+{% extends "layout/content_small.html" %}
+{% load bootstrap4 %}
+{% load static %}
+
+{% block title %}Demandeur d'emploi - Inscription{{ block.super }}{% endblock %}
+
+{% block content %}
+    <h1>
+        Inscription
+        <small class="text-muted">Candidat</small>
+    </h1>
+    <form method="post" action="{% url 'signup:job_seeker_situation' %}" role="form" class="js-prevent-multiple-submit">
+
+        {% csrf_token %}
+        
+        {% if redirect_field_value %}
+            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
+        {% endif %}
+
+        {% bootstrap_form form %}
+
+        {% buttons %}
+            <button type="submit" class="btn btn-primary">Continuer</button>
+        {% endbuttons %}
+
+    </form>
+{% endblock %}

--- a/itou/templates/signup/job_seeker_situation_not_eligible.html
+++ b/itou/templates/signup/job_seeker_situation_not_eligible.html
@@ -1,0 +1,15 @@
+{% extends "layout/content_small.html" %}
+{% load static %}
+
+{% block title %}Inscription{{ block.super }}{% endblock %}
+
+{% block content %}
+    <h1>
+        Inscription
+        <small class="text-muted">Candidat</small>
+    </h1>
+    <p>
+        <strong>Vous ne pouvez vous inscrire</strong>, veuillez vous rapprocher d’un prescripteur habilité (Pôle emploi, Mission Locale, Cap emploi…)
+        pour vous accompagner dans vos démarches. <a href="{% url 'search:prescribers_home' %}">Trouvez un prescripteur habilité</a>
+    </p>
+{% endblock %}

--- a/itou/templates/signup/job_seeker_situation_not_eligible.html
+++ b/itou/templates/signup/job_seeker_situation_not_eligible.html
@@ -9,7 +9,7 @@
         <small class="text-muted">Candidat</small>
     </h1>
     <p>
-        <strong>Vous ne pouvez vous inscrire</strong>, veuillez vous rapprocher d’un prescripteur habilité (Pôle emploi, Mission Locale, Cap emploi…)
-        pour vous accompagner dans vos démarches. <a href="{% url 'search:prescribers_home' %}">Trouvez un prescripteur habilité</a>
+        <strong>Vous ne pouvez pas vous inscrire</strong>, veuillez vous rapprocher d’un prescripteur habilité (Pôle emploi, Mission Locale, Cap emploi…)
+        pour vous accompagner dans vos démarches. <a href="{% url 'search:prescribers_home' %}">Trouver un prescripteur habilité</a>
     </p>
 {% endblock %}

--- a/itou/templates/signup/signup.html
+++ b/itou/templates/signup/signup.html
@@ -34,7 +34,7 @@
                 <h5 class="card-title font-weight-light mb-4">
                     Vous êtes en recherche d'un emploi et souhaitez postuler
                 </h5>
-                <a class="btn btn-primary" href="{% url 'signup:job_seeker' %}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
+                <a class="btn btn-primary" href="{% url 'signup:job_seeker_situation' %}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
                     Créer un compte
                 </a>
             </div>

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -17,7 +17,7 @@ class ItouLoginView(LoginView):
     # The reverse() method cannot be used here as it causes
     # a cryptic loop import error in config/urls.py
     ACCOUNT_TYPE_TO_SIGNUP_URL = {
-        "job_seeker": "signup:job_seeker",
+        "job_seeker": "signup:job_seeker_situation",
         "prescriber": "signup:prescriber_is_pole_emploi",
         "siae": "signup:siae_select",
     }

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -13,7 +13,6 @@ from itou.utils.apis.geocoding import get_geocoding_data
 from itou.utils.password_validation import CnilCompositionPasswordValidator
 from itou.utils.tokens import siae_signup_token_generator
 from itou.utils.validators import validate_code_safir, validate_siren, validate_siret
-from itou.utils.widgets import MultipleSwitchCheckboxWidget
 
 
 BLANK_CHOICE = (("", "---------"),)
@@ -38,14 +37,14 @@ class FullnameFormMixin(forms.Form):
 class JobSeekerSituationForm(forms.Form):
 
     ERROR_NOTHING_CHECKED = (
-        "Si vous êtes dans l’une des situations ci-dessus, " "vous devez cocher au moins une case  avant de continuer"
+        "Si vous êtes dans l’une des situations ci-dessous, vous devez cocher au moins une case  avant de continuer"
     )
 
     SITUATIONS_CHOICES = (
         ("rsa", "Bénéficiaire du RSA (revenu de solidarité active)"),
         ("ass", "Allocataire ASS (allocation spécifique de solidarité)"),
         ("aah", "Allocataire AAH (allocation adulte handicapé) ou bénéficiaire d'une RQTH"),
-        ("pe", "Inscrit à Pôle emploi depuis plus de 2 ans (inscription en continue)"),
+        ("pe", "Inscrit à Pôle emploi depuis plus de 2 ans (inscription en continu)"),
         ("autre", "Autre"),
     )
 
@@ -54,7 +53,7 @@ class JobSeekerSituationForm(forms.Form):
     situation = forms.MultipleChoiceField(
         label="Quelle est votre situation ? ",
         choices=SITUATIONS_CHOICES,
-        widget=MultipleSwitchCheckboxWidget(),
+        widget=forms.CheckboxSelectMultiple,
         error_messages={"required": ERROR_NOTHING_CHECKED},
     )
 

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -36,6 +36,11 @@ class FullnameFormMixin(forms.Form):
 
 
 class JobSeekerSituationForm(forms.Form):
+
+    ERROR_NOTHING_CHECKED = (
+        "Si vous êtes dans l’une des situations ci-dessus, " "vous devez cocher au moins une case  avant de continuer"
+    )
+
     SITUATIONS_CHOICES = (
         ("rsa", "Bénéficiaire du RSA (revenu de solidarité active)"),
         ("ass", "Allocataire ASS (allocation spécifique de solidarité)"),
@@ -44,14 +49,13 @@ class JobSeekerSituationForm(forms.Form):
         ("autre", "Autre"),
     )
 
+    ELIGIBLE_SITUATION = ["rsa", "ass", "aah", "pe"]
+
     situation = forms.MultipleChoiceField(
         label="Quelle est votre situation ? ",
         choices=SITUATIONS_CHOICES,
         widget=MultipleSwitchCheckboxWidget(),
-        error_messages={
-            "required": "Si vous êtes dans l’une des situations ci-dessus, "
-            "vous devez cocher au moins une case  avant de continuer"
-        },
+        error_messages={"required": ERROR_NOTHING_CHECKED},
     )
 
 

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -13,6 +13,7 @@ from itou.utils.apis.geocoding import get_geocoding_data
 from itou.utils.password_validation import CnilCompositionPasswordValidator
 from itou.utils.tokens import siae_signup_token_generator
 from itou.utils.validators import validate_code_safir, validate_siren, validate_siret
+from itou.utils.widgets import MultipleSwitchCheckboxWidget
 
 
 BLANK_CHOICE = (("", "---------"),)
@@ -31,6 +32,26 @@ class FullnameFormMixin(forms.Form):
         max_length=User._meta.get_field("last_name").max_length,
         required=True,
         strip=True,
+    )
+
+
+class JobSeekerSituationForm(forms.Form):
+    SITUATIONS_CHOICES = (
+        ("rsa", "Bénéficiaire du RSA (revenu de solidarité active)"),
+        ("ass", "Allocataire ASS (allocation spécifique de solidarité)"),
+        ("aah", "Allocataire AAH (allocation adulte handicapé) ou bénéficiaire d'une RQTH"),
+        ("pe", "Inscrit à Pôle emploi depuis plus de 2 ans (inscription en continue)"),
+        ("autre", "Autre"),
+    )
+
+    situation = forms.MultipleChoiceField(
+        label="Quelle est votre situation ? ",
+        choices=SITUATIONS_CHOICES,
+        widget=MultipleSwitchCheckboxWidget(),
+        error_messages={
+            "required": "Si vous êtes dans l’une des situations ci-dessus, "
+            "vous devez cocher au moins une case  avant de continuer"
+        },
     )
 
 

--- a/itou/www/signup/urls.py
+++ b/itou/www/signup/urls.py
@@ -9,6 +9,12 @@ app_name = "signup"
 urlpatterns = [
     # Job seeker.
     path("job_seeker", views.JobSeekerSignupView.as_view(), name="job_seeker"),
+    path("job_seeker/situation", views.job_seeker_situation, name="job_seeker_situation"),
+    path(
+        "job_seeker/situation_not_eligible",
+        views.job_seeker_situation_not_eligible,
+        name="job_seeker_situation_not_eligible",
+    ),
     # Prescriber.
     path(
         "prescriber/is_pole_emploi",

--- a/itou/www/signup/urls.py
+++ b/itou/www/signup/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.views.generic import TemplateView
 
 from itou.www.signup import views
 
@@ -12,7 +13,7 @@ urlpatterns = [
     path("job_seeker/situation", views.job_seeker_situation, name="job_seeker_situation"),
     path(
         "job_seeker/situation_not_eligible",
-        views.job_seeker_situation_not_eligible,
+        TemplateView.as_view(template_name="signup/job_seeker_situation_not_eligible.html"),
         name="job_seeker_situation_not_eligible",
     ),
     # Prescriber.

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -82,6 +82,10 @@ def job_seeker_situation(
         if any(choice in eligible_choices for choice in form.cleaned_data["situation"]):
             next_url = reverse("signup:job_seeker")
 
+        # forward next page
+        if redirect_field_name in form.data:
+            next_url = f"{next_url}?{redirect_field_name}={form.data[redirect_field_name]}"
+
         return HttpResponseRedirect(next_url)
 
     context = {

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -69,7 +69,7 @@ def job_seeker_situation(
     """
     Entry point of the signup process for jobseeker.
 
-    The user is asked to choose at least one eligibility criterion to continue signup process
+    The user is asked to choose at least one eligibility criterion to continue the signup process.
     """
 
     form = forms.JobSeekerSituationForm(data=request.POST or None)
@@ -77,7 +77,7 @@ def job_seeker_situation(
     if request.method == "POST" and form.is_valid():
         next_url = reverse("signup:job_seeker_situation_not_eligible")
 
-        # at least one of the elegibility choices, go to signup form
+        # If at least one of the eligibility choices is selected, go to the signup form.
         if any(choice in forms.JobSeekerSituationForm.ELIGIBLE_SITUATION for choice in form.cleaned_data["situation"]):
             next_url = reverse("signup:job_seeker")
 
@@ -93,11 +93,6 @@ def job_seeker_situation(
         "redirect_field_value": get_safe_url(request, redirect_field_name),
     }
     return render(request, template_name, context)
-
-
-@require_GET
-def job_seeker_situation_not_eligible(request, template_name="signup/job_seeker_situation_not_eligible.html"):
-    return render(request, template_name, {})
 
 
 # SIAEs signup.

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -78,8 +78,7 @@ def job_seeker_situation(
         next_url = reverse("signup:job_seeker_situation_not_eligible")
 
         # at least one of the elegibility choices, go to signup form
-        eligible_choices = ["rsa", "ass", "aah", "pe"]
-        if any(choice in eligible_choices for choice in form.cleaned_data["situation"]):
+        if any(choice in forms.JobSeekerSituationForm.ELIGIBLE_SITUATION for choice in form.cleaned_data["situation"]):
             next_url = reverse("signup:job_seeker")
 
         # forward next page

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -63,6 +63,40 @@ class JobSeekerSignupView(SignupView):
         return super().post(request, *args, **kwargs)
 
 
+def job_seeker_situation(
+    request, template_name="signup/job_seeker_situation.html", redirect_field_name=REDIRECT_FIELD_NAME
+):
+    """
+    Entry point of the signup process for jobseeker.
+
+    The user is asked to choose at least one eligibility criterion to continue signup process
+    """
+
+    form = forms.JobSeekerSituationForm(data=request.POST or None)
+
+    if request.method == "POST" and form.is_valid():
+        next_url = reverse("signup:job_seeker_situation_not_eligible")
+
+        # at least one of the elegibility choices, go to signup form
+        eligible_choices = ["rsa", "ass", "aah", "pe"]
+        if any(choice in eligible_choices for choice in form.cleaned_data["situation"]):
+            next_url = reverse("signup:job_seeker")
+
+        return HttpResponseRedirect(next_url)
+
+    context = {
+        "form": form,
+        "redirect_field_name": redirect_field_name,
+        "redirect_field_value": get_safe_url(request, redirect_field_name),
+    }
+    return render(request, template_name, context)
+
+
+@require_GET
+def job_seeker_situation_not_eligible(request, template_name="signup/job_seeker_situation_not_eligible.html"):
+    return render(request, template_name, {})
+
+
 # SIAEs signup.
 # ------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Quoi ?

Les SIAE reçoivent des candidatures autonomes de candidats non éligibles à l'IAE

### Pourquoi ?

On vise une meilleure qualification des candidatures pour :
- éviter la déception des candidats
- diminuer le traitement des candidatures par les SIAE

### Comment ?

On ajoute une étape dans le workflow du parcours d'inscription candidat.
Le candidat doit déclarer sur l'honneur être dans l'une des situations administratives concernées pour pouvoir poursuivre son inscription
S'il n'est pas dans l'une des situations mentionnées, on l'invite à se rapprocher d'un prescripteur

### Captures d'écran

L'URL d'inscription d'un candidat est modifiée pour afficher ce formulaire :

![capture_formulaire_situation](https://user-images.githubusercontent.com/17601807/121909569-539e3900-cd2e-11eb-9b43-e49df0f67cb7.png)

Si au moins un des critères d'éligibilité est coché, l'utilisateur est redirigé vers le formulaire d'inscription.
Si "Autre" est coché seul, la page spécifique suivante est affichée : 

![capture_page_redirection__vers_prescripteur](https://user-images.githubusercontent.com/17601807/121909809-94964d80-cd2e-11eb-8611-8d71404ca026.png)



### Autre

Si aucune case n'est cochée, le formulaire affiche un message spécifique. Or, le message "inline" de Boostrap ne semble pas fonctionner : 

![capture_invalid-feedback_not_display](https://user-images.githubusercontent.com/17601807/121910174-ec34b900-cd2e-11eb-97dd-71c580b3f58d.png)
