### PR TITLE
Désactivation du stockage des résultats de Huey dans Redis

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -477,6 +477,8 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
 # Parameter `immediate` means `synchronous` (async here)
 HUEY = {
     "name": "ITOU",
+    # Don't store task results (see our Redis Post-Morten in documentation for more information),
+    "results": False,
     "url": REDIS_URL + f"/?db={REDIS_DB}",
     "consumer": {
         "workers": 2,


### PR DESCRIPTION

### Quoi ?

Modification de la configuration de Huey.

### Pourquoi ?

Suite au problème survenu sur l'instance Redis le 12.06.2021 (OOM), il est nécessaire de modifier
la configuration de Huey dans Django.

### Comment ?

Par défaut Huey stocke le résultat des tâches dans Redis en l'associant à un ID.
Dans le mesure où nos tâches actuelles ne renvoient rien ces résultats sont quasi-vides (contiennent peut être juste un code de retour) et prennent 40 octets avec le nom de la clef mais après l'envoi de 2,5 millions de mails nous atteignons les limites de mémoire de l'instance (100 Mo).
Ces résultats sont inutiles, il nous suffit de ne pas les stocker.
