### PR TITLE
Affichage du CV si JavaScript est activé dans le navigateur

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -362,7 +362,7 @@ _:-ms-fullscreen, :root .alert-old-browser {
 /* JavaScript disabled
 ---------------------------------------------------------------------------- */
 /* Element is shown with JavaScript. See static > js > utils.js */
-.jsDisplayIfJavascriptEnabled {
+.js-display-if-javascript-enabled {
     display: none;
 }
 

--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -359,6 +359,13 @@ _:-ms-fullscreen, :root .alert-old-browser {
     display: block;
 }
 
+/* JavaScript disabled
+---------------------------------------------------------------------------- */
+/* Element is shown with JavaScript. See static > js > utils.js */
+.jsDisplayIfJavascriptEnabled {
+    display: none;
+}
+
 /* Horizontal line with words in the middle.
 https://stackoverflow.com/questions/5214127/css-technique-for-a-horizontal-line-with-words-in-the-middle/44647131#44647131
 --------------------------------------------------------------------------- */

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -2,4 +2,6 @@ $(document).ready(() => {
     $(".jsPreventDefault").on("click", (event) => {
         event.preventDefault();
     });
+
+    $(".jsDisplayIfJavascriptEnabled").css("display", "block");
 });

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -1,7 +1,7 @@
 $(document).ready(() => {
-    $(".jsPreventDefault").on("click", (event) => {
+    $(".js-prevent-default").on("click", (event) => {
         event.preventDefault();
     });
 
-    $(".jsDisplayIfJavascriptEnabled").css("display", "block");
+    $(".js-display-if-javascript-enabled").css("display", "block");
 });

--- a/itou/templates/apply/submit_step_application.html
+++ b/itou/templates/apply/submit_step_application.html
@@ -23,7 +23,7 @@
         {% bootstrap_field form.message %}
         {{ form.resume_link.as_hidden }}
 
-        <label for="resume_form" class="jsDisplayIfJavascriptEnabled">{{ form.resume_link.label }}</label>
+        <label for="resume_form" class="js-display-if-javascript-enabled">{{ form.resume_link.label }}</label>
         {% include "storage/s3_upload_form.html" with dropzone_form_id="resume_form" %}
 
         {% buttons %}

--- a/itou/templates/apply/submit_step_application.html
+++ b/itou/templates/apply/submit_step_application.html
@@ -23,7 +23,7 @@
         {% bootstrap_field form.message %}
         {{ form.resume_link.as_hidden }}
 
-        <label for="resume_form">{{ form.resume_link.label }}</label>
+        <label for="resume_form" class="jsDisplayIfJavascriptEnabled">{{ form.resume_link.label }}</label>
         {% include "storage/s3_upload_form.html" with dropzone_form_id="resume_form" %}
 
         {% buttons %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -400,9 +400,9 @@
         <script src="{% static "js/city_autocomplete_field.js" %}"></script>
         <script src="{% static "js/configure_jobs.js" %}"></script>
         <script src="{% static "js/prevent_multiple_submit.js" %}"></script>
+        <script src="{% static 'js/utils.js'%}"></script>
         {% if SHOW_TEST_ACCOUNTS_BANNER %}
         <script src="{% static 'js/test_accounts.js'%}"></script>
-        <script src="{% static 'js/utils.js'%}"></script>
         {% endif %}
     {% endblock %}
 

--- a/itou/templates/storage/s3_upload_form.html
+++ b/itou/templates/storage/s3_upload_form.html
@@ -1,8 +1,8 @@
-<div class="jsDisplayIfJavascriptEnabled">
+<div class="js-display-if-javascript-enabled">
     <div id="{{ dropzone_form_id }}" class="dropzone border-dashed text-center text-secondary mb-2">
         <div class="dz-message my-1">
             <div class="h5">{% include "includes/icon.html" with icon="upload" size="30" %}</div>
-            <div class="h6"><a href="" class="jsPreventDefault">Choisissez un fichier</a> ou <b>glissez ici</b>.</div>
+            <div class="h6"><a href="" class="js-prevent-default">Choisissez un fichier</a> ou <b>glissez ici</b>.</div>
             <div class="small">Taille maximale : {{ s3_upload_config.max_file_size }} Mo</div>
             <div class="small">Type de fichier : PDF</div>
         </a>

--- a/itou/templates/storage/s3_upload_form.html
+++ b/itou/templates/storage/s3_upload_form.html
@@ -1,26 +1,28 @@
-<div id="{{ dropzone_form_id }}" class="dropzone border-dashed text-center text-secondary mb-2">
-    <div class="dz-message my-1">
-        <div class="h5">{% include "includes/icon.html" with icon="upload" size="30" %}</div>
-        <div class="h6"><a href="" class="jsPreventDefault">Choisissez un fichier</a> ou <b>glissez ici</b>.</div>
-        <div class="small">Taille maximale : {{ s3_upload_config.max_file_size }} Mo</div>
-        <div class="small">Type de fichier : PDF</div>
-    </a>
+<div class="jsDisplayIfJavascriptEnabled">
+    <div id="{{ dropzone_form_id }}" class="dropzone border-dashed text-center text-secondary mb-2">
+        <div class="dz-message my-1">
+            <div class="h5">{% include "includes/icon.html" with icon="upload" size="30" %}</div>
+            <div class="h6"><a href="" class="jsPreventDefault">Choisissez un fichier</a> ou <b>glissez ici</b>.</div>
+            <div class="small">Taille maximale : {{ s3_upload_config.max_file_size }} Mo</div>
+            <div class="small">Type de fichier : PDF</div>
+        </a>
+        </div>
     </div>
+
+
+    <p class="small mt-0">
+        {% include "includes/icon.html" with icon="help-circle" size="16" class="mr-1" %}
+        Ce fichier n'est pas un PDF ?
+        <a
+            href="https://doc.inclusion.beta.gouv.fr/mon-mode-demploi-prescripteur/postuler-pour-un-candidat#ajouter-un-cv-a-la-candidature"
+            target="_blank"
+            rel="noopener"
+            class="matomo-event"
+            matomo-category="ajout-fichier-candidature"
+            matomo-action="clic"
+            matomo-option="clic-sur-lien-aide-pdf"
+            >
+            Découvrez comment le convertir.
+        </a>
+    </p>
 </div>
-
-
-<p class="small mt-0">
-    {% include "includes/icon.html" with icon="help-circle" size="16" class="mr-1" %}
-    Ce fichier n'est pas un PDF ?
-    <a
-        href="https://doc.inclusion.beta.gouv.fr/mon-mode-demploi-prescripteur/postuler-pour-un-candidat#ajouter-un-cv-a-la-candidature"
-        target="_blank"
-        rel="noopener"
-        class="matomo-event"
-        matomo-category="ajout-fichier-candidature"
-        matomo-action="clic"
-        matomo-option="clic-sur-lien-aide-pdf"
-        >
-        Découvrez comment le convertir.
-    </a>
-</p>


### PR DESCRIPTION
### Quoi ?

Le formulaire permettant d'ajouter un CV à une candidature apparaît désormais uniquement si JavaScript est activé dans le navigateur.

### Pourquoi ?

Des utilisateurs ont écrit au support en se plaignant que le message de la candidature disparaissait après avoir essayé d'ajouter un CV en cliquant sur le lien "Choisissez un fichier". J'ai réussi à reproduire le problème en désactivant JavaScript. En effet, la classe `jsPreventDefault` n'a alors aucun effet et cliquer sur le lien a pour conséquence de rafraîchir la page.

### Comment ?

Ajout d'une classe `jsDisplayIfJavascriptEnabled` qui affiche l'élément en JavaScript.
Evidemment, il s'agit d'une rustine. Activer ce formulaire aux utilisateurs qui n'ont pas JavaScript demande un peu plus de développement et nous en discuterons probablement lors de la prochaine journée d'équipe.