### PR TITLE
Le script d'import des EA est manquant dans l'import ASP hebdomadaire

### DIFF
--- a/scripts/imports-asp.sh
+++ b/scripts/imports-asp.sh
@@ -24,7 +24,6 @@ unzip -P $ASP_UNZIP_PASSWORD asp_shared_bucket/Liste_Contact_EA*.zip -d itou/sia
 # Perform the necessary data imports
 time ./manage.py populate_metabase_fluxiae --verbosity 2
 time ./manage.py import_siae --verbosity=2
-# The EA import is currently broken due to data issues
 time ./manage.py import_ea_eatt --verbosity=2
 
 # Destroy the cleartext ASP data

--- a/scripts/imports-asp.sh
+++ b/scripts/imports-asp.sh
@@ -3,9 +3,9 @@
 # This shell script is meant to be run in production as part of a github workflow.
 #
 # It runs the frequent ASP data imports:
-# - populate_metabase_fluxiae.py. 
+# - populate_metabase_fluxiae.py.
 # - import_siae.py
-# - import_ea_eatt.py 
+# - import_ea_eatt.py
 # More details about this process:
 # https://github.com/betagouv/itou-private/blob/master/docs/supportix/import_asp.md
 
@@ -25,7 +25,7 @@ unzip -P $ASP_UNZIP_PASSWORD asp_shared_bucket/Liste_Contact_EA*.zip -d itou/sia
 time ./manage.py populate_metabase_fluxiae --verbosity 2
 time ./manage.py import_siae --verbosity=2
 # The EA import is currently broken due to data issues
-# time ./manage.py import_ea_eatt --verbosity=2
+time ./manage.py import_ea_eatt --verbosity=2
 
 # Destroy the cleartext ASP data
 rm -rf itou/siaes/management/commands/data/


### PR DESCRIPTION
### Quoi ?

L'import des EA ne se fait plus me semble-t-il dans le script `import-asp.sh`

### Pourquoi ?
Le script d'import des EA a été commenté dans l'import ASP hebdomadaire depuis 2 mois.

### Autre

- J'ai exécuté le script manuellement, et il ne semble pas planter, voir [ce thread slack 👀👀](https://itou-inclusion.slack.com/archives/CQ6D0QPPZ/p1636104781076100)
- @Keirua t'as peut être d'autres infos que je n'ai pas vu ?
