### PR TITLE
Correctif pour une erreur 404 lors de la reprise d'un agrément PE

### DIFF
--- a/itou/templates/approvals/pe_approval_search.html
+++ b/itou/templates/approvals/pe_approval_search.html
@@ -34,7 +34,7 @@
 
         <hr>
 
-    {% else %}
+    {% elif number %}
 
         <h2>Pas de résultat</h2>
 

--- a/itou/templates/approvals/pe_approval_search.html
+++ b/itou/templates/approvals/pe_approval_search.html
@@ -34,7 +34,7 @@
 
         <hr>
 
-    {% elif number %}
+    {% else %}
 
         <h2>Pas de résultat</h2>
 
@@ -47,7 +47,7 @@
 
     <h2>Rechercher un agrément Pôle emploi</h2>
 
-    <form method="GET" action="" role="form" class="js-prevent-multiple-submit">
+    <form method="get" action="" role="form" class="js-prevent-multiple-submit">
 
         {% bootstrap_form form alert_error_type="all" %}
 

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -144,4 +144,8 @@ class PoleEmploiApprovalSearchForm(forms.Form):
     Search for a PoleEmploiApproval by id
     """
 
-    number = forms.CharField(label="Numéro", required=True, min_length=12, max_length=15)
+    number = forms.CharField(label="Numéro", required=True, min_length=12, max_length=15, strip=True)
+
+    def clean_number(self):
+        number = self.cleaned_data.get("number", "")
+        return number.replace(" ", "")

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -234,20 +234,19 @@ def pe_approval_search(request, template_name="approvals/pe_approval_search.html
     """
     siae = get_current_siae_or_404(request)
 
-    # We search if the approval already exist with this exact number,
+    # We search if the approval already exists with this exact number,
     # or if it was created from the first 12 digits of a PoleEmploiApproval's number
     approval = None
     number = request.GET.get("number")
     if number:
         approval = Approval.objects.filter(number__in=[number, number[:12]]).first()
 
-    # # If the identifier matches an existing approval, we redirection to the matching job application
+    # If the identifier matches an existing approval, we redirection to the matching job application.
     if approval:
-        job_application_id = approval.user.last_accepted_job_application.id
-        application_details_url = reverse_lazy(
-            "apply:details_for_siae", kwargs={"job_application_id": job_application_id}
-        )
-        return HttpResponseRedirect(application_details_url)
+        job_app = approval.user.last_accepted_job_application
+        if job_app.to_siae == siae:
+            application_details_url = reverse_lazy("apply:details_for_siae", kwargs={"job_application_id": job_app.pk})
+            return HttpResponseRedirect(application_details_url)
 
     # Otherwise, we display a search, and whenever it's possible, a matching PoleEmploiApproval
     pe_approval = PoleEmploiApproval.objects.filter(

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from django.http import FileResponse, Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.template.response import SimpleTemplateResponse
-from django.urls import reverse_lazy
+from django.urls import reverse
 from django.utils.text import slugify
 
 from itou.approvals.models import Approval, PoleEmploiApproval, Suspension
@@ -90,7 +90,7 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
     if not approval.can_be_prolonged_by_siae(siae):
         raise PermissionDenied()
 
-    back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("dashboard:index"))
+    back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
     preview = False
 
     form = DeclareProlongationForm(approval=approval, siae=siae, data=request.POST or None)
@@ -135,7 +135,7 @@ def suspend(request, approval_id, template_name="approvals/suspend.html"):
     if not approval.can_be_suspended_by_siae(siae):
         raise PermissionDenied()
 
-    back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("dashboard:index"))
+    back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
     preview = False
 
     form = SuspensionForm(approval=approval, siae=siae, data=request.POST or None)
@@ -175,7 +175,7 @@ def suspension_update(request, suspension_id, template_name="approvals/suspensio
     if not suspension.can_be_handled_by_siae(siae):
         raise PermissionDenied()
 
-    back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("dashboard:index"))
+    back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
 
     form = SuspensionForm(approval=suspension.approval, siae=siae, instance=suspension, data=request.POST or None)
 
@@ -206,7 +206,7 @@ def suspension_delete(request, suspension_id, template_name="approvals/suspensio
     if not suspension.can_be_handled_by_siae(siae):
         raise PermissionDenied()
 
-    back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("dashboard:index"))
+    back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
 
     if request.method == "POST" and request.POST.get("confirm") == "true":
         suspension.delete()
@@ -273,7 +273,7 @@ def pe_approval_search_user(request, pe_approval_id, template_name="approvals/pe
     """
     pe_approval = get_object_or_404(PoleEmploiApproval, pk=pe_approval_id)
 
-    back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("dashboard:index"))
+    back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
 
     form = UserExistsForm(data=None)
 
@@ -293,7 +293,7 @@ def pe_approval_create(request, pe_approval_id):
 
     form = UserExistsForm(data=request.POST or None)
     if request.method != "POST" or not form.is_valid():
-        next_url = reverse_lazy("approvals:pe_approval_search_user", kwargs={"pe_approval_id": pe_approval_id})
+        next_url = reverse("approvals:pe_approval_search_user", kwargs={"pe_approval_id": pe_approval_id})
         return HttpResponseRedirect(next_url)
 
     # If there already is a user with this email, we take it, otherwise we create one
@@ -307,13 +307,13 @@ def pe_approval_create(request, pe_approval_id):
     if possible_matching_approval:
         messages.info(request, "Cet agrément Pôle emploi a déja été importé.")
         job_application = JobApplication.objects.filter(approval=possible_matching_approval).first()
-        next_url = reverse_lazy("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
+        next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
         return HttpResponseRedirect(next_url)
 
     # It is not possible to attach an approval to a job seeker that already has a valid approval
     if job_seeker.approvals_wrapper.has_valid and job_seeker.approvals_wrapper.latest_approval.is_pass_iae:
         messages.error(request, "Le candidat associé à cette adresse email a déja un PASS IAE valide.")
-        next_url = reverse_lazy("approvals:pe_approval_search_user", kwargs={"pe_approval_id": pe_approval_id})
+        next_url = reverse("approvals:pe_approval_search_user", kwargs={"pe_approval_id": pe_approval_id})
         return HttpResponseRedirect(next_url)
 
     with transaction.atomic():
@@ -341,5 +341,5 @@ def pe_approval_create(request, pe_approval_id):
     messages.success(
         request, "L'agrément Pôle emploi a bien été importé, vous pouvez désormais le prolonger ou le suspendre."
     )
-    next_url = reverse_lazy("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
+    next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
     return HttpResponseRedirect(next_url)


### PR DESCRIPTION
### Quoi ?

Correctif pour une erreur 404.

### Pourquoi ?

Quand une SIAE souhaite récupérer un agrément PE pour le prolonger, on vérifie que ce dernier n'a pas déjà été utilisé pour émettre un PASS IAE.

Si c'est le cas, alors on récupère la dernière candidature associée au PASS IAE.

Or si la SIAE destinataire de la dernière candidature n'est pas la SIAE connectée, on tombe sur une 404.

### Comment ?

Ajout d'une vérification pour s'assurer que la SIAE destinataire de la dernière candidature est bien la SIAE connectée.