### PR TITLE
Petit boost admin

### DIFF
--- a/itou/eligibility/admin.py
+++ b/itou/eligibility/admin.py
@@ -65,7 +65,7 @@ class EligibilityDiagnosisAdmin(admin.ModelAdmin):
         "is_valid",
         "is_considered_valid",
     )
-    search_fields = ("job_seeker__email", "author__email")
+    search_fields = ("pk", "job_seeker__email", "author__email")
     inlines = (AdministrativeCriteriaInline,)
 
     def is_valid(self, obj):

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -168,6 +168,7 @@ class SiaeConvention(admin.ModelAdmin):
     list_filter = ("kind", "is_active")
     raw_id_fields = ("reactivated_by",)
     readonly_fields = (
+        "asp_id",
         "kind",
         "siret_signature",
         "deactivated_at",
@@ -183,6 +184,7 @@ class SiaeConvention(admin.ModelAdmin):
                 "fields": (
                     "kind",
                     "siret_signature",
+                    "asp_id",
                 )
             },
         ),

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -20,6 +20,7 @@ class JobsInline(admin.TabularInline):
     model = models.Siae.jobs.through
     extra = 1
     raw_id_fields = ("appellation",)
+    readonly_fields = ("created_at", "updated_at")
 
 
 class FinancialAnnexesInline(admin.TabularInline):

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -13,6 +13,7 @@ from itou.siaes.admin_forms import SiaeAdminForm
 
 class SiaeMembersInline(MembersInline):
     model = models.Siae.members.through
+    readonly_fields = ("is_active", "created_at", "updated_at", "updated_by", "joined_at", "notifications")
 
 
 class JobsInline(admin.TabularInline):

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -88,6 +88,7 @@ class InstitutionMembershipInline(admin.TabularInline):
         "is_active",
         "created_at",
         "updated_at",
+        "updated_by",
     )
     can_delete = True
     fk_name = "user"

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -26,6 +26,7 @@ class SiaeMembershipInline(admin.TabularInline):
         "created_at",
         "updated_at",
         "updated_by",
+        "notifications",
     )
     can_delete = True
     show_change_link = True

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -18,7 +18,6 @@ class SiaeMembershipInline(admin.TabularInline):
     extra = 0
     raw_id_fields = ("siae",)
     readonly_fields = (
-        "siae",
         "siae_id_link",
         "joined_at",
         "is_admin",
@@ -50,7 +49,6 @@ class PrescriberMembershipInline(admin.TabularInline):
     extra = 0
     raw_id_fields = ("organization",)
     readonly_fields = (
-        "organization",
         "organization_id_link",
         "joined_at",
         "is_admin",
@@ -84,7 +82,6 @@ class InstitutionMembershipInline(admin.TabularInline):
         "updated_by",
     )
     readonly_fields = (
-        "institution",
         "institution_id_link",
         "joined_at",
         "is_admin",

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -176,7 +176,10 @@ class ItouUserAdmin(UserAdmin):
         "birth_place",
         "birth_country",
     )
-    search_fields = UserAdmin.search_fields + ("pk",)
+    search_fields = UserAdmin.search_fields + (
+        "pk",
+        "nir",
+    )
     readonly_fields = ("pk",)
 
     fieldsets = UserAdmin.fieldsets + (


### PR DESCRIPTION
### Quoi ?

Un batch d'améliorations mineures.

#### Admin des diagnostics

- Permettre la recherche par PK (demande de Sarah).

#### Admin des utilisateurs

- Permettre la recherche par NIR (demande de Sarah).
- Bugfix sur le champ notifications au niveau des structures qui était éditable sans raison et prenait trop de place.
- Bugfix sur l'ajout de nouvelles memberships qui n'était pas possible (structures+organisations+institutions) car le champ PK n'était pas éditable.
- Bugfix sur le champ "modifié par" au niveau des institutions qui était éditable sans raison.

#### Admin des conventions

- Montrer l'ID ASP de structure ASP. Logique puisqu'on le montre déjà côté FS.

#### Admin des structures

- Bugfix sur le champ notifications qui était éditable sans raison et prenait trop de place.
- Bugfix sur les fiches de poste : les champs "date de création" et "date de modification" ne sont plus éditables.
