### PR TITLE
Un candidat peut postuler s'il a un diagnostic valide

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1135,7 +1135,7 @@ class ApprovalsWrapper:
             sender_prescriber_organization is not None and sender_prescriber_organization.is_authorized
         )
 
-        # Only diagnosis made by authorized prescribers are taken into account.
+        # Only diagnoses made by authorized prescribers are taken into account.
         has_valid_diagnosis = self.user.has_valid_diagnosis()
         return (
             self.has_in_waiting_period

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1131,11 +1131,14 @@ class ApprovalsWrapper:
         An approval in waiting period can only be bypassed if the prescriber is authorized
         or if the structure is not a SIAE.
         """
+        from itou.eligibility.models import EligibilityDiagnosis
+
         is_sent_by_authorized_prescriber = (
             sender_prescriber_organization is not None and sender_prescriber_organization.is_authorized
         )
+        valid_diagnosis_exists = EligibilityDiagnosis.objects.has_considered_valid(job_seeker=self.user)
         return (
             self.has_in_waiting_period
             and siae.is_subject_to_eligibility_rules
-            and not is_sent_by_authorized_prescriber
+            and not (is_sent_by_authorized_prescriber or valid_diagnosis_exists)
         )

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1131,14 +1131,12 @@ class ApprovalsWrapper:
         An approval in waiting period can only be bypassed if the prescriber is authorized
         or if the structure is not a SIAE.
         """
-        from itou.eligibility.models import EligibilityDiagnosis
-
         is_sent_by_authorized_prescriber = (
             sender_prescriber_organization is not None and sender_prescriber_organization.is_authorized
         )
-        valid_diagnosis_exists = EligibilityDiagnosis.objects.has_considered_valid(job_seeker=self.user)
+
         return (
             self.has_in_waiting_period
             and siae.is_subject_to_eligibility_rules
-            and not (is_sent_by_authorized_prescriber or valid_diagnosis_exists)
+            and not (is_sent_by_authorized_prescriber or self.user.has_valid_diagnosis())
         )

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1135,8 +1135,10 @@ class ApprovalsWrapper:
             sender_prescriber_organization is not None and sender_prescriber_organization.is_authorized
         )
 
+        # Only diagnosis made by authorized prescribers are taken into account.
+        has_valid_diagnosis = self.user.has_valid_diagnosis()
         return (
             self.has_in_waiting_period
             and siae.is_subject_to_eligibility_rules
-            and not (is_sent_by_authorized_prescriber or self.user.has_valid_diagnosis())
+            and not (is_sent_by_authorized_prescriber or has_valid_diagnosis)
         )

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -27,11 +27,7 @@ from itou.approvals.notifications import NewProlongationToAuthorizedPrescriberNo
 from itou.eligibility.factories import EligibilityDiagnosisFactory, EligibilityDiagnosisMadeBySiaeFactory
 from itou.job_applications.factories import JobApplicationSentByJobSeekerFactory, JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
-from itou.prescribers.factories import (
-    AuthorizedPrescriberOrganizationFactory,
-    PrescriberOrganizationFactory,
-    PrescriberOrganizationWithMembershipFactory,
-)
+from itou.prescribers.factories import AuthorizedPrescriberOrganizationFactory, PrescriberOrganizationFactory
 from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
 from itou.siaes.models import Siae
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, UserFactory

--- a/itou/job_applications/csv_export.py
+++ b/itou/job_applications/csv_export.py
@@ -1,7 +1,5 @@
 import csv
 
-from itou.eligibility.models import EligibilityDiagnosis
-
 
 JOB_APPLICATION_CSV_HEADERS = [
     "Nom candidat",
@@ -52,7 +50,8 @@ def _get_selected_jobs(job_application):
 
 def _get_eligibility_status(job_application):
     eligibility = "non"
-    if EligibilityDiagnosis.objects.has_considered_valid(job_seeker=job_application.job_seeker):
+    # Eligibility diagnoses made by SIAE are ignored.
+    if job_application.job_seeker.has_valid_diagnosis():
         eligibility = "oui"
 
     return eligibility

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -455,7 +455,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         return (
             (self.state in JobApplicationWorkflow.CAN_BE_ACCEPTED_STATES)
             and self.to_siae.is_subject_to_eligibility_rules
-            and not EligibilityDiagnosis.objects.has_considered_valid(self.job_seeker, for_siae=self.to_siae)
+            and not self.job_seeker.has_valid_diagnosis(for_siae=self.to_siae)
         )
 
     @property

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -589,9 +589,12 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
 
             approvals_wrapper = self.job_seeker.approvals_wrapper
 
-            if approvals_wrapper.has_in_waiting_period and not self.is_sent_by_authorized_prescriber:
-                # Security check: it's supposed to be blocked upstream.
-                raise xwf_models.AbortTransition("Job seeker has an approval in waiting period.")
+            if approvals_wrapper.has_in_waiting_period:
+                if approvals_wrapper.cannot_bypass_waiting_period(
+                    siae=self.to_siae, sender_prescriber_organization=self.sender_prescriber_organization
+                ):
+                    # Security check: it's supposed to be blocked upstream.
+                    raise xwf_models.AbortTransition("Job seeker has an approval in waiting period.")
 
             if approvals_wrapper.has_valid:
                 # Automatically reuse an existing valid Itou or PE approval.

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from django_xworkflows import models as xwf_models
 
 from itou.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
-from itou.eligibility.factories import EligibilityDiagnosisMadeBySiaeFactory
+from itou.eligibility.factories import EligibilityDiagnosisFactory, EligibilityDiagnosisMadeBySiaeFactory
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.csv_export import generate_csv_export
 from itou.job_applications.factories import (
@@ -645,6 +645,11 @@ class NewQualifiedJobAppEmployersNotificationTest(TestCase):
 class JobApplicationWorkflowTest(TestCase):
     """Test JobApplication workflow."""
 
+    def setUp(self):
+        self.sent_pass_email_subject = "PASS IAE pour"
+        self.accept_email_subject_proxy = "Candidature acceptée et votre avis sur les emplois de l'inclusion"
+        self.accept_email_subject_job_seeker = "Candidature acceptée"
+
     def test_accept_job_application_sent_by_job_seeker_and_make_others_obsolete(self):
         """
         When a job seeker's application is accepted, the others are marked obsolete.
@@ -671,9 +676,9 @@ class JobApplicationWorkflowTest(TestCase):
         # Check sent emails.
         self.assertEqual(len(mail.outbox), 2)
         # Email sent to the job seeker.
-        self.assertIn("Candidature acceptée", mail.outbox[0].subject)
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
         # Email sent to the employer.
-        self.assertIn("PASS IAE pour", mail.outbox[1].subject)
+        self.assertIn(self.sent_pass_email_subject, mail.outbox[1].subject)
 
     def test_accept_obsolete(self):
         """
@@ -703,9 +708,9 @@ class JobApplicationWorkflowTest(TestCase):
         # Check sent emails.
         self.assertEqual(len(mail.outbox), 2)
         # Email sent to the job seeker.
-        self.assertIn("Candidature acceptée", mail.outbox[0].subject)
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
         # Email sent to the employer.
-        self.assertIn("PASS IAE pour", mail.outbox[1].subject)
+        self.assertIn(self.sent_pass_email_subject, mail.outbox[1].subject)
 
     def test_accept_job_application_sent_by_job_seeker_with_already_existing_valid_approval(self):
         """
@@ -726,9 +731,9 @@ class JobApplicationWorkflowTest(TestCase):
         # Check sent emails.
         self.assertEqual(len(mail.outbox), 2)
         # Email sent to the job seeker.
-        self.assertIn("Candidature acceptée", mail.outbox[0].subject)
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
         # Email sent to the employer.
-        self.assertIn("PASS IAE pour", mail.outbox[1].subject)
+        self.assertIn(self.sent_pass_email_subject, mail.outbox[1].subject)
 
     def test_accept_job_application_sent_by_job_seeker_with_already_existing_valid_approval_in_the_future(self):
         """
@@ -777,8 +782,8 @@ class JobApplicationWorkflowTest(TestCase):
         # Check sent email.
         self.assertEqual(len(mail.outbox), 2)
         # Email sent to the job seeker.
-        self.assertIn("Candidature acceptée", mail.outbox[0].subject)
-        # Email sent to the employer.
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
+        # Email sent to the team.
         self.assertIn("PASS IAE requis sur Itou", mail.outbox[1].subject)
 
     def test_accept_job_application_sent_by_prescriber(self):
@@ -797,11 +802,11 @@ class JobApplicationWorkflowTest(TestCase):
         # Check sent email.
         self.assertEqual(len(mail.outbox), 3)
         # Email sent to the job seeker.
-        self.assertIn("Candidature acceptée", mail.outbox[0].subject)
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
         # Email sent to the proxy.
-        self.assertIn("Candidature acceptée et votre avis sur les emplois de l'inclusion", mail.outbox[1].subject)
+        self.assertIn(self.accept_email_subject_proxy, mail.outbox[1].subject)
         # Email sent to the employer.
-        self.assertIn("PASS IAE pour", mail.outbox[2].subject)
+        self.assertIn(self.sent_pass_email_subject, mail.outbox[2].subject)
 
     def test_accept_job_application_sent_by_authorized_prescriber(self):
         """
@@ -820,11 +825,11 @@ class JobApplicationWorkflowTest(TestCase):
         # Check sent email.
         self.assertEqual(len(mail.outbox), 3)
         # Email sent to the job seeker.
-        self.assertIn("Candidature acceptée", mail.outbox[0].subject)
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
         # Email sent to the proxy.
-        self.assertIn("Candidature acceptée et votre avis sur les emplois de l'inclusion", mail.outbox[1].subject)
+        self.assertIn(self.accept_email_subject_proxy, mail.outbox[1].subject)
         # Email sent to the employer.
-        self.assertIn("PASS IAE pour", mail.outbox[2].subject)
+        self.assertIn(self.sent_pass_email_subject, mail.outbox[2].subject)
 
     def test_accept_job_application_sent_by_authorized_prescriber_with_approval_in_waiting_period(self):
         """
@@ -850,11 +855,11 @@ class JobApplicationWorkflowTest(TestCase):
         # Check sent emails.
         self.assertEqual(len(mail.outbox), 3)
         # Email sent to the job seeker.
-        self.assertIn("Candidature acceptée", mail.outbox[0].subject)
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
         # Email sent to the proxy.
-        self.assertIn("Candidature acceptée et votre avis sur les emplois de l'inclusion", mail.outbox[1].subject)
+        self.assertIn(self.accept_email_subject_proxy, mail.outbox[1].subject)
         # Email sent to the employer.
-        self.assertIn("PASS IAE pour", mail.outbox[2].subject)
+        self.assertIn(self.sent_pass_email_subject, mail.outbox[2].subject)
 
     def test_accept_job_application_sent_by_prescriber_with_approval_in_waiting_period(self):
         """
@@ -874,6 +879,37 @@ class JobApplicationWorkflowTest(TestCase):
         with self.assertRaises(xwf_models.AbortTransition):
             job_application.accept(user=job_application.to_siae.members.first())
 
+    def test_accept_job_application_sent_by_job_seeker_in_waiting_period_valid_diagnosis(self):
+        """
+        A job seeker with a valid diagnosis can start an IAE path
+        even if he's in a waiting period.
+        """
+        user = JobSeekerFactory()
+        # Ended 1 year ago.
+        end_at = datetime.date.today() - relativedelta(years=1)
+        start_at = end_at - relativedelta(years=2)
+        approval = PoleEmploiApprovalFactory(
+            pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate, start_at=start_at, end_at=end_at
+        )
+        self.assertTrue(approval.is_in_waiting_period)
+
+        diagnosis = EligibilityDiagnosisFactory(job_seeker=user)
+        self.assertTrue(diagnosis.is_valid)
+
+        job_application = JobApplicationSentByJobSeekerFactory(
+            job_seeker=user, state=JobApplicationWorkflow.STATE_PROCESSING
+        )
+        job_application.accept(user=job_application.to_siae.members.first())
+        self.assertIsNotNone(job_application.approval)
+        self.assertTrue(job_application.approval_number_sent_by_email)
+        self.assertEqual(job_application.approval_delivery_mode, job_application.APPROVAL_DELIVERY_MODE_AUTOMATIC)
+        # Check sent emails.
+        self.assertEqual(len(mail.outbox), 2)
+        # Email sent to the job seeker.
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
+        # Email sent to the employer.
+        self.assertIn(self.sent_pass_email_subject, mail.outbox[1].subject)
+
     def test_accept_job_application_by_siae_with_no_approval(self):
         """
         A SIAE can hire somebody without getting approval if they don't want one
@@ -891,9 +927,9 @@ class JobApplicationWorkflowTest(TestCase):
         # Check sent email (no notification of approval).
         self.assertEqual(len(mail.outbox), 2)
         # Email sent to the job seeker.
-        self.assertIn("Candidature acceptée", mail.outbox[0].subject)
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
         # Email sent to the proxy.
-        self.assertIn("Candidature acceptée et votre avis sur les emplois de l'inclusion", mail.outbox[1].subject)
+        self.assertIn(self.accept_email_subject_proxy, mail.outbox[1].subject)
 
     def test_accept_job_application_by_siae_not_subject_to_eligibility_rules(self):
         """
@@ -910,9 +946,9 @@ class JobApplicationWorkflowTest(TestCase):
         # Check sent emails.
         self.assertEqual(len(mail.outbox), 2)
         # Email sent to the job seeker.
-        self.assertIn("Candidature acceptée", mail.outbox[0].subject)
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
         # Email sent to the proxy.
-        self.assertIn("Candidature acceptée et votre avis sur les emplois de l'inclusion", mail.outbox[1].subject)
+        self.assertIn(self.accept_email_subject_proxy, mail.outbox[1].subject)
 
     def test_accept_has_link_to_eligibility_diagnosis(self):
         """

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -251,42 +251,6 @@ class JobApplicationQuerySetTest(TestCase):
         self.assertIn(job_app, JobApplication.objects.eligible_as_employee_record(job_app.to_siae))
 
 
-class JobApplicationFactoriesTest(TestCase):
-    def test_job_application_factory(self):
-        create_test_romes_and_appellations(["M1805"], appellations_per_rome=2)
-        job_application = JobApplicationFactory(selected_jobs=Appellation.objects.all())
-        self.assertEqual(job_application.selected_jobs.count(), 2)
-
-    def test_job_application_sent_by_job_seeker_factory(self):
-        job_application = JobApplicationSentByJobSeekerFactory()
-        self.assertEqual(job_application.sender_kind, JobApplication.SENDER_KIND_JOB_SEEKER)
-        self.assertEqual(job_application.job_seeker, job_application.sender)
-
-    def test_job_application_sent_by_prescriber_factory(self):
-        job_application = JobApplicationSentByPrescriberFactory()
-        self.assertEqual(job_application.sender_kind, JobApplication.SENDER_KIND_PRESCRIBER)
-        self.assertNotEqual(job_application.job_seeker, job_application.sender)
-        self.assertIsNone(job_application.sender_prescriber_organization)
-
-    def test_job_application_sent_by_prescriber_organization_factory(self):
-        job_application = JobApplicationSentByPrescriberOrganizationFactory()
-        self.assertEqual(job_application.sender_kind, JobApplication.SENDER_KIND_PRESCRIBER)
-        self.assertNotEqual(job_application.job_seeker, job_application.sender)
-        sender = job_application.sender
-        sender_prescriber_organization = job_application.sender_prescriber_organization
-        self.assertIn(sender, sender_prescriber_organization.members.all())
-        self.assertFalse(sender_prescriber_organization.is_authorized)
-
-    def test_job_application_sent_by_authorized_prescriber_organization_factory(self):
-        job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory()
-        self.assertEqual(job_application.sender_kind, JobApplication.SENDER_KIND_PRESCRIBER)
-        self.assertNotEqual(job_application.job_seeker, job_application.sender)
-        sender = job_application.sender
-        sender_prescriber_organization = job_application.sender_prescriber_organization
-        self.assertIn(sender, sender_prescriber_organization.members.all())
-        self.assertTrue(sender_prescriber_organization.is_authorized)
-
-
 class JobApplicationNotificationsTest(TestCase):
     """
     Test JobApplication notifications: emails content and receivers.

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -28,7 +28,7 @@
     {% endif %}
 </p>
 
-{% if job_application.is_pending %}
+{% if user.is_siae_staff and job_application.is_pending %}
     {% comment %}
     If the PASS IAE number is displayed at this time, some employers think that there is
     no need to validate the application because a number is already assigned.
@@ -120,19 +120,18 @@
         <b>Expiré</b> le {{ approval.extended_end_at|date:"d/m/Y" }} (depuis {{ approval.extended_end_at|timesince }})
     </p>
 
-    {% if job_application.is_pending and job_application.is_sent_by_authorized_prescriber %}
+    {% if user.is_siae_staff %}
+        {% if job_application.is_pending and job_application.get_eligibility_diagnosis.is_valid %}
+            {% comment %}
+            When an authorized prescriber bypasses the waiting period and sends a candidate
+            with an "expired" approval, the employer receives the application with the mention
+            "expired". He thinks that the hiring is impossible when he just has to validate
+            the job application to get a new PASS IAE.
 
-        {% comment %}
-        When an authorized prescriber bypasses the waiting period and sends a candidate
-        with an "expired" approval, the employer receives the application with the mention
-        "expired". He thinks that the hiring is impossible when he just has to validate
-        the job application to get a new PASS IAE.
+            Show a message explaining that.
+            {% endcomment %}
 
-        Show a message explaining that.
-        {% endcomment %}
-
-        <p><b>Le prescripteur a dérogé au délai de carence, vous pouvez obtenir un PASS IAE.</b></p>
-
+            <p><b>Un diagnostic d'éligibilité valide existe pour ce candidat. Vous pouvez obtenir un PASS IAE.</b></p>
+        {% endif %}
     {% endif %}
-
 {% endif %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -191,9 +191,13 @@
                             </div>
                             {% if approvals_wrapper.has_in_waiting_period %}
                                 <p class="card-text">
+                                    {% if user.has_valid_diagnosis %}
+                                        <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez donc commencer un nouveau parcours.</b></p>
+                                    {% else %}
                                     <small>
                                         {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}
                                     </small>
+                                    {% endif %}
                                 </p>
                             {% endif %}
                         </div>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -192,7 +192,7 @@
                             {% if approvals_wrapper.has_in_waiting_period %}
                                 <p class="card-text">
                                     {% if user.has_valid_diagnosis %}
-                                        <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez donc commencer un nouveau parcours.</b></p>
+                                        <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
                                     {% else %}
                                     <small>
                                         {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -249,6 +249,12 @@ class User(AbstractUser, AddressMixin):
     def has_jobseeker_profile(self):
         return self.is_job_seeker and hasattr(self, "jobseeker_profile")
 
+    @cached_property
+    def has_valid_diagnosis(self):
+        from itou.eligibility.models import EligibilityDiagnosis
+
+        return EligibilityDiagnosis.objects.has_considered_valid(job_seeker=self)
+
     def joined_recently(self):
         time_since_date_joined = timezone.now() - self.date_joined
         return time_since_date_joined.days < 7

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -249,11 +249,10 @@ class User(AbstractUser, AddressMixin):
     def has_jobseeker_profile(self):
         return self.is_job_seeker and hasattr(self, "jobseeker_profile")
 
-    @cached_property
-    def has_valid_diagnosis(self):
+    def has_valid_diagnosis(self, for_siae=None):
         from itou.eligibility.models import EligibilityDiagnosis
 
-        return EligibilityDiagnosis.objects.has_considered_valid(job_seeker=self)
+        return EligibilityDiagnosis.objects.has_considered_valid(job_seeker=self, for_siae=for_siae)
 
     def joined_recently(self):
         time_since_date_joined = timezone.now() - self.date_joined

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -250,9 +250,7 @@ class User(AbstractUser, AddressMixin):
         return self.is_job_seeker and hasattr(self, "jobseeker_profile")
 
     def has_valid_diagnosis(self, for_siae=None):
-        from itou.eligibility.models import EligibilityDiagnosis
-
-        return EligibilityDiagnosis.objects.has_considered_valid(job_seeker=self, for_siae=for_siae)
+        return self.eligibility_diagnoses.has_considered_valid(job_seeker=self, for_siae=for_siae)
 
     def joined_recently(self):
         time_since_date_joined = timezone.now() - self.date_joined

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -268,7 +268,7 @@ def step_eligibility(request, siae_pk, template_name="apply/submit_step_eligibil
         # Only "authorized prescribers" can perform an eligibility diagnosis.
         not user_info.is_authorized_prescriber
         # Eligibility diagnosis already performed.
-        or EligibilityDiagnosis.objects.has_considered_valid(job_seeker)
+        or job_seeker.has_valid_diagnosis()
     )
 
     if skip:


### PR DESCRIPTION
### Quoi ?

Donner la possibilité à un candidat de postuler s'il dispose d'un diagnostic valide, même s'il est en période de carence.

### Pourquoi ?

Actuellement, un candidat qui est en délai de carence ne peut pas postuler même si un prescripteur habilité a réalisé un diagnostic.
Le support a reçu plusieurs retours à ce sujet de la part de prescripteurs qui s'en étonnaient.
Nous adaptons donc le code au besoin métier.

### Comment ?

Mise à jour d'une méthode qui contourne la période de carence dans certains cas.
Mise à jour de l'interface.
Une requête en plus pour un affichage conditionnel sur le tableau de bord candidat.

### Captures d'écran

#### Candidat
AVANT : 
![image](https://user-images.githubusercontent.com/6150920/128211065-f585d2ee-f159-407e-af64-862798aef5fb.png)


MAINTENANT : 
![image](https://user-images.githubusercontent.com/6150920/128320642-ade2d9c5-1e86-4300-8620-7a0e0139e296.png)


#### Employeur
AVANT : 
![image](https://user-images.githubusercontent.com/6150920/128210921-1048123a-efcb-4348-ac07-6434c1a38988.png)


MAINTENANT : 
![image](https://user-images.githubusercontent.com/6150920/128210276-3dfa03df-8c4f-4b23-876c-2bac2cd83daa.png)


#### Prescripteur
AVANT : 
![image](https://user-images.githubusercontent.com/6150920/128210611-37b36459-a747-4293-9305-d44b4da8a3b0.png)

MAINTENANT : 
![image](https://user-images.githubusercontent.com/6150920/128210099-49e63efd-aa2d-4f3e-a850-be1dec5c801c.png)


