### PR TITLE
2 SIAE utilisent un même Pass délivré via un agrément PE

### DIFF
--- a/itou/www/approvals_views/tests/test_pe_approval.py
+++ b/itou/www/approvals_views/tests/test_pe_approval.py
@@ -141,6 +141,16 @@ class PoleEmploiApprovalSearchTest(TestCase):
         # The current user should be able to use the PASS IAE used by another SIAE
         response = self.client.get(self.url, {"number": job_application.approval.number})
         self.assertContains(response, "Utiliser le PASS IAE")
+        # It should be possible to apply to this PASS by going directly to the eligibility phase
+        # while skipping most of the initial "apply:step_*" steps
+        next_url = reverse("apply:step_eligibility", kwargs={"siae_pk": self.siae.pk})
+        self.assertContains(response, next_url)
+
+        response = self.client.get(next_url)
+        application_url = reverse("apply:step_application", kwargs={"siae_pk": self.siae.pk})
+        # the eligibility page is skipped since the approval is already granted, but we perform the skip anyway
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, application_url)
 
     def test_unlogged_is_not_authorized(self):
         """


### PR DESCRIPTION
# Quoi ?

On veut que 2 SIAE puissent utiliser un même pass (ex: 2 contrats à mi-temps), y compris si celui-ci est délivré via un agrément pole emploi
https://trello.com/c/9Udzp4Gh/1990-c1-bug-dans-le-module-de-reprise-dagr%C3%A9ment-sil-a-d%C3%A9j%C3%A0-%C3%A9t%C3%A9-repris-par-un-autre-employeur-avant

# Pourquoi ?

C’est le cas pour les PASS classiques, les agréments PE n’y font pas exception.

# Comment ?

Si un pass a déja été délivré pour une autre SIAE,
On redirige vers `"apply:step_eligibility", kwargs={"siae_pk": self.siae.pk}`, ce qui est au milieu d’un process qui démarre à `apply:step_start` et enrchit la session au fur et à mesure. En l’état, on se fait donc jeter par le middleware car les données de session sont vides ; ce correctif remplit correctement la session pour prendre le process en cours de route.

