### PR TITLE
Faire confirmer une prolongation par le prescripteur

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -387,6 +387,7 @@ ITOU_ENVIRONMENT = "PROD"
 ITOU_PROTOCOL = "https"
 ITOU_FQDN = "emplois.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact@inclusion.beta.gouv.fr"
+ITOU_EMAIL_PROLONGATION = "prolongation@inclusion.beta.gouv.fr"
 ITOU_ASSISTANCE_URL = "https://assistance.inclusion.beta.gouv.fr"
 
 DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -2,6 +2,7 @@ import datetime
 from unittest import mock
 
 from dateutil.relativedelta import relativedelta
+from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
@@ -1365,3 +1366,4 @@ class ProlongationNotificationsTest(TestCase):
         self.assertIn(prolongation.approval.number_with_spaces, email.body)
         self.assertIn(title(prolongation.approval.user.first_name), email.body)
         self.assertIn(title(prolongation.approval.user.last_name), email.body)
+        self.assertIn(settings.ITOU_EMAIL_PROLONGATION, email.body)

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -29,6 +29,10 @@
             {% bootstrap_form form alert_error_type="all" %}
 
             <p>
+                Jusqu'à la publication du décret d'application de la loi du 14 décembre 2020, vous ne pouvez solliciter qu'un conseiller Pôle emploi pour demander une prolongation.
+            </p>
+
+            <p>
                 <a href="{% url 'search:prescribers_home' %}" rel="noopener" target="_blank">
                     Rechercher des prescripteurs
                     {% include "includes/icon.html" with icon="external-link" title=external_link_title %}

--- a/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
+++ b/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
@@ -12,7 +12,8 @@ Bonjour,
 - Fin de la prolongation : {{ prolongation.end_at|date:"d/m/Y" }}
 - Motif de prolongation : {{ prolongation.get_reason_display }}
 
-Si vous avez autorisé cette prolongation, vous n'avez aucune démarche à faire.
+Pour confirmer et valider cette prolongation, merci de nous transférer
+ce message à : {{ itou_email_prolongation }}
 
 Si vous n'avez pas autorisé cette prolongation, merci de contacter notre assistance technique : {{ itou_assistance_url }}
 

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -28,11 +28,12 @@ def remove_extra_line_breaks(text):
 def get_email_text_template(template, context):
     context.update(
         {
-            "itou_doc_url": settings.ITOU_DOC_URL,
             "itou_assistance_url": settings.ITOU_ASSISTANCE_URL,
-            "itou_protocol": settings.ITOU_PROTOCOL,
-            "itou_fqdn": settings.ITOU_FQDN,
+            "itou_doc_url": settings.ITOU_DOC_URL,
+            "itou_email_prolongation": settings.ITOU_EMAIL_PROLONGATION,
             "itou_environment": settings.ITOU_ENVIRONMENT,
+            "itou_fqdn": settings.ITOU_FQDN,
+            "itou_protocol": settings.ITOU_PROTOCOL,
         }
     )
     return remove_extra_line_breaks(get_template(template).render(context).strip())

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -12,6 +12,7 @@ def expose_settings(request):
         "ITOU_ASSISTANCE_URL": settings.ITOU_ASSISTANCE_URL,
         "ITOU_COMMUNITY_URL": settings.ITOU_COMMUNITY_URL,
         "ITOU_DOC_URL": settings.ITOU_DOC_URL,
+        "ITOU_EMAIL_PROLONGATION": settings.ITOU_EMAIL_PROLONGATION,
         "ITOU_ENVIRONMENT": settings.ITOU_ENVIRONMENT,
         "ITOU_FQDN": settings.ITOU_FQDN,
         "ITOU_PROTOCOL": settings.ITOU_PROTOCOL,


### PR DESCRIPTION
### Quoi ?

Faire confirmer une prolongation par le prescripteur.

### Pourquoi ?

Demande DGEFP.

### Comment ?

Avec une version dégradée dans laquelle on demande au prescripteur de transférer un email à `prolongation@inclusion.beta.gouv.fr` afin de confirmer une prolongation. La demande est ensuite traitée en conciergerie par le support.

L'objectif est d'évaluer la quantité de confirmations à traiter avant d'investir plus de temps dans le code.