### PR TITLE
Correction d'un bug lors du téléchargement d'un PASS IAE

### DIFF
--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -30,7 +30,7 @@ def approval_as_pdf(request, job_application_id, template_name="approvals/approv
     if not job_application.can_download_approval_as_pdf:
         raise Http404(("Nous sommes au regret de vous informer que vous ne pouvez pas télécharger cet agrément."))
 
-    diagnosis = job_application.eligibility_diagnosis
+    diagnosis = job_application.get_eligibility_diagnosis()
     diagnosis_author = None
     diagnosis_author_org = None
     diagnosis_author_org_name = None


### PR DESCRIPTION
### Quoi ?

Une erreur est levée lorsqu'un PASS délivré par nous n'est lié à aucun diagnostic. Or, parfois ce diagnostic existe mais n'est pas trouvé.

### Pourquoi ?

Le code utilise l'attribut `eligibility_diagnosis` qui récupère le diagnostic associé à une candidature via la clé (voir les PR #750 et #759 ). Mais cela ignore les règles métier qui permettent de retrouver un diagnostic (`JobApplication.get_eligibility_diagnosis`).

### Comment ?

Rapide et efficace : remplacement de l'attribut par la méthode. 