### PR TITLE
Prévention de quelques erreurs de manipulation du support

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -10,6 +10,7 @@ from itou.institutions.models import InstitutionMembership
 from itou.prescribers.models import PrescriberMembership
 from itou.siaes.models import SiaeMembership
 from itou.users import models
+from itou.users.admin_forms import UserAdminForm
 
 
 class SiaeMembershipInline(admin.TabularInline):
@@ -150,6 +151,7 @@ class CreatedByProxyFilter(admin.SimpleListFilter):
 @admin.register(models.User)
 class ItouUserAdmin(UserAdmin):
 
+    form = UserAdminForm
     inlines = UserAdmin.inlines + [
         SiaeMembershipInline,
         PrescriberMembershipInline,

--- a/itou/users/admin_forms.py
+++ b/itou/users/admin_forms.py
@@ -21,3 +21,9 @@ class UserAdminForm(forms.ModelForm):
                 "Un utilisateur ne peut avoir qu'un rôle à la fois : soit candidat, soit prescripteur, "
                 "soit employeur, soit inspecteur."
             )
+
+        has_approval = self.instance.approvals_wrapper.latest_approval is not None
+        if has_approval and not self.cleaned_data["is_job_seeker"]:
+            raise ValidationError(
+                "Cet utilisateur possède déjà un PASS IAE et doit donc obligatoirement être un candidat."
+            )

--- a/itou/users/admin_forms.py
+++ b/itou/users/admin_forms.py
@@ -1,0 +1,23 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from itou.users.models import User
+
+
+class UserAdminForm(forms.ModelForm):
+    class Meta:
+        model = User
+        fields = "__all__"
+
+    def clean(self):
+        roles_count = (
+            int(self.cleaned_data["is_job_seeker"])
+            + int(self.cleaned_data["is_prescriber"])
+            + int(self.cleaned_data["is_siae_staff"])
+            + int(self.cleaned_data["is_labor_inspector"])
+        )
+        if roles_count != 1:
+            raise ValidationError(
+                "Un utilisateur ne peut avoir qu'un rôle à la fois : soit candidat, soit prescripteur, "
+                "soit employeur, soit inspecteur."
+            )


### PR DESCRIPTION
### Quoi ?

Prévention de quelques erreurs de manipulation du support.
- Un utilisateur ne peut avoir qu'un seul rôle à la fois.
- Un candidat ayant déjà un PASS IAE ne peut plus être converti en un autre rôle (prescripteur etc).

### Pourquoi ?

Le support a récemment converti en prescripteurs deux comptes candidats qui avaient déjà un PASS IAE. Cela donne une donnée pourrie (un compte prescripteur n'est pas censé avoir de PASS IAE) qui ne peut que causer des erreurs 500 en aval. Résolvons la cause une fois pour toutes et non le symptome, contrairement à la médecine moderne.

### Comment ?

En bloquant ces manipulations dans l'admin.

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/10533583/137341929-bea9a780-b4a2-4823-963e-799b18b61dd5.png)

![image](https://user-images.githubusercontent.com/10533583/137341937-fc20804c-6a10-495c-943a-b49a4eafd7d3.png)

