### PR TITLE
Désactivation temporaire de l'APM

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -35,15 +35,15 @@ ALLOW_POPULATING_METABASE = True
 # DRF Browseable API renderer is not available in production
 REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] = ["rest_framework.renderers.JSONRenderer"]
 
-# Active Elastic APM metrics
-# See https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html
-INSTALLED_APPS += ["elasticapm.contrib.django"]  # noqa F405
-
-ELASTIC_APM = {
-    "SERVICE_NAME": "itou-django",
-    "SERVER_URL": os.environ.get("APM_SERVER_URL", ""),
-    "SECRET_TOKEN": os.environ.get("APM_AUTH_TOKEN", ""),
-    "ENVIRONMENT": "prod",
-    "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
-    "TRANSACTION_IGNORE_URLS": ["/approvals/download/*"],  # to avoid `httpx` error
-}
+# # Active Elastic APM metrics
+# # See https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html
+# INSTALLED_APPS += ["elasticapm.contrib.django"]  # noqa F405
+#
+# ELASTIC_APM = {
+#     "SERVICE_NAME": "itou-django",
+#     "SERVER_URL": os.environ.get("APM_SERVER_URL", ""),
+#     "SECRET_TOKEN": os.environ.get("APM_AUTH_TOKEN", ""),
+#     "ENVIRONMENT": "prod",
+#     "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
+#     "TRANSACTION_IGNORE_URLS": ["/approvals/download/*"],  # to avoid `httpx` error
+# }

--- a/config/settings/review_apps.py
+++ b/config/settings/review_apps.py
@@ -28,15 +28,15 @@ sentry_init(dsn=os.environ["SENTRY_DSN_STAGING"])
 
 SHOW_TEST_ACCOUNTS_BANNER = True
 
-# Active Elastic APM metrics
-# See https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html
-INSTALLED_APPS += ["elasticapm.contrib.django"]  # noqa F405
-
-ELASTIC_APM = {
-    "SERVICE_NAME": "itou-django",
-    "SERVER_URL": os.environ.get("APM_SERVER_URL", ""),
-    "SECRET_TOKEN": os.environ.get("APM_AUTH_TOKEN", ""),
-    "ENVIRONMENT": "review",
-    "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
-    "TRANSACTION_IGNORE_URLS": ["/approvals/download/*"],  # to avoid `httpx` error
-}
+# # Active Elastic APM metrics
+# # See https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html
+# INSTALLED_APPS += ["elasticapm.contrib.django"]  # noqa F405
+#
+# ELASTIC_APM = {
+#     "SERVICE_NAME": "itou-django",
+#     "SERVER_URL": os.environ.get("APM_SERVER_URL", ""),
+#     "SECRET_TOKEN": os.environ.get("APM_AUTH_TOKEN", ""),
+#     "ENVIRONMENT": "review",
+#     "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
+#     "TRANSACTION_IGNORE_URLS": ["/approvals/download/*"],  # to avoid `httpx` error
+# }


### PR DESCRIPTION
### Quoi ?

Désactivation temporaire de l'APM.

### Pourquoi ?

Beaucoup d'erreurs Sentry :

- https://sentry.io/organizations/betagouv-f7/issues/2665037876/?project=5671910&query=is%3Aunresolved
- https://sentry.io/organizations/betagouv-f7/issues/2665039255/?project=5671910&query=is%3Aunresolved

Le serveur APM est down chez Clever Cloud. Ils sont au courant du problème.

![Capture d’écran 2021-09-22 à 16 03 39](https://user-images.githubusercontent.com/281139/134377059-c3fc7be5-090e-4de0-89d6-a3a6ce95d42e.png)

### Comment ?

Désactivation temporaire de l'APM en attendant résolution Clever.

