### PR TITLE
Modification du tunnel d'inscription des prescripteurs

### DIFF
--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -11,6 +11,12 @@
         <small class="text-muted">Prescripteur/Orienteur</small>
     </h1>
 
+    <ul class="list-unstyled multi-steps my-5">
+        <li class="is-active">Type de prescripteur</li>
+        <li>SIRET</li>
+        <li>Vos informations</li>
+    </ul>
+
     <div class="alert alert-warning pb-0" role="alert">
         <p>
             Les organisations habilitées permettent à leurs collaborateurs de valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique. Cette habilitation est officialisée par arrêté préfectoral.

--- a/itou/templates/signup/prescriber_choose_org.html
+++ b/itou/templates/signup/prescriber_choose_org.html
@@ -11,6 +11,12 @@
         <small class="text-muted">Prescripteur/Orienteur</small>
     </h1>
 
+    <ul class="list-unstyled multi-steps my-5">
+        <li class="is-active">Type de prescripteur</li>
+        <li>SIRET</li>
+        <li>Vos informations</li>
+    </ul>
+
     <form method="post" action="" class="js-prevent-multiple-submit">
 
         {% csrf_token %}

--- a/itou/templates/signup/prescriber_confirm_authorization.html
+++ b/itou/templates/signup/prescriber_confirm_authorization.html
@@ -12,6 +12,12 @@
         <small class="text-muted">Prescripteur habilité</small>
     </h1>
 
+    <ul class="list-unstyled multi-steps my-5">
+        <li class="is-active">Type de prescripteur</li>
+        <li>SIRET</li>
+        <li>Vos informations</li>
+    </ul>
+
     <form method="post" action="" class="js-prevent-multiple-submit">
 
         {% csrf_token %}

--- a/itou/templates/signup/prescriber_siren.html
+++ b/itou/templates/signup/prescriber_siren.html
@@ -39,7 +39,9 @@
 
     </form>
 
+    {% if not form.cleaned_data %}
     <a href="{% url 'signup:prescriber_user' %}" >Je ne fais partie d'aucune organisation</a>
+    {% endif %}
 
     {% if prescribers_with_members %}
         <div class="mt-5">

--- a/itou/templates/signup/prescriber_siren.html
+++ b/itou/templates/signup/prescriber_siren.html
@@ -1,0 +1,94 @@
+{% extends "layout/content_small.html" %}
+{% load bootstrap4 %}
+{% load static %}
+
+{% block title %}Prescripteur/Orienteur - Inscription{{ block.super }}{% endblock %}
+
+{% block content %}
+
+    <h1>
+        Inscription
+        <small class="text-muted">Prescripteur/Orienteur</small>
+    </h1>
+
+    <div class="alert alert-secondary" role="alert">
+        Retrouvez facilement votre numéro SIREN à partir du nom de votre organisation sur le site
+        <a href="https://sirene.fr/" rel="noopener" target="_blank">
+            sirene.fr
+            {% include "includes/icon.html" with icon="external-link" %}
+        </a>
+    </div>
+
+    <form method="post" action="" class="js-prevent-multiple-submit">
+
+        {% csrf_token %}
+
+        {% bootstrap_form form %}
+
+        {% buttons %}
+            {% if not form.cleaned_data %}
+            <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">
+                Retour
+            </a>
+            <button type="submit" class="btn btn-primary">Continuer</button>
+            {% endif %}
+            {% if form.cleaned_data %}
+            <button type="submit" class="btn btn-primary">Rechercher</button>
+            {% endif %}
+        {% endbuttons %}
+
+    </form>
+
+    <a href="{% url 'signup:prescriber_user' %}" >Je ne fais partie d'aucune organisation</a>
+
+    {% if prescribers_with_members %}
+        <div class="mt-5">
+            <h3>Organisation(s) déjà inscrite(s)</h3>
+            <div class="alert alert-secondary" role="info">
+                <i>Par sécurité vous devez obtenir une invitation pour rejoindre une organisation déjà inscrite.</i>
+            </div>
+            <ul>
+                {% for prescriber in prescribers_with_members %}
+                    <li>
+                        <p>
+                            <b>{{ prescriber.siret|slice:":9" }} {{ prescriber.siret|slice:"9:" }}</b> - {{ prescriber.kind }}
+                            <br>
+                            {{ prescriber.display_name }}
+                            <br>
+                            {{ prescriber.address_line_1 }},
+                            {% if prescriber.address_line_2 %}{{ prescriber.address_line_2 }},{% endif %}
+                            {{ prescriber.post_code }} {{ prescriber.city }}
+                            <br>
+                            {% if prescriber.active_admin_members %}
+                                {% with prescriber.active_admin_members.first as admin %}
+                                    {# For security, display only the first char of the last name. #}
+                                    <i>Pour obtenir une invitation, contactez {{ admin.first_name|title }} {{ admin.last_name|slice:1 }}.</i>
+                                {% endwith %}
+                            {% endif %}
+                        </p>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+        <div class="alert alert-warning mt-4" role="alert">
+            <p>
+                <small>
+                    Si vous ne retrouvez pas votre organisation dans cette liste, vous pouvez la créer.
+                </small>
+                <a href="{% url 'signup:prescriber_choose_org' %}" class="btn btn-primary mt-3">Ajouter mon organisation</a>
+            </p>
+        </div>
+    {% endif %}
+
+    {% if form.cleaned_data %}
+    <div class="mt-4">
+        <p>
+            En cas de problème contactez-nous : <a href="https://assistance.inclusion.beta.gouv.fr" rel="noopener" target="_blank">https://assistance.inclusion.beta.gouv.fr {% include "includes/icon.html" with icon="external-link" %}</a>
+        </p>
+    </div>
+    <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">
+        Retour
+    </a>
+    {% endif %}
+
+{% endblock %}

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -254,12 +254,10 @@ class PrescriberChooseKindForm(forms.Form):
 
     KIND_AUTHORIZED_ORG = "authorized_org"
     KIND_UNAUTHORIZED_ORG = "unauthorized_org"
-    KIND_SOLO = "solo"
 
     KIND_CHOICES = (
         (KIND_AUTHORIZED_ORG, "Pour une organisation habilitée par le Préfet"),
         (KIND_UNAUTHORIZED_ORG, "Pour une organisation non-habilitée"),
-        (KIND_SOLO, "Seul (sans organisation)"),
     )
 
     kind = forms.ChoiceField(

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -8,6 +8,7 @@ from django.utils.http import urlsafe_base64_decode
 from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
 from itou.siaes.models import Siae, SiaeMembership
 from itou.users.models import User
+from itou.utils.address.departments import DEPARTMENTS
 from itou.utils.apis.api_entreprise import EtablissementAPI
 from itou.utils.apis.geocoding import get_geocoding_data
 from itou.utils.password_validation import CnilCompositionPasswordValidator
@@ -221,6 +222,22 @@ class PrescriberIsPoleEmploiForm(forms.Form):
         choices=IS_POLE_EMPLOI_CHOICES,
         widget=forms.RadioSelect,
         coerce=int,
+    )
+
+
+class PrescriberSirenForm(forms.Form):
+
+    siren = forms.CharField(
+        label="Numéro SIREN de votre organisation",
+        min_length=9,
+        max_length=9,
+        validators=[validate_siren],
+        help_text="Le numéro SIREN contient 9 chiffres.",
+    )
+
+    department = forms.ChoiceField(
+        label="Département",
+        choices=DEPARTMENTS.items(),
     )
 
 

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -13,7 +13,11 @@ from django.utils.http import urlencode
 
 from itou.cities.factories import create_test_cities
 from itou.cities.models import City
-from itou.prescribers.factories import PrescriberOrganizationFactory, PrescriberPoleEmploiFactory
+from itou.prescribers.factories import (
+    PrescriberOrganizationFactory,
+    PrescriberOrganizationWithMembershipFactory,
+    PrescriberPoleEmploiFactory,
+)
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import Siae
@@ -407,10 +411,21 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
+        url = reverse("signup:prescriber_siren")
+        self.assertRedirects(response, url)
+
+        # Step 2: ask the user his SIREN number and department
+
+        post_data = {
+            "siren": siret[:9],
+            "department": "67",
+        }
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 302)
         url = reverse("signup:prescriber_choose_org")
         self.assertRedirects(response, url)
 
-        # Step 2: ask the user to choose the organization he's working for in a pre-existing list.
+        # Step 3: ask the user to choose the organization he's working for in a pre-existing list.
 
         post_data = {
             "kind": PrescriberOrganization.Kind.CAP_EMPLOI.value,
@@ -420,7 +435,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_siret")
         self.assertRedirects(response, url)
 
-        # Step 3: ask the user his SIRET number.
+        # Step 4: ask the user his SIRET number.
 
         post_data = {
             "siret": siret,
@@ -432,7 +447,7 @@ class PrescriberSignupTest(TestCase):
         mock_api_entreprise.assert_called_once()
         mock_call_ban_geocoding_api.assert_called_once()
 
-        # Step 4: user info.
+        # Step 5: user info.
 
         password = "!*p4ssw0rd123-"
         post_data = {
@@ -524,10 +539,21 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
+        url = reverse("signup:prescriber_siren")
+        self.assertRedirects(response, url)
+
+        # Step 2: ask the user his SIREN number and department
+
+        post_data = {
+            "siren": siret[:9],
+            "department": "67",
+        }
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 302)
         url = reverse("signup:prescriber_choose_org")
         self.assertRedirects(response, url)
 
-        # Step 2: ask the user to choose the organization he's working for in a pre-existing list.
+        # Step 3: ask the user to choose the organization he's working for in a pre-existing list.
 
         post_data = {
             "kind": PrescriberOrganization.Kind.OTHER.value,
@@ -537,7 +563,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_choose_kind")
         self.assertRedirects(response, url)
 
-        # Step 3: ask the user his kind of prescriber.
+        # Step 4: ask the user his kind of prescriber.
         post_data = {
             "kind": PrescriberChooseKindForm.KIND_AUTHORIZED_ORG,
         }
@@ -546,7 +572,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_confirm_authorization")
         self.assertRedirects(response, url)
 
-        # Step 4: ask the user to confirm the "authorized" character of his organization.
+        # Step 5: ask the user to confirm the "authorized" character of his organization.
 
         post_data = {
             "confirm_authorization": 1,
@@ -556,7 +582,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_siret")
         self.assertRedirects(response, url)
 
-        # Step 5: ask the user his SIRET number.
+        # Step 6: ask the user his SIRET number.
 
         post_data = {
             "siret": siret,
@@ -568,7 +594,7 @@ class PrescriberSignupTest(TestCase):
         mock_api_entreprise.assert_called_once()
         mock_call_ban_geocoding_api.assert_called_once()
 
-        # Step 6: user info.
+        # Step 7: user info.
 
         password = "!*p4ssw0rd123-"
         post_data = {
@@ -635,10 +661,21 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
+        url = reverse("signup:prescriber_siren")
+        self.assertRedirects(response, url)
+
+        # Step 2: ask the user his SIREN number and department
+
+        post_data = {
+            "siren": siret[:9],
+            "department": "67",
+        }
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 302)
         url = reverse("signup:prescriber_choose_org")
         self.assertRedirects(response, url)
 
-        # Step 2: ask the user to choose the organization he's working for in a pre-existing list.
+        # Step 3: ask the user to choose the organization he's working for in a pre-existing list.
 
         post_data = {
             "kind": PrescriberOrganization.Kind.OTHER.value,
@@ -648,7 +685,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_choose_kind")
         self.assertRedirects(response, url)
 
-        # Step 3: ask the user his kind of prescriber.
+        # Step 4: ask the user his kind of prescriber.
 
         post_data = {
             "kind": PrescriberChooseKindForm.KIND_UNAUTHORIZED_ORG,
@@ -658,7 +695,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_siret")
         self.assertRedirects(response, url)
 
-        # Step 4: ask the user his SIRET number.
+        # Step 5: ask the user his SIRET number.
 
         post_data = {
             "siret": siret,
@@ -670,7 +707,7 @@ class PrescriberSignupTest(TestCase):
         mock_api_entreprise.assert_called_once()
         mock_call_ban_geocoding_api.assert_called_once()
 
-        # Step 5: user info.
+        # Step 6: user info.
 
         password = "!*p4ssw0rd123-"
         post_data = {
@@ -712,6 +749,120 @@ class PrescriberSignupTest(TestCase):
         subject = mail.outbox[0].subject
         self.assertIn("Confirmez votre adresse e-mail", subject)
 
+    def test_create_user_prescriber_with_existing_siren_other_department(self):
+        """
+        Test the creation of a user of type prescriber with existing SIREN but in an other department
+        """
+
+        siret = "26570134200148"
+
+        # PrescriberOrganizationWithMembershipFactory
+        existing_org_with_siret = PrescriberOrganizationWithMembershipFactory(
+            siret=siret, kind=PrescriberOrganization.Kind.SPIP, department="01"
+        )
+        existing_org_with_siret.save()
+
+        # Step 1: Does the user work  for PE?
+
+        url = reverse("signup:prescriber_is_pole_emploi")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        post_data = {
+            "is_pole_emploi": 0,
+        }
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 302)
+        url = reverse("signup:prescriber_siren")
+        self.assertRedirects(response, url)
+
+        # Step 2: ask the user his SIREN number and department
+
+        post_data = {
+            "siren": siret[:9],
+            "department": "67",
+        }
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 302)
+        url = reverse("signup:prescriber_choose_org")
+        self.assertRedirects(response, url)
+
+    def test_create_user_prescriber_with_existing_siren_same_department(self):
+        """
+        Test the creation of a user of type prescriber with existing SIREN in a same department
+        """
+        siret = "26570134200148"
+
+        existing_org_with_siret = PrescriberOrganizationWithMembershipFactory(
+            siret=siret, kind=PrescriberOrganization.Kind.SPIP, department="67"
+        )
+        existing_org_with_siret.save()
+
+        # Step 1: Does the user work  for PE?
+
+        url = reverse("signup:prescriber_is_pole_emploi")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        post_data = {
+            "is_pole_emploi": 0,
+        }
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 302)
+        url = reverse("signup:prescriber_siren")
+        self.assertRedirects(response, url)
+
+        # Step 2: ask the user his SIREN number and department
+
+        post_data = {
+            "siren": siret[:9],
+            "department": "67",
+        }
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, existing_org_with_siret.display_name)
+
+        # new organisation link
+        self.assertContains(response, reverse("signup:prescriber_choose_org"))
+
+    def test_create_user_prescriber_with_existing_siren_without_member(self):
+        """
+        Test the creation of a user of type prescriber with existing organization does not have a member
+        """
+
+        siret = "26570134200148"
+
+        existing_org_with_siret = PrescriberOrganizationFactory(
+            siret=siret, kind=PrescriberOrganization.Kind.SPIP, department="67"
+        )
+        existing_org_with_siret.save()
+
+        # Step 1: Does the user work  for PE?
+
+        url = reverse("signup:prescriber_is_pole_emploi")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        post_data = {
+            "is_pole_emploi": 0,
+        }
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 302)
+        url = reverse("signup:prescriber_siren")
+        self.assertRedirects(response, url)
+
+        # Step 2: ask the user his SIREN number and department
+
+        post_data = {
+            "siren": siret[:9],
+            "department": "67",
+        }
+        response = self.client.post(url, data=post_data)
+        self.assertEqual(response.status_code, 302)
+
+        url = reverse("signup:prescriber_choose_org")
+        self.assertRedirects(response, url)
+
     def test_create_user_prescriber_without_org(self):
         """
         Test the creation of a user of type prescriber without organization.
@@ -728,30 +879,17 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
-        url = reverse("signup:prescriber_choose_org")
+        url = reverse("signup:prescriber_siren")
         self.assertRedirects(response, url)
 
-        # Step 2: ask the user to choose the organization he's working for in a pre-existing list.
+        # Step 2: ask the user his SIREN number and department or click on link "no organization"
+        response = self.client.get(url)
+        user_info_url = reverse("signup:prescriber_user")
+        self.assertContains(response, user_info_url)
+        response = self.client.get(user_info_url)
+        self.assertEqual(response.status_code, 200)
 
-        post_data = {
-            "kind": PrescriberOrganization.Kind.OTHER.value,
-        }
-        response = self.client.post(url, data=post_data)
-        self.assertEqual(response.status_code, 302)
-        url = reverse("signup:prescriber_choose_kind")
-        self.assertRedirects(response, url)
-
-        # Step 3: ask the user his kind of prescriber.
-
-        post_data = {
-            "kind": PrescriberChooseKindForm.KIND_SOLO,
-        }
-        response = self.client.post(url, data=post_data)
-        self.assertEqual(response.status_code, 302)
-        url = reverse("signup:prescriber_user")
-        self.assertRedirects(response, url)
-
-        # Step 4: user info.
+        # Step 3: user info.
 
         password = "!*p4ssw0rd123-"
         post_data = {
@@ -761,7 +899,7 @@ class PrescriberSignupTest(TestCase):
             "password1": password,
             "password2": password,
         }
-        response = self.client.post(url, data=post_data)
+        response = self.client.post(user_info_url, data=post_data)
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("account_email_verification_sent"))
 

--- a/itou/www/signup/urls.py
+++ b/itou/www/signup/urls.py
@@ -23,6 +23,11 @@ urlpatterns = [
         name="prescriber_is_pole_emploi",
     ),
     path(
+        "prescriber/siren",
+        views.prescriber_siren,
+        name="prescriber_siren",
+    ),
+    path(
         "prescriber/choose_org",
         views.prescriber_choose_org,
         name="prescriber_choose_org",

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -341,10 +341,6 @@ def prescriber_choose_kind(request, template_name="signup/prescriber_choose_kind
             kind = PrescriberOrganization.Kind.OTHER.value
             next_url = reverse("signup:prescriber_siret")
 
-        elif prescriber_kind == form.KIND_SOLO:
-            # Go to sign up screen without organization.
-            next_url = reverse("signup:prescriber_user")
-
         session_data.update(
             {
                 "authorization_status": authorization_status,


### PR DESCRIPTION
### Quoi ?

Ajout d'une étape de saisie du SIREN

### Pourquoi ?

Pour éviter les doublons d'organisations prescripteurs

### Comment ?

En demandant le SIREN avant le type d'organisation, il est ainsi possible de voir si l'organisation existe déjà sur un département. Ainsi, il ne devrait plus y avoir plusieurs fois la même organisation avec des types différents.

### Captures d'écran

Étape de saisie du SIREN

![inscription-prescripteur-siren](https://user-images.githubusercontent.com/17601807/124623950-b93c9b80-de7c-11eb-99ac-7b5b69040ae6.png)

Quand des organisations existent avec le même SIREN sur le même département : 

![inscription-prescripteur-orga-exists](https://user-images.githubusercontent.com/17601807/124624116-e426ef80-de7c-11eb-9d5f-d38a64500604.png)

Si aucune organisation n'est trouvée, l'étape de choix du type est affichée (avec train d'étapes) :
![inscription-prescripteur-choix-type-orga](https://user-images.githubusercontent.com/17601807/124624334-16385180-de7d-11eb-9c72-a924d8fcb802.png)

Lorsque nous choisissons "Autre", l'étape d'après ne propose plus l'option "Seul (sans organisation)" et affiche le train d'étapes :

![inscription-prescripteur-autre](https://user-images.githubusercontent.com/17601807/124624459-2e0fd580-de7d-11eb-8ab8-efd51bb010bb.png)


