### PR TITLE
Affichage de la date d'expiration du dernier diagnostic 

### DIFF
--- a/itou/eligibility/factories.py
+++ b/itou/eligibility/factories.py
@@ -38,6 +38,13 @@ class ExpiredEligibilityDiagnosisFactory(EligibilityDiagnosisFactory):
     )
 
 
+class ExpiredEligibilityDiagnosisMadeBySiaeFactory(EligibilityDiagnosisMadeBySiaeFactory):
+
+    created_at = factory.LazyAttribute(
+        lambda self: models.EligibilityDiagnosis.get_expiration_dt() - timezone.timedelta(days=1)
+    )
+
+
 class AdministrativeCriteriaFactory(factory.django.DjangoModelFactory):
     """
     The AdministrativeCriteria table is automatically populated with a fixture at the end of

--- a/itou/templates/apply/includes/eligibility_diagnosis.html
+++ b/itou/templates/apply/includes/eligibility_diagnosis.html
@@ -112,6 +112,13 @@
             Validés par <b>Pôle emploi</b>.
         </p>
 
+    {% elif expired_eligibility_diagnosis %}
+        <hr>
+        <h3 class="font-weight-normal text-muted">Éligibilité IAE</h3>
+        <div class="alert alert-warning" role="alert">
+            Le diagnostic d'éligibilité IAE de ce candidat a expiré le {{ expired_eligibility_diagnosis.considered_to_expire_at|date }}, 
+            vous devez valider les critères d'éligibilité.
+        </div>
     {% endif %}
 
 {% endif %}

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -67,6 +67,9 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
     approval_can_be_prolonged_by_siae = job_application.approval and job_application.approval.can_be_prolonged_by_siae(
         job_application.to_siae
     )
+    expired_eligibility_diagnosis = EligibilityDiagnosis.objects.last_considered_expired(
+        job_seeker=job_application.job_seeker, for_siae=job_application.to_siae
+    )
     back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("apply:list_for_siae"))
 
     context = {
@@ -75,6 +78,7 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
         "approval_can_be_prolonged_by_siae": approval_can_be_prolonged_by_siae,
         "cancellation_days": cancellation_days,
         "eligibility_diagnosis": job_application.get_eligibility_diagnosis(),
+        "expired_eligibility_diagnosis": expired_eligibility_diagnosis,
         "job_application": job_application,
         "transition_logs": transition_logs,
         "back_url": back_url,


### PR DESCRIPTION
### Quoi ?

Affichage de la date d'expiration du dernier diagnostic si aucun n'est valide

### Pourquoi ?

Pour expliquer aux employeurs pourquoi ils doivent refaire un diagnostic même lorsque la candidature vient d'un prescripteur habilité.

### Comment ?

En ajoutant la possibilité de récupérer le dernier diagnostic expiré si aucun diagnostic valide n'est trouvé.

### Captures d'écran

![capture_diagnostic_date_expiration](https://user-images.githubusercontent.com/17601807/129049188-7ae47b75-3eb1-4372-b73c-031cf53175fb.png)

