### PR TITLE
Mise à jour vers Django 3.2.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.2.0  # https://github.com/avian2/unidecode
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.2.4  # pyup: < 4.0  # https://www.djangoproject.com/
+django==3.2.5  # pyup: < 4.0  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.43.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
### Quoi ?

Mise à jour vers Django 3.2.5.

### Pourquoi ?

Mise à jour de sécurité.

> https://www.djangoproject.com/weblog/2021/jul/01/security-releases/