### PR TITLE
Mise à jour du bouton "Continuer avec un CV"

### DIFF
--- a/itou/templates/apply/submit_step_job_seeker_create.html
+++ b/itou/templates/apply/submit_step_job_seeker_create.html
@@ -37,7 +37,7 @@
 
         {% buttons %}
             <button type="submit" class="btn btn-primary">
-                Continuer avec un CV
+                Continuer
             </button>
         {% endbuttons %}
 


### PR DESCRIPTION
Suppression de la mention "avec un CV" pour plus de clarté.