### PR TITLE
Correction de la création de comptes demandeurs via l’admin

### DIFF
--- a/itou/users/admin_forms.py
+++ b/itou/users/admin_forms.py
@@ -21,9 +21,10 @@ class UserAdminForm(forms.ModelForm):
                 "Un utilisateur ne peut avoir qu'un rôle à la fois : soit candidat, soit prescripteur, "
                 "soit employeur, soit inspecteur."
             )
-
-        has_approval = self.instance.approvals_wrapper.latest_approval is not None
-        if has_approval and not self.cleaned_data["is_job_seeker"]:
-            raise ValidationError(
-                "Cet utilisateur possède déjà un PASS IAE et doit donc obligatoirement être un candidat."
-            )
+        # We may not necessarily have an approvals_wrapper during account creation
+        if self.instance.approvals_wrapper:
+            has_approval = self.instance.approvals_wrapper.latest_approval is not None
+            if has_approval and not self.cleaned_data["is_job_seeker"]:
+                raise ValidationError(
+                    "Cet utilisateur possède déjà un PASS IAE et doit donc obligatoirement être un candidat."
+                )


### PR DESCRIPTION
### Pourquoi ?

Quand `approvals_wrapper` est vide, la création plante, ce qui bloque le support

### Comment ?

En prenant plus de précautions avant d’accéder à `latest_approval`