### PR TITLE
Redirection de communaute.inclusion… vers forum.inclusion…

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -1,5 +1,7 @@
+import os
+
 from ._sentry import sentry_init
-from .base import *
+from .base import *  # noqa: F403
 
 
 # See `itou.utils.new_dns.middleware.NewDnsRedirectMiddleware`.
@@ -8,7 +10,7 @@ ALLOWED_HOSTS = [
     "inclusion.beta.gouv.fr",
     "emploi.inclusion.beta.gouv.fr",
     "emplois.inclusion.beta.gouv.fr",
-    "forum.inclusion.beta.gouv.fr",
+    "communaute.inclusion.beta.gouv.fr",
 ]
 
 DATABASES = {
@@ -33,7 +35,7 @@ sentry_init(dsn=os.environ["SENTRY_DSN_PROD"])
 ALLOW_POPULATING_METABASE = True
 
 # DRF Browseable API renderer is not available in production
-REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] = ["rest_framework.renderers.JSONRenderer"]
+REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] = ["rest_framework.renderers.JSONRenderer"]  # noqa F405
 
 # Active Elastic APM metrics
 # See https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -10,7 +10,6 @@ ALLOWED_HOSTS = [
     "inclusion.beta.gouv.fr",
     "emploi.inclusion.beta.gouv.fr",
     "emplois.inclusion.beta.gouv.fr",
-    "communaute.inclusion.beta.gouv.fr",
 ]
 
 DATABASES = {

--- a/itou/utils/new_dns/middleware.py
+++ b/itou/utils/new_dns/middleware.py
@@ -23,9 +23,6 @@ class NewDnsRedirectMiddleware:
         elif host == "staging.inclusion.beta.gouv.fr":
             new_host = "staging.emplois.inclusion.beta.gouv.fr"
 
-        elif host == "communaute.inclusion.beta.gouv.fr":
-            new_host = "forum.inclusion.beta.gouv.fr"
-
         if new_host:
             return HttpResponsePermanentRedirect(f"https://{new_host}{request.get_full_path()}")
 

--- a/itou/utils/new_dns/middleware.py
+++ b/itou/utils/new_dns/middleware.py
@@ -23,8 +23,8 @@ class NewDnsRedirectMiddleware:
         elif host == "staging.inclusion.beta.gouv.fr":
             new_host = "staging.emplois.inclusion.beta.gouv.fr"
 
-        elif host == "forum.inclusion.beta.gouv.fr":
-            new_host = "communaute.inclusion.beta.gouv.fr"
+        elif host == "communaute.inclusion.beta.gouv.fr":
+            new_host = "forum.inclusion.beta.gouv.fr"
 
         if new_host:
             return HttpResponsePermanentRedirect(f"https://{new_host}{request.get_full_path()}")


### PR DESCRIPTION
### Quoi ?

Modification des redirections vers le C3. 

### Pourquoi ?

Changement dans les noms de domaines. Dans un premier temps, on veut que l’adresse actuelle communaute.inclusion… pointe vers forum.inclusion (sur son ancienne sous domaine, d’où le code déjà existant).
Dans un second temps, nous enleverons cette redirection, communaute.inclusion hébergera sa propre application et gèrera les redirections.

### Comment ?

Modification du middleware existant

### Autre

PR à merger de manière synchro avec le changement de domaine de notre discourse afin de limiter le downtime sur le dns communaute.inclusion.
