### PR TITLE
Correctif pour pouvoir modifier une prolongation dans l'admin

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -212,6 +212,10 @@ class ProlongationAdmin(admin.ModelAdmin):
     is_in_progress.boolean = True
     is_in_progress.short_description = "En cours"
 
+    def get_queryset(self, request):
+        # Speed up the list display view by fecthing related objects.
+        return super().get_queryset(request).select_related("approval", "declared_by", "validated_by")
+
     def save_model(self, request, obj, form, change):
         if change:
             obj.updated_by = request.user

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -766,7 +766,8 @@ class Prolongation(models.Model):
 
         if hasattr(self, "approval"):
 
-            if self.start_at != self.get_start_at(self.approval):
+            # Avoid blocking updates in admin by limiting this check to only new instances.
+            if not self.pk and self.start_at != self.get_start_at(self.approval):
                 raise ValidationError(
                     "La date de début doit être la même que la date de fin du PASS IAE "
                     f"« {self.approval.end_at.strftime('%d/%m/%Y')} »."

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -768,7 +768,7 @@ class Prolongation(models.Model):
 
             if self.start_at != self.get_start_at(self.approval):
                 raise ValidationError(
-                    "La date de début ne peut pas être différente de la date de fin du PASS IAE "
+                    "La date de début doit être la même que la date de fin du PASS IAE "
                     f"« {self.approval.end_at.strftime('%d/%m/%Y')} »."
                 )
 

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -1188,9 +1188,7 @@ class ProlongationModelTest(TestCase):
         prolongation.start_at -= relativedelta(days=2)
         with self.assertRaises(ValidationError) as error:
             prolongation.clean()
-        self.assertIn(
-            "La date de début ne peut pas être différente de la date de fin du PASS IAE", error.exception.message
-        )
+        self.assertIn("La date de début doit être la même que la date de fin du PASS IAE", error.exception.message)
 
     def test_get_start_at(self):
 

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -27,7 +27,7 @@ from itou.approvals.notifications import NewProlongationToAuthorizedPrescriberNo
 from itou.job_applications.factories import JobApplicationSentByJobSeekerFactory, JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.prescribers.factories import AuthorizedPrescriberOrganizationFactory, PrescriberOrganizationFactory
-from itou.siaes.factories import SiaeFactory
+from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
 from itou.siaes.models import Siae
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, UserFactory
 
@@ -1181,11 +1181,19 @@ class ProlongationModelTest(TestCase):
         Given an existing prolongation, when setting a wrong `start_at`
         then a call to `clean()` is rejected.
         """
-        start_at = datetime.date.today()
+
+        approval = ApprovalFactory()
+        siae = SiaeWithMembershipFactory()
+
+        start_at = approval.end_at - relativedelta(days=2)
         end_at = start_at + relativedelta(months=1)
-        prolongation = ProlongationFactory(start_at=start_at, end_at=end_at)
-        # Set a `prolongation.start_at` different from `prolongation.approval.start_at`.
-        prolongation.start_at -= relativedelta(days=2)
+
+        # We need an object without `pk` to test `clean()`, so we use `build`
+        # which provides a local object without saving it to the database.
+        prolongation = ProlongationFactory.build(
+            start_at=start_at, end_at=end_at, approval=approval, declared_by_siae=siae
+        )
+
         with self.assertRaises(ValidationError) as error:
             prolongation.clean()
         self.assertIn("La date de début doit être la même que la date de fin du PASS IAE", error.exception.message)


### PR DESCRIPTION
## Quoi ?

L'erreur **La date de début ne peut pas être différente de la date de fin du PASS IAE** se produit quand je tente de modifier une prolongation dans l'admin.

## Pourquoi ?

Une prolongation doit commencer exactement le même jour qu'un PASS IAE.

Quand on fait une prolongation, la date de fin du PASS IAE est modifiée aussi pour coller à la fin de la prolongation.

Au moment de modifier une prolongation dans l'admin, le contrôle de la date de début se base sur la date de fin du PASS IAE pour s'assurer qu'il s'agit du même jour.

Or celle-ci est désormais la même que la date de fin de la prolongation qu'on tente de modifier.

La modification de la prolongation devient impossible.

## Comment ?

On limite le contrôle aux nouvelles prolongations.