### PR TITLE
Les antennes ont dorénavant toutes une convention sans exception

### DIFF
--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -178,4 +178,4 @@ def check_convention_data_consistency():
         source=Siae.SOURCE_USER_CREATED,
         convention__isnull=True,
     ).count()
-    print(f"{user_created_siaes_without_convention} user created siaes still have no convention (technical debt)")
+    assert user_created_siaes_without_convention == 0


### PR DESCRIPTION
### Quoi ?

Activation dans le script d'import des SIAE d'un contrôle que toutes les antennes ont dorénavant une convention sans exception.

Plus une petite simplification du code du modèle des structures qui fera plaisir à @kemar 

### Pourquoi ?

On trainait une dette technique d'antennes sans convention, remontant à l'époque où la création d'antenne se faisait sans garder un lien clair avec la structure mère.

J'ai résolu à la main la dizaine d'antennes qui restaient.

Cette situation ne devrait plus jamais se reproduire.