### PR TITLE
Les demandeurs d'emploi ne doivent pas pouvoir changer leur adresse mail dans la modification de leur profil

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -177,9 +177,6 @@ class User(AbstractUser, AddressMixin):
         super().save(*args, **kwargs)
 
     def can_edit_email(self, user):
-        if self == user:
-            return True
-
         return user.is_handled_by_proxy and user.is_created_by(self) and not user.has_verified_email
 
     def is_created_by(self, user):

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -196,7 +196,7 @@ class ModelTest(TestCase):
         job_seeker = JobSeekerFactory()
 
         # Same user.
-        self.assertTrue(user.can_edit_email(user))
+        self.assertFalse(user.can_edit_email(user))
 
         # All conditions are met.
         job_seeker = JobSeekerFactory(created_by=user)

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -21,6 +21,8 @@ class EditUserInfoForm(AddressFormMixin, forms.ModelForm):
         editor = kwargs.pop("editor")
         super().__init__(*args, **kwargs)
 
+        # Noboby can edit its own email.
+        # Only prescribers and employers can edit the job seeker's email here under certain conditions
         if not self.instance.is_job_seeker or not editor.can_edit_email(self.instance):
             del self.fields["email"]
 

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -85,6 +85,9 @@ class EditUserInfoViewTest(TestCase):
         self.assertEqual(user.phone, post_data["phone"])
         self.assertEqual(user.birthdate.strftime("%d/%m/%Y"), post_data["birthdate"])
 
+        # Ensure that the job seeker cannot edit email here.
+        self.assertNotEqual(user.email, post_data["email"])
+
 
 class EditJobSeekerInfo(TestCase):
     def test_edit_by_siae(self):


### PR DESCRIPTION
### Quoi ?

Empêcher la modification de l'adresse mail des demandeurs d'emploi dans leur profil

### Pourquoi ?

Pour éviter les incohérences et forcer les demandeurs d'emploi à utiliser la page dédiée à la modification de l'adresse Email

### Comment ?

Suppression du champ "email" quand c'est le demandeur d'emploi qui est sur la modification de son profil. On laisse la possibilité à un prescripteur de modifier l'adresse mail si celle-ci n'a pas encore été vérifiée.
