### PR TITLE
[Ne pas archiver] Mise à jour des données de démo

### DIFF
--- a/itou/utils/validators.py
+++ b/itou/utils/validators.py
@@ -45,7 +45,7 @@ def validate_pole_emploi_id(pole_emploi_id):
 
 
 def validate_nir(nir):
-    # http://nourtier.net/cle_NIR/cle_NIR.htm
+    ## http://nourtier.net/cle_NIR/cle_NIR.htm
     nir = str(nir).replace(" ", "").upper()
     # Replace 2A and 2B by 19 and 18 to handle digits.
     nir = nir.replace("2A", "19").replace("2B", "18")


### PR DESCRIPTION
### Quoi ?

Les données de la démo doivent être complétées suite à l'ajout du NIR. Cette recette jetable permet aux biz devs de travailler à un nouveau jeu de données.

### Pourquoi ?

L'unicité du NIR complique la création de faux comptes candidat. Les biz devs utilisent donc le contournement « NIR provisoire » en webinaire, mais ce n'est pas idéal car cela banalise une pratique qui devrait être exceptionnelle.
Nous pourrions supprimer tous les comptes actuels chaque nuit mais le jeu de données n'est pas assez fourni. Les biz devs ont besoin de le compléter afin de couvrir tous leurs cas d'usage.
Les biz devs vont donc créer les scénarios idoines sur cette recette jetable. Quand ce sera fait, les devs feront en sorte que la base de données de démonstration soit réinitialisée tous les soirs avec ce nouveau jeu de données. 

