### PR TITLE
Modification du niveau de log pour Sentry

### DIFF
--- a/config/settings/_sentry.py
+++ b/config/settings/_sentry.py
@@ -29,7 +29,7 @@ def strip_sentry_sensitive_data(event, hint):
 
 sentry_logging = LoggingIntegration(
     level=logging.INFO,  # Capture info and above as breadcrumbs.
-    event_level=logging.INFO,  # Send warnings as events.
+    event_level=logging.WARNING,  # Send warnings as events.
 )
 
 


### PR DESCRIPTION
PR sans revue.

Oubli de ma part de remonter le niveau de log de Sentry après les tests sur l'extraction de log