### PR TITLE
Correction de certains tests unitaires qui ne passent pas entre minuit et 1h

### DIFF
--- a/itou/invitations/tests.py
+++ b/itou/invitations/tests.py
@@ -86,7 +86,7 @@ class InvitationEmailsTest(TestCase):
         self.assertIn(capfirst(invitation.last_name), email.body)
         self.assertIn(invitation.acceptance_link, email.body)
 
-        self.assertIn(str(invitation.expiration_date.day), email.body)
+        self.assertIn(str(timezone.localdate(invitation.expiration_date).day), email.body)
 
         # To
         self.assertIn(invitation.email, email.to)

--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -1,8 +1,7 @@
-import datetime
-
 import factory
 import factory.fuzzy
 from dateutil.relativedelta import relativedelta
+from django.utils import timezone
 
 from itou.approvals.factories import ApprovalFactory
 from itou.eligibility.factories import EligibilityDiagnosisFactory
@@ -33,8 +32,8 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
     to_siae = factory.SubFactory(SiaeWithMembershipFactory)
     message = factory.Faker("sentence", nb_words=40)
     answer = factory.Faker("sentence", nb_words=40)
-    hiring_start_at = datetime.date.today()
-    hiring_end_at = datetime.date.today() + relativedelta(years=2)
+    hiring_start_at = timezone.localdate()
+    hiring_end_at = timezone.localdate() + relativedelta(years=2)
     resume_link = "https://server.com/rockie-balboa.pdf"
 
     @factory.post_generation
@@ -126,8 +125,8 @@ class JobApplicationWithoutApprovalFactory(JobApplicationSentByPrescriberFactory
 
 
 class JobApplicationWithApprovalNotCancellableFactory(JobApplicationWithApprovalFactory):
-    hiring_start_at = datetime.date.today() - relativedelta(days=5)
-    hiring_end_at = datetime.date.today() + relativedelta(years=2, days=-5)
+    hiring_start_at = timezone.localdate() - relativedelta(days=5)
+    hiring_end_at = timezone.localdate() + relativedelta(years=2, days=-5)
 
 
 class JobApplicationWithJobSeekerProfileFactory(JobApplicationWithApprovalNotCancellableFactory):

--- a/itou/www/apply/tests/test_edit.py
+++ b/itou/www/apply/tests/test_edit.py
@@ -109,9 +109,7 @@ class EditContractTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        future_start_date = (
-            timezone.now() + relativedelta(days=JobApplication.MAX_CONTRACT_POSTPONE_IN_DAYS + 1)
-        ).date()
+        future_start_date = timezone.localdate() + relativedelta(days=JobApplication.MAX_CONTRACT_POSTPONE_IN_DAYS + 1)
 
         post_data = {
             "hiring_start_at": future_start_date.strftime("%d/%m/%Y"),

--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -191,7 +191,12 @@ class ProcessListSiaeTest(ProcessListTest):
 
         # Negative indexing is not allowed in querysets
         end_date = jobs_in_range[len(jobs_in_range) - 1].created_at
-        query = urlencode({"start_date": start_date.strftime(date_format), "end_date": end_date.strftime(date_format)})
+        query = urlencode(
+            {
+                "start_date": timezone.localdate(start_date).strftime(date_format),
+                "end_date": timezone.localdate(end_date).strftime(date_format),
+            }
+        )
         url = f"{self.siae_base_url}?{query}"
         response = self.client.get(url)
         applications = response.context["job_applications_page"].object_list

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -180,6 +180,7 @@ class ProcessViewsTest(TestCase):
         """Test the `accept` transition."""
         create_test_cities(["54", "57"], num_per_department=2)
         city = City.objects.first()
+        today = timezone.localdate()
 
         job_seeker = JobSeekerWithAddressFactory(city=city.name)
         address = {
@@ -200,7 +201,7 @@ class ProcessViewsTest(TestCase):
             self.assertEqual(response.status_code, 200)
 
             # Good duration.
-            hiring_start_at = timezone.now().date()
+            hiring_start_at = today
             hiring_end_at = Approval.get_default_end_date(hiring_start_at)
             post_data = {
                 # Data for `JobSeekerPoleEmploiStatusForm`.
@@ -227,7 +228,7 @@ class ProcessViewsTest(TestCase):
         url = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
 
         # Wrong dates.
-        hiring_start_at = timezone.now().date()
+        hiring_start_at = today
         hiring_end_at = Approval.get_default_end_date(hiring_start_at)
         # Force `hiring_start_at` in past.
         hiring_start_at = hiring_start_at - relativedelta(days=1)
@@ -241,7 +242,7 @@ class ProcessViewsTest(TestCase):
         self.assertFormError(response, "form_accept", "hiring_start_at", JobApplication.ERROR_START_IN_PAST)
 
         # Wrong dates: end < start.
-        hiring_start_at = timezone.now().date()
+        hiring_start_at = today
         hiring_end_at = hiring_start_at - relativedelta(days=1)
         post_data = {
             "hiring_start_at": hiring_start_at.strftime("%d/%m/%Y"),
@@ -253,7 +254,7 @@ class ProcessViewsTest(TestCase):
         self.assertFormError(response, "form_accept", None, JobApplication.ERROR_END_IS_BEFORE_START)
 
         # Duration too long.
-        hiring_start_at = timezone.now().date()
+        hiring_start_at = today
         max_end_at = Approval.get_default_end_date(hiring_start_at)
         hiring_end_at = max_end_at + relativedelta(days=1)
         post_data = {
@@ -273,7 +274,7 @@ class ProcessViewsTest(TestCase):
         )
         url = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
 
-        hiring_start_at = timezone.now().date()
+        hiring_start_at = today
         hiring_end_at = Approval.get_default_end_date(hiring_start_at)
         post_data = {
             # Data for `JobSeekerPoleEmploiStatusForm`.
@@ -317,8 +318,8 @@ class ProcessViewsTest(TestCase):
             "city": city.name,
             "city_slug": city.slug,
             # Data for `AcceptForm`.
-            "hiring_start_at": timezone.now().date().strftime("%d/%m/%Y"),
-            "hiring_end_at": (timezone.now().date() + relativedelta(days=360)).strftime("%d/%m/%Y"),
+            "hiring_start_at": timezone.localdate().strftime("%d/%m/%Y"),
+            "hiring_end_at": (timezone.localdate() + relativedelta(days=360)).strftime("%d/%m/%Y"),
             "answer": "",
         }
         response = self.client.post(url, data=post_data)
@@ -372,7 +373,7 @@ class ProcessViewsTest(TestCase):
             "pole_emploi_id": job_seeker.pole_emploi_id,
             "answer": "",
         }
-        hiring_start_at = timezone.now().date() + relativedelta(months=2)
+        hiring_start_at = timezone.localdate() + relativedelta(months=2)
         hiring_end_at = hiring_start_at + relativedelta(months=2)
         approval_default_ending = Approval.get_default_end_date(start_at=hiring_start_at)
 
@@ -578,7 +579,7 @@ class ProcessViewsTest(TestCase):
         self.assertTrue(job_application.state.is_cancelled)
 
     def test_cannot_cancel(self):
-        cancellation_period_end = timezone.now().date() - relativedelta(
+        cancellation_period_end = timezone.localdate() - relativedelta(
             days=JobApplication.CANCELLATION_DAYS_AFTER_HIRING_STARTED
         )
         job_application = JobApplicationWithApprovalFactory(
@@ -608,7 +609,7 @@ class ProcessViewsTest(TestCase):
         self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
 
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
-        hiring_start_at = timezone.now().date()
+        hiring_start_at = timezone.localdate()
         hiring_end_at = Approval.get_default_end_date(hiring_start_at)
         post_data = {
             "hiring_start_at": hiring_start_at.strftime("%d/%m/%Y"),

--- a/itou/www/approvals_views/tests/test_suspend.py
+++ b/itou/www/approvals_views/tests/test_suspend.py
@@ -17,7 +17,7 @@ class ApprovalSuspendViewTest(TestCase):
         Test the creation of a suspension.
         """
 
-        today = timezone.now().date()
+        today = timezone.localdate()
 
         job_application = JobApplicationWithApprovalFactory(
             state=JobApplicationWorkflow.STATE_ACCEPTED,
@@ -76,7 +76,7 @@ class ApprovalSuspendViewTest(TestCase):
         Test the update of a suspension.
         """
 
-        today = timezone.now().date()
+        today = timezone.localdate()
 
         job_application = JobApplicationWithApprovalFactory(
             state=JobApplicationWorkflow.STATE_ACCEPTED,
@@ -126,7 +126,7 @@ class ApprovalSuspendViewTest(TestCase):
         Test the deletion of a suspension.
         """
 
-        today = timezone.now().date()
+        today = timezone.localdate()
 
         job_application = JobApplicationWithApprovalFactory(
             state=JobApplicationWorkflow.STATE_ACCEPTED,


### PR DESCRIPTION
### Quoi ?
Certains tests unitaires ne passent pas entre minuit et 1h.

### Pourquoi ?
Certaines dates sont naïves et d'autres conscientes, ce qui créé des décalages de date entre 0h et 1h.

### Comment ?
En passant par la méthode `localdate` de `timezone`
