### PR TITLE
Simplification du code lié aux diagnostics (bis)

### DIFF
--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -518,9 +518,7 @@ class ProcessViewsTest(TestCase):
         self.assertTrue(has_considered_valid_diagnoses)
 
         # Check diagnosis.
-        eligibility_diagnosis = EligibilityDiagnosis.objects.last_considered_valid(
-            job_application.job_seeker, for_siae=job_application.to_siae
-        )
+        eligibility_diagnosis = job_application.get_eligibility_diagnosis()
         self.assertEqual(eligibility_diagnosis.author, siae_user)
         self.assertEqual(eligibility_diagnosis.author_kind, EligibilityDiagnosis.AUTHOR_KIND_SIAE_STAFF)
         self.assertEqual(eligibility_diagnosis.author_siae, job_application.to_siae)

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -45,17 +45,21 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
     queryset = (
         JobApplication.objects.siae_member_required(request.user)
         .not_archived()
-        .select_related("job_seeker", "sender", "sender_siae", "sender_prescriber_organization", "to_siae", "approval")
+        .select_related(
+            "job_seeker",
+            "eligibility_diagnosis",
+            "sender",
+            "sender_siae",
+            "sender_prescriber_organization",
+            "to_siae",
+            "approval",
+        )
         .prefetch_related("selected_jobs__appellation")
     )
     job_application = get_object_or_404(queryset, id=job_application_id)
 
     transition_logs = job_application.logs.select_related("user").all().order_by("timestamp")
     cancellation_days = JobApplication.CANCELLATION_DAYS_AFTER_HIRING_STARTED
-
-    eligibility_diagnosis = EligibilityDiagnosis.objects.last_considered_valid(
-        job_application.job_seeker, for_siae=job_application.to_siae
-    )
 
     approval_can_be_suspended_by_siae = job_application.approval and job_application.approval.can_be_suspended_by_siae(
         job_application.to_siae
@@ -70,7 +74,7 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
         "approval_can_be_suspended_by_siae": approval_can_be_suspended_by_siae,
         "approval_can_be_prolonged_by_siae": approval_can_be_prolonged_by_siae,
         "cancellation_days": cancellation_days,
-        "eligibility_diagnosis": eligibility_diagnosis,
+        "eligibility_diagnosis": job_application.get_eligibility_diagnosis(),
         "job_application": job_application,
         "transition_logs": transition_logs,
         "back_url": back_url,
@@ -113,7 +117,7 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
 
     context = {
         "approvals_wrapper": job_application.job_seeker.approvals_wrapper,
-        "eligibility_diagnosis": job_application.eligibility_diagnosis,
+        "eligibility_diagnosis": job_application.get_eligibility_diagnosis(),
         "job_application": job_application,
         "transition_logs": transition_logs,
         "back_url": back_url,


### PR DESCRIPTION
### Quoi ?

Simplification du code lié aux diagnostics (bis).

### Pourquoi ?

La PR #750 permet de simplifier certain aspects du code.

### Comment ?

Unification de la méthode de récupération d'un diagnostic à partir d'une candidature quel que soit son état.

Permet d'économiser des requêtes SQL pour les candidatures qui ont déjà un diagnostic identifié.