### PR TITLE
Les employeurs peuvent prolonger un PASS IAE sans l'avis d'un prescripteur habilité pour deux motifs

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -672,6 +672,11 @@ class Prolongation(models.Model):
         },
     }
 
+    REASONS_NOT_NEED_PRESCRIBER_OPINION = (
+        Reason.SENIOR_CDI,
+        Reason.COMPLETE_TRAINING,
+    )
+
     approval = models.ForeignKey(Approval, verbose_name="PASS IAE", on_delete=models.CASCADE)
     start_at = models.DateField(verbose_name="Date de début", default=timezone.localdate, db_index=True)
     end_at = models.DateField(verbose_name="Date de fin", default=timezone.localdate, db_index=True)

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -1,4 +1,5 @@
 {% extends "layout/content_small.html" %}
+{% load js_filters %}
 {% load bootstrap4 %}
 
 {% block title %}Déclarer une prolongation de PASS IAE{{ block.super }}{% endblock %}
@@ -129,7 +130,7 @@
     {# Clicking on a reason that does not require the opinion of a prescriber hide email field  #}
     <script type="text/javascript">
         $(document).ready(() => {
-            var reasons_not_need_prescriber_opinion = ["{{ form.reasons_not_need_prescriber_opinion|join:'", "' }}"];
+            var reasons_not_need_prescriber_opinion = {{ form.reasons_not_need_prescriber_opinion|js }};
             $('#js-field-email').css("display", "none");
             
             function toggle_email_field_visibility() {

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -26,7 +26,17 @@
 
             {% csrf_token %}
 
-            {% bootstrap_form form alert_error_type="all" %}
+            {% bootstrap_form_errors form type="all" %}
+
+            {% bootstrap_field form.reason %}
+    
+            {% bootstrap_field form.end_at %}
+    
+            {% bootstrap_field form.reason_explanation %}
+    
+            <div id="js-field-email">
+                {% bootstrap_field form.email %}
+            </div>
 
             <p>
                 Jusqu'à la publication du décret d'application de la loi du 14 décembre 2020, vous ne pouvez solliciter qu'un conseiller Pôle emploi pour demander une prolongation.
@@ -79,11 +89,13 @@
                         jusqu'au
                         <span class="badge badge-success">{{ form.instance.end_at|date:"d/m/Y" }}</span>
                     </p>
+                    {% if form.instance.validated_by.email %}
                     <p class="card-text">
                         Un e-mail sera envoyé au prescripteur habilité ayant autorisé la prolongation :
                         <b>{{ form.instance.validated_by.get_full_name|title }}</b>
                         ({{ form.instance.validated_by.email }})
                     </p>
+                    {% endif %}
                 </div>
             </div>
 
@@ -113,4 +125,23 @@
     {{ block.super }}
     <!-- Needed to use the Datepicker JS widget. -->
     {{ form.media }}
+
+    {# Clicking on a reason that does not require the opinion of a prescriber hide email field  #}
+    <script type="text/javascript">
+        $(document).ready(() => {
+            var reasons_not_need_prescriber_opinion = ["{{ form.reasons_not_need_prescriber_opinion|join:'", "' }}"];
+            $('#js-field-email').css("display", "none");
+            
+            function toggle_email_field_visibility() {
+                const value = $('input[name="reason"]:checked').val();
+                if (reasons_not_need_prescriber_opinion.includes(value)) {
+                    $('#js-field-email').hide("slidedown");
+                } else {
+                    $('#js-field-email').show("slideup");
+                }
+            }
+            $('#id_reason input').on('change', toggle_email_field_visibility);
+            toggle_email_field_visibility();
+        });
+    </script>
 {% endblock %}

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -135,9 +135,9 @@
             function toggle_email_field_visibility() {
                 const value = $('input[name="reason"]:checked').val();
                 if (reasons_not_need_prescriber_opinion.includes(value)) {
-                    $('#js-field-email').hide("slidedown");
+                    $('#js-field-email').hide("slidedown").find('.form-group').removeClass("form-group-required");
                 } else {
-                    $('#js-field-email').show("slideup");
+                    $('#js-field-email').show("slideup").find('.form-group').addClass("form-group-required");
                 }
             }
             $('#id_reason input').on('change', toggle_email_field_visibility);

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -36,18 +36,18 @@
     
             <div id="js-field-email">
                 {% bootstrap_field form.email %}
+
+                <p>
+                    Pour enregistrer une prolongation avec ce motif, vous devez obtenir l'accord préalable d'un prescripteur habilité.
+                </p>
+
+                <p>
+                    <a href="{% url 'search:prescribers_home' %}" rel="noopener" target="_blank">
+                        Rechercher des prescripteurs
+                        {% include "includes/icon.html" with icon="external-link" title=external_link_title %}
+                    </a>
+                </p>
             </div>
-
-            <p>
-                Jusqu'à la publication du décret d'application de la loi du 14 décembre 2020, vous ne pouvez solliciter qu'un conseiller Pôle emploi pour demander une prolongation.
-            </p>
-
-            <p>
-                <a href="{% url 'search:prescribers_home' %}" rel="noopener" target="_blank">
-                    Rechercher des prescripteurs
-                    {% include "includes/icon.html" with icon="external-link" title=external_link_title %}
-                </a>
-            </p>
 
             <hr>
 

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -102,10 +102,12 @@
                             du {{ p.start_at|date:"d/m/Y" }} au {{ p.end_at|date:"d/m/Y" }}
                             <br>
                             <small>{{ p.get_reason_display }}</small>
+                            {% if p.validated_by %}
                             <br>
                             <small>
                                 Autorisation par <i>{{ p.validated_by.get_full_name|title }}</i> ({{ p.validated_by.email }})
                             </small>
+                            {% endif %}
                         </li>
                     {% endfor %}
                 </ul>

--- a/itou/utils/templatetags/js_filters.py
+++ b/itou/utils/templatetags/js_filters.py
@@ -1,0 +1,12 @@
+import json
+
+from django.template import Library
+from django.utils.safestring import mark_safe
+
+
+register = Library()
+
+
+@register.filter(is_safe=True)
+def js(obj):
+    return mark_safe(json.dumps(obj))

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -114,7 +114,8 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
             if form.cleaned_data.get("email"):
                 # Send an email w/o DB changes
                 prolongation.notify_authorized_prescriber()
-                messages.success(request, "Déclaration de prolongation enregistrée.")
+
+            messages.success(request, "Déclaration de prolongation enregistrée.")
             return HttpResponseRedirect(back_url)
 
     context = {

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -110,9 +110,11 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
             preview = True
         elif request.POST.get("save"):
             prolongation.save()
-            # Send an email w/o DB changes
-            prolongation.notify_authorized_prescriber()
-            messages.success(request, "Déclaration de prolongation enregistrée.")
+
+            if form.cleaned_data.get("email"):
+                # Send an email w/o DB changes
+                prolongation.notify_authorized_prescriber()
+                messages.success(request, "Déclaration de prolongation enregistrée.")
             return HttpResponseRedirect(back_url)
 
     context = {


### PR DESCRIPTION
### Quoi ?

Une prolongation doit pouvoir être validée sans saisie de l'email d'un prescripteur habilité.

### Pourquoi ?

Le nouveau décret précise qu'une SIAE a la possibilité de prolonger un PASS IAE sans accord préalable d'un prescripteur habilité pour 2 motifs :
- CDI conclu avec une personne âgée de + de 57 ans
- Fin de formation

### Comment ?

Retirer le champ "email d'un prescripteur habilité" si l'un des deux motifs ci-dessus a été sélectionné 

### Captures d'écran

Champs "Email" masqué pour un des deux motifs :

![Champs "Email" masqué](https://user-images.githubusercontent.com/17601807/139880091-4f540eff-21b7-49c0-8705-ec796eda5312.png)

Champs "Email" affiché pour les autres motifs :

![Champs "Email" affiché](https://user-images.githubusercontent.com/17601807/139880140-b3502289-ed83-45c7-befe-a0d358a21cf4.png)




