### PR TITLE
Configuration de Sentry pour remonter les warnings

### DIFF
--- a/config/settings/_sentry.py
+++ b/config/settings/_sentry.py
@@ -1,8 +1,9 @@
+import logging
 import os
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
-from sentry_sdk.integrations.logging import ignore_logger
+from sentry_sdk.integrations.logging import ignore_logger, LoggingIntegration
 
 
 def strip_sentry_sensitive_data(event, hint):
@@ -26,10 +27,16 @@ def strip_sentry_sensitive_data(event, hint):
     return event
 
 
+sentry_logging = LoggingIntegration(
+    level=logging.INFO,  # Capture info and above as breadcrumbs.
+    event_level=logging.WARNING, # Send warnings as events.
+)
+
+
 def sentry_init(dsn):
     sentry_sdk.init(
         dsn=dsn,
-        integrations=[DjangoIntegration()],
+        integrations=[sentry_logging, DjangoIntegration()],
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.


### PR DESCRIPTION
### Quoi ?

Nouvelle configuration de Sentry.

### Pourquoi ?

Pour remonter les alertes de niveau `warning`.

### Comment ?

> https://docs.sentry.io/platforms/python/guides/logging/

### Captures d'écran

![warning](https://user-images.githubusercontent.com/281139/122367793-0b189280-cf5d-11eb-8803-172d81dc0275.png)
