### PR TITLE
Simplification du code lié aux diagnostics

### DIFF
--- a/itou/eligibility/models.py
+++ b/itou/eligibility/models.py
@@ -93,28 +93,6 @@ class EligibilityDiagnosisManager(models.Manager):
 
         return last
 
-    def last_before(self, job_seeker, before, for_siae=None):
-        """
-        Retrieves the given job seeker's last diagnosis (valid or expired)
-        before the given date or None.
-
-        If the `for_siae` argument is passed, it means that we are looking for
-        a diagnosis from an employer perspective. The scope is restricted to
-        avoid showing diagnoses made by other employers.
-
-        A diagnosis made by a prescriber takes precedence even when an employer
-        diagnosis already exists.
-        """
-
-        last = None
-        query = self.for_job_seeker(job_seeker).before(before).order_by("created_at")
-
-        last = query.by_author_kind_prescriber().last()
-        if not last and for_siae:
-            last = query.authored_by_siae(for_siae).last()
-
-        return last
-
 
 class EligibilityDiagnosis(models.Model):
     """

--- a/itou/eligibility/tests.py
+++ b/itou/eligibility/tests.py
@@ -151,18 +151,6 @@ class EligibilityDiagnosisManagerTest(TestCase):
         # A diagnosis made by a prescriber takes precedence.
         self.assertEqual(last_considered_valid, prescriber_diagnosis)
 
-    def test_last_before(self):
-        """
-        Test the `last_before()` method.
-        """
-
-        job_seeker = JobSeekerFactory()
-        EligibilityDiagnosisMadeBySiaeFactory(job_seeker=job_seeker)
-        expired_diagnosis = ExpiredEligibilityDiagnosisFactory(job_seeker=job_seeker)
-
-        last_before = EligibilityDiagnosis.objects.last_before(job_seeker, datetime.date.today())
-        self.assertEqual(last_before, expired_diagnosis)
-
 
 class EligibilityDiagnosisModelTest(TestCase):
     def test_create_diagnosis(self):

--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -5,6 +5,7 @@ import factory.fuzzy
 from dateutil.relativedelta import relativedelta
 
 from itou.approvals.factories import ApprovalFactory
+from itou.eligibility.factories import EligibilityDiagnosisFactory
 from itou.job_applications import models
 from itou.jobs.models import Appellation
 from itou.prescribers.factories import (
@@ -103,19 +104,16 @@ class JobApplicationSentByAuthorizedPrescriberOrganizationFactory(JobApplication
 
 class JobApplicationWithApprovalFactory(JobApplicationSentByPrescriberFactory):
     """
-    Generates a Job Application and an Approval.
+    Generates a Job Application with an Approval.
     """
 
-    approval = factory.SubFactory(ApprovalFactory)
     state = models.JobApplicationWorkflow.STATE_ACCEPTED
-
-    @factory.post_generation
-    def set_approval_user(self, create, extracted, **kwargs):
-        if not create:
-            # Simple build, do nothing.
-            return
-        self.approval.user = self.job_seeker
-        self.approval.save()
+    approval = factory.SubFactory(ApprovalFactory, user=factory.SelfAttribute("..job_seeker"))
+    eligibility_diagnosis = factory.SubFactory(
+        EligibilityDiagnosisFactory,
+        job_seeker=factory.SelfAttribute("..job_seeker"),
+        author=factory.SelfAttribute("..sender"),
+    )
 
 
 class JobApplicationWithoutApprovalFactory(JobApplicationSentByPrescriberFactory):

--- a/itou/templates/approvals/approval_as_pdf.html
+++ b/itou/templates/approvals/approval_as_pdf.html
@@ -67,7 +67,7 @@
                         ({{ diagnosis_author_org_name|title }})
                     {% endif %}
 
-                    portant sur 
+                    portant sur
 
                 {% else %}
 

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -89,7 +89,13 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
     job_applications = get_all_available_job_applications_as_prescriber(request)
 
     queryset = job_applications.select_related(
-        "job_seeker", "sender", "sender_siae", "sender_prescriber_organization", "to_siae", "approval"
+        "job_seeker",
+        "eligibility_diagnosis",
+        "sender",
+        "sender_siae",
+        "sender_prescriber_organization",
+        "to_siae",
+        "approval",
     ).prefetch_related("selected_jobs__appellation")
     job_application = get_object_or_404(queryset, id=job_application_id)
 
@@ -103,13 +109,11 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
     else:
         before_date = datetime.datetime.now()
 
-    eligibility_diagnosis = EligibilityDiagnosis.objects.last_before(job_application.job_seeker, before_date)
-
     back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("apply:list_for_prescriber"))
 
     context = {
         "approvals_wrapper": job_application.job_seeker.approvals_wrapper,
-        "eligibility_diagnosis": eligibility_diagnosis,
+        "eligibility_diagnosis": job_application.eligibility_diagnosis,
         "job_application": job_application,
         "transition_logs": transition_logs,
         "back_url": back_url,


### PR DESCRIPTION
### Quoi ?

Simplification du code lié aux diagnostics.

### Pourquoi ?

La PR #750 permet de simplifier certain aspects du code.

### Comment ?

Suppression de `EligibilityDiagnosisManager.test_last_before`.