### PR TITLE
Correctifs pour `import_pe_approvals.py`

### DIFF
--- a/itou/approvals/management/commands/import_pe_approvals.py
+++ b/itou/approvals/management/commands/import_pe_approvals.py
@@ -91,7 +91,11 @@ class Command(BaseCommand):
 
             # This is known as "Identifiant Pôle emploi".
             ID_REGIONAL_BENE = str(row["ID_REGIONAL_BENE"]).strip()
-            assert len(ID_REGIONAL_BENE) == 8
+            if len(ID_REGIONAL_BENE) < 8:
+                self.logger.debug("-" * 80)
+                self.logger.debug("Bad format for ID_REGIONAL_BENE (PE ID) found, skipping…")
+                self.logger.debug("%s", ID_REGIONAL_BENE)
+                continue
             # Check the format of ID_REGIONAL_BENE.
             # First 7 chars should be digits.
             assert ID_REGIONAL_BENE[:7].isdigit()

--- a/itou/approvals/management/commands/import_pe_approvals.py
+++ b/itou/approvals/management/commands/import_pe_approvals.py
@@ -90,7 +90,7 @@ class Command(BaseCommand):
             assert len(CODE_STRUCT_AFFECT_BENE) in [4, 5]
 
             # This is known as "Identifiant Pôle emploi".
-            ID_REGIONAL_BENE = row["ID_REGIONAL_BENE"].strip()
+            ID_REGIONAL_BENE = str(row["ID_REGIONAL_BENE"]).strip()
             assert len(ID_REGIONAL_BENE) == 8
             # Check the format of ID_REGIONAL_BENE.
             # First 7 chars should be digits.


### PR DESCRIPTION
### Quoi ?

Correctifs pour `import_pe_approvals.py`.

### Pourquoi ?

Pour pouvoir importer le fichier fourni par PE.

### Comment ?

- on force la valeur `ID_REGIONAL_BENE` au format chaîne de caractère
- on zappe les ID Pôle emploi qui ne sont pas au bon format pour ne pas faire échouer la commande