### PR TITLE
Mise à jour de l'accès des CD à leurs stats

### DIFF
--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -266,13 +266,13 @@ class ModelTest(TestCase):
         self.assertEqual(user.get_stats_cd_department(current_org=org), org.department)
         self.assertNotEqual(user.get_stats_cd_department(current_org=org), "01")
 
-        # Non admin prescriber cannot access.
+        # Non admin prescriber can access as well.
         org = AuthorizedPrescriberOrganizationWithMembershipFactory(
             kind=PrescriberOrganization.Kind.DEPT, membership__is_admin=False
         )
         user = org.members.get()
-        self.assertFalse(user.can_view_stats_cd(current_org=org))
-        self.assertFalse(user.can_view_stats_dashboard_widget(current_org=org))
+        self.assertTrue(user.can_view_stats_cd(current_org=org))
+        self.assertTrue(user.can_view_stats_dashboard_widget(current_org=org))
 
         # Non authorized organization does not give access.
         org = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganization.Kind.DEPT)


### PR DESCRIPTION
### Quoi ?

- Mise à jour de l'accès des CD à leurs stats.
- Ajout de documentation dans la docstring de la méthode `user.can_view_stats_cd`.

Un CD == un conseil départemental.

### Pourquoi ?

- Pour débloquer Soumia dans son travail avec les CD.
 
### Comment ?

- En évitant de montrer les stats CD à des organisations qui ne sont pas vraiment des CD.
- En montrant ces stats non seulement aux admins des CD mais aussi à tous les membres.

