### PR TITLE
Ikarius/fix opening date

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -657,4 +657,4 @@ EMPLOYEE_RECORD_CUSTOM_SIAE_ID_LIST = [41, 4847, 4848]
 # This is the official and final production phase date of the employee record feature.
 # It is used as parameter to filter the eligible job applications for the feature.
 # (no job application before this date can be used for this feature)
-EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 9, 1)
+EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 7, 1)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -657,4 +657,4 @@ EMPLOYEE_RECORD_CUSTOM_SIAE_ID_LIST = [41, 4847, 4848]
 # This is the official and final production phase date of the employee record feature.
 # It is used as parameter to filter the eligible job applications for the feature.
 # (no job application before this date can be used for this feature)
-EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 9, 27)
+EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 9, 1)

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -202,7 +202,7 @@ class JobApplicationQuerySet(models.QuerySet):
                 to_siae=siae,
                 hiring_start_at__lt=cancellation_date,
                 # Must be accepted after production date:
-                updated_at__gte=settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE,
+                created_at__gte=settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE,
             )
             .select_related("job_seeker", "approval")
         )

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -202,7 +202,7 @@ class JobApplicationQuerySet(models.QuerySet):
                 to_siae=siae,
                 hiring_start_at__lt=cancellation_date,
                 # Must be accepted after production date:
-                created_at__gte=settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE,
+                updated_at__gte=settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE,
             )
             .select_related("job_seeker", "approval")
         )

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -71,14 +71,17 @@
 
     {# Employee record progressive opening notification #}
     {% if can_show_deployment_message %}
-        <div class="alert alert-info pb-0">
+        <div class="alert alert-danger pb-0">
             <p>
-                Les fonctionnalités de gestion des fiches salarié ASP sont actuellement en cours de déploiement.
+                Suite à la fermeture de la saisie de fiches salarié dans l'Extranet 2.0 de l'ASP à compter du 27 septembre 2021 (saisie manuelle ou inter-opérabilité depuis votre système d'information), 
+                nous vous permettons d'introduire de nouvelles fiches salariés (depuis votre tableau de bord) pour toutes embauches non déclarées dans l'Extranet 2.0 de l'ASP à compter du <b>1er juillet 2021</b>.
             </p>
+
             <p>
-                Dès que ces fonctionnalités seront disponibles pour votre structure, vous pourrez y accéder via un lien
-                dans la section <b>"Mes candidatures"</b> du tableau de bord.
+                Vous pouvez accéder à cette fonctionnalité via le lien <b>"Mes candidatures / Gérer mes fiches salarié"</b> du tableau de bord.
             </p>
+
+
         </div>
     {% endif %}
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -71,7 +71,7 @@
 
     {# Employee record progressive opening notification #}
     {% if can_show_deployment_message %}
-        <div class="alert alert-danger pb-0">
+        <div class="alert alert-warning pb-0">
             <p>
                 Suite à la fermeture de la saisie de fiches salarié dans l'Extranet 2.0 de l'ASP à compter du 27 septembre 2021 (saisie manuelle ou inter-opérabilité depuis votre système d'information), 
                 nous vous permettons d'introduire de nouvelles fiches salariés (depuis votre tableau de bord) pour toutes embauches non déclarées dans l'Extranet 2.0 de l'ASP à compter du <b>1er juillet 2021</b>.

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -69,7 +69,7 @@ class DashboardViewTest(TestCase):
 
         url = reverse("dashboard:index")
         response = self.client.get(url)
-        self.assertContains(response, "en cours de déploiement")
+        self.assertContains(response, "fermeture de la saisie de fiches salarié")
 
     def test_hide_progressive_deployment_message(self):
         # Message hidden if user is logged in with a non-eligible SIAE
@@ -79,7 +79,7 @@ class DashboardViewTest(TestCase):
 
         url = reverse("dashboard:index")
         response = self.client.get(url)
-        self.assertNotContains(response, "en cours de déploiement")
+        self.assertNotContains(response, "fermeture de la saisie de fiches salarié")
 
 
 class EditUserInfoViewTest(TestCase):


### PR DESCRIPTION
### Quoi ?

Changement de la date d'ouverture des fiche salarié (rétroactivement au 1er juillet)
+ Message informatif pour les utilisateurs

### Pourquoi ?

Certaines fiches salarié sont envoyées trimestriellement par certaines SIAE et l'ASP à coupé toute possibilité de saisie de fiches saisie avant le 27 septembre.

### Comment ?

Configuration `settings` et notification à l'utilisateur sur le dashboard 

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/147232/135470823-9231a44e-da31-41da-9a59-1c3b95024f90.png)


