### PR TITLE
Affichage du lien d'invitation

### DIFF
--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -9,6 +9,7 @@
                     <th scope="col">Nom</th>
                     <th scope="col">Email</th>
                     <th scope="col">Envoyée le</th>
+                    <th scope="col">Lien d'invitation</th>
                 </tr>
             </thead>
             <tbody>
@@ -18,9 +19,16 @@
                     <td>{{ invitation.first_name }} {{ invitation.last_name }}</td>
                     <td><a href="mailto:{{ invitation.email }}">{{ invitation.email }}</a></td>
                     <td>{{ invitation.sent_at|date:"d F Y à H:i" }}</td>
+                    <td>{{ invitation.acceptance_link }}</td>
                 </tr>
             {% endfor %}
             </tbody>
         </table>
+    </div>
+    <div class="alert alert-warning" role="alert">
+        Chaque collaborateur invité reçoit son propre lien d'invitation, ce lien est valable 15 jours
+        (lorsque le lien expire, l'invitation n'est plus affichée ci-dessus). 
+        Ce lien d'invitation est transmis automatiquement par e-mail.
+        En cas de besoin, vous pouvez également le copier depuis la colonne « Lien d'invitation ».
     </div>
 {% endif %}

--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -19,7 +19,20 @@
                     <td>{{ invitation.first_name }} {{ invitation.last_name }}</td>
                     <td><a href="mailto:{{ invitation.email }}">{{ invitation.email }}</a></td>
                     <td>{{ invitation.sent_at|date:"d F Y à H:i" }}</td>
-                    <td>{{ invitation.acceptance_link }}</td>
+                    <td>
+                        <p>
+                            <a data-toggle="collapse" href="#share-invitation-link-{{ forloop.counter }}" role="button" aria-expanded="false">
+                                Afficher le lien
+                            </a>
+                        </p>
+                        <div class="collapse form-group" id="share-invitation-link-{{ forloop.counter }}">
+                            <p>
+                                Copiez-collez le lien ci-dessous :
+                            </p>
+                            {# Poor man's copy and paste with onClick #}
+                            <input type="text" class="form-control" readonly="readonly" value="{{ invitation.acceptance_link }}" onClick="this.select()">
+                        </div>
+                    </td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/itou/templates/invitations_views/new_user.html
+++ b/itou/templates/invitations_views/new_user.html
@@ -8,7 +8,7 @@
     {% include "invitations_views/includes/invitation_errors.html" with invitation=invitation %}
 
     {% if form %}
-        <h1>Bienvenue !</h1>
+        <h1>Bienvenue {{ invitation.first_name }} {{ invitation.last_name }} !</h1>
         <form method="post" action="{{ invitation.acceptance_link }}" role="form" class="js-prevent-multiple-submit">
             {% csrf_token %}
 


### PR DESCRIPTION
### Quoi ?

Affichage du lien d'invitation directement dans la gestion des collaborteurs

### Pourquoi ?

Des utilisateurs disent ne pas recevoir le lien d'invitation. Le support doit alors le gérer manuellement, ce qui est chronophage.

### Comment ?

Le lien d'invitation est affiché dans le tableau dans un champs texte en lecture seul pour faciliter sa copie.
Pour limiter les erreurs, le nom du collaborateur est ajouté sur la page cible du lien d'invitation.

### Captures d'écran

Le tableau des collaborateurs : 

![Le tableau des collaborateurs](https://user-images.githubusercontent.com/17601807/125307996-d7007980-e330-11eb-9c2f-5d39744094df.png)

Page cible du lien d'invitation :

![lien-invitation-affiche-nom](https://user-images.githubusercontent.com/17601807/125307945-cc45e480-e330-11eb-96a8-2b6c2904e399.png)


