### PR TITLE
Remplacement du serveur de clés GPG

### DIFF
--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -32,7 +32,7 @@ RUN set -ex; \
 # uid                  PostgreSQL Debian Repository
     key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
     export GNUPGHOME="$(mktemp -d)"; \
-    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
     gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
     command -v gpgconf > /dev/null && gpgconf --kill all; \
     rm -rf "$GNUPGHOME"; \


### PR DESCRIPTION
### Quoi ?

Changement du serveur pour la récupération de la clé GPG de Postgres

### Pourquoi ?

Le serveur de clés utilisé n'est plus disponible

### Comment ?

Changement d'URL dans le Dockerfile