### PR TITLE
Téléchargement de la dernière sauvegarde

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,5 @@
+# Path to the itou-backup project repository.
+PATH_TO_ITOU_BACKUPS=~/sites/itou-backups
+
+# Download the last available backup when running `make postgres_restore_latest_backup`.
+DOWNLOAD_LAST_BACKUP=True

--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,2 @@
 # Path to the itou-backup project repository.
 PATH_TO_ITOU_BACKUPS=~/sites/itou-backups
-
-# Download the last available backup when running `make postgres_restore_latest_backup`.
-DOWNLOAD_LAST_BACKUP=True

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,11 @@ postgres_backup_restore:
 	docker-compose exec postgres restore $(FILE) && \
 	docker-compose stop
 
+# Download last prod backup and inject it locally.
+# ----------------------------------------------------
+# Prerequisites:
+# - Clone the git `itou-backups` project first and run `make build`. https://github.com/betagouv/itou-backups
+# - Copy .env.template and set correct values.
 postgres_restore_latest_backup: ./scripts/import-latest-db-backup.sh
 	./scripts/import-latest-db-backup.sh
 

--- a/scripts/import-latest-db-backup.sh
+++ b/scripts/import-latest-db-backup.sh
@@ -11,11 +11,9 @@ if [ -z $PATH_TO_ITOU_BACKUPS ]; then
 fi
 
 # Download last available backup, provided you already ran `make build` once.
-if [ $DOWNLOAD_LAST_BACKUP ]; then
-    echo "Downloading last available backup..."
-    ( cd $PATH_TO_ITOU_BACKUPS && make download )
-    echo "Download is over."
-fi
+echo "Downloading last available backup..."
+( cd $PATH_TO_ITOU_BACKUPS && make download )
+echo "Download is over."
 
 # Get the latest backup filename and path
 ITOU_DB_BACKUP_NAME=$(ls $PATH_TO_ITOU_BACKUPS/backups | tail -n1)

--- a/scripts/import-latest-db-backup.sh
+++ b/scripts/import-latest-db-backup.sh
@@ -10,6 +10,13 @@ if [ -z $PATH_TO_ITOU_BACKUPS ]; then
   exit
 fi
 
+# Download last available backup, provided you already ran `make build` once.
+if [ $DOWNLOAD_LAST_BACKUP ]; then
+    echo "Downloading last available backup..."
+    ( cd $PATH_TO_ITOU_BACKUPS && make download )
+    echo "Download is over."
+fi
+
 # Get the latest backup filename and path
 ITOU_DB_BACKUP_NAME=$(ls $PATH_TO_ITOU_BACKUPS/backups | tail -n1)
 ITOU_DB_BACKUP_PATH=$PATH_TO_ITOU_BACKUPS/backups/$ITOU_DB_BACKUP_NAME


### PR DESCRIPTION
### Quoi ?

Ajout d'une option pour télécharger la dernière sauvegarde de prod quand on lance la commande `make postgres_restore_latest_backup`.
Cela permet de tirer parti du [travail important réalisé par Clément](https://github.com/betagouv/itou-backups) mais qui a le désavantage de se trouver sur un tout autre projet.
Egalement, ajout d'un `.env.template`.

### Pourquoi ?

Cette commande doit être exécutée dans un autre répertoire et il est fastidieux d'y naviguer à chaque fois.
