### PR TITLE
Suppression des contrôles sur la date de fin d'embauche et la durée maximum d'un PASS IAE

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -275,7 +275,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
 
     ERROR_START_IN_PAST = "Il n'est pas possible d'antidater un contrat. Indiquez une date dans le futur."
     ERROR_END_IS_BEFORE_START = "La date de fin du contrat doit être postérieure à la date de début."
-    ERROR_DURATION_TOO_LONG = "La date de fin du contrat ne peut pas dépasser celle du PASS IAE : %s."
     ERROR_START_AFTER_APPROVAL_END = (
         "Attention, le PASS IAE sera expiré lors du début du contrat. Veuillez modifier la date de début."
     )

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -304,20 +304,6 @@ class AcceptForm(forms.ModelForm):
         if hiring_end_at < hiring_start_at:
             raise forms.ValidationError(JobApplication.ERROR_END_IS_BEFORE_START)
 
-        # Ensure that hiring end does not exceed a PASS IAE end date.
-        if self.instance.to_siae.is_subject_to_eligibility_rules:
-
-            max_end_at = Approval.get_default_end_date(hiring_start_at)
-
-            if self.instance.job_seeker.approvals_wrapper.has_valid:
-                in_progress_approval_end_at = (
-                    self.instance.job_seeker.approvals_wrapper.latest_approval.extended_end_at
-                )
-                max_end_at = min(max_end_at, in_progress_approval_end_at)
-
-            if hiring_end_at > max_end_at:
-                raise forms.ValidationError(JobApplication.ERROR_DURATION_TOO_LONG % max_end_at.strftime("%d/%m/%Y"))
-
         return cleaned_data
 
 


### PR DESCRIPTION
### Quoi ?

Suppression des contrôles sur la date de fin d'embauche et la durée maximum d'un PASS IAE (ajoutés dans #666).

### Pourquoi ?

> Maintenant que le module de prolongation est opérationnel, il ne faut plus bloquer.

> Nous ne sommes pas garants des dates des contrats, donc c'est à l'employeur de s'assurer que la durée du contrat sera couverte.