### PR TITLE
Éliminer des résultats les agréments Pôle emploi qui démarrent dans le futur

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1101,9 +1101,10 @@ class ApprovalsWrapper:
             return approvals
 
         approvals_numbers = [approval.number for approval in approvals]
+        today = datetime.date.today()
         pe_approvals = [
             pe_approval
-            for pe_approval in list(PoleEmploiApproval.objects.find_for(self.user))
+            for pe_approval in list(PoleEmploiApproval.objects.find_for(self.user).filter(start_at__lte=today))
             # A `PoleEmploiApproval` could already have been copied in `Approval`.
             if pe_approval not in approvals_numbers
         ]

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -769,8 +769,7 @@ class JobApplicationWorkflowTest(TestCase):
     def test_accept_job_application_sent_by_job_seeker_with_already_existing_valid_approval_in_the_future(self):
         """
         When a Pôle emploi approval already exists, it is reused.
-        Some Pole Emploi approvals have a starting date in the future, what should we do ?
-        Here is what happens today
+        Some Pole Emploi approvals have a starting date in the future, we discard them
         """
         hiring_start_at = datetime.date.today()
         start_at = datetime.date.today() + relativedelta(months=1)
@@ -786,9 +785,10 @@ class JobApplicationWorkflowTest(TestCase):
         job_application = JobApplicationSentByJobSeekerFactory(
             job_seeker=job_seeker, state=JobApplicationWorkflow.STATE_PROCESSING, hiring_start_at=hiring_start_at
         )
+        # the job application can be accepted but the approval is not attached to the PE approval
         job_application.accept(user=job_application.to_siae.members.first())
         self.assertIsNotNone(job_application.approval)
-        self.assertEqual(job_application.approval.number, pe_approval.number)
+        self.assertNotEqual(job_application.approval.number, pe_approval.number[0:12])
         pe_approval.refresh_from_db()
         # The job application is accepted
         self.assertTrue(job_application.state.is_accepted)

--- a/itou/www/approvals_views/tests/tests.py
+++ b/itou/www/approvals_views/tests/tests.py
@@ -401,6 +401,22 @@ class PoleEmploiApprovalConversionIntoApprovalTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Nous n'avons pas trouvé d'agrément")
 
+    def test_pe_approval_search_view_agrement_is_in_the_future(self):
+        """
+        The search for PE approval screen should display that there is no results
+        if a PE approval number was searched for but it is in the future
+        """
+        today = timezone.now().date()
+        self.pe_approval = PoleEmploiApprovalFactory(start_at=today + relativedelta(days=10))
+        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        params = urlencode({"number": self.pe_approval.number})
+        url = reverse("approvals:pe_approval_search")
+        url = f"{url}?{params}"
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Nous n'avons pas trouvé d'agrément")
+
     def test_pe_approval_search_view_has_matching_pass_iae(self):
         """
         The search for PE approval screen should redirect to the matching job application details screen if the

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -248,7 +250,9 @@ def pe_approval_search(request, template_name="approvals/pe_approval_search.html
         return HttpResponseRedirect(application_details_url)
 
     # Otherwise, we display a search, and whenever it's possible, a matching PoleEmploiApproval
-    pe_approval = PoleEmploiApproval.objects.filter(number=str(request.GET.get("number"))).first()
+    pe_approval = PoleEmploiApproval.objects.filter(
+        number=str(request.GET.get("number")), start_at__lte=datetime.date.today()
+    ).first()
     search_form = PoleEmploiApprovalSearchForm(request.GET if pe_approval else None)
 
     back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("dashboard:index"))


### PR DESCRIPTION
### Quoi ?
Filtrage des agréments pôle emploi qui démarrent dans le futur afin qu’ils n’apparaissent pas dans les résultats d’import.
https://trello.com/c/yvAp4kAe/1807-c1-plusieurs-agr%C3%A9ments-pe-commencent-dans-le-futur

### Pourquoi ?

Pour éliminer les erreurs de saisie dans les agréments ; avec un agrément dans le futur, on prend le risque d’une réutilisation

