### PR TITLE
Affichage du bouton d'éligibilité pour les candidatures refusées et obsolètes

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -435,7 +435,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         when processing an application, False otherwise.
         """
         return (
-            (self.state.is_processing or self.state.is_postponed)
+            (self.state in JobApplicationWorkflow.CAN_BE_ACCEPTED_STATES)
             and self.to_siae.is_subject_to_eligibility_rules
             and not EligibilityDiagnosis.objects.has_considered_valid(self.job_seeker, for_siae=self.to_siae)
         )

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -724,6 +724,21 @@ class ProcessTemplatesTest(TestCase):
 
         # Test template content.
         self.assertNotContains(response, self.url_process)
+        self.assertContains(response, self.url_eligibility)
+        self.assertNotContains(response, self.url_refuse)
+        self.assertNotContains(response, self.url_postpone)
+        self.assertNotContains(response, self.url_accept)
+
+    def test_details_template_for_state_obsolete_valid_diagnosis(self):
+        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        EligibilityDiagnosisFactory(job_seeker=self.job_application.job_seeker)
+        self.job_application.state = JobApplicationWorkflow.STATE_OBSOLETE
+        self.job_application.save()
+
+        response = self.client.get(self.url_details)
+
+        # Test template content.
+        self.assertNotContains(response, self.url_process)
         self.assertNotContains(response, self.url_eligibility)
         self.assertNotContains(response, self.url_refuse)
         self.assertNotContains(response, self.url_postpone)
@@ -732,6 +747,20 @@ class ProcessTemplatesTest(TestCase):
     def test_details_template_for_state_refused(self):
         """Test actions available for other states."""
         self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.job_application.state = JobApplicationWorkflow.STATE_REFUSED
+        self.job_application.save()
+        response = self.client.get(self.url_details)
+        # Test template content.
+        self.assertNotContains(response, self.url_process)
+        self.assertContains(response, self.url_eligibility)
+        self.assertNotContains(response, self.url_refuse)
+        self.assertNotContains(response, self.url_postpone)
+        self.assertNotContains(response, self.url_accept)
+
+    def test_details_template_for_state_refused_valid_diagnosis(self):
+        """Test actions available for other states."""
+        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        EligibilityDiagnosisFactory(job_seeker=self.job_application.job_seeker)
         self.job_application.state = JobApplicationWorkflow.STATE_REFUSED
         self.job_application.save()
         response = self.client.get(self.url_details)


### PR DESCRIPTION
### Quoi ?

Actuellement, des candidatures refusées ou obsolètes peuvent être acceptées sans diagnostic !

### Pourquoi ?

Les états dans `JobApplicationWorkflow.CAN_BE_ACCEPTED_STATES` n'ont pas été répercutés dans la méthode `JobApplication.eligibility_diagnosis_by_siae_required`.
Les tests ont été aveugles car nous l'avons été aussi ! En oubliant cette étape pourtant cruciale, les tests étaient toujours au vert.

### Comment ?

- Modification de la méthode `JobApplication.eligibility_diagnosis_by_siae_required`
- Modification des tests

