### PR TITLE
Ikarius/boost r26

### DIFF
--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -317,10 +317,13 @@ class PrescriberMembership(MembershipAbstract):
         to_user = self.user
         to = [to_user.email]
         invitation_url = "%s?%s" % (reverse("invitations_views:invite_prescriber_with_org"), urlencode(requestor))
+        # requestor is not a User, get_full_name can't be used in template
+        requestor_fullname = requestor["first_name"] + " " + requestor["last_name"]
         context = {
             "to": to_user,
             "organization": self.organization,
             "requestor": requestor,
+            "requestor_fullname": requestor_fullname,
             "invitation_url": get_absolute_url(invitation_url),
         }
         subject = "common/emails/request_for_invitation_subject.txt"

--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -318,7 +318,7 @@ class PrescriberMembership(MembershipAbstract):
         to = [to_user.email]
         invitation_url = "%s?%s" % (reverse("invitations_views:invite_prescriber_with_org"), urlencode(requestor))
         # requestor is not a User, get_full_name can't be used in template
-        full_name = requestor.get("first_name", "?") + " " + requestor.get("last_name", "?")
+        full_name = f"""{requestor.get("first_name")} {requestor.get("last_name")}"""
         context = {
             "to": to_user,
             "organization": self.organization,

--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -318,12 +318,13 @@ class PrescriberMembership(MembershipAbstract):
         to = [to_user.email]
         invitation_url = "%s?%s" % (reverse("invitations_views:invite_prescriber_with_org"), urlencode(requestor))
         # requestor is not a User, get_full_name can't be used in template
-        requestor_fullname = requestor["first_name"] + " " + requestor["last_name"]
+        full_name = requestor.get("first_name", "?") + " " + requestor.get("last_name", "?")
         context = {
             "to": to_user,
             "organization": self.organization,
             "requestor": requestor,
-            "requestor_fullname": requestor_fullname,
+            "full_name": full_name,
+            "email": requestor.get("email"),
             "invitation_url": get_absolute_url(invitation_url),
         }
         subject = "common/emails/request_for_invitation_subject.txt"

--- a/itou/templates/common/emails/request_for_invitation_body.txt
+++ b/itou/templates/common/emails/request_for_invitation_body.txt
@@ -4,7 +4,7 @@
 
 Bonjour {{ to.get_full_name|title }},
 
-{{ requestor.get_full_name|title }} a demandé à rejoindre votre organisation « {{ organization.display_name }} ».
+{{ requestor_fullname|title }} a demandé à rejoindre votre organisation « {{ organization.display_name }} ».
 
 Accédez aux invitations {{ invitation_url }} pour confirmer cette demande.
 Vous avez aussi la possibilité de contacter cette personne via son adresse e-mail {{ requestor.email }}

--- a/itou/templates/common/emails/request_for_invitation_body.txt
+++ b/itou/templates/common/emails/request_for_invitation_body.txt
@@ -4,10 +4,10 @@
 
 Bonjour {{ to.get_full_name|title }},
 
-{{ requestor_fullname|title }} a demandé à rejoindre votre organisation « {{ organization.display_name }} ».
+{{ full_name|title }} a demandé à rejoindre votre organisation « {{ organization.display_name }} ».
 
 Accédez aux invitations {{ invitation_url }} pour confirmer cette demande.
-Vous avez aussi la possibilité de contacter cette personne via son adresse e-mail {{ requestor.email }}
+Vous avez aussi la possibilité de contacter cette personne via son adresse e-mail {{ email }}
 
 En cas de refus, vous pouvez simplement ignorer ce mail.
 

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -94,8 +94,8 @@
 
                                         <div class="dropdown-divider"></div>
 
-                                        <a class="dropdown-item text-dark" id="js-logout" href="{% url 'account_logout' %}">
-                                            <i>Déconnexion</i>
+                                        <a class="dropdown-item text-danger" id="js-logout" href="{% url 'account_logout' %}">
+                                            Déconnexion
                                         </a>
                                     </div>
                                 </div>

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -57,7 +57,10 @@ class DeclareProlongationForm(forms.ModelForm):
         email = self.cleaned_data["email"]
         self.validated_by = User.objects.filter(email=email).first()
         if not self.validated_by or not self.validated_by.is_prescriber_with_authorized_org:
-            error = "Ce prescripteur n'a pas de compte sur les emplois de l'inclusion. Merci de renseigner l'e-mail d'un conseiller inscrit sur le service."
+            error = (
+                "Ce prescripteur n'a pas de compte sur les emplois de l'inclusion. "
+                "Merci de renseigner l'e-mail d'un conseiller inscrit sur le service."
+            )
             raise forms.ValidationError(error)
         return email
 

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -57,7 +57,7 @@ class DeclareProlongationForm(forms.ModelForm):
         email = self.cleaned_data["email"]
         self.validated_by = User.objects.filter(email=email).first()
         if not self.validated_by or not self.validated_by.is_prescriber_with_authorized_org:
-            error = "Cet utilisateur n'est pas un prescripteur habilité."
+            error = "Ce prescripteur n'a pas de compte sur les emplois de l'inclusion. Merci de renseigner l'e-mail d'un conseiller inscrit sur le service."
             raise forms.ValidationError(error)
         return email
 


### PR DESCRIPTION
### Quoi ?

Boost supportix release 26 : 
- modification d'un message d'erreur dans les prolongations d'agréments,
- fix petit bug dans l'envoi du message d'une demande d'invitation,
- modification du bouton de déconnexion

### Pourquoi ?

Ben ... pour dépiler [la colonne Trello boost dev / design](https://trello.com/c/InHqZULx/330-r%C3%A9alisables-en-une-demi-journ%C3%A9e-max).

### Comment ?

Avec patience et beaucoup de café

### Autre

Il y aura une autre PR semaine prochaine avec l'intégration d’éléments de suivi Matomo
