### PR TITLE
Fix deploiement vers clever de la tâche populate-metabase

### DIFF
--- a/.github/workflows/populate-metabase.yml
+++ b/.github/workflows/populate-metabase.yml
@@ -80,7 +80,7 @@ jobs:
 # - run what’s in CC_RUN_SUCCEEDED_HOOK
 # - destroy the app once the task is over
     - name: 🚀 Deploy to Clever Cloud
-      run: $CLEVER_CLI deploy --branch $DEPLOY_BRANCH --force
+      run: $CLEVER_CLI deploy --alias $CRON_TASK_APP_NAME --branch $DEPLOY_BRANCH --force
 
     - name: 🗑 Delete the app once the work is done
       run:

--- a/.github/workflows/populate-metabase.yml
+++ b/.github/workflows/populate-metabase.yml
@@ -6,6 +6,7 @@ name: Populate metabase
 # - runs the desired command through CC_RUN_SUCCEEDED_HOOK
 # - destroys the machine once the update is done
 on:
+  workflow_dispatch: # allows us to run this action manually
   schedule:
     - cron: '12 0 * * *' # Run this workflow at 0:12am every day
 


### PR DESCRIPTION
### Quoi ?

Tentative de correction de cette erreur lors de la github action `populate-metabase`:

```bash
Run $CLEVER_CLI deploy --branch $DEPLOY_BRANCH --force
Error:  Could not find master_clever.
Error: Process completed with exit code 1.
```

### Pourquoi ?

Le cron ne tourne pas à cause de ça

### Comment ?

 - Ajout du nom d’application
 - Ajout de la possibilité de jouer le workflow à la main
