### PR TITLE
Un membre retiré d'une structure peut être réinvité

### DIFF
--- a/itou/invitations/models.py
+++ b/itou/invitations/models.py
@@ -108,10 +108,6 @@ class InvitationAbstract(models.Model):
         self.save()
         self.accepted_notif_sender()
 
-    def extend_expiration_date(self):
-        self.sent_at = timezone.now()
-        self.save()
-
     def send(self):
         self.sent = True
         self.sent_at = timezone.now()

--- a/itou/invitations/tests.py
+++ b/itou/invitations/tests.py
@@ -61,12 +61,6 @@ class InvitationModelTest(TestCase):
         invitation = SentSiaeStaffInvitationFactory()
         self.assertTrue(invitation.can_be_accepted)
 
-    def test_extend_expiration_date(self):
-        invitation = ExpiredSiaeStaffInvitationFactory()
-        self.assertTrue(invitation.has_expired)
-        invitation.extend_expiration_date()
-        self.assertFalse(invitation.has_expired)
-
     def test_get_model_from_string(self):
         invitation_type = InvitationAbstract.get_model_from_string("siae_staff")
         self.assertEqual(invitation_type, SiaeStaffInvitation)

--- a/itou/www/invitations_views/forms.py
+++ b/itou/www/invitations_views/forms.py
@@ -41,23 +41,10 @@ class PrescriberWithOrgInvitationForm(forms.ModelForm):
                     error = forms.ValidationError("Cette personne fait déjà partie de votre organisation.")
                     self.add_error("email", error)
 
-    def _extend_expiration_date_or_error(self, email):
-        invitation_model = self.Meta.model
-        existing_invitation = invitation_model.objects.filter(
-            email__iexact=email, organization=self.organization
-        ).first()
-        if existing_invitation:
-            #
-            # WARNING The form is now bound to this instance
-            #
-            self.instance = existing_invitation
-            self.instance.extend_expiration_date()
-
     def clean_email(self):
         email = self.cleaned_data["email"]
 
         self._invited_user_exists_error(email)
-        self._extend_expiration_date_or_error(email)
         if self.organization.kind == PrescriberOrganization.Kind.PE and not email.endswith(
             settings.POLE_EMPLOI_EMAIL_SUFFIX
         ):
@@ -143,20 +130,9 @@ class SiaeStaffInvitationForm(forms.ModelForm):
                     error = forms.ValidationError("Cette personne fait déjà partie de votre structure.")
                     self.add_error("email", error)
 
-    def _extend_expiration_date_or_error(self, email):
-        invitation_model = self.Meta.model
-        existing_invitation = invitation_model.objects.filter(email__iexact=email, siae=self.siae).first()
-        if existing_invitation:
-            #
-            # WARNING The form is now bound to this instance
-            #
-            self.instance = existing_invitation
-            self.instance.extend_expiration_date()
-
     def clean_email(self):
         email = self.cleaned_data["email"]
         self._invited_user_exists_error(email)
-        self._extend_expiration_date_or_error(email)
         return email
 
     def save(self, *args, **kwargs):  # pylint: disable=unused-argument

--- a/itou/www/invitations_views/tests/tests_prescriber_organization.py
+++ b/itou/www/invitations_views/tests/tests_prescriber_organization.py
@@ -83,7 +83,8 @@ class TestSendPrescriberWithOrgInvitation(TestCase):
         # Invite user (the revenge)
         response = self.client.post(INVITATION_URL, data=self.post_data, follow=True)
         self.assertRedirects(response, INVITATION_URL)
-        self.assert_created_invitation()
+        invitations_count = PrescriberWithOrgInvitation.objects.filter(organization=self.organization).count()
+        self.assertEqual(invitations_count, 2)
 
 
 class TestSendPrescriberWithOrgInvitationExceptions(TestCase):

--- a/itou/www/invitations_views/tests/tests_siae_send.py
+++ b/itou/www/invitations_views/tests/tests_siae_send.py
@@ -4,7 +4,6 @@ from django.test import TestCase
 from django.utils import timezone
 from django.utils.html import escape
 
-from itou.invitations.factories import ExpiredSiaeStaffInvitationFactory
 from itou.invitations.models import SiaeStaffInvitation
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.factories import SiaeMembershipFactory, SiaeWithMembershipFactory
@@ -95,25 +94,6 @@ class TestSendSingleSiaeInvitation(TestCase):
             for key, _errors in error_dict.items():
                 self.assertEqual(key, "email")
                 self.assertEqual(error_dict["email"][0], "Cet utilisateur n'est pas un employeur.")
-
-    def test_extend_expired_invitation(self):
-        self.client.login(email=self.sender.email, password=DEFAULT_PASSWORD)
-        ExpiredSiaeStaffInvitationFactory(
-            sender=self.sender,
-            first_name=self.guest_data["first_name"],
-            last_name=self.guest_data["last_name"],
-            email=self.guest_data["email"],
-            siae=self.siae,
-        )
-        response = self.client.post(INVITATION_URL, data=self.post_data, follow=True)
-        self.assertContains(response, "Votre invitation a été envoyée par e-mail.")
-
-        # Make sure an email has been sent to the invited person
-        self.assertEqual(len(mail.outbox), 1)
-        self.assertIn(self.guest_data["email"], mail.outbox[0].to)
-
-        # but there is still only one invitation in DB
-        self.assertEqual(SiaeStaffInvitation.objects.count(), 1)
 
     def test_two_employers_invite_the_same_guest(self):
         # SIAE 1 invites guest.


### PR DESCRIPTION
### Quoi ?

Suppression d'une condition dans le mécanisme d'invitation. Nous regardions si l'invitation était expirée. Si c'était le cas, nous prolongions l'invitation au lieu de la renvoyer.
Cela cause de nombreux soucis et ajoute de la complexité inutilement.

### Pourquoi ?
Imaginons un membre, Georges, qui a rejoint une organisation en cliquant sur un lien d'invitation.
L'administrateur de cette organisation décide de le désactiver. Georges n'est plus membre.
Mais voilà que l'administrateur l'engage de nouveau ! Il pense envoyer une nouvelle invitation mais, en réalité, notre algorithme prolonge la date de validité de la première invitation envoyée !
Georges clique sur le lien d'acceptation mais il voit le message d'erreur suivant : "Invitation déjà acceptée".

### Comment ?

Envoi de l'invitation systématique.
