### PR TITLE
Landing page API

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -3,7 +3,6 @@ from django.contrib import admin
 from django.urls import include, path, re_path, register_converter
 from django.views.generic import TemplateView
 
-from itou.france_connect import views as france_connect_views
 from itou.utils.urls import SiretConverter
 from itou.www.dashboard import views as dashboard_views
 from itou.www.login import views as login_views
@@ -54,6 +53,7 @@ urlpatterns = [
     # --------------------------------------------------------------------------------------
     # API.
     path("api/v1/", include("itou.api.urls", namespace="v1")),
+    path("api/", include("itou.www.api.urls")),
     # www.
     path("", include("itou.www.home.urls")),
     path("apply/", include("itou.www.apply.urls")),

--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -6,38 +6,36 @@
     <div class="container">
        <div class="row no-gutters pt-3">
            <div class="col col-lg-10 offset-lg-1 mt-4">
-            <div class="jumbotron">
-                <h1>API Les emplois de l’inclusion</h1>
-                <p class="lead">L'API des <a href="{% url 'home:hp' %}">emplois de l'inclusion</a> met à disposition des données de la plateforme.</p>
-                <p>Cette API est encore en construction et est appelée à évoluer.</p>
-                <p>
-                <p class="text-muted">Version: 1</p>
-            </div>
-            <div class="row mt-5">
-                <div class="col-12 bg-info text-white p-3">
-                    L’accès à certaines ressources peut nécessiter une authentification avec des droits particuliers.<br />
-                    Si vous désirez obtenir ces droits sur votre compte, merci de <a class="text-warning text-decoration-underline font-weight-bold" href="mailto:{{ ITOU_EMAIL_CONTACT }}">nous contacter {% include "includes/icon.html" with icon="external-link" %}</a>.
+                <div class="jumbotron">
+                    <h1>API Les emplois de l’inclusion</h1>
+                    <p class="lead">L'API des <a href="{% url 'home:hp' %}">emplois de l'inclusion</a> met à disposition des données de la plateforme.</p>
+                    <p>Cette API est encore en construction et est appelée à évoluer.</p>
+                    <p>
+                    <p class="text-muted">Version: 1</p>
                 </div>
-            </div>
-            <div class="row mt-5">
-                <div class="col-12">
-                    <h3 class="mb-3">Dernières Nouveautés</h3>
-                    <div class="container">
-                        <dl class="row">
-                            <dt class="col-sm-3">Ajout de l’API /siae</dt>
-                        </dl>
+                <div class="row mt-5">
+                    <div class="col-12 bg-info text-white p-3">
+                        L’accès à certaines ressources peut nécessiter une authentification avec des droits particuliers.<br />
+                        Si vous désirez obtenir ces droits sur votre compte, merci de <a class="text-warning text-decoration-underline font-weight-bold" href="mailto:{{ ITOU_EMAIL_CONTACT }}">nous contacter {% include "includes/icon.html" with icon="external-link" %}</a>.
                     </div>
                 </div>
-            </div>
-            <div class="row">
-                <div class="col-md-12">
-                    <h2>Documentation</h2>
-                    <p>Cette documentation est générée automatiquement à partir du code.</p>
-                    <p><a href="{% url 'v1:redoc' %}" class="btn btn-success">Ouvrir la documentation</a></p>
+                <div class="row mt-5">
+                    <div class="col-12">
+                        <h3 class="mb-3">Dernières Nouveautés</h3>
+                        <div class="container">
+                            <dl class="row">
+                                <dt class="col-sm-3">Ajout de l’API /siae</dt>
+                            </dl>
+                        </div>
+                    </div>
                 </div>
-            </div>
-            <hr>
-
+                <div class="row mt-5">
+                    <div class="col-md-12">
+                        <h2>Documentation</h2>
+                        <p>Cette documentation est générée automatiquement à partir du code.</p>
+                        <p><a href="{% url 'v1:redoc' %}" class="btn btn-success">Ouvrir la documentation</a></p>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -2,15 +2,6 @@
 
 {% block title %}API Les emplois de l’inclusion{% endblock %}
 
-{% block extra_head %}
-    {{ block.super }}
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-    <link rel="shortcut icon" href="/static/favicon.ico" type="image/ico">
-    <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" rel="stylesheet">
-    <script crossorigin="anonymous" integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2" src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-<script crossorigin="anonymous" integrity="sha384-Piv4xVNRyMGpqkS2by6br4gNJ7DXjqk09RmUpJ8jgGtD7zP9yug3goQfGII0yAns" src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js"></script>
-{% endblock %}
-
 {% block content %}   
     <div class="container">
        <div class="row no-gutters pt-3">

--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -9,14 +9,14 @@
             <div class="jumbotron">
                 <h1>API Les emplois de l’inclusion</h1>
                 <p class="lead">L'API des <a href="{% url 'home:hp' %}">emplois de l'inclusion</a> met à disposition des données de la plateforme.</p>
-                <p>Cet API est encore en construction, et est appellée à évoluer.</p>
+                <p>Cette API est encore en construction et est appelée à évoluer.</p>
                 <p>
                 <p class="text-muted">Version: 1</p>
             </div>
             <div class="row mt-5">
                 <div class="col-12 bg-info text-white p-3">
                     L’accès à certaines ressources peut nécessiter une authentification avec des droits particuliers.<br />
-                    Si vous désirez obtenir ces droits sur votre compte, merci de nous contacter.
+                    Si vous désirez obtenir ces droits sur votre compte, merci de <a class="text-warning text-decoration-underline font-weight-bold" href="mailto:{{ ITOU_EMAIL_CONTACT }}">nous contacter {% include "includes/icon.html" with icon="external-link" %}</a>.
                 </div>
             </div>
             <div class="row mt-5">

--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -6,12 +6,13 @@
     <div class="container">
        <div class="row no-gutters pt-3">
            <div class="col col-lg-10 offset-lg-1 mt-4">
-                <div class="jumbotron">
-                    <h1>API Les emplois de l’inclusion</h1>
-                    <p class="lead">L'API des <a href="{% url 'home:hp' %}">emplois de l'inclusion</a> met à disposition des données de la plateforme.</p>
-                    <p>Cette API est encore en construction et est appelée à évoluer.</p>
-                    <p>
-                    <p class="text-muted">Version: 1</p>
+                <div class="row mt-5">
+                    <div class="col-12 p-3">
+                        <h1>API Les emplois de l’inclusion</h1>
+                        <p class="lead">L'API des <a href="{% url 'home:hp' %}">emplois de l'inclusion</a> met à disposition des données de la plateforme.</p>
+                        <p>Cette API est encore en construction et est appelée à évoluer.</p>
+                        <p class="text-muted">Version: 1</p>
+                    </div>
                 </div>
                 <div class="row mt-5">
                     <div class="col-12 bg-info text-white p-3">

--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -1,0 +1,53 @@
+{% extends "layout/content.html" %}
+
+{% block title %}API Les emplois de l’inclusion{% endblock %}
+
+{% block extra_head %}
+    {{ block.super }}
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    <link rel="shortcut icon" href="/static/favicon.ico" type="image/ico">
+    <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" rel="stylesheet">
+    <script crossorigin="anonymous" integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2" src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+<script crossorigin="anonymous" integrity="sha384-Piv4xVNRyMGpqkS2by6br4gNJ7DXjqk09RmUpJ8jgGtD7zP9yug3goQfGII0yAns" src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+
+{% block content %}   
+    <div class="container">
+       <div class="row no-gutters pt-3">
+           <div class="col col-lg-10 offset-lg-1 mt-4">
+            <div class="jumbotron">
+                <h1>API Les emplois de l’inclusion</h1>
+                <p class="lead">L'API des <a href="{% url 'home:hp' %}">emplois de l'inclusion</a> met à disposition des données de la plateforme.</p>
+                <p>Cet API est encore en construction, et est appellée à évoluer.</p>
+                <p>
+                <p class="text-muted">Version: 1</p>
+            </div>
+            <div class="row mt-5">
+                <div class="col-12 bg-info text-white p-3">
+                    L’accès à certaines ressources peut nécessiter une authentification avec des droits particuliers.<br />
+                    Si vous désirez obtenir ces droits sur votre compte, merci de nous contacter.
+                </div>
+            </div>
+            <div class="row mt-5">
+                <div class="col-12">
+                    <h3 class="mb-3">Dernières Nouveautés</h3>
+                    <div class="container">
+                        <dl class="row">
+                            <dt class="col-sm-3">Ajout de l’API /siae</dt>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <h2>Documentation</h2>
+                    <p>Cette documentation est générée automatiquement à partir du code.</p>
+                    <p><a href="{% url 'v1:redoc' %}" class="btn btn-success">Ouvrir la documentation</a></p>
+                </div>
+            </div>
+            <hr>
+
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/itou/www/api/urls.py
+++ b/itou/www/api/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from itou.www.api import views
+
+
+app_name = "api"
+
+
+urlpatterns = [
+    path("", views.index, name="index"),
+]

--- a/itou/www/api/views.py
+++ b/itou/www/api/views.py
@@ -1,0 +1,11 @@
+from django.shortcuts import render
+from django.views.decorators.cache import cache_page
+
+
+@cache_page(60 * 60)  # 1 hour
+def index(request, template_name="api/index.html"):
+    """
+    Render the home page for the API
+    """
+
+    return render(request, template_name)


### PR DESCRIPTION
### Quoi ?

Ajout d’une landing page pour présenter l’API

### Pourquoi ?

 - favoriser et faciliter son utilisation
 - absence d’une telle page surprenante du point de vue des utilisateurs

### Comment ?

 - Ajout d’une page `/api`
 - Code/style calqué sur la [page équivalente du marché](https://api.lemarche.inclusion.beta.gouv.fr/).

### Captures d'écran (optionnel)
![Sélection_104](https://user-images.githubusercontent.com/1223316/133800699-c5ad2e22-e625-471c-a347-79aab176eea6.png)


