### PR TITLE
Démo : utilisation de la base de données par défaut de l'extension Postgres Clever

### DIFF
--- a/clevercloud/review-app-after-success.sh
+++ b/clevercloud/review-app-after-success.sh
@@ -11,13 +11,3 @@ PGPASSWORD=$POSTGRESQL_ADDON_PASSWORD pg_restore -d $POSTGRESQL_ADDON_DB -h $POS
 # does not have execution rights on the $APP_HOME directory.
 echo "Loading fixtures"
 ls -d $APP_HOME/itou/fixtures/django/* | xargs django-admin loaddata
-
-echo "Updating super admin password"
-django-admin shell <<EOF
-import os
-from itou.users.models import User
-password = os.environ.get("ADMIN_PASSWORD")
-user = User.objects.get(email="admin@test.com")
-user.set_password(password)
-user.save()
-EOF

--- a/config/settings/demo.py
+++ b/config/settings/demo.py
@@ -9,7 +9,7 @@ DATABASES = {
         "ENGINE": "django.contrib.gis.db.backends.postgis",
         "HOST": os.environ.get("POSTGRESQL_ADDON_HOST"),
         "PORT": os.environ.get("POSTGRESQL_ADDON_PORT"),
-        "NAME": os.environ.get("DEMO_APP_DB_NAME"),
+        "NAME": os.environ.get("POSTGRESQL_ADDON_DB"),
         "USER": os.environ.get("POSTGRESQL_ADDON_USER"),
         "PASSWORD": os.environ.get("POSTGRESQL_ADDON_PASSWORD"),
     }


### PR DESCRIPTION
### Quoi ?

Tout est dans le titre. :)

### Pourquoi ?

Les recettes jetables sont maintenant dans une organisation dédiée. Nous n'avons donc plus besoin d'une base de données personnalisée pour la démo.
J'ai migré les données de l'ancienne BDD vers la nouvelle, tout fonctionne.