### PR TITLE
Ajout de drf-spectacular

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -568,6 +568,14 @@ REST_FRAMEWORK = {
     ],
 }
 
+# DRF Spectacular
+# ------------------------------------------------------------------------------
+SPECTACULAR_SETTINGS = {
+    'TITLE': "API - Les emplois de l'inclusion",
+    'DESCRIPTION': "Documentation de l'API **emplois.inclusion.beta.gouv.fr**",
+    'VERSION': '1.0.0',
+}
+
 # Requests
 # ------------------------------------------------------------------------------
 # Requests default timeout is None... See https://blog.mathieu-leplatre.info/handling-requests-timeout-in-python.html

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -56,6 +56,7 @@ THIRD_PARTY_APPS = [
     "huey.contrib.djhuey",
     "rest_framework",  # DRF (Django Rest Framework).
     "rest_framework.authtoken",  # Required for DRF TokenAuthentication.
+    "drf_spectacular",
 ]
 
 
@@ -560,6 +561,7 @@ REST_FRAMEWORK = {
         # For DRF browseable API access
         "rest_framework.renderers.BrowsableAPIRenderer",
     ],
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     # Default permissions for API views: user must be authenticated
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",

--- a/itou/api/urls.py
+++ b/itou/api/urls.py
@@ -1,8 +1,7 @@
 from django.urls import include, path
-from django.views.generic import TemplateView
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView
 from rest_framework import routers
 from rest_framework.authtoken import views as auth_views
-from rest_framework.schemas import get_schema_view
 
 from .employee_record_api.viewsets import DummyEmployeeRecordViewSet, EmployeeRecordViewSet
 
@@ -16,6 +15,7 @@ router = routers.DefaultRouter()
 router.register(r"employee-records", EmployeeRecordViewSet, basename="employee-records")
 router.register(r"dummy-employee-records", DummyEmployeeRecordViewSet, basename="dummy-employee-records")
 
+
 urlpatterns = [
     # TokenAuthentication endpoint to get token from login/password.
     path("token-auth/", auth_views.obtain_auth_token, name="token-auth"),
@@ -26,16 +26,12 @@ urlpatterns = [
     # OAS 3 YAML schema (downloadable)
     path(
         "oas3/",
-        get_schema_view(
-            title="API - Les emplois de l'inclusion",
-            version="v1",
-            description="Documentation de l'API **emplois.inclusion.beta.gouv.fr**",
-        ),
+        SpectacularAPIView.as_view(),
         name="openapi_schema",
     ),
     path(
         "redoc/",
-        TemplateView.as_view(template_name="api/openapi.html", extra_context={"schema_url": "v1:openapi_schema"}),
+        SpectacularRedocView.as_view(url_name="v1:openapi_schema"),
         name="redoc",
     ),
 ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,6 +26,10 @@ django-xworkflows==1.0.0  # https://github.com/rbarrois/django_xworkflows
 # DRF (Django Rest Framework)
 djangorestframework==3.12.2  # https://www.django-rest-framework.org/
 
+# DRF-Spectacular (Django Rest Framework Spectacular, open API schema browser)
+drf-spectacular==0.17.3  # https://github.com/tfranzel/drf-spectacular
+
+
 # Front-end
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Quoi ?

- Ajout de `drf-spectacular` et replacement du schéma OpenAPI par défaut par celui de drf-spectacular
- Ce changement corrige `https://emplois.inclusion.beta.gouv.fr/api/v1/redoc/` qui est cassé pour des raisons de droit d’accès au schéma OpenAPI.

# Pourquoi ?

Le schéma OpenApi par défaut de DRF est assez pénible à personnaliser, drf-spectacular permet facilement [d’annoter les vues](https://drf-spectacular.readthedocs.io/en/latest/readme.html#customization-by-using-extend-schema) avec les éléments que l’on souhaite: plus de codes de retour que ce qui est automatiquement deviné, personnalisation des payload d’erreur, spécitication des règles d’authentification… Avec l’arrivée de l’API PE, ça devient utile voire nécessaire pour ne pas trop s’embêter.