### PR TITLE
Opt-in / opt-out Matomo dans tarteaucitron

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -384,6 +384,11 @@
         {% if ITOU_ENVIRONMENT == "DEMO" %}tarteaucitron.user.hotjarId = 1861487;{% endif %}
         tarteaucitron.user.HotjarSv = 6;
 
+        // Matomo :
+        tarteaucitron.user.matomoId = 117;
+        tarteaucitron.user.matomoHost = "https://stats.data.gouv.fr/";
+        (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
+            
         // livestorm
         const tablet_width = 750;
         tarteaucitron.services.livestorm = {


### PR DESCRIPTION
### Quoi ?

Ajoute une option d'opt-in / opt-out dans les paramètres personnalisés de tarteaucitron

### Pourquoi ?

Demande Thomas / DPO

### Comment ?

- Ajout d'un "service" personnalisé Matomo dans tarteaucitron,
- modification du template `base.html`.

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/147232/132231301-c66c85ab-90fb-4239-a58d-5b59ded1e4c2.png)


### Autre 
- lien vers la [carte Trello](https://trello.com/c/Wf5ciffG/1761-int%C3%A9grer-la-fonctionnalit%C3%A9-dopt-out-au-sein-de-notre-politique-de-confidentialit%C3%A9)
- [Thread de contexte](https://itou-inclusion.slack.com/archives/CQQBH3YFR/p1621935514002400) sur Slack
- Discussion récente [sur Slack](https://itou-inclusion.slack.com/archives/CQQBH3YFR/p1626935208004700)
