### PR TITLE
Suivi des recrutements des salariés en insertion

### DIFF
--- a/itou/metabase/management/commands/sql/009_suivi_recrutements.sql
+++ b/itou/metabase/management/commands/sql/009_suivi_recrutements.sql
@@ -1,0 +1,42 @@
+/*
+
+L'objectif est d'avoir un suivi annuel des recrutements en se basant sur les déclarations mensuelles des structures dans l'extranet asp
+
+*/
+
+select 
+    /* On prend le min des dates de recrutement par salarié et par convention */
+    min(date_recrutement) as min_date_recrutement,
+    date_part('year', date_recrutement) as annee_recrutement, 
+    etablissement_Public_Territorial, 
+    niveau_formation_salarie,
+    genre_salarie,
+    rsa, 
+    type_siae,
+    identifiant_salarie,
+    id_structure_asp, 
+    structure_denomination,
+    commune_structure, 
+    code_insee_structure, 
+    nom_departement_structure, 
+    nom_region_structure,
+    af_numero_convention,
+    af_numero_annexe_financiere
+from 
+    saisies_mensuelles_IAE
+group by 
+    annee_recrutement,
+    etablissement_Public_Territorial, 
+    niveau_formation_salarie,
+    genre_salarie,
+    rsa, 
+    type_siae,
+    identifiant_salarie,
+    id_structure_asp, 
+    structure_denomination,
+    commune_structure, 
+    code_insee_structure, 
+    nom_departement_structure, 
+    nom_region_structure,
+    af_numero_convention,
+    af_numero_annexe_financiere


### PR DESCRIPTION
### Quoi ?

Table contenant le suivi des recrutements des salariés en insertion 

### Pourquoi ?

Mettre en place un tableau de bord qui permet au CD et DDETS de suivre en temps réel l'évolution des recrutements des salariés en insertion dans les structures