### PR TITLE
Correction de la configuration des cronjobs

### DIFF
--- a/.github/workflows/imports-asp.yml
+++ b/.github/workflows/imports-asp.yml
@@ -74,7 +74,7 @@ jobs:
       run: |
         $CLEVER_CLI link $IMPORT_APP_NAME --org $ITOU_ORGANIZATION_NAME
         $CLEVER_CLI service link-addon c1-imports-config
-        $CLEVER_CLI service link-addon c1-prod-config
+        $CLEVER_CLI service link-addon c1-fast-machine-config
         $CLEVER_CLI service link-addon c1-prod-database-encrypted
         $CLEVER_CLI service link-addon c1-itou-redis
 

--- a/.github/workflows/populate-metabase.yml
+++ b/.github/workflows/populate-metabase.yml
@@ -76,7 +76,7 @@ jobs:
     - name: 🗺 Add environment variables and addons to the app
       run: |
         $CLEVER_CLI link $CRON_TASK_APP_NAME --org $CRON_APPS_ORGANIZATION_NAME
-        $CLEVER_CLI service link-addon c1-prod-config
+        $CLEVER_CLI service link-addon c1-fast-machine-config
         $CLEVER_CLI service link-addon c1-prod-database-encrypted
         $CLEVER_CLI service link-addon c1-itou-redis
 


### PR DESCRIPTION
### Quoi ?

Correction de la configuration des cronjobs.
Ils doivent utiliser `c1-fast-machine-config` et non `c1-prod-config`.
Sans quoi les cronjobs se mettent à envoyer des Fiches Salarié !
Voir [ce thread](https://itou-inclusion.slack.com/archives/CQ6D0QPPZ/p1635849885014500).