### PR TITLE
Ajout de 2 nouveaux champs dans metabase [sera MEP le 1er juillet]

### DIFF
--- a/itou/metabase/management/commands/_organizations.py
+++ b/itou/metabase/management/commands/_organizations.py
@@ -143,3 +143,12 @@ TABLE_COLUMNS += [
 TABLE_COLUMNS += get_establishment_last_login_date_column()
 
 TABLE_COLUMNS += get_establishment_is_active_column()
+
+TABLE_COLUMNS += [
+    {
+        "name": "brsa",
+        "type": "boolean",
+        "comment": "Organisation conventionnée pour le suivi des BRSA",
+        "fn": lambda o: o.is_brsa,
+    },
+]

--- a/itou/metabase/management/commands/_siaes.py
+++ b/itou/metabase/management/commands/_siaes.py
@@ -43,6 +43,12 @@ def get_siae_last_month_hirings(siae):
 
 TABLE_COLUMNS = [
     {"name": "id", "type": "integer", "comment": "ID de la structure", "fn": lambda o: o.id},
+    {
+        "name": "id_asp",
+        "type": "integer",
+        "comment": "ID de la structure ASP correspondante",
+        "fn": lambda o: o.convention.asp_id if o.convention else None,
+    },
     {"name": "nom", "type": "varchar", "comment": "Nom de la structure", "fn": lambda o: o.display_name},
     {
         "name": "description",


### PR DESCRIPTION
### Quoi ?

Ajout de 2 nouveaux champs dans metabase
- structures.id_asp
- organisations.brsa

### Pourquoi ?

Pour débloquer Soumia.

Noter que le master doc est bien tenu à jour à chaque changement de colonnes : https://docs.google.com/spreadsheets/d/1H1YkxeremqE0niJIu66pghgL8wAHLuY0PUt7JGEFG3E/edit#gid=316863205