### PR TITLE
Ajout d'une étape au processus de candidature si le candidat existe déjà

### DIFF
--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -32,7 +32,7 @@
     <p>
         <a href="{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
             class="btn btn-outline-primary">
-            Modifier les informations
+            Modifier les informations personnelles
         </a>
     </p>
 {% else %}

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -14,9 +14,59 @@
         <p>{% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}</p>
 
         {% buttons %}
-            <button type="submit" class="btn btn-primary">Continuer</button>
+            {# Reload this page and show a modal containing more information about the job seeker. #}
+            <button type="submit" name="preview" value="1" class="btn btn-primary">
+                Continuer
+            </button>
         {% endbuttons %}
 
+        {% if preview_mode %}
+            <!-- Modal -->
+            <div class="modal" id="email-confirmation-modal" tabindex="-1" aria-labelledby="email-confirmation-label" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="email-confirmation-label">Email existant</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+                        <div class="modal-body">
+                            <p>Vous allez postuler pour <b>{{ job_seeker_name }}</b>.</p>
+                            <p>
+                                L'identité du candidat est une information clé pour la structure.
+                                Si cette candidature n'est pas pour <b>{{ job_seeker_name }}</b>, cliquez sur
+                                « Ce n'est pas mon candidat » afin de fournir à la structure <b>{{ siae.display_name }}</b>
+                                les informations personnelles du candidat pour lequel vous allez postuler.
+                            </p>
+                        </div>
+                        <div class="modal-footer">
+                            {% buttons %}
+                                {# Reload this page with a new form. #}
+                                <button type="submit" name="cancel" value="1" class="btn btn-secondary">
+                                    Ce n'est pas mon candidat
+                                </button>
+                                {# Go to the next step. #}
+                                <button type="submit" name="save" value="1" class="btn btn-primary">
+                                    Continuer
+                                </button>
+                            {% endbuttons %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
     </form>
 
+{% endblock %}
+
+{% block script %}
+    {% if preview_mode %}
+        {# Show the confirmation modal after submitting the form. #}
+        <script type="text/javascript">
+            // Adding the "show" CSS class is not enough and not documented.
+            // A JS initialization is recommended.
+            $("#email-confirmation-modal").modal("show");
+        </script>
+    {% endif %}
 {% endblock %}

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -36,8 +36,8 @@
                             <p>
                                 L'identité du candidat est une information clé pour la structure.
                                 Si cette candidature n'est pas pour <b>{{ job_seeker_name }}</b>, cliquez sur
-                                « Ce n'est pas mon candidat » afin de fournir à la structure <b>{{ siae.display_name }}</b>
-                                les informations personnelles du candidat pour lequel vous allez postuler.
+                                « Ce n'est pas mon candidat » afin d'enregistrer ses informations
+                                personnelles.
                             </p>
                         </div>
                         <div class="modal-footer">

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -32,7 +32,7 @@
                             </button>
                         </div>
                         <div class="modal-body">
-                            <p>Vous allez postuler pour <b>{{ job_seeker_name }}</b>.</p>
+                            <p>L'adresse {{ form.email.value }} est associée au compte de <b>{{ job_seeker_name }}</b>.</p>
                             <p>
                                 L'identité du candidat est une information clé pour la structure.
                                 Si cette candidature n'est pas pour <b>{{ job_seeker_name }}</b>, cliquez sur

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -1,10 +1,16 @@
 {% extends "layout/content_small.html" %}
 {% load bootstrap4 %}
 
-{% block title %}Modification d'un candidat{{ block.super }}{% endblock %}
+{% block title %}Informations personnelles de {{ job_application.job_seeker.get_full_name|title }}{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1>Candidature de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
+<h1>Informations personnelles de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
+
+<div class="alert alert-warning" role="alert">
+  <b>Vous allez modifier des informations sensibles</b> concernant ce candidat ou cette candidate.<br>
+  Tout changement entraînera une modification définitive dans notre base de données. <b>Les informations
+  supprimées seront perdues.</b>
+</div>
 
 <form method="post" action="" class="js-prevent-multiple-submit">
 
@@ -14,7 +20,7 @@
 
     {% buttons %}
         <a class="btn btn-secondary" href="{{ prev_url }}">Annuler</a>
-        <button type="submit" class="btn btn-primary">Enregistrer</button>
+        <button type="submit" class="btn btn-primary">Mettre à jour</button>
     {% endbuttons %}
 
 </form>

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -276,7 +276,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.get(next_url)
         self.assertEqual(response.status_code, 200)
 
-        post_data = {"email": "new.job.seeker@test.com"}
+        post_data = {"email": "new.job.seeker@test.com", "save": "1"}
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
@@ -398,7 +398,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         self.assertEqual(last_url, reverse("apply:step_job_seeker", kwargs={"siae_pk": siae.pk}))
 
         # …choose one, then follow all redirections…
-        post_data = {"email": job_seeker.email}
+        post_data = {"email": job_seeker.email, "save": "1"}
         response = self.client.post(last_url, data=post_data, follow=True)
 
         # …until the eligibility step which should trigger a 200 OK.
@@ -466,7 +466,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.get(next_url)
         self.assertEqual(response.status_code, 200)
 
-        post_data = {"email": "new.job.seeker@test.com"}
+        post_data = {"email": "new.job.seeker@test.com", "save": "1"}
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
@@ -617,7 +617,7 @@ class ApplyAsPrescriberTest(TestCase):
         response = self.client.get(next_url)
         self.assertEqual(response.status_code, 200)
 
-        post_data = {"email": "new.job.seeker@test.com"}
+        post_data = {"email": "new.job.seeker@test.com", "save": "1"}
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
@@ -730,7 +730,7 @@ class ApplyAsPrescriberTest(TestCase):
         self.assertEqual(last_url, reverse("apply:step_job_seeker", kwargs={"siae_pk": siae.pk}))
 
         # …choose one, then follow all redirections…
-        post_data = {"email": job_seeker.email}
+        post_data = {"email": job_seeker.email, "save": "1"}
         response = self.client.post(last_url, data=post_data, follow=True)
 
         # …until the expected 403.
@@ -816,7 +816,7 @@ class ApplyAsSiaeTest(TestCase):
         response = self.client.get(next_url)
         self.assertEqual(response.status_code, 200)
 
-        post_data = {"email": "new.job.seeker@test.com"}
+        post_data = {"email": "new.job.seeker@test.com", "save": "1"}
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
@@ -927,7 +927,7 @@ class ApplyAsSiaeTest(TestCase):
         self.assertEqual(last_url, reverse("apply:step_job_seeker", kwargs={"siae_pk": siae.pk}))
 
         # …choose one, then follow all redirections…
-        post_data = {"email": job_seeker.email}
+        post_data = {"email": job_seeker.email, "save": "1"}
         response = self.client.post(last_url, data=post_data, follow=True)
 
         # …until the expected 403.

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -6,6 +6,7 @@ from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.http import urlencode
+from django.utils.safestring import mark_safe
 
 from itou.approvals.models import Approval
 from itou.eligibility.models import EligibilityDiagnosis
@@ -131,24 +132,46 @@ def step_job_seeker(request, siae_pk, template_name="apply/submit_step_job_seeke
         request.session.modified = True
         return HttpResponseRedirect(next_url)
 
+    job_seeker_name = None
+    form = UserExistsForm(data=request.POST or None)
+    preview_mode = False
     siae = get_object_or_404(Siae, pk=session_data["to_siae_pk"])
 
-    form = UserExistsForm(data=request.POST or None)
-
     if request.method == "POST" and form.is_valid():
-
         job_seeker = form.get_user()
 
         if job_seeker:
-            session_data["job_seeker_pk"] = job_seeker.pk
-            request.session.modified = True
-            return HttpResponseRedirect(next_url)
+            # Go to the next step.
+            if request.POST.get("save"):
+                session_data["job_seeker_pk"] = job_seeker.pk
+                request.session.modified = True
+                return HttpResponseRedirect(next_url)
 
-        args = urlencode({"email": form.cleaned_data["email"]})
-        next_url = reverse("apply:step_create_job_seeker", kwargs={"siae_pk": siae.pk})
-        return HttpResponseRedirect(f"{next_url}?{args}")
+            # Display a modal containing more information.
+            if request.POST.get("preview"):
+                preview_mode = True
+                job_seeker_name = job_seeker.get_full_name()
+                if request.user.is_prescriber and not request.user.is_prescriber_with_authorized_org:
+                    # Don't display personal information to unauthorized members.
+                    job_seeker_name = f"{job_seeker.first_name[0]}… {job_seeker.last_name[0]}…"
 
-    context = {"siae": siae, "form": form}
+            # Create a new form to start from new.
+            elif request.POST.get("cancel"):
+                msg = mark_safe(
+                    f"L'email <b>{ form.data['email'] }</b> est déjà utilisé par un autre candidat "
+                    "sur la Plateforme.<br>"
+                    "Merci de renseigner <b>l'adresse email personnelle et unique</b> "
+                    "du candidat pour lequel vous souhaitez postuler."
+                )
+                form = UserExistsForm()
+                messages.warning(request, msg)
+
+        else:
+            args = urlencode({"email": form.cleaned_data["email"]})
+            next_url = reverse("apply:step_create_job_seeker", kwargs={"siae_pk": siae.pk})
+            return HttpResponseRedirect(f"{next_url}?{args}")
+
+    context = {"job_seeker_name": job_seeker_name, "form": form, "preview_mode": preview_mode, "siae": siae}
     return render(request, template_name, context)
 
 


### PR DESCRIPTION
### Quoi ?

Ajout d'une étape de confirmation pour s'assurer que l'e-mail entré est bien le bon.

### Pourquoi ?

Des prescripteurs ou des employeurs utilisent une même adresse e-mail pour plusieurs candidats.

### Comment ?

- Ajout d'une modale avec des informations sur le candidat trouvé en base
- Modifications diverses de l'interface

### Captures d'écran

#### Pendant le processus de candidature

Si le prescripteur est orienteur :
![image](https://user-images.githubusercontent.com/6150920/132507370-e36828b7-75ca-4d4b-afa3-cb05573296da.png)

Si l'utilisateur est employeur ou prescripteur habilité :
![image](https://user-images.githubusercontent.com/6150920/132507516-3e029aa7-2172-4537-b4ec-e7558311cf79.png)


#### Clic sur « Ce n'est pas mon candidat  » :
![image](https://user-images.githubusercontent.com/6150920/132368004-bb53b443-0a67-46f4-8682-ec4a70421cf6.png)

#### Clic sur « Continuer »

Aucun changement.

#### Page de candidature
![image](https://user-images.githubusercontent.com/6150920/132368313-e2c7c84f-4ed5-4ebb-90a2-2b7801918e6c.png)

#### Page de modification des informations du candidat

![image](https://user-images.githubusercontent.com/6150920/132368416-4b6b56eb-2887-46f1-bc6a-5afa2c0cca0c.png)


### Autre

Changements par rapport aux maquettes :
- J'ai remplacé les guillemets ("") par les guillemets français («»).
- Message « Email existant » : « les informations personnelles du candidat pour **qui** vous allez postuler » par « les informations personnelles du candidat pour **lequel** vous allez postuler ».
- le message qui apparaît après avoir cliqué sur « Ce n'est pas mon candidat » est tout en haut et non après le titre. Pour des raisons techniques, c'est plus pratique. Si vraiment il faut l'indiquer après, vous pouvez me le dire et je ferai une modification plus poussée.
- Message qui apparaît après avoir cliqué sur « Modifier les informations personnelles » : j'ai ajouté « ou cette candidate » car cela me paraissait bizarre à cet endroit-là. À voir si c'est pertinent. Dans les autres messages c'était un peu lourd.
- Toujours concernant ce message, j'ai remplacé le texte souligné par du gras pour éviter toute confusion avec un lien hypertexte. Et même remarque que ci-dessus (qui par lequel).