### PR TITLE
Ajout d’un script pour automatiser la création d’une machine pour les imports

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,9 @@ POSTGRES_PORT_ON_DOCKER_HOST=5433
 
 # Path to the itou-backup project repository.
 PATH_TO_ITOU_BACKUPS=~/sites/itou-backups
+
+# CLEVER_TOKEN and CLEVER_SECRET are to create a machine in
+# ./scripts/create-fast-machine.sh
+# You can find them with "clever login" once you have installed "clever-tools".
+CLEVER_TOKEN=set_me
+CLEVER_SECRET=set_me

--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# you can find me with "clever login"
+source .env
+
+if [ -z $CLEVER_TOKEN ]; then
+  echo "please add 'CLEVER_TOKEN=some_token' in .env at the root of the project in order to run this script"
+  exit
+fi
+if [ -z $CLEVER_SECRET ]; then
+  echo "please add 'CLEVER_SECRET=some_secret' in .env at the root of the project in order to run this script"
+  exit
+fi
+
+ITOU_ORGANIZATION_NAME=Itou
+IMPORT_APP_NAME=c1-imports-$(date +%y-%m-%d-%Hh-%M)
+DEPLOY_BRANCH=master_clever
+
+clever login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
+# Create a new application on Clever Cloud.
+# -t: application type (Python).
+# --org: organization name.
+# --region: server location ("par" means Paris).
+# --alias: custom application name, used to find it with the CLI.
+clever create $IMPORT_APP_NAME -t python --region par --alias $IMPORT_APP_NAME --org Itou
+clever link $IMPORT_APP_NAME --org $ITOU_ORGANIZATION_NAME
+clever scale --flavor XL --alias $IMPORT_APP_NAME
+clever service link-addon c1-imports-config --alias $IMPORT_APP_NAME
+clever service link-addon c1-prod-config --alias $IMPORT_APP_NAME
+clever service link-addon c1-prod-database-encrypted  --alias $IMPORT_APP_NAME
+clever service link-addon c1-itou-redis --alias $IMPORT_APP_NAME
+
+clever deploy --alias $IMPORT_APP_NAME --branch $DEPLOY_BRANCH --force

--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -47,7 +47,7 @@ clever service link-addon c1-itou-redis --alias $IMPORT_APP_NAME
 
 clever deploy --alias $IMPORT_APP_NAME --branch $DEPLOY_BRANCH --force
 
-IMPORT_APP_NAME=pouet; cat << EOF
+cat << EOF
 
 🎉 Le déploiement est terminé 🎉
 

--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -1,29 +1,44 @@
 #!/bin/bash
 
-# you can find me with "clever login"
-source .env
+# This script creates a machine on Clever Cloud that is then used in order to perform the database imports
+# It is meant to be run from the root (./scripts/create-fast-machine.sh)
 
+# It requires clever tools in order to be run:
+# - https://github.com/CleverCloud/clever-tools/
+# - https://www.clever-cloud.com/doc/getting-started/cli/
+
+RUN_DIRECTORY=`dirname $0`
+if [[ ! $RUN_DIRECTORY =~ "scripts" ]]; then
+   echo "This script is meant to be run from the root of the project, in order to properly load everything, like this:"
+   echo "./scripts/`basename $0`"
+   exit 1
+fi
+
+# If the script is loaded from the root we can import the local environment variables
+source .env
 if [ -z $CLEVER_TOKEN ]; then
-  echo "please add 'CLEVER_TOKEN=some_token' in .env at the root of the project in order to run this script"
-  exit
+  echo "please add 'CLEVER_TOKEN=some_token' in .env at the root of the project in order to run this script. You can find its value with 'clever login'"
+  exit 1
 fi
 if [ -z $CLEVER_SECRET ]; then
-  echo "please add 'CLEVER_SECRET=some_secret' in .env at the root of the project in order to run this script"
-  exit
+  echo "please add 'CLEVER_SECRET=some_secret' in .env at the root of the project in order to run this script. You can find its value with 'clever login'"
+  exit 1
 fi
 
-ITOU_ORGANIZATION_NAME=Itou
+# Then we can create the machine
+
+ORGANIZATION_NAME=Itou
 IMPORT_APP_NAME=c1-imports-$(date +%y-%m-%d-%Hh-%M)
 DEPLOY_BRANCH=master_clever
 
 clever login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
 # Create a new application on Clever Cloud.
-# -t: application type (Python).
+# --type: application type (Python).
 # --org: organization name.
 # --region: server location ("par" means Paris).
 # --alias: custom application name, used to find it with the CLI.
-clever create $IMPORT_APP_NAME -t python --region par --alias $IMPORT_APP_NAME --org Itou
-clever link $IMPORT_APP_NAME --org $ITOU_ORGANIZATION_NAME
+clever create $IMPORT_APP_NAME --type python --region par --alias $IMPORT_APP_NAME --org $ORGANIZATION_NAME
+clever link $IMPORT_APP_NAME --org $ORGANIZATION_NAME
 clever scale --flavor XL --alias $IMPORT_APP_NAME
 clever service link-addon c1-imports-config --alias $IMPORT_APP_NAME
 clever service link-addon c1-prod-config --alias $IMPORT_APP_NAME
@@ -31,3 +46,18 @@ clever service link-addon c1-prod-database-encrypted  --alias $IMPORT_APP_NAME
 clever service link-addon c1-itou-redis --alias $IMPORT_APP_NAME
 
 clever deploy --alias $IMPORT_APP_NAME --branch $DEPLOY_BRANCH --force
+
+IMPORT_APP_NAME=pouet; cat << EOF
+
+🎉 Le déploiement est terminé 🎉
+
+Vous pouvez maintenant:
+ - ✈️ Aller sur la machine:
+    clever ssh --alias $IMPORT_APP_NAME
+ - 🔨 Jouer un script d’import, par ex:
+    cd app_* && ./scripts/import_asp.sh
+ - 🍺 Supprimer la machine:
+    clever delete --alias $IMPORT_APP_NAME --yes
+EOF
+
+exit 0


### PR DESCRIPTION
### Quoi ?

Création d’une machine clever cloud depuis la machine locale pour lancer des commandes sur une machine qui ressemble à la prod, sans l’être, et sans solliciter la machine d’un dev, par exemple pour les imports.

### Pourquoi ?

Solution intermédiaire plutôt qu’utiliser les github actions.

Le faire depuis github montre des limitations:
 - on perd les logs lorsque la machine est détruite
 - en cas de crash on a du mal à lire les logs, les machines restent présentes car la destruction n’est pas réalisée

### Comment ?

Nécessite l’installation de [`clever tools`](https://github.com/CleverCloud/clever-tools/) en local
Les commandes prévues dans `.github/workflows/imports-asp.yml` sont jouées dans un script dédié qui fait les appels
Ensuite il reste à:
 - aller sur la machine (`clever ssh --alias nom_de_la_machine`)
 - jouer un script d’import (par ex `cd app_* && ./scripts/import_asp.sh`)
 - supprimer la machine (`clever delete --alias nom_de_la_machine --yes`)
