### PR TITLE
Boost Metabase

### DIFF
--- a/itou/metabase/management/commands/_job_seekers.py
+++ b/itou/metabase/management/commands/_job_seekers.py
@@ -135,6 +135,12 @@ TABLE_COLUMNS = [
         "fn": lambda o: o.is_peamu,
     },
     {
+        "name": "pe_inscrit",
+        "type": "boolean",
+        "comment": "Le candidat a un identifiant PE",
+        "fn": lambda o: o.pole_emploi_id is not None and o.pole_emploi_id != "",
+    },
+    {
         "name": "date_dernière_connexion",
         "type": "date",
         "comment": "Date de dernière connexion au service du candidat",

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -281,6 +281,7 @@ class Command(BaseCommand):
         queryset = (
             JobApplication.objects.select_related("to_siae", "sender_siae", "sender_prescriber_organization")
             .prefetch_related("logs")
+            .filter(created_from_pe_approval=False)
             .all()
         )
 

--- a/itou/prescribers/factories.py
+++ b/itou/prescribers/factories.py
@@ -5,6 +5,7 @@ import factory.fuzzy
 
 from itou.prescribers import models
 from itou.users.factories import PrescriberFactory
+from itou.utils.address.departments import DEPARTMENTS
 
 
 class PrescriberOrganizationFactory(factory.django.DjangoModelFactory):
@@ -19,6 +20,7 @@ class PrescriberOrganizationFactory(factory.django.DjangoModelFactory):
     phone = factory.fuzzy.FuzzyText(length=10, chars=string.digits)
     email = factory.Faker("email", locale="fr_FR")
     kind = models.PrescriberOrganization.Kind.PE
+    department = factory.fuzzy.FuzzyChoice(DEPARTMENTS.keys())
 
 
 class AuthorizedPrescriberOrganizationFactory(PrescriberOrganizationFactory):

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -260,10 +260,14 @@ class ModelTest(TestCase):
         CD as in "Conseil Départemental".
         """
         # Admin prescriber of authorized CD can access.
-        org = AuthorizedPrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganization.Kind.DEPT)
+        org = AuthorizedPrescriberOrganizationWithMembershipFactory(
+            kind=PrescriberOrganization.Kind.DEPT, department="02"
+        )
         user = org.members.get()
         self.assertTrue(user.can_view_stats_cd(current_org=org))
         self.assertTrue(user.can_view_stats_dashboard_widget(current_org=org))
+        self.assertEqual(user.get_stats_cd_department(current_org=org), org.department)
+        self.assertNotEqual(user.get_stats_cd_department(current_org=org), "01")
 
         # Non admin prescriber cannot access.
         org = AuthorizedPrescriberOrganizationWithMembershipFactory(
@@ -290,6 +294,13 @@ class ModelTest(TestCase):
         user = PrescriberFactory()
         self.assertFalse(user.can_view_stats_cd(current_org=org))
         self.assertFalse(user.can_view_stats_dashboard_widget(current_org=org))
+
+        # VIP user can always access, even without a CD.
+        org = None
+        user = UserFactory(is_stats_vip=True)
+        self.assertTrue(user.can_view_stats_cd(current_org=org))
+        self.assertTrue(user.can_view_stats_dashboard_widget(current_org=org))
+        self.assertEqual(user.get_stats_cd_department(current_org=org), "01")
 
 
 def mock_get_geocoding_data(address, post_code=None, limit=1):

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -76,7 +76,10 @@ def stats_cd(request, template_name=_STATS_HTML_TEMPLATE):
     "Intégrer ce dashboard dans une application" then inside "Paramètres" on the right, make sure the relevant
     parameter "Département" is "Verrouillé" and "Région" is "Désactivé".
     """
-    current_org = get_current_org_or_404(request)
+    if request.user.is_stats_vip:
+        current_org = None
+    else:
+        current_org = get_current_org_or_404(request)
     if not request.user.can_view_stats_cd(current_org=current_org):
         raise PermissionDenied
     department = request.user.get_stats_cd_department(current_org=current_org)

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -79,7 +79,7 @@ def stats_cd(request, template_name=_STATS_HTML_TEMPLATE):
     current_org = get_current_org_or_404(request)
     if not request.user.can_view_stats_cd(current_org=current_org):
         raise PermissionDenied
-    department = current_org.department
+    department = request.user.get_stats_cd_department(current_org=current_org)
     context = {
         "iframeurl": metabase_embedded_url(settings.CD_STATS_DASHBOARD_ID, department=department),
         "page_title": f"Données de mon département : {DEPARTMENTS[department]}",


### PR DESCRIPTION
### Quoi ?

- Ajout d'une colonne qui précise si le candidat est inscript à PE
- Filtrage des "fausses" candidatures liées à des agréments PE
- Les utilisateurs VIP (Soumia etc) peuvent maintenant avoir accès au TDB CD, le département sera toujours le 01.

