### PR TITLE
Simplification du Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,17 +34,6 @@ coverage:
 coverage_venv:
 	coverage run ./manage.py test itou --settings=config.settings.test && coverage html
 
-setup_git_pre_commit_hook:
-	touch .git/hooks/pre-commit
-	chmod +x .git/hooks/pre-commit
-	echo -e "\
-	docker exec -t itou_django black itou\n\
-	docker exec -t itou_django isort itou\n\
-	" > .git/hooks/pre-commit
-
-setup_git_pre_commit_hook_venv:
-	pre-commit install
-
 # Django.
 # =============================================================================
 

--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,10 @@ graph_models_itou_venv:
 .PHONY: test
 
 # make test
-# make test TARGET=itou.utils
-# make test TARGET=itou.utils.tests.UtilsTemplateTagsTestCase.test_url_add_query
+# make test TARGET=itou.utils MAX=8
+MAX = 4 # Default parallel tests.
 test:
-	docker exec -ti itou_django django-admin test --settings=config.settings.test --noinput --failfast --parallel=2 $(TARGET)
+	docker exec -ti itou_django django-admin test --settings=config.settings.test --noinput --failfast --parallel=$(MAX) $(TARGET)
 
 # Lets you add a debugger.
 test-interactive:

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,8 @@ graph_models_itou_venv:
 
 .PHONY: test
 
-# make test
-# make test TARGET=itou.utils MAX=8
-MAX = 4 # Default parallel tests.
 test:
-	docker exec -ti itou_django django-admin test --settings=config.settings.test --noinput --failfast --parallel=$(MAX) $(TARGET)
+	docker exec -ti itou_django django-admin test --settings=config.settings.test --noinput --failfast --parallel $(TARGET)
 
 # Lets you add a debugger.
 test-interactive:

--- a/Makefile
+++ b/Makefile
@@ -15,18 +15,14 @@ cdsitepackages:
 	docker exec -ti -w /usr/local/lib/$(PYTHON_VERSION)/site-packages itou_django /bin/bash
 
 quality:
-	docker exec -ti itou_django black --check itou
-	docker exec -ti itou_django isort --check-only itou
+	docker exec -ti itou_django black itou
+	docker exec -ti itou_django isort itou
 	docker exec -ti itou_django flake8 itou
 
 quality_venv:
-	black --check itou
-	isort --check-only itou
+	black itou
+	isort itou
 	flake8 itou
-
-style:
-	docker exec -ti itou_django black itou
-	docker exec -ti itou_django isort itou
 
 pylint:
 	docker exec -ti itou_django pylint itou


### PR DESCRIPTION
### Quoi ?

- Fusion des commandes `style` et `quality` : si tout le monde est d'accord.
- Commande `test` : ajout d'une option pour passer en paramètre le nombre de tests à faire tourner en parallèle.
- Suppression de commandes obsolètes.

### Pourquoi ?

Parce que le ménage n'est pas réservé au printemps.

### Autre

J'ai mis toute l'équipe en relecture car la fusion de `style` et `quality` peut venir perturber des habitudes individuelles.
