### PR TITLE
Correctif pour les erreurs Sentry relatives au format de la date du datepicker

### DIFF
--- a/itou/utils/widgets.py
+++ b/itou/utils/widgets.py
@@ -48,7 +48,9 @@ class DuetDatePickerWidget(forms.DateInput):
                 datetime.datetime.strptime(value, self.INPUT_DATE_FORMAT)
                 return value
             except ValueError:
-                raise ValueError(f'Date format of {value} must be "{self.INPUT_DATE_FORMAT}".')
+                # `value` isn't guaranteed to be valid input. Error handling is delegated
+                # to the `forms.Field` instance to which this widget is assigned.
+                pass
         return value
 
     def build_attrs(self, base_attrs, extra_attrs=None):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.2.0  # https://github.com/avian2/unidecode
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.2.6  # pyup: < 4.0  # https://www.djangoproject.com/
+django==3.2.7  # pyup: < 4.0  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.45.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
### Quoi ?

Correctif pour les erreurs Sentry relatives au format de la date du datepicker.

J'en profite pour inclure [la mise à jour bugfix de Django 3.2.7](https://docs.djangoproject.com/en/3.2/releases/3.2.7/).

### Pourquoi ?

Pour fixer des erreurs rencontrées par les usagers.

### Comment ?

En supprimant le `raise ValueError` du code du widget. La validation est faite par le `Field` sous jacent. Le widget ne s'occupe que de présentation.