### PR TITLE
Mise à jour de l'agent Elastic APM

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -35,15 +35,17 @@ ALLOW_POPULATING_METABASE = True
 # DRF Browseable API renderer is not available in production
 REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] = ["rest_framework.renderers.JSONRenderer"]
 
-# # Active Elastic APM metrics
-# # See https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html
-# INSTALLED_APPS += ["elasticapm.contrib.django"]  # noqa F405
-#
-# ELASTIC_APM = {
-#     "SERVICE_NAME": "itou-django",
-#     "SERVER_URL": os.environ.get("APM_SERVER_URL", ""),
-#     "SECRET_TOKEN": os.environ.get("APM_AUTH_TOKEN", ""),
-#     "ENVIRONMENT": "prod",
-#     "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
-#     "TRANSACTION_IGNORE_URLS": ["/approvals/download/*"],  # to avoid `httpx` error
-# }
+# Active Elastic APM metrics
+# See https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html
+INSTALLED_APPS += ["elasticapm.contrib.django"]  # noqa F405
+
+ELASTIC_APM = {
+    "ENABLED": os.environ.get("APM_ENABLED", True),
+    "SERVICE_NAME": "itou-django",
+    "SERVICE_VERSION": os.environ.get("COMMIT_ID", None),
+    "SERVER_URL": os.environ.get("APM_SERVER_URL", ""),
+    "SECRET_TOKEN": os.environ.get("APM_AUTH_TOKEN", ""),
+    "ENVIRONMENT": "prod",
+    "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
+    "TRANSACTION_SAMPLE_RATE": 0.1,
+}

--- a/config/settings/review_apps.py
+++ b/config/settings/review_apps.py
@@ -28,15 +28,17 @@ sentry_init(dsn=os.environ["SENTRY_DSN_STAGING"])
 
 SHOW_TEST_ACCOUNTS_BANNER = True
 
-# # Active Elastic APM metrics
-# # See https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html
-# INSTALLED_APPS += ["elasticapm.contrib.django"]  # noqa F405
-#
-# ELASTIC_APM = {
-#     "SERVICE_NAME": "itou-django",
-#     "SERVER_URL": os.environ.get("APM_SERVER_URL", ""),
-#     "SECRET_TOKEN": os.environ.get("APM_AUTH_TOKEN", ""),
-#     "ENVIRONMENT": "review",
-#     "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
-#     "TRANSACTION_IGNORE_URLS": ["/approvals/download/*"],  # to avoid `httpx` error
-# }
+# Active Elastic APM metrics
+# See https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html
+INSTALLED_APPS += ["elasticapm.contrib.django"]  # noqa F405
+
+ELASTIC_APM = {
+    "ENABLED": os.environ.get("APM_ENABLED", True),
+    "SERVICE_NAME": "itou-django",
+    "SERVICE_VERSION": os.environ.get("COMMIT_ID", None),
+    "SERVER_URL": os.environ.get("APM_SERVER_URL", ""),
+    "SECRET_TOKEN": os.environ.get("APM_AUTH_TOKEN", ""),
+    "ENVIRONMENT": "review",
+    "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
+    "TRANSACTION_SAMPLE_RATE": 1,
+}

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -23,8 +23,6 @@ from itou.www.approvals_views.forms import DeclareProlongationForm, PoleEmploiAp
 def approval_as_pdf(request, job_application_id, template_name="approvals/approval_as_pdf.html"):
     """
     Displays the approval in pdf format
-
-    Warning: this view is temporarily excluded from the Elastic APM to avoid an error during the stream type httpx call
     """
     siae = get_current_siae_or_404(request)
 

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -2,4 +2,4 @@
 
 uwsgi==2.0.19.1  # https://github.com/unbit/uwsgi
 sentry-sdk==1.4.3  # https://github.com/getsentry/sentry-python
-elastic-apm==6.4.0  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html
+elastic-apm==6.6.0  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html


### PR DESCRIPTION
### Quoi ?

Mise à jour de l'agent Elastic APM

### Pourquoi ?

Pour corriger l'erreur levée avec `httpx`

### Comment ?

En passant le paquet `elastic-apm` à la version 6.6.0