### PR TITLE
Filtre de tri pour l’API SIAE

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -56,6 +56,7 @@ THIRD_PARTY_APPS = [
     "rest_framework",  # DRF (Django Rest Framework).
     "rest_framework.authtoken",  # Required for DRF TokenAuthentication.
     "drf_spectacular",
+    "django_filters",
 ]
 
 

--- a/itou/api/siae_api/viewsets.py
+++ b/itou/api/siae_api/viewsets.py
@@ -18,19 +18,13 @@ DISTANCE_FROM_CODE_INSEE_PARAM_NAME = "distance_max_km"
 MAX_DISTANCE_RADIUS_KM = 100
 
 SIAE_ORDERING_FILTER_MAPPING = {
-    "created_at": "cree_le",
-    "updated_at": "mis_a_jour_le",
-    "kind": "type",
-    "city": "ville",
-    "post_code": "code_postal",
-    "address_line_1": "addresse_ligne_1",
-    "address_line_2": "addresse_ligne_2",
-    "department": "departement",
-    "name": "raison_sociale",
-    "display_name": "enseigne",
     "block_job_applications": "bloque_candidatures",
+    "kind": "type",
+    "department": "departement",
+    "post_code": "code_postal",
+    "city": "ville",
     "siret": "siret",
-    "website": "site_web",
+    "name": "raison_sociale",
 }
 
 
@@ -92,6 +86,13 @@ class SiaeViewSet(viewsets.ReadOnlyModelViewSet):
         response_only=True,
         status_codes=["404"],
     )
+    sort_description = """
+Critère de tri.
+
+On peut spécifier la direction de tri :
+ - o=critère pour l’ordre croissant
+ - o=-critère pour l’ordre décroissant
+    """
 
     @extend_schema(
         parameters=[
@@ -106,7 +107,10 @@ class SiaeViewSet(viewsets.ReadOnlyModelViewSet):
             ),
             OpenApiParameter(name="format", description="Format de sortie", required=False, enum=["json", "api"]),
             OpenApiParameter(
-                name="o", description="Critère de tri", required=False, enum=SIAE_ORDERING_FILTER_MAPPING.values()
+                name="o",
+                description=sort_description,
+                required=False,
+                enum=SIAE_ORDERING_FILTER_MAPPING.values(),
             ),
         ],
         responses={200: SiaeSerializer, 404: OpenApiTypes.OBJECT},

--- a/itou/siaes/serializers.py
+++ b/itou/siaes/serializers.py
@@ -30,8 +30,9 @@ class SiaeSerializer(serializers.ModelSerializer):
     type = serializers.ChoiceField(source="kind", label="Type de SIAE", choices=Siae.KIND_CHOICES)
     ville = serializers.CharField(source="city", label="Ville où se trouve la SIAE")
     code_postal = serializers.CharField(source="post_code", label="Code postal de la SIAE")
-    addresse_line_1 = serializers.CharField(source="address_line_1", label="1ère ligne d’adresse de la SIAE")
-    addresse_line_2 = serializers.CharField(source="address_line_2", label="2nde ligne d’adresse de la SIAE")
+    site_web = serializers.CharField(source="website", label="URL du site web de la SIAE")
+    addresse_ligne_1 = serializers.CharField(source="address_line_1", label="1ère ligne d’adresse de la SIAE")
+    addresse_ligne_2 = serializers.CharField(source="address_line_2", label="2nde ligne d’adresse de la SIAE")
     departement = serializers.CharField(source="department", label="Le département où se trouve la SIAE")
     raison_sociale = serializers.CharField(source="name", label="Raison sociale de la SIAE")
     enseigne = serializers.CharField(source="display_name", label="Nom de la SIAE utilisé pour affichage")
@@ -49,11 +50,11 @@ class SiaeSerializer(serializers.ModelSerializer):
             "type",
             "raison_sociale",
             "enseigne",
-            "website",
+            "site_web",
             "description",
             "bloque_candidatures",
-            "addresse_line_1",
-            "addresse_line_2",
+            "addresse_ligne_1",
+            "addresse_ligne_2",
             "code_postal",
             "ville",
             "departement",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,6 +29,8 @@ djangorestframework==3.12.2  # https://www.django-rest-framework.org/
 # DRF-Spectacular (Django Rest Framework Spectacular, open API schema browser)
 drf-spectacular==0.17.3  # https://github.com/tfranzel/drf-spectacular
 
+# Django filter (filtering/ordering of API results)
+django-filter==2.4.0 # https://django-filter.readthedocs.io/en/stable/
 
 # Front-end
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
### Quoi ?

Ajout de la possibilité d’ordonner les différents résultats de l’API `api/v1/siae`

### Pourquoi ?

Demande de Pole Emploi

### Comment ?

 - Introduction de `django_filter` pour ne pas écrire de code dédié (pas trouvé mieux, mais dès la doc de DRF [ils suggèrent cette option](https://www.django-rest-framework.org/api-guide/filtering/#orderingfilter))
 - Introduction d’une classe de mapping entre nom du paramètre de requête (en francais, comme en sortie de l’API) et les propriétés du modèle sur lequel faire le tri
 - MAJ de la documentation d’API (les critères de tri ne sont pas inféré automatiquement) pour refléter cette possibilité

![Sélection_136](https://user-images.githubusercontent.com/1223316/132856219-2dc71a56-57cd-464c-b101-6f59f7791c8f.png)
![Sélection_137](https://user-images.githubusercontent.com/1223316/132856222-cc5aba93-c22e-4399-8987-3a5d80387c55.png)
