### PR TITLE
FIX  - intégration fiches salarié 01

### DIFF
--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -10,6 +10,7 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
         "created_at",
         "approval_number",
         "siret",
+        "asp_processing_code",
         "status",
     )
     list_filter = ("status",)
@@ -18,6 +19,8 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
         "pk",
         "siret",
         "approval_number",
+        "asp_processing_code",
+        "asp_batch_file",
     )
 
     raw_id_fields = (

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -443,7 +443,7 @@ class EmployeeRecord(models.Model):
         return (
             PrescriberType.from_itou_prescriber_kind(prescriber_organization.kind).value
             if prescriber_organization
-            else None
+            else PrescriberType.SPONTANEOUS_APPLICATION
         )
 
     @property

--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -106,6 +106,12 @@ class _EmployeeAddress(serializers.ModelSerializer):
             "adrCpltDistribution",
         ]
 
+        # Don't send extended address if it must be truncated:
+        # Do not lower quality of data on itou side
+        # Check ASP rule : T030_c026_rg002
+        if len(result.get("adrCpltDistribution", "")) > 32:
+            result["adrCpltDistribution"] = None
+
         # Don't send phone number if not in ASP expected format
         # (we don't want any post-processing or update on this field)
         if result.get("adrTelephone"):

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -271,7 +271,14 @@ class JobSeekerProfileAdmin(admin.ModelAdmin):
         "user",
         "hexa_commune",
     )
+
     list_display = ("pk", "user", "username")
+
+    search_fields = (
+        "user__first_name",
+        "user__last_name",
+        "user__email",
+    )
 
     readonly_fields = (
         "hexa_lane_number",


### PR DESCRIPTION
### Quoi ?

FIX 1: 
- type orienteur
- pas de dégradation de données, si pas au format on ne transmet pas le complément d'adresse
- amélioration de l'admin pour les contraintes de la prod (real life)

### Pourquoi ?

Traitement des retours d'intégration ASP / cas limites ou nouveau

### Comment ?

Vite

### Autre (optionnel)

- plusieurs PR du style à prévoir aujourd'hui
- - la plupart du temps sans revue (mais les tests sont toujours ok !)
