### PR TITLE
Renommage de la branche principale de l'action Github pour l'édition des PR

### DIFF
--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -82,7 +82,7 @@ jobs:
       run: $CLEVER_CLI deploy --branch $BRANCH --force
 
     - name: 🍻 Add link to pull request
-      uses: thollander/actions-comment-pull-request@master
+      uses: thollander/actions-comment-pull-request@main
       with:
         message: "🥁 La recette jetable est prête ! [👉 Je veux tester cette PR !](https://${{ env.DEPLOY_URL }})"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Quoi ?

Renommage de la branche principale de l'action Github pour l'édition des PR pour ajouter l'URL des recettes jetables.

### Pourquoi ?

La branche a été renommée de master à main > https://github.com/thollander/actions-comment-pull-request/issues/24
