### PR TITLE
Correctif intégration fiches salarié - 06

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,6 +1,6 @@
 [
   "1 0 * * * $ROOT/clevercloud/update-prescriber-organization-with-api-entreprise.sh",
-  "25 6-22/2 * * 1-5 $ROOT/clevercloud/download_employee_records.sh",
+  "25 6-22/1 * * 1-5 $ROOT/clevercloud/download_employee_records.sh",
   "55 6-22/1 * * 1-5 $ROOT/clevercloud/upload_employee_records.sh",
   "5 23 * * 1-5 $ROOT/clevercloud/archive_employee_records.sh"
 ]

--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -120,6 +120,11 @@ class _EmployeeAddress(serializers.ModelSerializer):
             if not re.match("^\\+?[0-9]{1,16}$", result.get("adrTelephone")):
                 result["adrTelephone"] = None
 
+        # Remove diacritics and parenthesis from adrLibelleVoie field fixes ASP error 3330
+        # (parenthesis are not described as invalid characters in specification document)
+        if lane := result.get("adrLibelleVoie"):
+            result["adrLibelleVoie"] = unidecode(lane.translate({ord(ch): "" for ch in "()"}))
+
         for field in empty_as_null_fields:
             if result.get(field) == "":
                 result[field] = None

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -207,8 +207,8 @@ class JobApplicationQuerySet(models.QuerySet):
             .filter(
                 to_siae=siae,
                 hiring_start_at__lt=cancellation_date,
-                # Must be accepted after production date:
-                updated_at__gte=settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE,
+                # Hiring must start after production date:
+                hiring_start_at__gte=settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE,
             )
             .select_related("job_seeker", "approval")
         )


### PR DESCRIPTION
### Quoi ?

- correction d’éléments d'adresse mal spécifiés
- modification des horaires de téléchargement des résultats ASP

### Pourquoi ?

Le CDC ASP est "victime" d'un copier / coller sauvage.
Certains descriptifs de validité sont copiés / collés et complètement faux pour certains champs (par exemple le libellé de la voie pour l'adresse du candidat).
Malheureusement, c'est déjà le 3eme cas ou les descriptifs du cahier des charges sont erronés.

Concernant le CRON, l'ASP ne respecte pas les horaires indiqués, donc jusqu`à normalisation, le téléchargement des fichiers aura lieu toutes les heures.

Ce pourrait être du "temporaire qui dure".

### Comment ?

Modification "à la volée" dans le sérialiseur des éléments à transférer (pas de dégradation des données de la plateforme).

### Divers

Pas de revue
