### PR TITLE
Fixtures fiches salarié

### DIFF
--- a/itou/fixtures/django/17_employee_records.json
+++ b/itou/fixtures/django/17_employee_records.json
@@ -1,74 +1,78 @@
 [
-{
+  {
     "model": "employee_record.employeerecord",
     "pk": 1,
     "fields": {
-        "created_at": "2021-05-12T10:16:09.639Z",
-        "updated_at": "2021-05-12T10:27:43.343Z",
-        "status": "SENT",
-        "job_application": "5f844eff-2dbb-450e-8f8b-6ec99f216c31",
-        "financial_annex": 148712,	
-        "approval_number": "XXXXX0000002",
-        "asp_id": 3430,
-        "asp_processing_code": null,
-        "asp_processing_label": null,
-        "asp_batch_file": "RIAE_FS_20210512102743.json",
-        "asp_batch_line_number": 4,
-        "archived_json": null
+      "created_at": "2021-05-12T10:16:09.639Z",
+      "updated_at": "2021-05-12T10:27:43.343Z",
+      "status": "SENT",
+      "job_application": "5f844eff-2dbb-450e-8f8b-6ec99f216c31",
+      "financial_annex": 148712,
+      "approval_number": "XXXXX0000002",
+      "siret": "99999999999991",
+      "asp_id": 3430,
+      "asp_processing_code": null,
+      "asp_processing_label": null,
+      "asp_batch_file": "RIAE_FS_20210512102743.json",
+      "asp_batch_line_number": 4,
+      "archived_json": null
     }
-},
-{
+  },
+  {
     "model": "employee_record.employeerecord",
     "pk": 2,
     "fields": {
-        "created_at": "2021-05-12T10:16:55.551Z",
-        "updated_at": "2021-05-12T15:12:05.098Z",
-        "status": "PROCESSED",
-        "job_application": "61883223-4a9b-45d6-afa6-25ab6fccaaab",
-        "financial_annex": 148712,
-        "approval_number": "XXXXX0000003",
-        "asp_id": 3430,
-        "asp_processing_code": "0000",
-        "asp_processing_label": "OK",
-        "asp_batch_file": "RIAE_FS_20210512102743.json",
-        "asp_batch_line_number": 3,
-        "archived_json": "{\"numLigne\":1,\"typeMouvement\":\"C\",\"numeroAnnexe\":\"ACI023201111A0M0\",\"mesure\":\"EI_DC\",\"siret\":\"33055039301440\",\"personnePhysique\":{\"passIae\":\"XXXXX0000003\",\"idItou\":\"55a0c7f6e4c873dbea8de4b528fc41\",\"civilite\":\"M\",\"nomUsage\":\"Peck\",\"prenom\":\"Templeton \\\"Faceman\\\"\",\"dateNaissance\":\"01/01/1970\",\"codeInseePays\":\"404\",\"codeGroupePays\":\"3\",\"sufPassIae\":null,\"nomNaissance\":null},\"adresse\":{\"adrTelephone\":\"\",\"adrMail\":\"templeton.faceman.peck@a-team.fake.com\",\"adrNumeroVoie\":\"5\",\"codeextensionvoie\":\"\",\"codetypevoie\":\"RUE\",\"adrLibelleVoie\":\"Rue du Refuge\",\"adrCpltDistribution\":null,\"codeinseecom\":\"34172\",\"codepostalcedex\":\"34000\"},\"situationSalarie\":{\"niveauFormation\":\"40\",\"salarieEnEmploi\":true,\"salarieSansEmploiDepuis\":null,\"salarieSansRessource\":false,\"inscritPoleEmploi\":false,\"inscritPoleEmploiDepuis\":\"\",\"numeroIDE\":\"\",\"salarieRQTH\":false,\"salarieOETH\":false,\"salarieAideSociale\":true,\"salarieBenefRSA\":\"OUI-NM\",\"salarieBenefRSADepuis\":null,\"salarieBenefASS\":false,\"salarieBenefASSDepuis\":null,\"salarieBenefAAH\":false,\"salarieBenefAAHDepuis\":null,\"salarieBenefATA\":false,\"salarieBenefATADepuis\":null,\"salarieTypeEmployeur\":\"01\",\"orienteur\":\"99\"},\"codeTraitement\":\"0000\",\"libelleTraitement\":\"OK\"}"
+      "created_at": "2021-05-12T10:16:55.551Z",
+      "updated_at": "2021-05-12T15:12:05.098Z",
+      "status": "PROCESSED",
+      "job_application": "61883223-4a9b-45d6-afa6-25ab6fccaaab",
+      "financial_annex": 148712,
+      "approval_number": "XXXXX0000003",
+      "siret": "99999999999992",
+      "asp_id": 3430,
+      "asp_processing_code": "0000",
+      "asp_processing_label": "OK",
+      "asp_batch_file": "RIAE_FS_20210512102743.json",
+      "asp_batch_line_number": 3,
+      "archived_json": "{\"numLigne\":1,\"typeMouvement\":\"C\",\"numeroAnnexe\":\"ACI023201111A0M0\",\"mesure\":\"EI_DC\",\"siret\":\"33055039301440\",\"personnePhysique\":{\"passIae\":\"XXXXX0000003\",\"idItou\":\"55a0c7f6e4c873dbea8de4b528fc41\",\"civilite\":\"M\",\"nomUsage\":\"Peck\",\"prenom\":\"Templeton \\\"Faceman\\\"\",\"dateNaissance\":\"01/01/1970\",\"codeInseePays\":\"404\",\"codeGroupePays\":\"3\",\"sufPassIae\":null,\"nomNaissance\":null},\"adresse\":{\"adrTelephone\":\"\",\"adrMail\":\"templeton.faceman.peck@a-team.fake.com\",\"adrNumeroVoie\":\"5\",\"codeextensionvoie\":\"\",\"codetypevoie\":\"RUE\",\"adrLibelleVoie\":\"Rue du Refuge\",\"adrCpltDistribution\":null,\"codeinseecom\":\"34172\",\"codepostalcedex\":\"34000\"},\"situationSalarie\":{\"niveauFormation\":\"40\",\"salarieEnEmploi\":true,\"salarieSansEmploiDepuis\":null,\"salarieSansRessource\":false,\"inscritPoleEmploi\":false,\"inscritPoleEmploiDepuis\":\"\",\"numeroIDE\":\"\",\"salarieRQTH\":false,\"salarieOETH\":false,\"salarieAideSociale\":true,\"salarieBenefRSA\":\"OUI-NM\",\"salarieBenefRSADepuis\":null,\"salarieBenefASS\":false,\"salarieBenefASSDepuis\":null,\"salarieBenefAAH\":false,\"salarieBenefAAHDepuis\":null,\"salarieBenefATA\":false,\"salarieBenefATADepuis\":null,\"salarieTypeEmployeur\":\"01\",\"orienteur\":\"99\"},\"codeTraitement\":\"0000\",\"libelleTraitement\":\"OK\"}"
     }
-},
-{
+  },
+  {
     "model": "employee_record.employeerecord",
     "pk": 3,
     "fields": {
-        "created_at": "2021-05-12T10:17:33.420Z",
-        "updated_at": "2021-05-12T10:27:43.333Z",
-        "status": "SENT",
-        "job_application": "6e09f9d5-aa9b-42db-89c3-63db5a9d323b",
-        "financial_annex": 148712,
-        "approval_number": "XXXXX0000004",
-        "asp_id": 3430,
-        "asp_processing_code": null,
-        "asp_processing_label": null,
-        "asp_batch_file": "RIAE_FS_20210512102743.json",
-        "asp_batch_line_number": 2,
-        "archived_json": null
+      "created_at": "2021-05-12T10:17:33.420Z",
+      "updated_at": "2021-05-12T10:27:43.333Z",
+      "status": "SENT",
+      "job_application": "6e09f9d5-aa9b-42db-89c3-63db5a9d323b",
+      "financial_annex": 148712,
+      "approval_number": "XXXXX0000004",
+      "siret": "99999999999993",
+      "asp_id": 3430,
+      "asp_processing_code": null,
+      "asp_processing_label": null,
+      "asp_batch_file": "RIAE_FS_20210512102743.json",
+      "asp_batch_line_number": 2,
+      "archived_json": null
     }
-},
-{
+  },
+  {
     "model": "employee_record.employeerecord",
     "pk": 4,
     "fields": {
-        "created_at": "2021-05-12T10:17:57.000Z",
-        "updated_at": "2021-05-12T14:45:55.281Z",
-        "status": "REJECTED",
-        "job_application": "bca602f3-9249-46cf-b949-4d5a9324a5a5",
-        "financial_annex": 148712,
-        "approval_number": "XXXXX0000005",
-        "asp_id": 3430,
-        "asp_processing_code": "0012",
-        "asp_processing_label": "JSON Invalide",
-        "asp_batch_file": "RIAE_FS_20210512102743.json",
-        "asp_batch_line_number": 1,
-        "archived_json": null
+      "created_at": "2021-05-12T10:17:57.000Z",
+      "updated_at": "2021-05-12T14:45:55.281Z",
+      "status": "REJECTED",
+      "job_application": "bca602f3-9249-46cf-b949-4d5a9324a5a5",
+      "financial_annex": 148712,
+      "approval_number": "XXXXX0000005",
+      "siret": "99999999999994",
+      "asp_id": 3430,
+      "asp_processing_code": "0012",
+      "asp_processing_label": "JSON Invalide",
+      "asp_batch_file": "RIAE_FS_20210512102743.json",
+      "asp_batch_line_number": 1,
+      "archived_json": null
     }
-}
+  }
 ]

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -247,7 +247,7 @@ class JobApplicationQuerySetTest(TestCase):
         job_app = JobApplicationFactory(state=JobApplicationWorkflow.STATE_ACCEPTED)
         self.assertNotIn(job_app, JobApplication.objects.eligible_as_employee_record(job_app.to_siae))
 
-        # Approval start date is also check (must be older then CANCELLATION_DAY_AFTER_HIRING STARTEDc
+        # Approval start date is also checked (must be older then CANCELLATION_DAY_AFTER_HIRING STARTED).
         job_app = JobApplicationWithApprovalNotCancellableFactory()
         self.assertIn(job_app, JobApplication.objects.eligible_as_employee_record(job_app.to_siae))
 

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -247,6 +247,7 @@ class JobApplicationQuerySetTest(TestCase):
         job_app = JobApplicationFactory(state=JobApplicationWorkflow.STATE_ACCEPTED)
         self.assertNotIn(job_app, JobApplication.objects.eligible_as_employee_record(job_app.to_siae))
 
+        # Approval start date is also check (must be older then CANCELLATION_DAY_AFTER_HIRING STARTEDc
         job_app = JobApplicationWithApprovalNotCancellableFactory()
         self.assertIn(job_app, JobApplication.objects.eligible_as_employee_record(job_app.to_siae))
 

--- a/itou/templates/employee_record/create.html
+++ b/itou/templates/employee_record/create.html
@@ -17,8 +17,8 @@
         <div class="card-body p-1">
             <div class="row">
                 <div class="col-sm-9 pt-3">
-                    <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
-                    <div>Fin du contrat : <b>{{ job_application.hiring_end_at }}</b></div>
+                    <div>Début du contrat : <b>{{ job_application.hiring_start_at|default_if_none:"Non renseigné" }}</b></div>
+                    <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default_if_none:"Non renseigné" }}</b></div>
                     <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
                 </div>
                 <div class="col-sm-3 text-right">

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -7,8 +7,8 @@
     <div class="card-body">
         <div class="row">
             <div class="col-md-7">
-                <p class="m-0">Début de contrat : <b>{{ item.hiring_start_at }}</b></p>
-                <p class="m-0">Fin de contrat : <b>{{ item.hiring_end_at }}</b></p>
+                <p class="m-0">Début de contrat : <b>{{ item.hiring_start_at|default_if_none:"Non renseigné" }}</b></p>
+                <p class="m-0">Fin de contrat : <b>{{ item.hiring_end_at|default_if_none:"Non renseigné" }}</b></p>
                 <p class="m-0">Numéro de PASS IAE (agrément) : <b>{{ item.approval.number_with_spaces }}</b></p>
             </div>
 


### PR DESCRIPTION
### Quoi ?

Modification des fixtures des fiches salarié (ajout du SIRET)
Simplification de la requête de filtre des candidatures

### Pourquoi ?

- Pour permettre d'utiliser l'environnement de DEV par défaut avec les fiches salarié pré-enregistrées
- Simplifier le filtrage des embauches éligibles aux fiches salarié (conditions redondantes)

### Comment ?

- en ajoutant un SIRET bidon aux exemples de fiches salarié
- faire confiance au processus d'annulation d'embauche: le PASS temporaire est détruit si l'embauche est annulée, donc l'éligibilité est automatiquement bloquée (pas de PASS IAE dispo)