### PR TITLE
Déploiement d'une recette jetable en fonction de l'activité d'une branche

### DIFF
--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -112,5 +112,9 @@ jobs:
         $CLEVER_CLI login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
         $CLEVER_CLI link $REVIEW_APP_NAME --org $REVIEW_APPS_ORGANIZATION_NAME
 
+    - name: ⏭ Skip fixtures
+      run:
+        $CLEVER_CLI env set SKIP_FIXTURES true
+
     - name: 🚀 Deploy to Clever Cloud
       run: $CLEVER_CLI deploy --branch $BRANCH --force

--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   create:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'recette-jetable'
+    if: github.event.action == 'labeled' && github.event.label.name == 'recette-jetable'
 
     steps:
     - name: 📥 Checkout to the PR branch

--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -1,12 +1,12 @@
 # See https://developer.github.com/v3/
 # and https://help.github.com/en/actions
-name: 🕵 Review app creation
+name: 🕵 Review app
 
 # Run this pipeline when a label is added and when a push is made on this PR.
 # `types: [ synchronize ]` targets a push event made on a PR.
 on:
   pull_request:
-    types: [ labeled ]
+    types: [ labeled, synchronize ]
 
 env:
   CLEVER_TOOLS_DOWNLOAD_URL: https://clever-tools.clever-cloud.com/releases/latest/clever-tools-latest_linux.tar.gz
@@ -52,6 +52,11 @@ jobs:
         curl $CLEVER_TOOLS_DOWNLOAD_URL > $CLEVER_TAR_FILE
         tar -xvf $CLEVER_TAR_FILE
         $CLEVER_CLI login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
+        # Create a new application on Clever Cloud.
+        # -t: application type (Python).
+        # --org: organization name.
+        # --region: server location ("par" means Paris).
+        # --alias: custom application name, used to find it with the CLI.
         $CLEVER_CLI create $REVIEW_APP_NAME -t python --org $REVIEW_APPS_ORGANIZATION_NAME --region par --alias $REVIEW_APP_NAME
         $CLEVER_CLI domain add $DEPLOY_URL --alias $REVIEW_APP_NAME
         $CLEVER_CLI link $REVIEW_APP_NAME --org $REVIEW_APPS_ORGANIZATION_NAME
@@ -74,10 +79,38 @@ jobs:
         $CLEVER_CLI env import-vars DEPLOY_URL
 
     - name: 🚀 Deploy to Clever Cloud
-      run: $CLEVER_CLI deploy --branch $BRANCH --force --verbose
+      run: $CLEVER_CLI deploy --branch $BRANCH --force
 
     - name: 🍻 Add link to pull request
       uses: thollander/actions-comment-pull-request@master
       with:
         message: "🥁 La recette jetable est prête ! [👉 Je veux tester cette PR !](https://${{ env.DEPLOY_URL }})"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ 
+  redeploy:
+    runs-on: ubuntu-latest
+    # A push event targets a new deployment.
+    if: github.event.action == 'synchronize' && contains( github.event.pull_request.labels.*.name, 'recette-jetable')
+
+    steps:
+    - name: 📥 Checkout to the PR branch
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+
+    - name: 📥 Fetch git branches
+      run: git fetch --prune --unshallow
+
+    - name: 🏷 Set review app name
+      run:
+        echo "REVIEW_APP_NAME=`echo \"c1-review-$BRANCH\" | sed -r 's/[-;\\/._]+/-/g'`" >> $GITHUB_ENV
+
+    - name: 🤝 Find the application on Clever Cloud
+      run: |
+        curl $CLEVER_TOOLS_DOWNLOAD_URL > $CLEVER_TAR_FILE
+        tar -xvf $CLEVER_TAR_FILE
+        $CLEVER_CLI login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
+        $CLEVER_CLI link $REVIEW_APP_NAME --org $REVIEW_APPS_ORGANIZATION_NAME
+
+    - name: 🚀 Deploy to Clever Cloud
+      run: $CLEVER_CLI deploy --branch $BRANCH --force

--- a/clevercloud/review-app-after-success.sh
+++ b/clevercloud/review-app-after-success.sh
@@ -4,6 +4,12 @@
 ###################### Review apps entrypoint #####################
 ###################################################################
 
+# Skip this step when redeploying a review app.
+if [ "$SKIP_FIXTURES" = true ] ; then
+    echo "Skipping fixtures."
+    exit
+fi
+
 echo "Loading cities"
 PGPASSWORD=$POSTGRESQL_ADDON_PASSWORD pg_restore -d $POSTGRESQL_ADDON_DB -h $POSTGRESQL_ADDON_HOST -p $POSTGRESQL_ADDON_PORT -U $POSTGRESQL_ADDON_USER --if-exists --clean --no-owner --no-privileges $APP_HOME/itou/fixtures/postgres/cities.sql
 


### PR DESCRIPTION
### Quoi ?

Possibilité de redéployer une recette jetable sans avoir à la détruire. 
Chaque _push_ effectué sur une branche qui a l'étiquette "recette-jetable" déclenche un nouveau déploiement chez Clever. 

### Pourquoi ?

Il est très pénible de supprimer puis de créer une nouvelle recette jetable pour refléter un changement applicatif. C'est une perte de temps et d'énergie.

### Comment ?

Ajout d'une étape conditionnelle dans le script de création des recettes jetables.
