### PR TITLE
Ajout d’une commande 'make deploy_prod'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,3 +155,9 @@ postgres_backups_clean:
 postgres_dump_cities:
 	docker exec -ti itou_postgres bash -c "pg_dump --clean --if-exists --format c --no-owner --no-privileges -d itou -t cities_city > /backups/cities.sql"
 	docker cp itou_postgres:/backups/cities.sql itou/fixtures/postgres/
+
+# Deployment
+# =============================================================================
+
+deploy_prod: deploy_prod.sh
+	./deploy_prod.sh

--- a/Makefile
+++ b/Makefile
@@ -159,5 +159,5 @@ postgres_dump_cities:
 # Deployment
 # =============================================================================
 
-deploy_prod: deploy_prod.sh
-	./deploy_prod.sh
+deploy_prod: scripts/deploy_prod.sh
+	./scripts/deploy_prod.sh

--- a/deploy_prod.sh
+++ b/deploy_prod.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Ensure working directory in version branch clean
+if ! git diff-index --quiet HEAD; then
+  echo "Working directory not clean, please commit your changes first"
+  exit
+fi
+
+# Merge master into master_clever, then push master_clever
+# Deployment to Clever Cloud is actually triggered via a hook
+# on a push on this branch
+git checkout master
+git pull origin master
+git checkout master_clever 
+git pull origin master_clever 
+git merge master --no-edit
+git push origin master_clever 

--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -15,7 +15,7 @@ git checkout master
 git pull origin master
 git checkout master_clever 
 git pull origin master_clever 
-git merge master --no-edit
+git merge master --no-edit --no-ff
 git push origin master_clever 
 
 # When we are done, we want to restore the initial state

--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+initial_branch=`git branch --show-current`
+
 # Ensure working directory is clean
 if ! git diff-index --quiet HEAD; then
   echo "Working directory not clean, please commit your changes first"
@@ -15,3 +17,16 @@ git checkout master_clever
 git pull origin master_clever 
 git merge master --no-edit
 git push origin master_clever 
+
+# When we are done, we want to restore the initial state
+# (in order to avoid writing things directly on master_clever by accident)
+if [ -z $initial_branch ]; then
+    # The initial_branch is empty when user is in detached state, so we simply go back to master
+    git checkout master
+    echo
+    echo "You were on detached state before deploying, you are back to master"
+else
+    git checkout $initial_branch
+    echo
+    echo "Back to $initial_branch"
+fi

--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Ensure working directory in version branch clean
+# Ensure working directory is clean
 if ! git diff-index --quiet HEAD; then
   echo "Working directory not clean, please commit your changes first"
   exit


### PR DESCRIPTION
### Quoi ?

Ajout d’une commande `make deploy_prod`

### Pourquoi ?

Pour:

- faciliter le déploiement
- centraliser/documenter la manière de faire
- éviter que tout le monde réécrive ce script chez lui
- éviter les erreurs dues aux opérations manuelles

### Comment ?

Ajout d’un script bash