### PR TITLE
Ajustements au tunnel d'inscription des prescripteurs

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@ load-plugins=pylint_django
 django-settings-module=config.settings.dev
 
 [MESSAGES CONTROL]
-disable=missing-docstring,invalid-name,duplicate-code,bad-continuation,arguments-differ,too-few-public-methods,no-self-use
+disable=missing-docstring,invalid-name,duplicate-code,bad-continuation,arguments-differ,too-few-public-methods,no-self-use,no-member
 
 [FORMAT]
 

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -2,14 +2,17 @@ import logging
 
 from .base import *
 
+
 # `ManifestStaticFilesStorage` (used in base settings) requires `collectstatic` to be run.
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
-# Prevent calls to external APIs.
+# Prevent calls to external APIs but keep a valid scheme
 API_BAN_BASE_URL = None
-API_ENTREPRISE_BASE_URL = None
+API_ENTREPRISE_BASE_URL = "http://example.com"
 API_ESD_KEY = None
 API_ESD_SECRET = None
+API_ENTREPRISE_RECIPIENT = 12345
+API_ENTREPRISE_TOKEN = 12345
 
 # Disable logging and traceback in unit tests for readability.
 # https://docs.python.org/3/library/logging.html#logging.disable

--- a/itou/templates/signup/prescriber_signup.html
+++ b/itou/templates/signup/prescriber_signup.html
@@ -1,5 +1,6 @@
 {% extends "layout/content_small.html" %}
 {% load bootstrap4 %}
+{% load format_filters %}
 
 {% block title %}Prescripteur/Orienteur - Inscription{{ block.super }}{% endblock %}
 
@@ -26,7 +27,7 @@
     {% if prescriber_org_data %}
         <div class="alert alert-secondary pb-0" role="alert">
             <p>
-                <b>{{ prescriber_org_data.name }}</b> - {{ prescriber_org_data.siret }}<br>
+                <b>{{ prescriber_org_data.name }}</b> - {{ prescriber_org_data.siret|format_siret }}<br>
                 {% if prescriber_org_data.address_line_1 %}{{ prescriber_org_data.address_line_1 }}<br>{% endif %}
                 {% if prescriber_org_data.address_line_2 %}{{ prescriber_org_data.address_line_2 }}<br>{% endif %}
                 {{ prescriber_org_data.post_code }} {{ prescriber_org_data.city }}

--- a/itou/templates/signup/prescriber_siren.html
+++ b/itou/templates/signup/prescriber_siren.html
@@ -11,7 +11,7 @@
         <small class="text-muted">Prescripteur/Orienteur</small>
     </h1>
 
-    <div class="alert alert-secondary" role="alert">
+    <div class="alert alert-info" role="alert">
         Retrouvez facilement votre numéro SIREN à partir du nom de votre organisation sur le site
         <a href="https://sirene.fr/" rel="noopener" target="_blank">
             sirene.fr

--- a/itou/templates/signup/prescriber_siren.html
+++ b/itou/templates/signup/prescriber_siren.html
@@ -1,6 +1,7 @@
 {% extends "layout/content_small.html" %}
 {% load bootstrap4 %}
 {% load static %}
+{% load format_filters %}
 
 {% block title %}Prescripteur/Orienteur - Inscription{{ block.super }}{% endblock %}
 
@@ -47,7 +48,7 @@
                 {% for prescriber in prescribers_with_members %}
                     <li>
                         <p>
-                            <b>{{ prescriber.siret|slice:":9" }} {{ prescriber.siret|slice:"9:" }}</b> - {{ prescriber.kind }}
+                            <b>{{ prescriber.siret|format_siret }}</b> - {{ prescriber.kind }}
                             <br>
                             {{ prescriber.display_name }}
                             <br>

--- a/itou/templates/signup/prescriber_siret.html
+++ b/itou/templates/signup/prescriber_siret.html
@@ -29,7 +29,32 @@
 
         {% csrf_token %}
 
-        {% bootstrap_form form alert_error_type="all" %}
+        {% bootstrap_label "Numéro SIRET de votre organisation *" %}
+        <div class="form-group form-group-required row{% if form.errors %} is-invalid{% endif %}">
+            <div class="col-md-2 p-2 text-right">
+                <span class="text-muted">{{ siren }}</span>
+            </div>
+
+            <div class="col-md-3">
+                <input type="text"
+                    class="form-control{% if form.errors %} is-invalid{% endif %}"
+                    name="{{ form.partial_siret.name }}"
+                    value="{{ form.partial_siret.value|default_if_none:'' }}"
+                    maxlength="5" minlength="5"
+                    placeholder="00000"
+                    required
+                    id="id_{{ form.partial_siret.name }}"
+                >
+            </div>
+            {% if form.partial_siret.errors %}
+            <div class="col-md-12">
+                <div class="invalid-feedback d-block">{{ form.partial_siret.errors|join:", " }}</div>
+            </div>
+            {% endif %}
+            <div class="col-md-12">
+                <small class="form-text text-muted">Complétez le numéro SIREN avec les 5 derniers chiffres du SIRET de votre organisation.</small>
+            </div>
+        </div>
 
         {% buttons %}
             <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">

--- a/itou/templates/signup/prescriber_siret.html
+++ b/itou/templates/signup/prescriber_siret.html
@@ -17,7 +17,7 @@
         <li>Vos informations</li>
     </ul>
 
-    <div class="alert alert-secondary" role="alert">
+    <div class="alert alert-info" role="alert">
         Retrouvez facilement votre numéro SIRET à partir du nom de votre organisation sur le site
         <a href="https://sirene.fr/" rel="noopener" target="_blank">
             sirene.fr

--- a/itou/templates/signup/prescriber_siret.html
+++ b/itou/templates/signup/prescriber_siret.html
@@ -30,32 +30,41 @@
 
         {% csrf_token %}
 
-        {% bootstrap_label "Numéro SIRET de votre organisation *" %}
-        <div class="form-group form-group-required row{% if form.errors %} is-invalid{% endif %}">
+        <div class="form-group form-group-required{% if form.errors %} is-invalid{% endif %}">
+            {% bootstrap_label "Numéro SIRET de votre organisation" %}
 
-            <div class="col-md-2 p-2 text-right">
-                <span class="text-muted">{{ siren|format_siret }}</span>
+            <div class="row ml-2">
+                <div class="py-2 text-right">
+                    <span class="text-muted">{{ siren|format_siret }}</span>
+                </div>
+
+                <div class="col-md-3">
+                    <input type="text"
+                        class="form-control{% if form.errors %} is-invalid{% endif %}"
+                        name="{{ form.partial_siret.name }}"
+                        value="{{ form.partial_siret.value|default_if_none:'' }}"
+                        maxlength="5" minlength="5"
+                        placeholder="00000"
+                        required
+                        id="id_{{ form.partial_siret.name }}"
+                    >
+                </div>
             </div>
 
-            <div class="col-md-3">
-                <input type="text"
-                    class="form-control{% if form.errors %} is-invalid{% endif %}"
-                    name="{{ form.partial_siret.name }}"
-                    value="{{ form.partial_siret.value|default_if_none:'' }}"
-                    maxlength="5" minlength="5"
-                    placeholder="00000"
-                    required
-                    id="id_{{ form.partial_siret.name }}"
-                >
+            <div class="row">
+                {% if form.partial_siret.errors %}
+                    <div class="col-md-12">
+                        <div class="invalid-feedback d-block">{{ form.partial_siret.errors|join:", " }}</div>
+                    </div>
+                {% endif %}
             </div>
-            {% if form.partial_siret.errors %}
-            <div class="col-md-12">
-                <div class="invalid-feedback d-block">{{ form.partial_siret.errors|join:", " }}</div>
+
+            <div class="row">
+                <div class="col-md-12">
+                    <small class="form-text text-muted">Complétez le numéro SIREN avec les 5 derniers chiffres du SIRET de votre organisation.</small>
+                </div>
             </div>
-            {% endif %}
-            <div class="col-md-12">
-                <small class="form-text text-muted">Complétez le numéro SIREN avec les 5 derniers chiffres du SIRET de votre organisation.</small>
-            </div>
+
         </div>
 
         {% buttons %}

--- a/itou/templates/signup/prescriber_siret.html
+++ b/itou/templates/signup/prescriber_siret.html
@@ -1,6 +1,7 @@
 {% extends "layout/content_small.html" %}
 {% load bootstrap4 %}
 {% load static %}
+{% load format_filters %}
 
 {% block title %}Prescripteur/Orienteur - Inscription{{ block.super }}{% endblock %}
 
@@ -31,8 +32,9 @@
 
         {% bootstrap_label "Numéro SIRET de votre organisation *" %}
         <div class="form-group form-group-required row{% if form.errors %} is-invalid{% endif %}">
+
             <div class="col-md-2 p-2 text-right">
-                <span class="text-muted">{{ siren }}</span>
+                <span class="text-muted">{{ siren|format_siret }}</span>
             </div>
 
             <div class="col-md-3">

--- a/itou/users/factories.py
+++ b/itou/users/factories.py
@@ -12,7 +12,7 @@ from itou.utils.address.departments import DEPARTMENTS
 from itou.utils.mocks.address_format import BAN_GEOCODING_API_RESULTS_MOCK
 
 
-DEFAULT_PASSWORD = "p4ssw0rd"
+DEFAULT_PASSWORD = "P4ssw0rd!*"
 
 # Register ASP fakers
 factory.Faker.add_provider(INSEECommuneProvider)

--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -27,8 +27,6 @@ class EtablissementAPI:
     https://doc.entreprise.api.gouv.fr/?json#etablissements-v2
     """
 
-    ERROR_IS_CLOSED = "La base Sirene indique que l'état administratif de l'établissement est fermé."
-
     def __init__(self, siret, reason="Inscription aux emplois de l'inclusion"):
         self.etablissement, self.error = self.get(siret=siret, reason=reason)
 

--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -22,55 +22,57 @@ class Etablissement:
     is_closed: bool
 
 
-class EtablissementAPI:
+def etablissement_get_or_error(siret, reason="Inscription aux emplois de l'inclusion"):
     """
+    Return a tuple (etablissement, error) where error is None on success.
     https://doc.entreprise.api.gouv.fr/?json#etablissements-v2
     """
+    data = None
+    etablissement = None
+    error = None
 
-    def __init__(self, siret, reason="Inscription aux emplois de l'inclusion"):
-        self.etablissement, self.error = self.get(siret=siret, reason=reason)
+    query_string = urlencode(
+        {
+            "recipient": settings.API_ENTREPRISE_RECIPIENT,
+            "context": settings.API_ENTREPRISE_CONTEXT,
+            "object": reason,
+        }
+    )
 
-    def get(self, siret, reason):
-        data = None
-        etablissement = None
-        error = None
+    url = f"{settings.API_ENTREPRISE_BASE_URL}/etablissements/{siret}?{query_string}"
+    headers = {"Authorization": f"Bearer {settings.API_ENTREPRISE_TOKEN}"}
 
-        query_string = urlencode(
-            {
-                "recipient": settings.API_ENTREPRISE_RECIPIENT,
-                "context": settings.API_ENTREPRISE_CONTEXT,
-                "object": reason,
-            }
-        )
-
-        url = f"{settings.API_ENTREPRISE_BASE_URL}/etablissements/{siret}?{query_string}"
-        headers = {"Authorization": f"Bearer {settings.API_ENTREPRISE_TOKEN}"}
-
-        try:
-            r = httpx.get(url, headers=headers)
-            r.raise_for_status()
-            data = r.json()
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 422:
-                error = f"SIRET « {siret} » non reconnu."
-            else:
-                logger.error("Error while fetching `%s`: %s", url, e)
-                error = "Problème de connexion à la base Sirene. Essayez ultérieurement."
-            return None, error
-
-        if data and data.get("errors"):
-            error = data["errors"][0]
+    try:
+        r = httpx.get(url, headers=headers)
+        r.raise_for_status()
+        data = r.json()
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 422:
+            error = f"SIRET « {siret} » non reconnu."
         else:
-            address = data["etablissement"]["addresse"]
-            etablissement = Etablissement(
-                name=address["l1"],
-                # FIXME To check (l4 => line_1)
-                address_line_1=address["l4"],
-                address_line_2=address["l3"],
-                post_code=address["code_postal"],
-                city=address["localite"],
-                department=department_from_postcode(self.post_code),
-                is_closed=data["etablissement"]["etat_administratif"]["value"] == "F",
-            )
+            logger.error("Error while fetching `%s`: %s", url, e)
+            error = "Problème de connexion à la base Sirene. Essayez ultérieurement."
+        return None, error
 
-        return etablissement, error
+    if data and data.get("errors"):
+        error = data["errors"][0]
+        return None, error
+
+    if not data.get("etablissement") or not data["etablissement"].get("adresse"):
+        logger.error("Invalid format of response from API Entreprise")
+        error = "Le format de la réponse API Entreprise est non valide."
+        return None, error
+
+    address = data["etablissement"]["adresse"]
+    etablissement = Etablissement(
+        name=address["l1"],
+        # FIXME To check (l4 => line_1)
+        address_line_1=address["l4"],
+        address_line_2=address["l3"],
+        post_code=address["code_postal"],
+        city=address["localite"],
+        department=department_from_postcode(address["code_postal"]),
+        is_closed=data["etablissement"]["etat_administratif"]["value"] == "F",
+    )
+
+    return etablissement, None

--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -42,10 +42,10 @@ class EtablissementAPI:
             data = r.json()
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 422:
-                error = "SIRET non reconnu."
+                error = f"SIRET « {siret} » non reconnu."
             else:
                 logger.error("Error while fetching `%s`: %s", url, e)
-                error = "Problème de connexion à la base Sirene. Veuillez réessayer ultérieurement."
+                error = "Problème de connexion à la base Sirene. Essayez ultérieurement."
 
         if data and data.get("errors"):
             error = data["errors"][0]

--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -17,10 +17,10 @@ class EtablissementAPI:
 
     ERROR_IS_CLOSED = "La base Sirene indique que l'état administratif de l'établissement est fermé."
 
-    def __init__(self, siret, object="Inscription aux emplois de l'inclusion"):
-        self.data, self.error = self.get(siret, object)
+    def __init__(self, siret, reason="Inscription aux emplois de l'inclusion"):
+        self.data, self.error = self.get(siret=siret, reason=reason)
 
-    def get(self, siret, object):
+    def get(self, siret, reason):
 
         data = None
         error = None
@@ -29,7 +29,7 @@ class EtablissementAPI:
             {
                 "recipient": settings.API_ENTREPRISE_RECIPIENT,
                 "context": settings.API_ENTREPRISE_CONTEXT,
-                "object": object,
+                "object": reason,
             }
         )
 

--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -58,6 +58,7 @@ class EtablissementAPI:
             else:
                 logger.error("Error while fetching `%s`: %s", url, e)
                 error = "Problème de connexion à la base Sirene. Essayez ultérieurement."
+            return None, error
 
         if data and data.get("errors"):
             error = data["errors"][0]

--- a/itou/utils/templatetags/format_filters.py
+++ b/itou/utils/templatetags/format_filters.py
@@ -21,3 +21,21 @@ def format_phone(phone_number):
     if not phone_number:
         return ""
     return " ".join(wrap(phone_number, 2))
+
+
+@register.filter
+@stringfilter
+def format_siret(siret):
+    """
+    Format SIREN and SIRET
+    Example: 12345678901234 => 123 456 789 00123
+    """
+    if len(siret) < 9:
+        # Don't format invalid SIREN/SIRET
+        return siret
+
+    siren = f"{siret[0:3]} {siret[3:6]} {siret[6:9]}"
+    if len(siret) == 9:
+        return siren
+
+    return f"{siren} {siret[9:]}"

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -400,6 +400,15 @@ class UtilsTemplateFiltersTestCase(TestCase):
         self.assertEqual(dict_filters.get_dict_item(my_dict, "key1"), "value1")
         self.assertEqual(dict_filters.get_dict_item(my_dict, "key2"), "value2")
 
+    def test_format_siret(self):
+        # Don't format invalid SIRET
+        self.assertEqual(format_filters.format_siret("1234"), "1234")
+        self.assertEqual(format_filters.format_siret(None), "None")
+        # SIREN
+        self.assertEqual(format_filters.format_siret("123456789"), "123 456 789")
+        # SIRET
+        self.assertEqual(format_filters.format_siret("12345678912345"), "123 456 789 12345")
+
 
 class UtilsEmailsTestCase(TestCase):
     def test_get_safe_url(self):

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -708,7 +708,7 @@ class UtilsEmailsSplitRecipientTest(TestCase):
     def test_dont_split_emails(self):
         recipients = []
         # Only one email is needed
-        for i in range(49):
+        for _ in range(49):
             recipients.append(Faker("email", locale="fr_FR"))
 
         message = EmailMessage(from_email="unit-test@tests.com", body="", to=recipients)
@@ -720,7 +720,7 @@ class UtilsEmailsSplitRecipientTest(TestCase):
     def test_must_split_emails(self):
         # 2 emails are needed; one with 50 the other with 25
         recipients = []
-        for i in range(75):
+        for _ in range(75):
             recipients.append(Faker("email", locale="fr_FR"))
 
         message = EmailMessage(from_email="unit-test@tests.com", body="", to=recipients)

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -326,7 +326,7 @@ class PrescriberSiretForm(forms.Form):
             raise forms.ValidationError(etablissement.error)
 
         if etablissement.is_closed:
-            raise forms.ValidationError(etablissement.ERROR_IS_CLOSED)
+            raise forms.ValidationError("La base Sirene indique quel'établissement est fermé.")
 
         # Perform another API call to fetch geocoding data.
         address_fields = [

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -309,7 +309,7 @@ class PrescriberSiretForm(forms.Form):
         # Does an org with this SIRET already exist?
         org = PrescriberOrganization.objects.filter(siret=siret, kind=self.kind).first()
         if org:
-            error = f'"{org.display_name}" utilise déjà ce SIRET.'
+            error = f"« {org.display_name} » utilise déjà ce SIRET."
             admin = org.get_admins().first()
             if admin:
                 error += (

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -9,7 +9,7 @@ from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
 from itou.siaes.models import Siae, SiaeMembership
 from itou.users.models import User
 from itou.utils.address.departments import DEPARTMENTS
-from itou.utils.apis.api_entreprise import EtablissementAPI
+from itou.utils.apis.api_entreprise import etablissement_get_or_error
 from itou.utils.apis.geocoding import get_geocoding_data
 from itou.utils.password_validation import CnilCompositionPasswordValidator
 from itou.utils.tokens import siae_signup_token_generator
@@ -320,10 +320,9 @@ class PrescriberSiretForm(forms.Form):
             raise forms.ValidationError(error)
 
         # Fetch name and address from API entreprise.
-        etablissement = EtablissementAPI(siret)
-
-        if etablissement.error:
-            raise forms.ValidationError(etablissement.error)
+        etablissement, error = etablissement_get_or_error(siret)
+        if error:
+            raise forms.ValidationError(error)
 
         if etablissement.is_closed:
             raise forms.ValidationError("La base Sirene indique quel'établissement est fermé.")

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -291,23 +291,18 @@ class PrescriberSiretForm(forms.Form):
     Retrieve info about an organization from a given SIRET.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, kind, siren, **kwargs):
         # We need the kind of the SIAE to check constraint on SIRET number
-        self.kind = kwargs.pop("kind", None)
-
-        super().__init__(*args, **kwargs)
+        self.kind = kind
+        self.siren = siren
         self.org_data = None
+        super().__init__(**kwargs)
 
-    siret = forms.CharField(
-        label="Numéro SIRET de votre organisation",
-        min_length=14,
-        help_text="Le numéro SIRET contient 14 chiffres.",
-    )
+    # On rendering, the SIREN is displayed just before this input
+    partial_siret = forms.CharField(label="Numéro SIRET de votre organisation", min_length=5, max_length=5)
 
-    def clean_siret(self):
-
-        # `max_length` is skipped so that we can allow an arbitrary number of spaces in the user-entered value.
-        siret = self.cleaned_data["siret"].replace(" ", "")
+    def clean_partial_siret(self):
+        siret = self.siren + self.cleaned_data["partial_siret"]
 
         validate_siret(siret)
 

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -325,7 +325,7 @@ class PrescriberSiretForm(forms.Form):
             raise forms.ValidationError(error)
 
         if etablissement.is_closed:
-            raise forms.ValidationError("La base Sirene indique quel'établissement est fermé.")
+            raise forms.ValidationError("La base Sirene indique que l'établissement est fermé.")
 
         # Perform another API call to fetch geocoding data.
         address_fields = [

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -66,11 +66,11 @@ class SiaeSignupTest(TestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
 
-            # Find an SIAE by SIREN
+            # Find an SIAE by SIREN.
             response = self.client.get(url, {"siren": siae.siret[:9]})
             self.assertEqual(response.status_code, 200)
 
-            # Choose an SIAE between results
+            # Choose an SIAE between results.
             post_data = {"siaes": siae.pk}
             # Pass `siren` in request.GET
             response = self.client.post(f"{url}?siren={siae.siret[:9]}", data=post_data)
@@ -85,11 +85,11 @@ class SiaeSignupTest(TestCase):
             response = self.client.get(magic_link)
             self.assertEqual(response.status_code, 200)
 
-            # No error when opening magic link a second time
+            # No error when opening magic link a second time.
             response = self.client.get(magic_link)
             self.assertEqual(response.status_code, 200)
 
-            # Create user
+            # Create user.
             url = siae.signup_magic_link
             post_data = {
                 # Hidden fields
@@ -113,30 +113,30 @@ class SiaeSignupTest(TestCase):
             self.assertFalse(User.objects.filter(email=user_email).exists())
             user = User.objects.get(email=user_secondary_email)
 
-            # Check `User` state
+            # Check `User` state.
             self.assertFalse(user.is_job_seeker)
             self.assertFalse(user.is_prescriber)
             self.assertTrue(user.is_siae_staff)
             self.assertTrue(user.is_active)
             self.assertTrue(siae.has_admin(user))
             self.assertEqual(1, siae.members.count())
-            # `username` should be a valid UUID, see `User.generate_unique_username()`
+            # `username` should be a valid UUID, see `User.generate_unique_username()`.
             self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
             self.assertEqual(user.first_name, user_first_name)
             self.assertEqual(user.last_name, post_data["last_name"])
             self.assertEqual(user.email, user_secondary_email)
-            # Check `EmailAddress` state
+            # Check `EmailAddress` state.
             self.assertEqual(user.emailaddress_set.count(), 1)
             user_email = user.emailaddress_set.first()
             self.assertFalse(user_email.verified)
 
-            # Check sent email
+            # Check sent email.
             self.assertEqual(len(mail.outbox), 2)
             subjects = [email.subject for email in mail.outbox]
             self.assertIn("[Action requise] Un nouvel utilisateur souhaite rejoindre votre structure !", subjects)
             self.assertIn("Confirmez votre adresse e-mail", subjects)
 
-            # Magic link is no longer valid because siae.members.count() has changed
+            # Magic link is no longer valid because siae.members.count() has changed.
             response = self.client.get(magic_link, follow=True)
             redirect_url, status_code = response.redirect_chain[-1]
             self.assertEqual(status_code, 302)
@@ -148,14 +148,14 @@ class SiaeSignupTest(TestCase):
             )
             self.assertContains(response, escape(expected_message))
 
-            # User cannot log in until confirmation
+            # User cannot log in until confirmation.
             post_data = {"login": user.email, "password": DEFAULT_PASSWORD}
             url = reverse("account_login")
             response = self.client.post(url, data=post_data)
             self.assertEqual(response.status_code, 302)
             self.assertEqual(response.url, reverse("account_email_verification_sent"))
 
-            # Confirm email + auto login
+            # Confirm email + auto login.
             confirmation_token = EmailConfirmationHMAC(user_email).key
             confirm_email_url = reverse("account_confirm_email", kwargs={"key": confirmation_token})
             response = self.client.post(confirm_email_url)
@@ -174,19 +174,19 @@ class JobSeekerSignupTest(TestCase):
         Test the redirects according to the chosen situations
         """
 
-        # Check if the form page is displayed correctly
+        # Check if the form page is displayed correctly.
         url = reverse("signup:job_seeker_situation")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-        # Check if none of the boxes are checked
-        # 'some data' needed to raise form error
+        # Check if none of the boxes are checked 'some data' needed to raise
+        # form error.
         post_data = {"some": "data"}
         response = self.client.post(url, post_data)
         self.assertEqual(response.status_code, 200)
         self.assertFormError(response, "form", "situation", [JobSeekerSituationForm.ERROR_NOTHING_CHECKED])
 
-        # Check if one of eligibility criterion is checked
+        # Check if one of eligibility criterion is checked.
         next_url = reverse("signup:job_seeker")
         for choice in JobSeekerSituationForm.ELIGIBLE_SITUATION:
             post_data = {"situation": [choice]}
@@ -199,20 +199,20 @@ class JobSeekerSignupTest(TestCase):
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, next_url)
 
-        # Check if all the eligibility criteria are checked
+        # Check if all the eligibility criteria are checked.
         post_data = {"situation": JobSeekerSituationForm.ELIGIBLE_SITUATION}
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, next_url)
 
-        # Check if "Autre" is the only one checked
+        # Check if "Autre" is the only one checked.
         post_data = {"situation": "autre"}
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
         next_url = reverse("signup:job_seeker_situation_not_eligible")
         self.assertRedirects(response, next_url)
 
-        # Check not eligible destination page
+        # Check not eligible destination page.
         url = reverse("signup:job_seeker_situation_not_eligible")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -246,20 +246,20 @@ class JobSeekerSignupTest(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("account_email_verification_sent"))
 
-        # Check `User` state
+        # Check `User` state.
         user = User.objects.get(email=post_data["email"])
-        # `username` should be a valid UUID, see `User.generate_unique_username()`
+        # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertTrue(user.is_job_seeker)
         self.assertFalse(user.is_prescriber)
         self.assertFalse(user.is_siae_staff)
 
-        # Check `EmailAddress` state
+        # Check `EmailAddress` state.
         self.assertEqual(user.emailaddress_set.count(), 1)
         user_email = user.emailaddress_set.first()
         self.assertFalse(user_email.verified)
 
-        # Check sent email
+        # Check sent email.
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]
         self.assertIn("Confirmez votre adresse e-mail", email.subject)
@@ -268,14 +268,14 @@ class JobSeekerSignupTest(TestCase):
         self.assertEqual(len(email.to), 1)
         self.assertEqual(email.to[0], user.email)
 
-        # User cannot log in until confirmation
+        # User cannot log in until confirmation.
         post_data = {"login": user.email, "password": DEFAULT_PASSWORD}
         url = reverse("account_login")
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse("account_email_verification_sent"))
 
-        # Confirm email + auto login
+        # Confirm email + auto login.
         confirmation_token = EmailConfirmationHMAC(user_email).key
         confirm_email_url = reverse("account_confirm_email", kwargs={"key": confirmation_token})
         response = self.client.post(confirm_email_url)
@@ -294,14 +294,14 @@ class PrescriberSignupTest(TestCase):
         response = self.client.get(url)
         self.assertContains(response, "Travaillez-vous pour Pôle emploi ?")
 
-        # Data stored in session (on GET 🤦)
+        # Data stored in session (on GET 🤦).
         self.assertIn("prescriber_signup", list(self.client.session.keys()))
 
-        # POST Yes
+        # POST Yes.
         response = self.client.post(url, data={"is_pole_emploi": 1})
         self.assertRedirects(response, reverse("signup:prescriber_pole_emploi_safir_code"))
 
-        # POST No
+        # POST No.
         response = self.client.post(url, data={"is_pole_emploi": 0})
         self.assertRedirects(response, reverse("signup:prescriber_siren"))
 
@@ -312,11 +312,11 @@ class PrescriberSignupTest(TestCase):
 
         organization = PrescriberPoleEmploiFactory()
 
-        # Step 1: the user works for PE
+        # Step 1: the user works for PE.
         url = reverse("signup:prescriber_is_pole_emploi")
         response = self.client.post(url, data={"is_pole_emploi": 1})
 
-        # Step 2: fill the SAFIR code
+        # Step 2: fill the SAFIR code.
         url = reverse("signup:prescriber_pole_emploi_safir_code")
         self.assertRedirects(response, url)
         post_data = {
@@ -361,15 +361,15 @@ class PrescriberSignupTest(TestCase):
         user_email = user_emails[0]
         self.assertFalse(user_email.verified)
 
-        # Check organization
+        # Check organization.
         self.assertTrue(organization.is_authorized)
         self.assertEqual(organization.authorization_status, PrescriberOrganization.AuthorizationStatus.VALIDATED)
 
-        # Check membership
+        # Check membership.
         self.assertIn(user, organization.members.all())
         self.assertEqual(1, user.prescriberorganization_set.count())
 
-        # Check sent email
+        # Check sent email.
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]
         self.assertIn("Confirmez votre adresse e-mail", email.subject)
@@ -401,11 +401,11 @@ class PrescriberSignupTest(TestCase):
 
         siret = "11122233300001"
 
-        # Step 1: the user doesn't work for PE
+        # Step 1: the user doesn't work for PE.
         url = reverse("signup:prescriber_is_pole_emploi")
         response = self.client.post(url, data={"is_pole_emploi": 0})
 
-        # Step 2: search organisations with SIREN and department
+        # Step 2: search organisations with SIREN and department.
         url = reverse("signup:prescriber_siren")
         self.assertRedirects(response, url)
         get_data = {
@@ -422,7 +422,7 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.post(url, data=post_data)
 
-        # Step 4: fill the SIRET number
+        # Step 4: fill the SIRET number.
         respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/etablissements/{siret}").mock(
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
         )
@@ -434,7 +434,7 @@ class PrescriberSignupTest(TestCase):
         response = self.client.post(url, data=post_data)
         mock_call_ban_geocoding_api.assert_called_once()
 
-        # Step 5: user information
+        # Step 5: user information.
         url = reverse("signup:prescriber_user")
         self.assertRedirects(response, url)
         post_data = {
@@ -447,7 +447,7 @@ class PrescriberSignupTest(TestCase):
         response = self.client.post(url, data=post_data)
         self.assertRedirects(response, reverse("account_email_verification_sent"))
 
-        # Check `User` state
+        # Check `User` state.
         user = User.objects.get(email=post_data["email"])
         # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
@@ -455,30 +455,30 @@ class PrescriberSignupTest(TestCase):
         self.assertTrue(user.is_prescriber)
         self.assertFalse(user.is_siae_staff)
 
-        # Check `EmailAddress` state
+        # Check `EmailAddress` state.
         user_emails = user.emailaddress_set.all()
         self.assertEqual(len(user_emails), 1)
         user_email = user_emails[0]
         self.assertFalse(user_email.verified)
 
-        # Check organization
+        # Check organization.
         org = PrescriberOrganization.objects.get(siret=siret)
         self.assertFalse(org.is_authorized)
         self.assertEqual(org.authorization_status, PrescriberOrganization.AuthorizationStatus.NOT_SET)
 
-        # Check membership
+        # Check membership.
         self.assertEqual(1, user.prescriberorganization_set.count())
         membership = user.prescribermembership_set.get(organization=org)
         self.assertTrue(membership.is_admin)
 
-        # Check sent email
+        # Check sent email.
         self.assertEqual(len(mail.outbox), 2)
 
-        # Check email has been sent to support (validation/refusal of authorisation needed)
+        # Check email has been sent to support (validation/refusal of authorisation needed).
         email = mail.outbox[0]
         self.assertIn("Vérification de l'habilitation d'une nouvelle organisation", email.subject)
 
-        # Check email has been sent to confirm the user's email
+        # Check email has been sent to confirm the user's email.
         email = mail.outbox[1]
         self.assertIn("Confirmez votre adresse e-mail", email.subject)
         self.assertIn("Afin de finaliser votre inscription, cliquez sur le lien suivant", email.body)
@@ -486,13 +486,13 @@ class PrescriberSignupTest(TestCase):
         self.assertEqual(len(email.to), 1)
         self.assertEqual(email.to[0], user.email)
 
-        # User cannot log in until confirmation
+        # User cannot log in until confirmation.
         post_data = {"login": user.email, "password": DEFAULT_PASSWORD}
         url = reverse("account_login")
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.url, reverse("account_email_verification_sent"))
 
-        # Confirm email + auto login
+        # Confirm email + auto login.
         confirmation_token = EmailConfirmationHMAC(user_email).key
         confirm_email_url = reverse("account_confirm_email", kwargs={"key": confirmation_token})
         response = self.client.post(confirm_email_url)
@@ -509,11 +509,11 @@ class PrescriberSignupTest(TestCase):
 
         siret = "11122233300001"
 
-        # Step 1: the user doesn't work for PE
+        # Step 1: the user doesn't work for PE.
         url = reverse("signup:prescriber_is_pole_emploi")
         response = self.client.post(url, data={"is_pole_emploi": 0})
 
-        # Step 2: search organisations with SIREN and department
+        # Step 2: search organisations with SIREN and department.
         url = reverse("signup:prescriber_siren")
         self.assertRedirects(response, url)
         get_data = {
@@ -522,7 +522,7 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.get(url, data=get_data)
 
-        # Step 3: set 'other' organisation
+        # Step 3: set 'other' organisation.
         url = reverse("signup:prescriber_choose_org")
         self.assertRedirects(response, url)
         post_data = {
@@ -530,7 +530,7 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.post(url, data=post_data)
 
-        # Step 4: ask the user his kind of prescriber
+        # Step 4: ask the user his kind of prescriber.
         url = reverse("signup:prescriber_choose_kind")
         self.assertRedirects(response, url)
         post_data = {
@@ -538,7 +538,7 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.post(url, data=post_data)
 
-        # Step 5: ask the user to confirm the "authorized" character of his organization
+        # Step 5: ask the user to confirm the "authorized" character of his organization.
         url = reverse("signup:prescriber_confirm_authorization")
         self.assertRedirects(response, url)
         post_data = {
@@ -546,7 +546,7 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.post(url, data=post_data)
 
-        # Step 6: fill the SIRET number
+        # Step 6: fill the SIRET number.
         api_entreprise_route = respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/etablissements/{siret}").mock(
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
         )
@@ -559,7 +559,7 @@ class PrescriberSignupTest(TestCase):
         self.assertTrue(api_entreprise_route.called)
         mock_call_ban_geocoding_api.assert_called_once()
 
-        # Step 7: fill the user information
+        # Step 7: fill the user information.
         url = reverse("signup:prescriber_user")
         self.assertRedirects(response, url)
         post_data = {
@@ -572,7 +572,7 @@ class PrescriberSignupTest(TestCase):
         response = self.client.post(url, data=post_data)
         self.assertRedirects(response, reverse("account_email_verification_sent"))
 
-        # Check `User` state
+        # Check `User` state.
         user = User.objects.get(email=post_data["email"])
         # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
@@ -580,26 +580,26 @@ class PrescriberSignupTest(TestCase):
         self.assertTrue(user.is_prescriber)
         self.assertFalse(user.is_siae_staff)
 
-        # Check `EmailAddress` state
+        # Check `EmailAddress` state.
         user_emails = user.emailaddress_set.all()
         self.assertEqual(len(user_emails), 1)
         self.assertFalse(user_emails[0].verified)
 
-        # Check org
+        # Check org.
         org = PrescriberOrganization.objects.get(siret=siret)
         self.assertFalse(org.is_authorized)
         self.assertEqual(org.authorization_status, PrescriberOrganization.AuthorizationStatus.NOT_SET)
 
-        # Check membership
+        # Check membership.
         self.assertEqual(1, user.prescriberorganization_set.count())
         membership = user.prescribermembership_set.get(organization=org)
         self.assertTrue(membership.is_admin)
 
-        # Check email has been sent to support (validation/refusal of authorisation needed)
+        # Check email has been sent to support (validation/refusal of authorisation needed).
         self.assertEqual(len(mail.outbox), 2)
         subject = mail.outbox[0].subject
         self.assertIn("Vérification de l'habilitation d'une nouvelle organisation", subject)
-        # Full email validation process is tested in `test_create_user_prescriber_with_authorized_org_of_known_kind`
+        # Full email validation process is tested in `test_create_user_prescriber_with_authorized_org_of_known_kind`.
         subject = mail.outbox[1].subject
         self.assertIn("Confirmez votre adresse e-mail", subject)
 
@@ -612,20 +612,20 @@ class PrescriberSignupTest(TestCase):
 
         siret = "11122233300001"
 
-        # Step 1: the user doesn't work for PE
+        # Step 1: the user doesn't work for PE.
         url = reverse("signup:prescriber_is_pole_emploi")
         response = self.client.post(url, data={"is_pole_emploi": 0})
         url = reverse("signup:prescriber_siren")
         self.assertRedirects(response, url)
 
-        # Step 2: search organisations with SIREN and department
+        # Step 2: search organisations with SIREN and department.
         get_data = {
             "siren": siret[:9],
             "department": "67",
         }
         response = self.client.get(url, data=get_data)
 
-        # Step 3: select kind of organisation
+        # Step 3: select kind of organisation.
         url = reverse("signup:prescriber_choose_org")
         self.assertRedirects(response, url)
         post_data = {
@@ -633,7 +633,7 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.post(url, data=post_data)
 
-        # Step 4: select the kind of prescriber 'UNAUTHORIZED'
+        # Step 4: select the kind of prescriber 'UNAUTHORIZED'.
         url = reverse("signup:prescriber_choose_kind")
         self.assertRedirects(response, url)
         post_data = {
@@ -641,7 +641,7 @@ class PrescriberSignupTest(TestCase):
         }
         response = self.client.post(url, data=post_data)
 
-        # Step 5: fill the SIRET number
+        # Step 5: fill the SIRET number.
         url = reverse("signup:prescriber_siret")
         self.assertRedirects(response, url)
         api_entreprise_route = respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/etablissements/{siret}").mock(
@@ -654,7 +654,7 @@ class PrescriberSignupTest(TestCase):
         self.assertTrue(api_entreprise_route.called)
         mock_call_ban_geocoding_api.assert_called_once()
 
-        # Step 6: user information
+        # Step 6: user information.
         url = reverse("signup:prescriber_user")
         self.assertRedirects(response, url)
         post_data = {
@@ -667,7 +667,7 @@ class PrescriberSignupTest(TestCase):
         response = self.client.post(url, data=post_data)
         self.assertRedirects(response, reverse("account_email_verification_sent"))
 
-        # Check `User` state
+        # Check `User` state.
         user = User.objects.get(email=post_data["email"])
         # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
@@ -680,17 +680,17 @@ class PrescriberSignupTest(TestCase):
         self.assertEqual(len(user_emails), 1)
         self.assertFalse(user_emails[0].verified)
 
-        # Check organization
+        # Check organization.
         org = PrescriberOrganization.objects.get(siret=siret)
         self.assertFalse(org.is_authorized)
         self.assertEqual(org.authorization_status, PrescriberOrganization.AuthorizationStatus.NOT_REQUIRED)
 
-        # Check membership
+        # Check membership.
         self.assertEqual(1, user.prescriberorganization_set.count())
         membership = user.prescribermembership_set.get(organization=org)
         self.assertTrue(membership.is_admin)
 
-        # Full email validation process is tested in `test_create_user_prescriber_with_authorized_org_of_known_kind`
+        # Full email validation process is tested in `test_create_user_prescriber_with_authorized_org_of_known_kind`.
         self.assertEqual(len(mail.outbox), 1)
         subject = mail.outbox[0].subject
         self.assertIn("Confirmez votre adresse e-mail", subject)
@@ -702,17 +702,17 @@ class PrescriberSignupTest(TestCase):
 
         siret = "26570134200148"
 
-        # PrescriberOrganizationWithMembershipFactory
+        # PrescriberOrganizationWithMembershipFactory.
         existing_org_with_siret = PrescriberOrganizationWithMembershipFactory(
             siret=siret, kind=PrescriberOrganization.Kind.SPIP, department="01"
         )
         existing_org_with_siret.save()
 
-        # Step 1: the user doesn't work for PE
+        # Step 1: the user doesn't work for PE.
         url = reverse("signup:prescriber_is_pole_emploi")
         response = self.client.post(url, data={"is_pole_emploi": 0})
 
-        # Step 2: ask the user the SIREN number and departement of the organization
+        # Step 2: ask the user the SIREN number and departement of the organization.
         url = reverse("signup:prescriber_siren")
         self.assertRedirects(response, url)
         get_data = {
@@ -734,11 +734,11 @@ class PrescriberSignupTest(TestCase):
         )
         existing_org_with_siret.save()
 
-        # Step 1: the user doesn't work for PE
+        # Step 1: the user doesn't work for PE.
         url = reverse("signup:prescriber_is_pole_emploi")
         response = self.client.post(url, data={"is_pole_emploi": 0})
 
-        # Step 2: search organisations with SIREN and department
+        # Step 2: search organisations with SIREN and department.
         url = reverse("signup:prescriber_siren")
         self.assertRedirects(response, url)
         get_data = {
@@ -748,7 +748,7 @@ class PrescriberSignupTest(TestCase):
         response = self.client.get(url, data=get_data)
         self.assertContains(response, existing_org_with_siret.display_name)
 
-        # new organisation link
+        # New organisation link.
         self.assertContains(response, reverse("signup:prescriber_choose_org"))
 
     def test_create_user_prescriber_with_existing_siren_without_member(self):
@@ -763,14 +763,14 @@ class PrescriberSignupTest(TestCase):
         )
         existing_org_with_siret.save()
 
-        # Step 1: the user doesn't work for PE
+        # Step 1: the user doesn't work for PE.
         url = reverse("signup:prescriber_is_pole_emploi")
         response = self.client.post(
             url,
             data={"is_pole_emploi": 0},
         )
 
-        # Step 2: search organisations with SIREN and department
+        # Step 2: search organisations with SIREN and department.
         url = reverse("signup:prescriber_siren")
         self.assertRedirects(response, url)
         get_data = {
@@ -786,25 +786,26 @@ class PrescriberSignupTest(TestCase):
         Test the creation of a user of type prescriber without organization.
         """
 
-        # Step 1: the user doesn't work for PE
+        # Step 1: the user doesn't work for PE.
         url = reverse("signup:prescriber_is_pole_emploi")
         response = self.client.post(
             url,
             data={"is_pole_emploi": 0},
         )
 
-        # Step 2: redirected on search
+        # Step 2: redirected on search.
         url = reverse("signup:prescriber_siren")
         self.assertRedirects(response, url)
 
-        # Step 3: the user clicks on "No organization" in search of organisation (SIREN and department)
+        # Step 3: the user clicks on "No organization" in search of organisation
+        # (SIREN and department).
         response = self.client.get(url)
         user_info_url = reverse("signup:prescriber_user")
         self.assertContains(response, user_info_url)
         response = self.client.get(user_info_url)
         self.assertEqual(response.status_code, 200)
 
-        # Step 3: fill the user information
+        # Step 3: fill the user information.
         post_data = {
             "first_name": "John",
             "last_name": "Doe",
@@ -815,23 +816,24 @@ class PrescriberSignupTest(TestCase):
         response = self.client.post(user_info_url, data=post_data)
         self.assertRedirects(response, reverse("account_email_verification_sent"))
 
-        # Check `User` state
+        # Check `User` state.
         user = User.objects.get(email=post_data["email"])
-        # `username` should be a valid UUID, see `User.generate_unique_username()`
+        # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
         self.assertFalse(user.is_job_seeker)
         self.assertTrue(user.is_prescriber)
         self.assertFalse(user.is_siae_staff)
 
-        # Check `EmailAddress` state
+        # Check `EmailAddress` state.
         self.assertEqual(user.emailaddress_set.count(), 1)
         user_email = user.emailaddress_set.first()
         self.assertFalse(user_email.verified)
 
-        # Check membership
+        # Check membership.
         self.assertEqual(0, user.prescriberorganization_set.count())
 
-        # Full email validation process is tested in `test_create_user_prescriber_with_authorized_org_of_known_kind`
+        # Full email validation process is tested in
+        # `test_create_user_prescriber_with_authorized_org_of_known_kind`.
         self.assertEqual(len(mail.outbox), 1)
         subject = mail.outbox[0].subject
         self.assertIn("Confirmez votre adresse e-mail", subject)
@@ -850,7 +852,7 @@ class PrescriberSignupTest(TestCase):
         - user can create a PLIE and a ML with the same SIRET
         """
 
-        # same SIRET as mock
+        # Same SIRET as mock.
         siret = "26570134200148"
         respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/etablissements/{siret}").mock(
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
@@ -858,7 +860,7 @@ class PrescriberSignupTest(TestCase):
         existing_org_with_siret = PrescriberOrganizationFactory(siret=siret, kind=PrescriberOrganization.Kind.ML)
         existing_org_with_siret.save()
 
-        # Step 1: the user doesn't work for PE
+        # Step 1: the user doesn't work for PE.
         url = reverse("signup:prescriber_is_pole_emploi")
         post_data = {
             "is_pole_emploi": 0,
@@ -894,7 +896,7 @@ class PrescriberSignupTest(TestCase):
         response = self.client.post(url, data=post_data)
         self.assertRedirects(response, reverse("account_email_verification_sent"))
 
-        # Check new org is ok
+        # Check new org is OK.
         same_siret_orgs = PrescriberOrganization.objects.filter(siret=siret).order_by("kind").all()
         self.assertEqual(2, len(same_siret_orgs))
         org1, org2 = same_siret_orgs
@@ -910,7 +912,7 @@ class PrescriberSignupTest(TestCase):
         * there is no duplicate of the (kind, siret) pair
         """
 
-        # same SIRET as mock but with same expected kind
+        # Same SIRET as mock but with same expected kind.
         siret = "26570134200148"
         respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/etablissements/{siret}").mock(
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -412,7 +412,7 @@ class PrescriberSignupTest(TestCase):
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
         )
         post_data = {
-            "siret": siret,
+            "partial_siret": siret[-5:],
         }
         response = self.client.post(url, data=post_data)
         url = reverse("signup:prescriber_user")
@@ -537,7 +537,7 @@ class PrescriberSignupTest(TestCase):
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
         )
         post_data = {
-            "siret": siret,
+            "partial_siret": siret[-5:],
         }
         response = self.client.post(url, data=post_data)
         url = reverse("signup:prescriber_user")
@@ -632,7 +632,7 @@ class PrescriberSignupTest(TestCase):
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
         )
         post_data = {
-            "siret": siret,
+            "partial_siret": siret[-5:],
         }
         response = self.client.post(url, data=post_data)
         url = reverse("signup:prescriber_user")

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -410,7 +410,6 @@ class PrescriberSignupTest(TestCase):
         self.assertRedirects(response, url)
 
         # Step 4: ask the user his SIRET number.
-
         post_data = {
             "siret": siret,
         }

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -53,7 +53,6 @@ class SiaeSignupTest(TestCase):
         user_first_name = "Jacques"
         user_email = "jacques.doe@siae.com"
         user_secondary_email = "jacques.doe@hotmail.com"
-        password = "!*p4ssw0rd123-"
 
         siae = SiaeFactory(kind=Siae.KIND_ETTI)
         self.assertEqual(0, siae.members.count())
@@ -102,8 +101,8 @@ class SiaeSignupTest(TestCase):
                 "first_name": user_first_name,
                 "last_name": "Doe",
                 "email": user_secondary_email,
-                "password1": password,
-                "password2": password,
+                "password1": DEFAULT_PASSWORD,
+                "password2": DEFAULT_PASSWORD,
             }
             response = self.client.post(url, data=post_data)
             self.assertEqual(response.status_code, 302)
@@ -148,7 +147,7 @@ class SiaeSignupTest(TestCase):
             self.assertContains(response, escape(expected_message))
 
             # User cannot log in until confirmation.
-            post_data = {"login": user.email, "password": password}
+            post_data = {"login": user.email, "password": DEFAULT_PASSWORD}
             url = reverse("account_login")
             response = self.client.post(url, data=post_data)
             self.assertEqual(response.status_code, 302)
@@ -223,7 +222,6 @@ class JobSeekerSignupTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-        password = "!*p4ssw0rd123-"
         address_line_1 = "Test adresse"
         address_line_2 = "Test adresse complémentaire"
         city = City.objects.first()
@@ -233,8 +231,8 @@ class JobSeekerSignupTest(TestCase):
             "first_name": "John",
             "last_name": "Doe",
             "email": "john.doe@siae.com",
-            "password1": password,
-            "password2": password,
+            "password1": DEFAULT_PASSWORD,
+            "password2": DEFAULT_PASSWORD,
             "address_line_1": address_line_1,
             "address_line_2": address_line_2,
             "post_code": post_code,
@@ -269,7 +267,7 @@ class JobSeekerSignupTest(TestCase):
         self.assertEqual(email.to[0], user.email)
 
         # User cannot log in until confirmation.
-        post_data = {"login": user.email, "password": password}
+        post_data = {"login": user.email, "password": DEFAULT_PASSWORD}
         url = reverse("account_login")
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
@@ -332,13 +330,12 @@ class PrescriberSignupTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(CnilCompositionPasswordValidator.HELP_MSG, response.context["form"].errors["password1"])
 
-        password = "!*p4ssw0rd123-"
         post_data = {
             "first_name": "John",
             "last_name": "Doe",
             "email": f"john.doe{settings.POLE_EMPLOI_EMAIL_SUFFIX}",
-            "password1": password,
-            "password2": password,
+            "password1": DEFAULT_PASSWORD,
+            "password2": DEFAULT_PASSWORD,
         }
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
@@ -372,7 +369,7 @@ class PrescriberSignupTest(TestCase):
         self.assertEqual(email.to[0], user.email)
 
         # User cannot log in until confirmation.
-        post_data = {"login": user.email, "password": password}
+        post_data = {"login": user.email, "password": DEFAULT_PASSWORD}
         url = reverse("account_login")
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
@@ -448,14 +445,12 @@ class PrescriberSignupTest(TestCase):
         mock_call_ban_geocoding_api.assert_called_once()
 
         # Step 5: user info.
-
-        password = "!*p4ssw0rd123-"
         post_data = {
             "first_name": "John",
             "last_name": "Doe",
             "email": f"john.doe{settings.POLE_EMPLOI_EMAIL_SUFFIX}",
-            "password1": password,
-            "password2": password,
+            "password1": DEFAULT_PASSWORD,
+            "password2": DEFAULT_PASSWORD,
         }
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
@@ -500,7 +495,7 @@ class PrescriberSignupTest(TestCase):
         self.assertEqual(email.to[0], user.email)
 
         # User cannot log in until confirmation.
-        post_data = {"login": user.email, "password": password}
+        post_data = {"login": user.email, "password": DEFAULT_PASSWORD}
         url = reverse("account_login")
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
@@ -528,8 +523,7 @@ class PrescriberSignupTest(TestCase):
 
         siret = "11122233300001"
 
-        # Step 1: Does the user work  for PE?
-
+        # Step 1: Does the user work for PE?
         url = reverse("signup:prescriber_is_pole_emploi")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -543,7 +537,6 @@ class PrescriberSignupTest(TestCase):
         self.assertRedirects(response, url)
 
         # Step 2: ask the user his SIREN number and department
-
         get_data = {
             "siren": siret[:9],
             "department": "67",
@@ -553,8 +546,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_choose_org")
         self.assertRedirects(response, url)
 
-        # Step 3: ask the user to choose the organization he's working for in a pre-existing list.
-
+        # Step 3: ask the user to choose the organization he's working for in a pre-existing list
         post_data = {
             "kind": PrescriberOrganization.Kind.OTHER.value,
         }
@@ -563,7 +555,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_choose_kind")
         self.assertRedirects(response, url)
 
-        # Step 4: ask the user his kind of prescriber.
+        # Step 4: ask the user his kind of prescriber
         post_data = {
             "kind": PrescriberChooseKindForm.KIND_AUTHORIZED_ORG,
         }
@@ -572,8 +564,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_confirm_authorization")
         self.assertRedirects(response, url)
 
-        # Step 5: ask the user to confirm the "authorized" character of his organization.
-
+        # Step 5: ask the user to confirm the "authorized" character of his organization
         post_data = {
             "confirm_authorization": 1,
         }
@@ -582,8 +573,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_siret")
         self.assertRedirects(response, url)
 
-        # Step 6: ask the user his SIRET number.
-
+        # Step 6: ask the user his SIRET number
         post_data = {
             "siret": siret,
         }
@@ -594,21 +584,19 @@ class PrescriberSignupTest(TestCase):
         mock_api_entreprise.assert_called_once()
         mock_call_ban_geocoding_api.assert_called_once()
 
-        # Step 7: user info.
-
-        password = "!*p4ssw0rd123-"
+        # Step 7: user info
         post_data = {
             "first_name": "John",
             "last_name": "Doe",
             "email": f"john.doe{settings.POLE_EMPLOI_EMAIL_SUFFIX}",
-            "password1": password,
-            "password2": password,
+            "password1": DEFAULT_PASSWORD,
+            "password2": DEFAULT_PASSWORD,
         }
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("account_email_verification_sent"))
 
-        # Check `User` state.
+        # Check `User` state
         user = User.objects.get(email=post_data["email"])
         # `username` should be a valid UUID, see `User.generate_unique_username()`.
         self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
@@ -650,8 +638,7 @@ class PrescriberSignupTest(TestCase):
 
         siret = "11122233300001"
 
-        # Step 1: Does the user work  for PE?
-
+        # Step 1: Does the user work for PE?
         url = reverse("signup:prescriber_is_pole_emploi")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -665,7 +652,6 @@ class PrescriberSignupTest(TestCase):
         self.assertRedirects(response, url)
 
         # Step 2: ask the user his SIREN number and department
-
         get_data = {
             "siren": siret[:9],
             "department": "67",
@@ -675,8 +661,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_choose_org")
         self.assertRedirects(response, url)
 
-        # Step 3: ask the user to choose the organization he's working for in a pre-existing list.
-
+        # Step 3: ask the user to choose the organization he's working for in a pre-existing list
         post_data = {
             "kind": PrescriberOrganization.Kind.OTHER.value,
         }
@@ -685,8 +670,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_choose_kind")
         self.assertRedirects(response, url)
 
-        # Step 4: ask the user his kind of prescriber.
-
+        # Step 4: ask the user his kind of prescriber
         post_data = {
             "kind": PrescriberChooseKindForm.KIND_UNAUTHORIZED_ORG,
         }
@@ -695,8 +679,7 @@ class PrescriberSignupTest(TestCase):
         url = reverse("signup:prescriber_siret")
         self.assertRedirects(response, url)
 
-        # Step 5: ask the user his SIRET number.
-
+        # Step 5: ask the user his SIRET number
         post_data = {
             "siret": siret,
         }
@@ -708,14 +691,12 @@ class PrescriberSignupTest(TestCase):
         mock_call_ban_geocoding_api.assert_called_once()
 
         # Step 6: user info.
-
-        password = "!*p4ssw0rd123-"
         post_data = {
             "first_name": "John",
             "last_name": "Doe",
             "email": f"john.doe{settings.POLE_EMPLOI_EMAIL_SUFFIX}",
-            "password1": password,
-            "password2": password,
+            "password1": DEFAULT_PASSWORD,
+            "password2": DEFAULT_PASSWORD,
         }
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
@@ -890,14 +871,12 @@ class PrescriberSignupTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # Step 3: user info.
-
-        password = "!*p4ssw0rd123-"
         post_data = {
             "first_name": "John",
             "last_name": "Doe",
             "email": f"john.doe{settings.POLE_EMPLOI_EMAIL_SUFFIX}",
-            "password1": password,
-            "password2": password,
+            "password1": DEFAULT_PASSWORD,
+            "password2": DEFAULT_PASSWORD,
         }
         response = self.client.post(user_info_url, data=post_data)
         self.assertEqual(response.status_code, 302)
@@ -944,7 +923,6 @@ class PrescriberSignupTest(TestCase):
 
         # same SIRET as mock
         siret = "26570134200148"
-        password = "!*p4ssw0rd123-"
 
         existing_org_with_siret = PrescriberOrganizationFactory(siret=siret, kind=PrescriberOrganization.Kind.ML)
         existing_org_with_siret.save()
@@ -961,8 +939,8 @@ class PrescriberSignupTest(TestCase):
             "first_name": "John",
             "last_name": "Doe",
             "email": "john.doe@ma-plie.fr",
-            "password1": password,
-            "password2": password,
+            "password1": DEFAULT_PASSWORD,
+            "password2": DEFAULT_PASSWORD,
         }
         response = self.client.post(url, data=post_data)
         url = reverse("signup:prescriber_choose_org")
@@ -1054,13 +1032,13 @@ class PasswordResetTest(TestCase):
         password_change_url = reverse("account_reset_password_from_key", kwargs={"uidb36": uidb36, "key": key})
         response = self.client.get(password_change_url)
         password_change_url_with_hidden_key = response.url
-        post_data = {"password1": "Mlkjhgf!sq2", "password2": "Mlkjhgf!sq2"}
+        post_data = {"password1": DEFAULT_PASSWORD, "password2": DEFAULT_PASSWORD}
         response = self.client.post(password_change_url_with_hidden_key, data=post_data)
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("account_reset_password_from_key_done"))
 
         # User can log in with his new password.
-        self.assertTrue(self.client.login(username=user.email, password="Mlkjhgf!sq2"))
+        self.assertTrue(self.client.login(username=user.email, password=DEFAULT_PASSWORD))
         self.client.logout()
 
     def test_password_reset_with_nonexistent_email(self):
@@ -1091,12 +1069,13 @@ class PasswordChangeTest(TestCase):
         url = reverse("account_change_password")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        post_data = {"oldpassword": DEFAULT_PASSWORD, "password1": "Mlkjhgf!sq2", "password2": "Mlkjhgf!sq2"}
+        new_password = "Mlkjhgf!sq2"
+        post_data = {"oldpassword": DEFAULT_PASSWORD, "password1": new_password, "password2": new_password}
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("dashboard:index"))
 
         # User can log in with his new password.
         self.client.logout()
-        self.assertTrue(self.client.login(username=user.email, password="Mlkjhgf!sq2"))
+        self.assertTrue(self.client.login(username=user.email, password=new_password))
         self.client.logout()

--- a/itou/www/signup/tests.py
+++ b/itou/www/signup/tests.py
@@ -286,6 +286,25 @@ class JobSeekerSignupTest(TestCase):
 
 
 class PrescriberSignupTest(TestCase):
+    def test_prescriber_is_pole_emploi(self):
+        # GET
+        self.assertNotIn("prescriber_signup", list(self.client.session.keys()))
+
+        url = reverse("signup:prescriber_is_pole_emploi")
+        response = self.client.get(url)
+        self.assertContains(response, "Travaillez-vous pour Pôle emploi ?")
+
+        # Data stored in session (on GET 🤦)
+        self.assertIn("prescriber_signup", list(self.client.session.keys()))
+
+        # POST Yes
+        response = self.client.post(url, data={"is_pole_emploi": 1})
+        self.assertRedirects(response, reverse("signup:prescriber_pole_emploi_safir_code"))
+
+        # POST No
+        response = self.client.post(url, data={"is_pole_emploi": 0})
+        self.assertRedirects(response, reverse("signup:prescriber_siren"))
+
     def test_create_user_prescriber_member_of_pole_emploi(self):
         """
         Test the creation of a user of type prescriber and his joining to a Pole emploi agency.

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -241,7 +241,9 @@ def prescriber_is_pole_emploi(request, template_name="signup/prescriber_is_pole_
     return render(request, template_name, context)
 
 
-# FIXME GET method with side-effect (session update)
+# TODO 2021-07-28 GET method with side-effect (session update), to rewrite as:
+# - POST but not a very choice for search view
+# - GET with params w/o session update
 @valid_prescriber_signup_session_required
 @push_url_in_history(settings.ITOU_SESSION_PRESCRIBER_SIGNUP_KEY)
 def prescriber_siren(request, template_name="signup/prescriber_siren.html"):
@@ -467,7 +469,10 @@ def prescriber_siret(request, template_name="signup/prescriber_siret.html"):
         data=request.POST or None,
     )
 
-    # Request Sirene API to validate SIRET
+    # `PrescriberSiretForm` performs several API calls:
+    # - to SIRENE API to validate the SIRET existence and the status of the organisation
+    # - get geolocalisation from Adresse API
+    # See PrescriberSiretForm.clean_partial_siret.
     if request.method == "POST" and form.is_valid():
 
         session_data["prescriber_org_data"] = form.org_data

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -447,10 +447,14 @@ def prescriber_siret(request, template_name="signup/prescriber_siret.html"):
     """
 
     session_data = request.session[settings.ITOU_SESSION_PRESCRIBER_SIGNUP_KEY]
+    siren = session_data["siren"]
+    form = forms.PrescriberSiretForm(
+        kind=session_data["kind"],
+        siren=siren,
+        data=request.POST or None,
+    )
 
-    initial_data = {"siret": session_data.get("siren")}
-    form = forms.PrescriberSiretForm(data=request.POST or None, initial=initial_data, kind=session_data.get("kind"))
-
+    # Request Sirene API to validate SIRET
     if request.method == "POST" and form.is_valid():
         session_data["prescriber_org_data"] = form.org_data
         request.session.modified = True
@@ -459,6 +463,7 @@ def prescriber_siret(request, template_name="signup/prescriber_siret.html"):
 
     context = {
         "form": form,
+        "siren": siren,
         "prev_url": get_prev_url_from_history(request, settings.ITOU_SESSION_PRESCRIBER_SIGNUP_KEY),
     }
     return render(request, template_name, context)

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -243,6 +243,7 @@ def prescriber_is_pole_emploi(request, template_name="signup/prescriber_is_pole_
     return render(request, template_name, context)
 
 
+# FIXME GET method with side-effect (session update)
 @valid_prescriber_signup_session_required
 @push_url_in_history(settings.ITOU_SESSION_PRESCRIBER_SIGNUP_KEY)
 def prescriber_siren(request, template_name="signup/prescriber_siren.html"):
@@ -470,6 +471,7 @@ def prescriber_siret(request, template_name="signup/prescriber_siret.html"):
 
     # Request Sirene API to validate SIRET
     if request.method == "POST" and form.is_valid():
+
         session_data["prescriber_org_data"] = form.org_data
         request.session.modified = True
         next_url = reverse("signup:prescriber_user")

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -232,12 +232,10 @@ def prescriber_is_pole_emploi(request, template_name="signup/prescriber_is_pole_
 
     if request.method == "POST" and form.is_valid():
 
-        next_url = reverse("signup:prescriber_siren")
-
         if form.cleaned_data["is_pole_emploi"]:
-            next_url = reverse("signup:prescriber_pole_emploi_safir_code")
+            return HttpResponseRedirect(reverse("signup:prescriber_pole_emploi_safir_code"))
 
-        return HttpResponseRedirect(next_url)
+        return HttpResponseRedirect(reverse("signup:prescriber_siren"))
 
     context = {"form": form}
     return render(request, template_name, context)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -68,7 +68,7 @@ redis==3.5.3  # https://github.com/andymccurdy/redis-py
 PyJWT==2.0.1  # https://github.com/jpadilla/pyjwt
 
 # Requests alternative including a default time out
-httpx==0.17.1  # https://github.com/encode/httpx/
+httpx==0.18.2  # https://github.com/encode/httpx/
 
 # SFTP file transfer for ASP
 pysftp==0.2.9  # https://bitbucket.org/dundeemt/pysftp/src/master/
@@ -81,7 +81,5 @@ boto3==1.17.53  # https://github.com/boto/boto3
 # API
 # ------------------------------------------------------------------------------
 # For automatic OpenAPI schema generation
-uritemplate==3.0.1  # https://github.com/python-hyper/uritemplate  
+uritemplate==3.0.1  # https://github.com/python-hyper/uritemplate
 pyyaml==5.4.1  # https://github.com/yaml/pyyaml
-
-

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,6 +35,7 @@ django-admin-logs==1.0.1  # https://pypi.org/project/django-admin-logs/
 # Test & Mock
 # ------------------------------------------------------------------------------
 requests-mock==1.8.0  # https://github.com/jamielennox/requests-mock
+respx==0.17.1  # https://lundberg.github.io/respx/
 
 # Data extracts
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
### Quoi ?

- nouveau formulaire de saisie du SIRET
- nouvelle interface pour l'API Entreprise
- contrôles supplémentaires des données
- amélioration des tests
- mise en forme SIRET/SIREN
- mock plus fin de l'API

### Pourquoi ?

Ces améliorations ont pour but de rendre l'interface plus agréable et le code plus robuste mais une refonte complète de l'UX est nécessaire (voir la carte associée).

### Comment ?

La librairie respx permet de ne mocker que les appels HTTP ainsi il est possible de tester le code d'erreur et le traitement de la réponse.

Pour éviter que l'utilisateur saisisse un SIRET différent de celui utilisé pour la recherche d'établissement et pour éviter qu'il est l'impression de saisir une seconde fois la même information, la partie SIREN est positionné en lecture seule devant le champ
de saisie des 5 derniers chiffres du SIRET.

### Captures d'écran 

Est-ce une amélioration ?

![Capture d’écran de 2021-07-27 20-38-03](https://user-images.githubusercontent.com/1815/127209462-a1298c4a-a146-4302-b75b-2efc539b5df2.png)

### Autre

Cf la carte Trello.

- https://lundberg.github.io/respx/