### PR TITLE
Lien vers le support en cas d'erreur 500

### DIFF
--- a/itou/templates/500.html
+++ b/itou/templates/500.html
@@ -6,6 +6,13 @@
 
     <h1>Erreur 500</h1>
     <p class="lead">Une erreur technique s'est produite.</p>
-    <p>Notre équipe technique a été informée du problème et s'en occupera le plus rapidement possible.
+    <p>Notre équipe technique a été informée du problème et s'en occupera le plus rapidement possible.</p>
+
+    {# Using ITOU_ASSISTANCE_URL would have required a custom error handler. #}
+    <p>
+        Toutefois, nous vous invitons à contacter
+        <a href="https://assistance.inclusion.beta.gouv.fr/accueil/support/"> l'assistance de la Plateforme de l'inclusion</a>
+        afin que nous disposions de toutes les informations nécessaires à la résolution du problème.
+    </p>
 
 {% endblock %}


### PR DESCRIPTION
### Quoi ?

Ajout d'un lien.

### Pourquoi ?

Le message initial laisse croire que le problème va être traité et nous ne sommes pas toujours suffisamment réactifs ou nous ne prenons pas bien la mesure du problème.

### Comment ?

Avec ce lien, le but est d'avoir un contact avec l'utilisateur et d'obtenir plus d'infos.

