### PR TITLE
Script de réimport de base de données

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,9 @@ postgres_backup_restore:
 	docker-compose exec postgres restore $(FILE) && \
 	docker-compose stop
 
+postgres_restore_latest_backup: ./scripts/import-latest-db-backup.sh
+	./scripts/import-latest-db-backup.sh
+
 postgres_backups_clean:
 	docker-compose exec postgres clean
 

--- a/scripts/import-latest-db-backup.sh
+++ b/scripts/import-latest-db-backup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source .env
+
+if [ -z $PATH_TO_ITOU_BACKUPS ]; then
+  echo "please add 'PATH_TO_ITOU_BACKUPS=/your/itou-backups/root/directory' in .env at the root of the project in order to run this script"
+  exit
+fi
+
+# # Get the latest backup filename and path
+ITOU_DB_BACKUP_NAME=$(ls $PATH_TO_ITOU_BACKUPS/backups | tail -n1)
+ITOU_DB_BACKUP_PATH=$PATH_TO_ITOU_BACKUPS/backups/$ITOU_DB_BACKUP_NAME
+
+echo "Going to inject ITOU_DB_BACKUP_PATH=$ITOU_DB_BACKUP_PATH"
+
+docker cp $ITOU_DB_BACKUP_PATH itou_postgres:/backups && docker-compose -f docker-compose.yml down && make postgres_backup_restore FILE=$ITOU_DB_BACKUP_NAME; echo "Ignore warnings above."
+
+cat << EOF
+
+Import is over. Now you need to:
+ - restart your container: make run
+ - make django_admin COMMAND=set_fake_passwords
+EOF

--- a/scripts/import-latest-db-backup.sh
+++ b/scripts/import-latest-db-backup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# PLEASE RUN THIS SCRIPT WITH:
+# make postgres_restore_latest_backup
+
 source .env
 
 if [ -z $PATH_TO_ITOU_BACKUPS ]; then
@@ -7,7 +10,7 @@ if [ -z $PATH_TO_ITOU_BACKUPS ]; then
   exit
 fi
 
-# # Get the latest backup filename and path
+# Get the latest backup filename and path
 ITOU_DB_BACKUP_NAME=$(ls $PATH_TO_ITOU_BACKUPS/backups | tail -n1)
 ITOU_DB_BACKUP_PATH=$PATH_TO_ITOU_BACKUPS/backups/$ITOU_DB_BACKUP_NAME
 


### PR DESCRIPTION
### Quoi ?

Ajout d’un script d’import de dump de base

### Pourquoi ?

Cette tâche est documentée au format texte dans un dépot tiers, ce qui nécessite en l’état:
 - de copier coller un script ailleurs
 - que chacun réimplémente cette logique

Dans un souci de mutualisation et d’automatisation des tâches récurrentes, j’ai l’impression que cela a du sens d’avoir un tel script dans le projet.

### Comment ?

Ajout d’un script dédié qui tire partie de nos outils.
