### PR TITLE
Suppression des warnings dans les tests

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -4,7 +4,10 @@ https://docs.djangoproject.com/en/dev/ref/settings
 """
 import datetime
 import os
+
+import pytz
 from django.utils import timezone
+
 
 # Paths.
 # ------------------------------------------------------------------------------
@@ -657,4 +660,4 @@ EMPLOYEE_RECORD_CUSTOM_SIAE_ID_LIST = [41, 4847, 4848]
 # This is the official and final production phase date of the employee record feature.
 # It is used as parameter to filter the eligible job applications for the feature.
 # (no job application before this date can be used for this feature)
-EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 7, 1)
+EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 7, 1, tzinfo=pytz.UTC)

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -1,6 +1,9 @@
 import logging
 
-from .base import *
+import pytz
+from django.utils import timezone
+
+from .base import *  # noqa: F401,F403
 
 
 # `ManifestStaticFilesStorage` (used in base settings) requires `collectstatic` to be run.
@@ -26,7 +29,7 @@ ASP_FS_KNOWN_HOSTS = None
 
 # Temporary: employee record deployment
 EMPLOYEE_RECORD_PROGRESSIVE_OPENING_ENABLED = True
-EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 1, 1)
+EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 1, 1, tzinfo=pytz.UTC)
 
 FRANCE_CONNECT_CLIENT_ID = "FC_CLIENT_ID_123"
 FRANCE_CONNECT_CLIENT_SECRET = "FC_CLIENT_SECRET_123"

--- a/itou/api/siae_api/viewsets.py
+++ b/itou/api/siae_api/viewsets.py
@@ -74,6 +74,7 @@ class SiaeViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = SiaeSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_class = SiaeOrderingFilter
+    ordering = ["id"]
 
     # No authentication is required on this API and everybody can query anything − it’s read-only.
     authentication_classes = []
@@ -130,7 +131,7 @@ On peut spécifier la direction de tri :
         queryset = self._filter_by_query_params(self.request, queryset)
 
         try:
-            return queryset
+            return queryset.order_by("id")
         finally:
             # Tracking is currently done via user-agent header
             logger.info(


### PR DESCRIPTION
# Quoi?

Suppression des warning en CI et via `make test`

# Pourquoi ?

Les warning suggèrent des pistes d’amélioration

# Comment

 - un ordre de tri par défaut explicite manquait dans l’API
 - une timezone manquant dans une constante crée des erreurs de filtrage