### PR TITLE
Résolution de l'erreur Elastic APM lors des appels httpx

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -34,3 +34,16 @@ ALLOW_POPULATING_METABASE = True
 
 # DRF Browseable API renderer is not available in production
 REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] = ["rest_framework.renderers.JSONRenderer"]
+
+# Active Elastic APM metrics
+# See https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html
+INSTALLED_APPS += ["elasticapm.contrib.django"]  # noqa F405
+
+ELASTIC_APM = {
+    "SERVICE_NAME": "itou-django",
+    "SERVER_URL": os.environ.get("APM_SERVER_URL", ""),
+    "SECRET_TOKEN": os.environ.get("APM_AUTH_TOKEN", ""),
+    "ENVIRONMENT": "prod",
+    "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
+    "TRANSACTION_IGNORE_URLS": ["/approvals/download/*"],  # to avoid `httpx` error
+}

--- a/config/settings/review_apps.py
+++ b/config/settings/review_apps.py
@@ -33,9 +33,10 @@ SHOW_TEST_ACCOUNTS_BANNER = True
 INSTALLED_APPS += ["elasticapm.contrib.django"]  # noqa F405
 
 ELASTIC_APM = {
-    "SERVICE_NAME": "itou-django-review",
+    "SERVICE_NAME": "itou-django",
     "SERVER_URL": os.environ.get("APM_SERVER_URL", ""),
     "SECRET_TOKEN": os.environ.get("APM_AUTH_TOKEN", ""),
     "ENVIRONMENT": "review",
     "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
+    "TRANSACTION_IGNORE_URLS": ["/approvals/download/*"],  # to avoid `httpx` error
 }

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -21,7 +21,11 @@ from itou.www.approvals_views.forms import DeclareProlongationForm, PoleEmploiAp
 
 @login_required
 def approval_as_pdf(request, job_application_id, template_name="approvals/approval_as_pdf.html"):
+    """
+    Displays the approval in pdf format
 
+    Warning: this view is temporarily excluded from the Elastic APM to avoid an error during the stream type httpx call
+    """
     siae = get_current_siae_or_404(request)
 
     queryset = JobApplication.objects.select_related("job_seeker", "eligibility_diagnosis", "approval", "to_siae")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -71,7 +71,7 @@ redis==3.5.3  # https://github.com/andymccurdy/redis-py
 PyJWT==2.1.0  # https://github.com/jpadilla/pyjwt
 
 # Requests alternative including a default time out
-httpx==0.18.2  # https://github.com/encode/httpx/
+httpx==0.19.0  # https://github.com/encode/httpx/
 
 # SFTP file transfer for ASP
 pysftp==0.2.9  # https://bitbucket.org/dundeemt/pysftp/src/master/

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -2,4 +2,4 @@
 
 uwsgi==2.0.19.1  # https://github.com/unbit/uwsgi
 sentry-sdk==1.3.1  # https://github.com/getsentry/sentry-python
-elastic-apm==6.3.3  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html
+elastic-apm==6.4.0  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html


### PR DESCRIPTION
### Quoi ?

L'appel pour la génération du pdf des PASS IAE ne fonctionne pas avec l'APM activé.

### Pourquoi ?

L'agent APM lève une erreur au moment de la capture de l'appel externe fait avec `httpx`.

### Comment ?

Mise à jour de l'agent et de `httpx`