### PR TITLE
Affichage permanent des filtres

### DIFF
--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -35,54 +35,54 @@
             </h3>
         {% endif %}
 
-        {% if not prescriber_orgs_page %}
-            <h4 class="font-weight-normal text-muted">
-                Aucun résultat.
-            </h4>
+        <h4 class="font-weight-normal text-muted">
+            {% with prescriber_orgs_page.number as current_page and prescriber_orgs_page.paginator.num_pages as total_pages and prescriber_orgs_page.paginator.count as counter %}
+                <b>{{ counter }}</b> résultat{% if counter > 1 %}s{% endif %}
+                {% if prescriber_orgs_page.paginator.num_pages > 1 %}
+                    - Page <b>{{ current_page }}</b>/{{ total_pages }}
+                {% endif %}
+            {% endwith %}
+        </h4>
 
-        {% else %}
-
-            <h4 class="font-weight-normal text-muted">
-                {% with prescriber_orgs_page.number as current_page and prescriber_orgs_page.paginator.num_pages as total_pages and prescriber_orgs_page.paginator.count as counter %}
-                    <b>{{ counter }}</b> résultat{% if counter > 1 %}s{% endif %}
-                    {% if prescriber_orgs_page.paginator.num_pages > 1 %}
-                        - Page <b>{{ current_page }}</b>/{{ total_pages }}
-                    {% endif %}
-                {% endwith %}
-            </h4>
-
-            <div class="row">
-                <div class="col-12 col-md-4">
-                    {% include "search/includes/prescribers_search_filters.html" with form=form %}
-                </div>
-                <div class="col-12 col-md-8">
-                    {% for prescriber_org in prescriber_orgs_page %}
-                        <div class="card my-4">
-                            <div class="card-body">
-                                <h5 class="card-title">
-                                    <a href="{{ prescriber_org.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                                        {{ prescriber_org.name }}
-                                    </a>
-                                </h5>
-                                <h6 class="card-subtitle mb-2 text-muted">
-                                    {{ prescriber_org.get_kind_display }}
-                                    {% if prescriber_org.is_brsa %}(conventionné par le Département pour le suivi des BRSA){% endif %}
-                                </h6>
-                                <hr>
-                                <h6 class="card-subtitle mb-2 text-muted">
-                                    {{ prescriber_org.address_on_one_line }}
-                                </h6>
-                                <p class="card-text">
-                                    <span class="badge badge-dark">{{ prescriber_org.distance.km|floatformat:"-1" }} km</span>
-                                    de votre lieu de recherche
-                                </p>
-                            </div>
+        <div class="row">
+            <div class="col-12 col-md-4">
+                {% include "search/includes/prescribers_search_filters.html" with form=form %}
+            </div>
+            <div class="col-12 col-md-8">
+                {% for prescriber_org in prescriber_orgs_page %}
+                    <div class="card my-4">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                <a href="{{ prescriber_org.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                                    {{ prescriber_org.name }}
+                                </a>
+                            </h5>
+                            <h6 class="card-subtitle mb-2 text-muted">
+                                {{ prescriber_org.get_kind_display }}
+                                {% if prescriber_org.is_brsa %}(conventionné par le Département pour le suivi des BRSA){% endif %}
+                            </h6>
+                            <hr>
+                            <h6 class="card-subtitle mb-2 text-muted">
+                                {{ prescriber_org.address_on_one_line }}
+                            </h6>
+                            <p class="card-text">
+                                <span class="badge badge-dark">{{ prescriber_org.distance.km|floatformat:"-1" }} km</span>
+                                de votre lieu de recherche
+                            </p>
                         </div>
-                    {% endfor %}
+                    </div>
+                {% empty %}
+                    <div class="card my-4">
+                        <div class="card-body">
+                            <p class="font-weight-normal text-muted">
+                                Aucun résultat avec les filtres actuels.
+                            </p>
+                        </div>
+                    </div>
+                {% endfor %}
 
-                    {% include "includes/pagination.html" with page=prescriber_orgs_page %}
-                </div> {# col-8 #}
-            </div> {# row #}
-        {% endif %}
+                {% include "includes/pagination.html" with page=prescriber_orgs_page %}
+            </div>
+        </div>
     </form>
 {% endblock %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -36,106 +36,99 @@
             </h3>
         {% endif %}
 
-        {% if not siaes_step_1 %}
-            <h4 class="font-weight-normal text-muted">
-                Aucun résultat.
-            </h4>
-        {% else %}
+        <p>
+            <small>
+                Les employeurs solidaires situés dans le rayon choisi sont classés en deux groupes. Les employeurs ayant des fiches de postes actives sont dans le premier groupe et affichés en priorité, les autres employeurs sont dans le second groupe. Chaque jour, l'ordonnancement au sein de ces groupes change pour ne pas favoriser un employeur au détriment d'un autre.
+            </small>
+        </p>
 
-            <p>
-                <small>
-                    Les employeurs solidaires situés dans le rayon choisi sont classés en deux groupes. Les employeurs ayant des fiches de postes actives sont dans le premier groupe et affichés en priorité, les autres employeurs sont dans le second groupe. Chaque jour, l'ordonnancement au sein de ces groupes change pour ne pas favoriser un employeur au détriment d'un autre.
-                </small>
-            </p>
+        <h4 class="font-weight-normal text-muted mb-0">
+            {% with siaes_page.number as current_page and siaes_page.paginator.num_pages as total_pages and siaes_page.paginator.count as counter %}
+                <b>{{ counter }}</b> résultat{% if counter > 1 %}s{% endif %}
+                {% if siaes_page.paginator.num_pages > 1 %}
+                    - Page <b>{{ current_page }}</b>/{{ total_pages }}
+                {% endif %}
+            {% endwith %}
+        </h4>
 
-            <h4 class="font-weight-normal text-muted mb-0">
-                {% with siaes_page.number as current_page and siaes_page.paginator.num_pages as total_pages and siaes_page.paginator.count as counter %}
-                    <b>{{ counter }}</b> résultat{% if counter > 1 %}s{% endif %}
-                    {% if siaes_page.paginator.num_pages > 1 %}
-                        - Page <b>{{ current_page }}</b>/{{ total_pages }}
-                    {% endif %}
-                {% endwith %}
-            </h4>
-
-            <div class="row">
-                <div class="col-12 col-md-4">
-                    {% include "search/includes/siaes_search_filters.html" with form=form %}
-                </div>
-                <div class="col-12 col-md-8">
-                    {% for siae in siaes_page %}
-                        <div class="card my-4">
-                            <div class="card-body">
-                                <h5 class="card-title">
-                                    <b><abbr title="{{ siae.get_kind_display }}">{{ siae.kind }}</abbr></b>
-                                    -
-                                    <a href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                                        {{ siae.display_name }}
-                                    </a>
-                                    {# Display non-user-edited name too. #}
-                                    {% if siae.brand %}<small class="text-muted">({{ siae.name|title }})</small>{% endif %}
-                                </h5>
-                                <h6 class="card-subtitle mb-2 text-muted">{{ siae.address_on_one_line }}</h6>
-                                {% if siae.kind in ea_eatt_kinds %}
-                                    <p class="card-text">
-                                        <span class="badge badge-dark">Priorité aux bénéficiaires de RQTH</span>
-                                    </p>
-                                {% endif %}
-                                <div class="mb-3">
-                                    <span class="badge badge-dark">{{ siae.distance|floatformat:"-1" }} km</span> de votre lieu de recherche.
-                                </div>
-                                {% if siae.job_description_through.exists and not siae.block_job_applications %}
-                                    <h6 class="border-bottom border-gray pb-2">Métiers proposés</h6>
-                                    <ul class="mb-0">
-                                    {% for job in siae.job_description_through.all %}
-                                        <li>
-                                            <a href="{{ job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}">
-                                                {{ job.display_name }}
-                                            </a>
-                                            {% if job.is_popular %}
-                                            <small>
-                                                <span class="ml-3">
-                                                        {% include "includes/icon.html" with icon="layers" size=15 class="mr-1 text-danger" %}
-                                                        Plus de {{ job.POPULAR_THRESHOLD }} candidatures reçues
-                                                    </span>
-                                            </small>
-                                            {% endif %}
-                                        </li>
-                                    {% endfor %}
-                                    </ul>
-                                {% endif %}
+        <div class="row">
+            <div class="col-12 col-md-4">
+                {% include "search/includes/siaes_search_filters.html" with form=form %}
+            </div>
+            <div class="col-12 col-md-8">
+                {% for siae in siaes_page %}
+                    <div class="card my-4">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                <b><abbr title="{{ siae.get_kind_display }}">{{ siae.kind }}</abbr></b>
+                                -
+                                <a href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                                    {{ siae.display_name }}
+                                </a>
+                                {# Display non-user-edited name too. #}
+                                {% if siae.brand %}<small class="text-muted">({{ siae.name|title }})</small>{% endif %}
+                            </h5>
+                            <h6 class="card-subtitle mb-2 text-muted">{{ siae.address_on_one_line }}</h6>
+                            {% if siae.kind in ea_eatt_kinds %}
+                                <p class="card-text">
+                                    <span class="badge badge-dark">Priorité aux bénéficiaires de RQTH</span>
+                                </p>
+                            {% endif %}
+                            <div class="mb-3">
+                                <span class="badge badge-dark">{{ siae.distance|floatformat:"-1" }} km</span> de votre lieu de recherche.
                             </div>
-
-                            <div class="card-footer">
-                                {% if not siae.has_active_members %}
-                                    <a class="btn btn-sm btn-outline-secondary disabled" href="" aria-label="Vous ne pouvez pas postuler auprès de l'employeur solidaire {{ siae.display_name }}">
-                                        {% include "includes/icon.html" with icon="message-square" %} Postuler
-                                    </a>
-                                    <small>Cet employeur n'a pas encore créé son compte.</small>
-                                {% elif siae.block_job_applications %}
-                                    <a class="btn btn-sm btn-outline-secondary disabled" href="" aria-label="Vous ne pouvez pas postuler auprès de l'employeur solidaire {{ siae.display_name }}">
-                                        {% include "includes/icon.html" with icon="message-square" %} Postuler
-                                    </a>
-                                    <small>Cet employeur n'accepte plus de candidatures pour le moment</small>
-                                {% else %}
-                                    <a class="btn btn-sm btn-outline-primary" href="{% url 'apply:start' siae_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
-                                        {% include "includes/icon.html" with icon="message-square" %} Postuler
-                                    </a>
-                                {% endif %}
-                            </div>
-
+                            {% if siae.job_description_through.exists and not siae.block_job_applications %}
+                                <h6 class="border-bottom border-gray pb-2">Métiers proposés</h6>
+                                <ul class="mb-0">
+                                {% for job in siae.job_description_through.all %}
+                                    <li>
+                                        <a href="{{ job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}">
+                                            {{ job.display_name }}
+                                        </a>
+                                        {% if job.is_popular %}
+                                        <small>
+                                            <span class="ml-3">
+                                                    {% include "includes/icon.html" with icon="layers" size=15 class="mr-1 text-danger" %}
+                                                    Plus de {{ job.POPULAR_THRESHOLD }} candidatures reçues
+                                                </span>
+                                        </small>
+                                        {% endif %}
+                                    </li>
+                                {% endfor %}
+                                </ul>
+                            {% endif %}
                         </div>
-                    {% empty %}
-                        <div class="card my-4">
-                            <div class="card-body">
-                                Aucun résultat avec les filtres actuels.
-                            </div>
-                        </div>
-                    {% endfor %}
 
-                    {% include "includes/pagination.html" with page=siaes_page %}
-                </div> {# col-8 #}
-            </div> {# row #}
-        {% endif %}
+                        <div class="card-footer">
+                            {% if not siae.has_active_members %}
+                                <a class="btn btn-sm btn-outline-secondary disabled" href="" aria-label="Vous ne pouvez pas postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                                    {% include "includes/icon.html" with icon="message-square" %} Postuler
+                                </a>
+                                <small>Cet employeur n'a pas encore créé son compte.</small>
+                            {% elif siae.block_job_applications %}
+                                <a class="btn btn-sm btn-outline-secondary disabled" href="" aria-label="Vous ne pouvez pas postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                                    {% include "includes/icon.html" with icon="message-square" %} Postuler
+                                </a>
+                                <small>Cet employeur n'accepte plus de candidatures pour le moment</small>
+                            {% else %}
+                                <a class="btn btn-sm btn-outline-primary" href="{% url 'apply:start' siae_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                                    {% include "includes/icon.html" with icon="message-square" %} Postuler
+                                </a>
+                            {% endif %}
+                        </div>
+
+                    </div>
+                {% empty %}
+                    <div class="card my-4">
+                        <div class="card-body">
+                            Aucun résultat avec les filtres actuels.
+                        </div>
+                    </div>
+                {% endfor %}
+
+                {% include "includes/pagination.html" with page=siaes_page %}
+            </div> {# col-8 #}
+        </div> {# row #}
     </form>
 
 {% endblock %}

--- a/itou/www/search/tests.py
+++ b/itou/www/search/tests.py
@@ -49,7 +49,7 @@ class SearchSiaeTest(TestCase):
 
     def test_not_existing(self):
         response = self.client.get(self.url, {"city": "foo-44"})
-        self.assertContains(response, "Aucun résultat.")
+        self.assertContains(response, "Aucun résultat avec les filtres actuels.")
 
     def test_district(self):
         city_slug = "paris-75"


### PR DESCRIPTION
### Quoi ?

Affichage des critères de recherche quels que soit les critères de ville et distance utilisés.

### Pourquoi ?

Si un utilisateur saisit une ville qui n'a pas de résultats (employeurs ou prescripteurs) dans la distance par défaut, il n'a pas la possibilité de modifier ses critères.

### Comment ?

En ne conditionnant plus l'affichage des filtres selon le résultat du queryset et en fournissant un affichage adapté au queryset vide.

### Captures d'écran (optionnel)

![Capture d’écran de 2021-06-17 15-05-41](https://user-images.githubusercontent.com/1815/122402222-9275fe00-cf7d-11eb-9c20-9a1766bce128.png)

## Formulation

Je suis preneur d'une meilleure formulation « Aucun résultat avec les filtres actuels. » ou « Aucun résultat avec les critères sélectionnés. ».
