### PR TITLE
FIX intégration ASP 03

### DIFF
--- a/itou/common_apps/address/format.py
+++ b/itou/common_apps/address/format.py
@@ -1,3 +1,5 @@
+import re
+
 from unidecode import unidecode
 
 from itou.asp.models import LaneExtension, LaneType, find_lane_type_aliases
@@ -8,6 +10,8 @@ ERROR_HEXA_CONVERSION = "Impossible de transformer cet objet en adresse HEXA"
 ERROR_GEOCODING_API = "Erreur de geocoding, impossible d'obtenir un résultat"
 ERROR_INCOMPLETE_ADDRESS_DATA = "Données d'adresse incomplètes"
 ERROR_UNKNOWN_ADDRESS_LANE = "Impossible d'obtenir le nom de la voie"
+
+LANE_NUMBER_RE = r"^([0-9]{1,5})(.*?)$"
 
 
 def format_address(obj):
@@ -61,8 +65,12 @@ def format_address(obj):
     # Street extension processing (bis, ter ...)
     # Extension is part of the resulting streetnumber geo API field
     number_plus_ext = address.get("number")
+
     if number_plus_ext:
-        number, *extension = number_plus_ext.split()
+        # API change : now extension can be "stuck" to lane number
+        # This was not he case before (space in between)
+        # REGEX to the rescue to fix ASP error 3323
+        [[number, extension]] = re.findall(LANE_NUMBER_RE, number_plus_ext)
 
         if number:
             result["number"] = number

--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -34,6 +34,7 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
         "updated_at",
         "approval_number",
         "siret",
+        "asp_id",
         "asp_batch_file",
         "asp_batch_line_number",
         "asp_processing_code",

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -281,6 +281,7 @@ class JobSeekerProfileAdmin(admin.ModelAdmin):
     )
 
     readonly_fields = (
+        "pole_emploi_id",
         "hexa_lane_number",
         "hexa_std_extension",
         "hexa_non_std_extension",
@@ -297,6 +298,7 @@ class JobSeekerProfileAdmin(admin.ModelAdmin):
                 "fields": (
                     "user",
                     "education_level",
+                    "pole_emploi_id",
                     "pole_emploi_since",
                     "unemployed_since",
                     "resourceless",
@@ -336,4 +338,8 @@ class JobSeekerProfileAdmin(admin.ModelAdmin):
     def username(self, obj):
         return f"{obj.user.first_name} {obj.user.last_name}"
 
+    def pole_emploi_id(self, obj):
+        return f"{obj.user.pole_emploi_id}"
+
     username.short_description = "Nom complet"
+    pole_emploi_id.short_description = "Identifiant Pôle emploi"

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -339,7 +339,7 @@ class JobSeekerProfileAdmin(admin.ModelAdmin):
         return f"{obj.user.first_name} {obj.user.last_name}"
 
     def pole_emploi_id(self, obj):
-        return f"{obj.user.pole_emploi_id}"
+        return obj.user.pole_emploi_id
 
     username.short_description = "Nom complet"
     pole_emploi_id.short_description = "Identifiant Pôle emploi"

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -272,7 +272,12 @@ class JobSeekerProfileAdmin(admin.ModelAdmin):
         "hexa_commune",
     )
 
-    list_display = ("pk", "user", "username")
+    list_display = (
+        "pk",
+        "user",
+        "username",
+        "pole_emploi_id",
+    )
 
     search_fields = (
         "user__first_name",
@@ -339,7 +344,7 @@ class JobSeekerProfileAdmin(admin.ModelAdmin):
         return f"{obj.user.first_name} {obj.user.last_name}"
 
     def pole_emploi_id(self, obj):
-        return obj.user.pole_emploi_id
+        return obj.user.pole_emploi_id or "-"
 
     username.short_description = "Nom complet"
     pole_emploi_id.short_description = "Identifiant Pôle emploi"

--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -42,8 +42,8 @@ class Command(BaseCommand):
             # cities.City
             "view_city",
             # employee_record.EmployeeRecord
-            "view_employee_record",
-            "change_employee_record",
+            "view_employeerecord",
+            "change_employeerecord",
             # eligibility.AdministrativeCriteria
             "view_administrativecriteria",
             # eligibility.EligibilityDiagnosis

--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -41,6 +41,9 @@ class Command(BaseCommand):
             "view_prolongation",
             # cities.City
             "view_city",
+            # employee_record.EmployeeRecord
+            "view_employee_record",
+            "change_employee_record",
             # eligibility.AdministrativeCriteria
             "view_administrativecriteria",
             # eligibility.EligibilityDiagnosis
@@ -99,6 +102,9 @@ class Command(BaseCommand):
             "add_user",
             "change_user",
             "view_user",
+            # users.JobseekerProfile
+            "view_jobseekerprofile",
+            "change_jobseekerprofile",
             # ASP
             "view_commune",
             "view_country",

--- a/itou/utils/mocks/address_format.py
+++ b/itou/utils/mocks/address_format.py
@@ -2,7 +2,7 @@ BAN_GEOCODING_API_RESULTS_MOCK = [
     {
         "score": 0.8745736363636364,
         "address_line_1": "37 B Rue du Général De Gaulle",
-        "number": "37 b",
+        "number": "37b",
         "lane": "Rue du Général de Gaulle",
         "address": "37 b Rue du Général de Gaulle",
         "post_code": "67118",
@@ -194,7 +194,7 @@ BAN_GEOCODING_API_RESULTS_MOCK = [
     {
         "score": 0.8745736363636364,
         "address_line_1": "37 Ter Rue du Général De Gaulle",
-        "number": "37 t",
+        "number": "37t",
         "lane": "Rue du Général de Gaulle",
         "address": "37 t Rue du Général de Gaulle",
         "post_code": "67118",
@@ -206,7 +206,7 @@ BAN_GEOCODING_API_RESULTS_MOCK = [
     {
         "score": 0.8745736363636364,
         "address_line_1": "37 G Rue du Général De Gaulle",
-        "number": "37 g",
+        "number": "37g",
         "lane": "Rue du Général de Gaulle",
         "address": "37 G Rue du Général de Gaulle",
         "post_code": "67118",


### PR DESCRIPTION
### Quoi ?

Suite des fixes "à la volée" de l'intégration des fiches salarié. Moins critiques au fil du temps

### Pourquoi ?

Essentiellement amélioration du taux de transfert sans erreur et amélioration de l'admin

### Comment ?

- amélioration de l'admin et de la recherche sur les fiches salarié
- ajout des droits pour les admin
- fix du formatage des voies et des extensions (bis. ter ...) suite a un breaking change de l'API geo

