### PR TITLE
Génération d'un CSV à partir d'un script SQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,12 @@ psql_itou:
 psql_root:
 	docker exec -ti -e PGPASSWORD=password itou_postgres psql -U postgres
 
+# Write query results to a CSV file
+psql_to_csv:
+	docker cp $(FILEPATH) itou_postgres:/script.sql
+	docker exec -ti -e PGPASSWORD=password itou_postgres psql -U itou -d itou --csv -f /script.sql -o export.csv
+	docker cp itou_postgres:/export.csv exports/
+
 # Postgres (backup / restore).
 # Inspired by:
 # https://cookiecutter-django.readthedocs.io/en/latest/docker-postgres-backups.html

--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,15 @@ psql_itou:
 psql_root:
 	docker exec -ti -e PGPASSWORD=password itou_postgres psql -U postgres
 
-# Write query results to a CSV file
+# Write query results to a CSV file.
+# --
+# make psql_to_csv FILEPATH=path/to/script.sql
+# make psql_to_csv FILEPATH=path/to/script.sql EXPORTNAME=extract.csv
 psql_to_csv:
 	docker cp $(FILEPATH) itou_postgres:/script.sql
-	docker exec -ti -e PGPASSWORD=password itou_postgres psql -U itou -d itou --csv -f /script.sql -o export.csv
-	docker cp itou_postgres:/export.csv exports/
+	docker exec -ti -e PGPASSWORD=password itou_postgres psql -U itou -d itou --csv -f /script.sql -o /export.csv
+	docker cp itou_postgres:/export.csv exports/$(EXPORTNAME)
+	docker exec -ti itou_postgres rm /script.sql /export.csv
 
 # Postgres (backup / restore).
 # Inspired by:


### PR DESCRIPTION
### Quoi ?

Ajout d'une commande qui écrit le résultat d'une requête SQL dans un fichier CSV. Plus précisément, la commande prend en entrée un **fichier** SQL et génère en sortie un CSV dans le dossier `exports`.

### Pourquoi ?

Nous avons tous des manières différentes de générer les CSV : certains le font en Python, d'autres avec un `COPY` ou encore avec `psql --csv`. Je propose l'ajout de cette commande Make afin de faciliter la vie de Supportix et de passer moins de temps à la génération du CSV en tant que tel. 

### Comment ?

Pour ceux qui utilisent Docker :
`make psql_to_csv FILEPATH=path/to/script.sql`

Pour les autres, je trouve que la commande d'origine est assez simple et ne mérite pas sa place dans le Makefile.

`psql --csv -f path/to/script.sql -o exports/export.csv`
