### PR TITLE
FIX: Type de prescripteur

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -440,7 +440,11 @@ class EmployeeRecord(models.Model):
 
         prescriber_organization = self.job_application.sender_prescriber_organization
 
-        return PrescriberType.from_itou_prescriber_kind(prescriber_organization.kind).value
+        return (
+            PrescriberType.from_itou_prescriber_kind(prescriber_organization.kind).value
+            if prescriber_organization
+            else None
+        )
 
     @property
     def asp_siae_type(self):


### PR DESCRIPTION
### Quoi ?

Le type de prescripteur (optionnel) transmis à l'ASP peut être mal formaté

### Pourquoi ?

Ce champ peut ne pas être existant en base (valeur vide)

### Comment ?

Un peu plus défensif sur la valeur (test de `None`)

### Autre

Pas de revue (fix PROD)
