### PR TITLE
CRON des fiches salarié conditionnel

### DIFF
--- a/clevercloud/sync_employee_records.sh
+++ b/clevercloud/sync_employee_records.sh
@@ -2,10 +2,13 @@
 
 # Fetch and upload files to ASP SFTP server
 
-#
+# Do not run if this env var is not set:
+if [[ -z "$EMPLOYEE_RECORD_CRON_ENABLED" ]]; then
+    exit 0
+fi
+
 # About clever cloud cronjobs:
 # https://www.clever-cloud.com/doc/tools/crons/
-#
 
 if [[ "$INSTANCE_NUMBER" != "0" ]]; then
     echo "Instance number is ${INSTANCE_NUMBER}. Stop here."


### PR DESCRIPTION

### Quoi ?

Faire en sorte que le CRON de transfert des fiches salarié vers l'ASP ne fonctionne que sur les environnements sélectionnés

### Pourquoi ?

Pour éviter de pourrir les logs (et le sentry) des instances ne disposant pas de cette fonctionnalité

### Comment ?

Conditionner le lancement du script à la présence sur l'instance de la variable d'environnement `EMPLOYEE_RECORD_CRON_ENABLED` 
