### PR TITLE
Un prescripteur peut revenir à sa recherche après une candidature

### DIFF
--- a/itou/templates/apply/submit_step_application_sent.html
+++ b/itou/templates/apply/submit_step_application_sent.html
@@ -1,12 +1,14 @@
-{% extends "apply/submit_base.html" %}
+{% extends "layout/content_small.html" %}
 
 {% block content %}
 
     {{ block.super }}
 
     {# This template is shown only to prescribers. #}
+    <h1>Candidature envoyée</h1>
 
-    <p>La candidature a bien été envoyée.</p>
+    <p>La candidature pour <b>{{ job_seeker.get_full_name }}</b> a bien été envoyée
+        chez <b>{{ siae.display_name }}</b>.</p>
 
     {% if back_url %}
         <a class="btn btn-primary" href="{{ back_url }}">Revenir à la recherche</a>

--- a/itou/templates/apply/submit_step_application_sent.html
+++ b/itou/templates/apply/submit_step_application_sent.html
@@ -1,0 +1,19 @@
+{% extends "apply/submit_base.html" %}
+
+{% block content %}
+
+    {{ block.super }}
+
+    {# This template is shown only to prescribers. #}
+
+    <p>La candidature a bien été envoyée.</p>
+
+    {% if back_url %}
+        <a class="btn btn-primary" href="{{ back_url }}">Revenir à la recherche</a>
+    {% else %}
+        <a class="btn btn-primary" href="/">Nouvelle recherche</a>
+    {% endif %}
+
+    <a class="btn btn-primary" href="{% url 'dashboard:index' %}">Tableau de bord</a>
+
+{% endblock %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -111,7 +111,7 @@
                                 </a>
                                 <small>Cet employeur n'accepte plus de candidatures pour le moment</small>
                             {% else %}
-                                <a class="btn btn-sm btn-outline-primary matomo-event" href="{% url 'apply:start' siae_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}" data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-bt-postuler">
+                                <a class="btn btn-sm btn-outline-primary matomo-event" href="{% url 'apply:start' siae_pk=siae.pk %}?back_url={{ request.get_full_path|urlencode }}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}" data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-bt-postuler">
                                     {% include "includes/icon.html" with icon="message-square" %} Postuler
                                 </a>
                             {% endif %}

--- a/itou/templates/siaes/card.html
+++ b/itou/templates/siaes/card.html
@@ -83,7 +83,9 @@
         {% if siae.has_members %}
             <hr>
             <p>
-                <a class="btn btn-outline-primary" href="{% url 'apply:start' siae_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                <a class="btn btn-outline-primary"
+                    href="{% url 'apply:start' siae_pk=siae.pk %}{% if back_url %}?back_url={{ back_url }}{% endif %}"
+                    aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                     {% include "includes/icon.html" with icon="message-square" %} Postuler
                 </a>
             </p>

--- a/itou/templates/siaes/job_description_card.html
+++ b/itou/templates/siaes/job_description_card.html
@@ -23,7 +23,9 @@
 
     {% if siae.has_members %}
         <p>
-            <a class="btn btn-outline-primary" href="{% url 'apply:start' siae_pk=siae.pk %}?job_description_id={{ job.pk }}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+            <a class="btn btn-outline-primary"
+                href="{% url 'apply:start' siae_pk=siae.pk %}?job_description_id={{ job.pk }}&{% if back_url %}back_url={{ back_url }}{% endif %}"
+                aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                 {% include "includes/icon.html" with icon="message-square" %} Postuler
             </a>
         </p>

--- a/itou/utils/urls.py
+++ b/itou/utils/urls.py
@@ -3,9 +3,9 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.safestring import mark_safe
 
 
-def get_safe_url(request, param_name, fallback_url=None):
+def get_safe_url(request, param_name=None, fallback_url=None, url=None):
 
-    url = request.GET.get(param_name) or request.POST.get(param_name)
+    url = url or request.GET.get(param_name) or request.POST.get(param_name)
 
     allowed_hosts = settings.ALLOWED_HOSTS
     require_https = request.is_secure()

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -353,7 +353,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
-        next_url = reverse("apply:list_for_prescriber")
+        next_url = reverse("apply:step_application_sent")
         self.assertEqual(response.url, next_url)
 
         job_application = JobApplication.objects.get(job_seeker=new_job_seeker, sender=user, to_siae=siae)
@@ -538,7 +538,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
-        next_url = reverse("apply:list_for_prescriber")
+        next_url = reverse("apply:step_application_sent")
         self.assertEqual(response.url, next_url)
 
         job_application = JobApplication.objects.get(job_seeker=new_job_seeker, sender=user, to_siae=siae)
@@ -689,7 +689,7 @@ class ApplyAsPrescriberTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
-        next_url = reverse("apply:list_for_prescriber")
+        next_url = reverse("apply:step_application_sent")
         self.assertEqual(response.url, next_url)
 
         job_application = JobApplication.objects.get(job_seeker=new_job_seeker, sender=user, to_siae=siae)

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -42,6 +42,7 @@ class ApplyAsJobSeekerTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": None,
             "to_siae_pk": siae.pk,
             "sender_pk": None,
@@ -64,6 +65,7 @@ class ApplyAsJobSeekerTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": None,
             "to_siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -86,6 +88,7 @@ class ApplyAsJobSeekerTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": user.pk,
             "to_siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -165,7 +168,7 @@ class ApplyAsJobSeekerTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
-        next_url = reverse("apply:list_for_job_seeker")
+        next_url = reverse("apply:step_application_sent", kwargs={"siae_pk": siae.pk})
         self.assertEqual(response.url, next_url)
 
         job_application = JobApplication.objects.get(job_seeker=user, sender=user, to_siae=siae)
@@ -235,6 +238,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": None,
             "to_siae_pk": siae.pk,
             "sender_pk": None,
@@ -257,6 +261,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": None,
             "to_siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -310,6 +315,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": new_job_seeker.pk,
             "to_siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -353,7 +359,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
-        next_url = reverse("apply:step_application_sent")
+        next_url = reverse("apply:step_application_sent", kwargs={"siae_pk": siae.pk})
         self.assertEqual(response.url, next_url)
 
         job_application = JobApplication.objects.get(job_seeker=new_job_seeker, sender=user, to_siae=siae)
@@ -425,6 +431,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": None,
             "to_siae_pk": siae.pk,
             "sender_pk": None,
@@ -447,6 +454,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": None,
             "to_siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -500,6 +508,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": new_job_seeker.pk,
             "to_siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -538,7 +547,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
-        next_url = reverse("apply:step_application_sent")
+        next_url = reverse("apply:step_application_sent", kwargs={"siae_pk": siae.pk})
         self.assertEqual(response.url, next_url)
 
         job_application = JobApplication.objects.get(job_seeker=new_job_seeker, sender=user, to_siae=siae)
@@ -576,6 +585,7 @@ class ApplyAsPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": None,
             "to_siae_pk": siae.pk,
             "sender_pk": None,
@@ -598,6 +608,7 @@ class ApplyAsPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": None,
             "to_siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -653,6 +664,7 @@ class ApplyAsPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": new_job_seeker.pk,
             "to_siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -689,7 +701,7 @@ class ApplyAsPrescriberTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
-        next_url = reverse("apply:step_application_sent")
+        next_url = reverse("apply:step_application_sent", kwargs={"siae_pk": siae.pk})
         self.assertEqual(response.url, next_url)
 
         job_application = JobApplication.objects.get(job_seeker=new_job_seeker, sender=user, to_siae=siae)
@@ -775,6 +787,7 @@ class ApplyAsSiaeTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": None,
             "to_siae_pk": siae.pk,
             "sender_pk": None,
@@ -797,6 +810,7 @@ class ApplyAsSiaeTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": None,
             "to_siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -850,6 +864,7 @@ class ApplyAsSiaeTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = {
+            "back_url": None,
             "job_seeker_pk": new_job_seeker.pk,
             "to_siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -886,7 +901,7 @@ class ApplyAsSiaeTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
-        next_url = reverse("apply:list_for_siae")
+        next_url = reverse("apply:step_application_sent", kwargs={"siae_pk": siae.pk})
         self.assertEqual(response.url, next_url)
 
         job_application = JobApplication.objects.get(job_seeker=new_job_seeker, sender=user, to_siae=siae)

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     ),
     path("<int:siae_pk>/step_eligibility", submit_views.step_eligibility, name="step_eligibility"),
     path("<int:siae_pk>/step_application", submit_views.step_application, name="step_application"),
+    path("<int:siae_pk>/step_application_sent", submit_views.step_application_sent, name="step_application_sent"),
     # List.
     path("job_seeker/list", list_views.list_for_job_seeker, name="list_for_job_seeker"),
     path("prescriber/list", list_views.list_for_prescriber, name="list_for_prescriber"),

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -19,6 +19,7 @@ from itou.siaes.models import Siae
 from itou.users.models import User
 from itou.utils.perms.user import get_user_info
 from itou.utils.storage.s3 import S3Upload
+from itou.utils.urls import get_safe_url
 from itou.www.apply.forms import CheckJobSeekerInfoForm, CreateJobSeekerForm, SubmitJobApplicationForm, UserExistsForm
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm
 
@@ -78,8 +79,11 @@ def start(request, siae_pk):
         # Message only visible in DEBUG
         raise Http404("Cette organisation n'accepte plus de candidatures pour le moment.")
 
+    back_url = get_safe_url(request, "back_url")
+
     # Start a fresh session.
     request.session[settings.ITOU_SESSION_JOB_APPLICATION_KEY] = {
+        "back_url": back_url,
         "job_seeker_pk": None,
         "to_siae_pk": siae.pk,
         "sender_pk": None,
@@ -333,11 +337,7 @@ def step_application(request, siae_pk, template_name="apply/submit_step_applicat
     approvals_wrapper = get_approvals_wrapper(request, job_seeker, siae)
 
     if request.method == "POST" and form.is_valid():
-        next_url = reverse("apply:list_for_job_seeker")
-        if request.user.is_prescriber:
-            next_url = reverse("apply:list_for_prescriber")
-        elif request.user.is_siae_staff:
-            next_url = reverse("apply:list_for_siae")
+        next_url = reverse("apply:step_application_sent", kwargs={"siae_pk": siae_pk})
 
         # Prevent multiple rapid clicks on the submit button to create multiple
         # job applications.
@@ -373,8 +373,6 @@ def step_application(request, siae_pk, template_name="apply/submit_step_applicat
         if job_application.is_sent_by_proxy:
             job_application.email_new_for_prescriber.send()
 
-        messages.success(request, "Candidature bien envoyée !")
-
         return HttpResponseRedirect(next_url)
 
     s3_upload = S3Upload(kind="resume")
@@ -388,5 +386,32 @@ def step_application(request, siae_pk, template_name="apply/submit_step_applicat
         "approvals_wrapper": approvals_wrapper,
         "s3_form_values": s3_form_values,
         "s3_upload_config": s3_upload_config,
+    }
+    return render(request, template_name, context)
+
+
+@login_required
+@valid_session_required
+def step_application_sent(request, siae_pk, template_name="apply/submit_step_application_sent.html"):
+
+    dashboard_url = reverse("apply:list_for_job_seeker")
+    if request.user.is_prescriber:
+        dashboard_url = reverse("apply:list_for_prescriber")
+    elif request.user.is_siae_staff:
+        dashboard_url = reverse("apply:list_for_siae")
+
+    if not request.user.is_prescriber:
+        messages.success(request, "Candidature bien envoyée !")
+        return HttpResponseRedirect(dashboard_url)
+
+    session_data = request.session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+    back_url = get_safe_url(request=request, url=session_data["back_url"])
+    job_seeker = get_object_or_404(User, pk=session_data["job_seeker_pk"])
+    siae = get_object_or_404(Siae, pk=session_data["to_siae_pk"])
+
+    context = {
+        "back_url": back_url,
+        "job_seeker": job_seeker,
+        "siae": siae,
     }
     return render(request, template_name, context)

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -393,14 +393,8 @@ def step_application(request, siae_pk, template_name="apply/submit_step_applicat
 @login_required
 @valid_session_required
 def step_application_sent(request, siae_pk, template_name="apply/submit_step_application_sent.html"):
-
-    dashboard_url = reverse("apply:list_for_job_seeker")
-    if request.user.is_prescriber:
-        dashboard_url = reverse("apply:list_for_prescriber")
-    elif request.user.is_siae_staff:
+    if request.user.is_siae_staff:
         dashboard_url = reverse("apply:list_for_siae")
-
-    if not request.user.is_prescriber:
         messages.success(request, "Candidature bien envoyée !")
         return HttpResponseRedirect(dashboard_url)
 


### PR DESCRIPTION
### Quoi ?

Le prescripteur peut revenir à sa recherche après avoir postulé pour un candidat.

### Pourquoi ?

Les prescripteurs réalisent parfois plusieurs candidatures d'affilée. Revenir à la recherche leur fait donc gagner du temps.

### Comment ?

Ajout d'une étape supplémentaire à la fin parcours de candidature avec deux boutons.
:warning: Cette étape apparaît uniquement aux prescripteurs. Les employeurs et les candidats autonomes ne sont pas concernés, ils continuent d'être redirigés vers la liste des candidatures.

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/6150920/133252691-4b2e5d82-e989-4e30-91c9-76870aa17fc2.png)