### PR TITLE
Montée en version de seulement uwsgi sans pandas.

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,5 +1,5 @@
 -r ./base.txt
 
-uwsgi==2.0.19.1  # https://github.com/unbit/uwsgi
+uwsgi==2.0.20  # https://github.com/unbit/uwsgi
 sentry-sdk==1.4.3  # https://github.com/getsentry/sentry-python
 elastic-apm==6.4.0  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html


### PR DESCRIPTION
### Quoi ?

Montée en version de seulement uwsgi sans pandas.

### Pourquoi ?

Pour réparer le build avec le minimum de risque.