### PR TITLE
Retrait de l'export XLS des PASS IAE via l'admin

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -42,7 +42,7 @@ urlpatterns = [
     # /accounts/logout/ <=> account_logout
     # We need custom code to process PEAMU logout.
     re_path(r"^accounts/logout/$", dashboard_views.logout),
-    # --------------------------------------------------------------------------------------    
+    # --------------------------------------------------------------------------------------
     # Other allauth URLs.
     path("accounts/", include("allauth.urls")),
     # --------------------------------------------------------------------------------------

--- a/itou/templates/admin/approvals/change_list.html
+++ b/itou/templates/admin/approvals/change_list.html
@@ -1,8 +1,0 @@
-{% extends 'admin/change_list.html' %}
-
-{% block object-tools-items %}
-    {{ block.super }}
-    <li>
-        <a href="{% url 'admin:approvals_approval_export_approvals' %}">Exporter les PASS IAE (EXCEL)</a>
-    </li>
-{% endblock %}


### PR DESCRIPTION
### Quoi ?

C'est dans le titre.

La management command `export_approvals`reste active bien sur.

### Pourquoi ?

L'export des PASS IAE déclenché via l'admin est fait via le worker principal sur Clever, et c'est un peu trop lourd pour lui:

```
2021-06-16T15:14:29+02:00 Wed Jun 16 13:11:07 2021 - *** HARAKIRI ON WORKER 2 (pid: 4628, try: 1) ***
2021-06-16T15:14:29+02:00 Exported 72262 approvals in 37.82 sec.
2021-06-16T15:14:29+02:00 Loading suspension data...
2021-06-16T15:17:10+02:00 Respawned uWSGI worker 2 (new pid: 4648)
2021-06-16T15:17:10+02:00 Wed Jun 16 13:11:21 2021 - HARAKIRI !!! end of worker 2 status !!!
2021-06-16T15:17:10+02:00 Wed Jun 16 13:11:15 2021 - HARAKIRI [core 0] 85.203.70.152 - GET /admin/approvals/approval/export_approvals since 1623849005
2021-06-16T15:17:10+02:00 DAMN ! worker 2 (pid: 4628) died, killed by signal 9 :( trying respawn ...
2021-06-16T15:17:10+02:00 Wed Jun 16 13:11:12 2021 - HARAKIRI !!! worker 2 status !!!
```

Ce qui mène à une erreur HTTP 502 en prod (moche)

### Comment ?

Retrait du bouton d'action et de la config dans le site d'admin.

Encore une fois il est toujours possible d'effectuer les exports via la management command prévue à cet effet.

### Divers

- l'export XLS en local prend quand même une quinzaine de secondes
- on a déjà passé du temps à réduire ce temps de production des fichiers XLS
- nous n'aurons plus cet export à faire à partir de Juillet 2021
- de ce tsmps il est plus pertinent de le faire manuellement  (vu avec Eric)