### PR TITLE
Restreint le wrapper de DB aux ressources

### DIFF
--- a/itou/metabase/management/commands/_database_psycopg2.py
+++ b/itou/metabase/management/commands/_database_psycopg2.py
@@ -15,6 +15,5 @@ class MetabaseDatabaseCursor:
         return self.cur, self.conn
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.conn.commit()
         self.cur.close()
         self.conn.close()

--- a/itou/metabase/management/commands/_database_psycopg2.py
+++ b/itou/metabase/management/commands/_database_psycopg2.py
@@ -19,5 +19,7 @@ class MetabaseDatabaseCursor:
         return self.cursor, self.connection
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.cursor.close()
-        self.connection.close()
+        if self.cursor:
+            self.cursor.close()
+        if self.connection:
+            self.connection.close()

--- a/itou/metabase/management/commands/_database_psycopg2.py
+++ b/itou/metabase/management/commands/_database_psycopg2.py
@@ -3,17 +3,21 @@ from django.conf import settings
 
 
 class MetabaseDatabaseCursor:
+    def __init__(self):
+        self.cursor = None
+        self.connection = None
+
     def __enter__(self):
-        self.conn = psycopg2.connect(
+        self.connection = psycopg2.connect(
             host=settings.METABASE_HOST,
             port=settings.METABASE_PORT,
             dbname=settings.METABASE_DATABASE,
             user=settings.METABASE_USER,
             password=settings.METABASE_PASSWORD,
         )
-        self.cur = self.conn.cursor()
-        return self.cur, self.conn
+        self.cursor = self.connection.cursor()
+        return self.cursor, self.connection
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.cur.close()
-        self.conn.close()
+        self.cursor.close()
+        self.connection.close()


### PR DESCRIPTION
### Quoi ?

N'effectue pas de `commit` en cas d'erreur.

### Pourquoi ?

Pour éviter d'enregistrer une table partiellement valide (et inutile car non renommée).

### Comment ?

Réserve `__exit__` à la gestion des ressources que la classe a créée.

