### PR TITLE
Rendre possible la suspension d'une candidature sans date de début

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -571,10 +571,9 @@ class Suspension(models.Model):
         """
         if approval.last_old_suspension:
             return approval.last_old_suspension.end_at + relativedelta(days=1)
-        if approval.user.last_accepted_job_application.hiring_start_at:
-            return approval.user.last_accepted_job_application.hiring_start_at
-
-        return datetime.date.today()
+        if approval.user.last_accepted_job_application.created_from_pe_approval:
+            return datetime.date.today()
+        return approval.user.last_accepted_job_application.hiring_start_at
 
 
 class ProlongationQuerySet(models.QuerySet):

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -571,7 +571,10 @@ class Suspension(models.Model):
         """
         if approval.last_old_suspension:
             return approval.last_old_suspension.end_at + relativedelta(days=1)
-        return approval.user.last_accepted_job_application.hiring_start_at
+        if approval.user.last_accepted_job_application.hiring_start_at:
+            return approval.user.last_accepted_job_application.hiring_start_at
+
+        return datetime.date.today()
 
 
 class ProlongationQuerySet(models.QuerySet):

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -43,7 +43,7 @@
 {% endif %}
 
 {% if job_application.created_from_pe_approval %}
-    <p>Ce PASS IAE a été importé depuis un agrément Pole Emploi.</p>
+    <p>Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
 {% endif %}
 
 {% if approval.is_valid %}

--- a/itou/www/approvals_views/tests/tests.py
+++ b/itou/www/approvals_views/tests/tests.py
@@ -509,7 +509,7 @@ class PoleEmploiApprovalConversionIntoApprovalTest(TestCase):
         self.assertEqual(len(messages), 1)
         self.assertEqual(
             str(messages[0]),
-            "L'agrément Pole Emploi a bien été importé, vous pouvez désormais le prolonger ou le suspendre.",
+            "L'agrément Pôle emploi a bien été importé, vous pouvez désormais le prolonger ou le suspendre.",
         )
 
     def test_pe_approval_create_when_pole_emploi_approval_has_already_been_imported(self):
@@ -532,7 +532,7 @@ class PoleEmploiApprovalConversionIntoApprovalTest(TestCase):
         self.assertEqual(Approval.objects.count(), initial_approval_count)
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
-        self.assertEqual(str(messages[0]), "Cet agrément Pole Emploi a déja été importé.")
+        self.assertEqual(str(messages[0]), "Cet agrément Pôle emploi a déja été importé.")
 
     def test_pe_approval_create_from_existing_user_with_approval(self):
         """

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -314,7 +314,7 @@ def pe_approval_create(request, pe_approval_id):
     # If the PoleEmploiApproval has already been imported, it is not possible to import it again
     possible_matching_approval = Approval.objects.filter(number=pe_approval.number[:12]).first()
     if possible_matching_approval:
-        messages.info(request, "Cet agrément Pole Emploi a déja été importé.")
+        messages.info(request, "Cet agrément Pôle emploi a déja été importé.")
         job_application = JobApplication.objects.filter(approval=possible_matching_approval).first()
         next_url = reverse_lazy("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
         return HttpResponseRedirect(next_url)
@@ -348,7 +348,7 @@ def pe_approval_create(request, pe_approval_id):
         job_application.save()
 
     messages.success(
-        request, "L'agrément Pole Emploi a bien été importé, vous pouvez désormais le prolonger ou le suspendre."
+        request, "L'agrément Pôle emploi a bien été importé, vous pouvez désormais le prolonger ou le suspendre."
     )
     next_url = reverse_lazy("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
     return HttpResponseRedirect(next_url)


### PR DESCRIPTION
### Quoi ?

Les candidatures créées à partir d’un agrément Pole emploi n’ont pas de date de début (car cette information ne nous est pas fournie par PE). Il faut cependant quand même pouvoir les suspendre, et le code actuel utilise la date d’embauche comme date minimale de suspension.

### Pourquoi ?

PE ne fait plus les suspensions, nous devons proposer cette fonctionnalité.

### Comment ?

Le formulaire de suspension `SuspensionForm` permet de sélectionner une date de début de suspension via, initialisée via
```python
min_start_at_str = Suspension.next_min_start_at(self.approval).strftime("%Y/%m/%d")
```

Cette ligne plante si `approval.user.last_accepted_job_application.hiring_start_at == None`.
Correction proposée: si pas de `hiring_start_at`, on renvoie la date du jour.
