### PR TITLE
Code de communes INSEE historisés

### DIFF
--- a/itou/static/js/commune_autocomplete_field.js
+++ b/itou/static/js/commune_autocomplete_field.js
@@ -9,17 +9,19 @@ $(document).ready(() => {
 
   let autoSubmitOnEnterPressed = communeSearchInput.data('autosubmit-on-enter-pressed')
 
+  // Date / period parameter is defined with this attribute
+  let periodDate = communeSearchInput.data('period-date')
+
   function clearInput() {
     communeSearchInput.val('')
     hiddenCommuneInput.val('')
     searchButton.prop("disabled", true)
   }
 
-  function fetchBirthDate() {
-    // Try to fetch the value of the field 'birthDate' (if existing)
+  function fetchPeriodDate() {
+    // Try to fetch the value of the field 'period-date' (if existing)
     // => allows browsing in history of INSEE communes codes
-    let birthDate = $('input[name=birthdate]').val()
-    return birthDate
+    return $('input[name=' + periodDate + ']').val()
   }
 
   communeSearchInput
@@ -30,14 +32,14 @@ $(document).ready(() => {
       // Use a callback to add custom parameter 'date':
       source: function(request, response) {
         $.getJSON(communeSearchInput.data('autocomplete-source-url'), 
-          {term: request.term, date: fetchBirthDate()}, 
+          {term: request.term, date: fetchPeriodDate()}, 
           response)
       },
       autoFocus: true,
       // Make a selection on focus.
       focus: (event, ui) => {
         searchButton.prop("disabled", true)
-        fetchBirthDate()
+        fetchPeriodDate()
         hiddenCommuneInput.val(ui.item.code)  // Store commune code.
         hiddenCommuneInput.data('title', ui.item.value)  // Store commune name.
       },

--- a/itou/static/js/commune_autocomplete_field.js
+++ b/itou/static/js/commune_autocomplete_field.js
@@ -27,7 +27,12 @@ $(document).ready(() => {
     .autocomplete({
       delay: 150,
       minLength: 1,
-      source: communeSearchInput.data('autocomplete-source-url'),
+      // Use a callback to add custom parameter 'date':
+      source: function(request, response) {
+        $.getJSON(communeSearchInput.data('autocomplete-source-url'), 
+          {term: request.term, date: fetchBirthDate()}, 
+          response)
+      },
       autoFocus: true,
       // Make a selection on focus.
       focus: (event, ui) => {

--- a/itou/static/js/commune_autocomplete_field.js
+++ b/itou/static/js/commune_autocomplete_field.js
@@ -15,6 +15,13 @@ $(document).ready(() => {
     searchButton.prop("disabled", true)
   }
 
+  function fetchBirthDate() {
+    // Try to fetch the value of the field 'birthDate' (if existing)
+    // => allows browsing in history of INSEE communes codes
+    let birthDate = $('input[name=birthdate]').val()
+    return birthDate
+  }
+
   communeSearchInput
     // https://api.jqueryui.com/autocomplete/
     .autocomplete({
@@ -25,6 +32,7 @@ $(document).ready(() => {
       // Make a selection on focus.
       focus: (event, ui) => {
         searchButton.prop("disabled", true)
+        fetchBirthDate()
         hiddenCommuneInput.val(ui.item.code)  // Store commune code.
         hiddenCommuneInput.data('title', ui.item.value)  // Store commune name.
       },

--- a/itou/static/js/commune_autocomplete_field.js
+++ b/itou/static/js/commune_autocomplete_field.js
@@ -10,6 +10,7 @@ $(document).ready(() => {
   let autoSubmitOnEnterPressed = communeSearchInput.data('autosubmit-on-enter-pressed')
 
   // Date / period parameter is defined with this attribute
+  // FIXME: not clean, allow the DuetDatePicker component to have custom classes
   let periodDate = communeSearchInput.data('period-date')
 
   function clearInput() {
@@ -39,7 +40,6 @@ $(document).ready(() => {
       // Make a selection on focus.
       focus: (event, ui) => {
         searchButton.prop("disabled", true)
-        fetchPeriodDate()
         hiddenCommuneInput.val(ui.item.code)  // Store commune code.
         hiddenCommuneInput.data('title', ui.item.value)  // Store commune name.
       },

--- a/itou/www/autocomplete/views.py
+++ b/itou/www/autocomplete/views.py
@@ -73,7 +73,7 @@ def communes_autocomplete(request):
 
     try:
         dt = datetime.fromisoformat(request.GET.get("date"))
-    except:
+    except ValueError:
         # Can't extract date in iso format, use fallback
         dt = datetime.fromisoformat("1900-01-01")
 

--- a/itou/www/autocomplete/views.py
+++ b/itou/www/autocomplete/views.py
@@ -68,10 +68,14 @@ def communes_autocomplete(request):
     Returns JSON data compliant with the jQuery UI Autocomplete Widget:
     https://api.jqueryui.com/autocomplete/#option-source
     """
-
-    term = request.GET.get("term", "").strip()
-    dt = datetime.fromisoformat(request.GET.get("date", "1900-01-01"))
     communes = []
+    term = request.GET.get("term", "").strip()
+
+    try:
+        dt = datetime.fromisoformat(request.GET.get("date"))
+    except:
+        # Can't extract date in iso format, use fallback
+        dt = datetime.fromisoformat("1900-01-01")
 
     if term:
         communes = (

--- a/itou/www/autocomplete/views.py
+++ b/itou/www/autocomplete/views.py
@@ -61,6 +61,10 @@ def communes_autocomplete(request):
     """
     Autocomplete endpoint for INSEE communes (ASP ref. files)
 
+    Slight variation : a `date` parameter is send with search term
+    in order to get valid INSEE codes (with this date within a period between
+    commune.start_date and commune.end_date)
+
     Returns JSON data compliant with the jQuery UI Autocomplete Widget:
     https://api.jqueryui.com/autocomplete/#option-source
     """
@@ -71,8 +75,8 @@ def communes_autocomplete(request):
 
     if term:
         communes = (
-            Commune.objects.filter(start_date__gt=dt)
-            .filter(Q(end_date=None) | Q(end_date__lt=dt))
+            Commune.objects.filter(start_date__lte=dt)
+            .filter(Q(end_date=None) | Q(end_date__gt=dt))
             .annotate(similarity=TrigramSimilarity("name", term))
             .filter(similarity__gt=0.1)
             .order_by("-similarity")

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -62,6 +62,7 @@ class NewEmployeeRecordStep1Form(forms.ModelForm):
             attrs={
                 "class": "js-commune-autocomplete-input form-control",
                 "data-autocomplete-source-url": COMMUNE_AUTOCOMPLETE_SOURCE_URL,
+                "data-period-date": "birthdate",
                 "data-autosubmit-on-enter-pressed": 0,
                 "placeholder": "Nom de la commune",
                 "autocomplete": "off",

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -54,6 +54,12 @@ class NewEmployeeRecordStep1Form(forms.ModelForm):
         "birth_country",
     ]
 
+    # FIXME:
+    # `data-period-date` class attribute should not be on this component
+    # but on `DuetDatePickerWidget`
+    # For the moment :
+    # - adding custom classes attrs via `widget.attrs` on datepicker does not work
+    # - keep using the autocomplete as "holder" of the period information
     insee_commune = forms.CharField(
         label="Commune de naissance",
         required=False,

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -210,6 +210,7 @@ def create_step_2(request, job_application_id, template_name="employee_record/cr
         "job_application": job_application,
         "form": form,
         "profile": profile,
+        "job_seeker": job_seeker,
         "address_updated_by_user": address_updated_by_user,
         "maps_url": maps_url,
         "steps": STEPS,


### PR DESCRIPTION
### Quoi ?

Modification de l'auto-complétion lors de la première étape de saisie des fiches salarié. 

### Pourquoi ?

Suite à une imprécision dans le cahier des charges, l'implémentation d'une vérification d'existence du code INSEE **à la date de naissance** du salarié n'a pas été effectuée.

### Comment ?

Lors de l'auto-complétion de la commune sur le premier écran de saisie,
la date de naissance du salarié est transmise en paramètre à l'URL de complétion (query param `date`).

Si aucune date n'est trouvée dans le formulaire, le 01/01/1900 est pris pour borne basse de la période (minima dans les référentiels ASP).

Les résultats sont filtrés pour ne ressortir que les codes existant à la date de naissance du salarié.