### PR TITLE
Import des données ASP via une github action

### DIFF
--- a/.github/workflows/imports-asp.yml
+++ b/.github/workflows/imports-asp.yml
@@ -1,0 +1,88 @@
+name: Imports ASP
+
+# Runs the various ASP data imports.
+# A github action takes care of the cron task that:
+# - creates a machine on demand
+# - runs the desired shell script through CC_RUN_SUCCEEDED_HOOK
+# - destroys the machine once the update is done
+on:
+  workflow_dispatch: # this is voluntarily empty; it allows to trigger the task manually
+
+# How to run this:
+# Locally:
+# - download and install locally "act" (https://github.com/nektos/act)
+# - create a file "act.secrets" with all the necessary secrets (see the env variables below)
+# - "act --secret-file ./act.secrets -j imports_asp" will run the job imports_asp with the specified environment variables
+# In production:
+# - with github cli (https://cli.github.com/manual/): gh workflow run imports-asp.yml
+# - with github’s web UI: https://github.com/betagouv/itou/actions
+env:
+  CLEVER_TOOLS_DOWNLOAD_URL: https://clever-tools.clever-cloud.com/releases/latest/clever-tools-latest_linux.tar.gz
+  CLEVER_TAR_FILE: clever-tools-latest_linux.tar.gz
+  CLEVER_CLI: clever-tools-latest_linux/clever
+  CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+  CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+  ITOU_ORGANIZATION_NAME: ${{ secrets.CLEVER_ITOU_ORGANIZATION_NAME }}
+  DEPLOY_BRANCH: master_clever
+
+jobs:
+  imports_asp:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: 📥 Checkout to the latest version
+      uses: actions/checkout@v2
+
+    - name: 📥 Fetch git branches
+      run: git fetch --prune --unshallow
+
+    - name: 🏷 Setup app name
+      run:
+        echo "IMPORT_APP_NAME=`echo \"c1-imports-$(date +%y-%m-%d-%Hh-%M)"`" >> $GITHUB_ENV
+
+    # CC_RUN_SUCCEEDED_HOOK is a clever-cloud-specific environment variable.
+    # We set the command we want to run once the app is started
+    # The goal of this entire file relies on this variable !
+    # https://www.clever-cloud.com/doc/develop/build-hooks/
+    - name: 🏷 Setup post-deployment hook
+      run:
+        echo 'CC_RUN_SUCCEEDED_HOOK=./scripts/imports-asp.sh' >> $GITHUB_ENV
+
+    - name: 🧫 Create a cron app on Clever Cloud on a strong machine
+      run: |
+        curl $CLEVER_TOOLS_DOWNLOAD_URL > $CLEVER_TAR_FILE
+        tar -xvf $CLEVER_TAR_FILE
+        $CLEVER_CLI login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
+        # Create a new application on Clever Cloud.
+        # -t: application type (Python).
+        # --org: organization name.
+        # --region: server location ("par" means Paris).
+        # --alias: custom application name, used to find it with the CLI.
+        $CLEVER_CLI create $IMPORT_APP_NAME -t python --region par --alias $IMPORT_APP_NAME --org Itou
+        $CLEVER_CLI link $IMPORT_APP_NAME --org $ITOU_ORGANIZATION_NAME
+        $CLEVER_CLI scale --flavor XL
+
+    # We need at the minimum a database and redis in order to boot the app, as well as all the necessary
+    # environment variables a configuration addon provides us
+    - name: 🗺 Add environment variables and addons to the app
+      run: |
+        $CLEVER_CLI link $IMPORT_APP_NAME --org $ITOU_ORGANIZATION_NAME
+        $CLEVER_CLI service link-addon c1-imports-config
+        $CLEVER_CLI service link-addon c1-prod-config
+        $CLEVER_CLI service link-addon c1-prod-database-encrypted
+        $CLEVER_CLI service link-addon c1-itou-redis
+
+    - name: "🚀 Deploy post-deploy hook to Clever"
+      run: $CLEVER_CLI env import-vars CC_RUN_SUCCEEDED_HOOK
+
+# OK, here is the tricky part: we use a hook, so in the following 2 tasks
+# we deploy and destroy the app, but in fact we sequentially:
+# - deploy the application
+# - run what’s in CC_RUN_SUCCEEDED_HOOK
+# - destroy the app once the task is over
+    - name: 🚀 Deploy to Clever Cloud
+      run: $CLEVER_CLI deploy --alias $CRON_TASK_APP_NAME --branch $DEPLOY_BRANCH --force
+
+    - name: 🗑 Delete the app once the work is done
+      run:
+        $CLEVER_CLI delete --yes

--- a/scripts/imports-asp.sh
+++ b/scripts/imports-asp.sh
@@ -22,9 +22,10 @@ unzip -P $ASP_UNZIP_PASSWORD asp_shared_bucket/fluxIAE_*.zip -d itou/siaes/manag
 unzip -P $ASP_UNZIP_PASSWORD asp_shared_bucket/Liste_Contact_EA*.zip -d itou/siaes/management/commands/data/
 
 # Perform the necessary data imports
-time ./manage.py populate_metabase_fluxiae --verbosity 2 --dry-run
+time ./manage.py populate_metabase_fluxiae --verbosity 2
 time ./manage.py import_siae --verbosity=2
-time ./manage.py import_ea_eatt --verbosity=2 --dry-run
+# The EA import is currently broken due to data issues
+# time ./manage.py import_ea_eatt --verbosity=2
 
 # Destroy the cleartext ASP data
 rm -rf itou/siaes/management/commands/data/

--- a/scripts/imports-asp.sh
+++ b/scripts/imports-asp.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This shell script is meant to be run in production as part of a github workflow.
+#
+# It runs the frequent ASP data imports:
+# - populate_metabase_fluxiae.py. 
+# - import_siae.py
+# - import_ea_eatt.py 
+# More details about this process:
+# https://github.com/betagouv/itou-private/blob/master/docs/supportix/import_asp.md
+
+echo "Running the ASP import script"
+
+cd $APP_HOME
+
+# creates the "data" directory inside of the app and clear it of any previously existing data
+mkdir -p itou/siaes/management/commands/data/
+rm -rf itou/siaes/management/commands/data/*
+
+# Unzip ASP files
+unzip -P $ASP_UNZIP_PASSWORD asp_shared_bucket/fluxIAE_*.zip -d itou/siaes/management/commands/data/
+unzip -P $ASP_UNZIP_PASSWORD asp_shared_bucket/Liste_Contact_EA*.zip -d itou/siaes/management/commands/data/
+
+# Perform the necessary data imports
+time ./manage.py populate_metabase_fluxiae --verbosity 2 --dry-run
+time ./manage.py import_siae --verbosity=2
+time ./manage.py import_ea_eatt --verbosity=2 --dry-run
+
+# Destroy the cleartext ASP data
+rm -rf itou/siaes/management/commands/data/


### PR DESCRIPTION
### Quoi ?

Automatisation des imports de données de l’ASP

### Pourquoi ?

À la main, c’est long et source d’erreurs. Solliciter une machine de dev pour l’import metabase montre ses limites.

### Comment ?

Sur le même modèle que https://github.com/betagouv/itou/pull/830:
 - un workflow github s’occupe de créer la machine
 - la tache à effectuer (`script/imports-asp.sh`) est stocké dans un hook clever
 - on récupère les données, on exécute les 3 imports, on supprime les données en clair et la machine

