### PR TITLE
Prise en compte du NIR dans la déduplication

### DIFF
--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -127,24 +127,24 @@ class Command(BaseCommand):
             if len(users_with_approval) <= 1:
 
                 count_easy_cases += 1
-
-                user_with_approval = next((u for u in duplicates if u.approvals.exists()), None)
+                target = None
 
                 # Give priority to the user with a PASS IAE.
+                user_with_approval = next((u for u in duplicates if u.approvals.exists()), None)
                 if user_with_approval:
-                    self.merge_easy_cases(duplicates, target=user_with_approval)
+                    target = user_with_approval
 
                 # Handle duplicates without any PASS IAE.
                 else:
-
-                    # Give priority to the first user who already logged in.
+                    # Give priority to the first user who already logged in…
                     first_autonomous_user = next((u for u in duplicates if u.last_login), None)
                     if first_autonomous_user:
-                        self.merge_easy_cases(duplicates, target=first_autonomous_user)
-
-                    # Choose an arbitrary user to merge others into.
+                        target = first_autonomous_user
+                    # …or choose an arbitrary user to merge others into.
                     else:
-                        self.merge_easy_cases(duplicates, target=duplicates[0])
+                        target = duplicates[0]
+
+                self.merge_easy_cases(duplicates, target=target)
 
             # Hard cases.
             # More than one PASS IAE was issued for the same person.

--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -13,8 +13,21 @@ class Command(BaseCommand):
     """
     Deduplicate job seekers.
 
-    This is temporary and should be deleted after the release of the NIR
-    which should prevent duplication.
+    How are duplicates created?
+    The identification of a person was done on the basis of the `email` field.
+    But it happens that a SIAE (or a prescriber):
+    - makes a typing error in the email
+    - creates an email on the fly because job seekers do not remember their own
+    - enters a fancy email
+    - enters another family member's email
+    This results in duplicates that we try to correct when possible whith this
+    management command.
+
+    The NIR is now used to ensure the uniqueness of job seekers and should be
+    the safety pin that prevents duplicates.
+
+    This command is temporary and should be deleted as soon as a sufficient
+    number of users have a NIR.
 
     To run the command without any change in DB and have a preview of which
     accounts will be merged:

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -161,21 +161,21 @@ class ManagementCommandsTest(TestCase):
         }
 
         # Create `user1` through a job application sent by him.
-        job_app1 = JobApplicationSentByJobSeekerFactory(**kwargs)
+        job_app1 = JobApplicationSentByJobSeekerFactory(job_seeker__nir=None, **kwargs)
         user1 = job_app1.job_seeker
 
         self.assertEqual(1, user1.job_applications.count())
         self.assertEqual(job_app1.sender, user1)
 
         # Create `user2` through a job application sent by him.
-        job_app2 = JobApplicationSentByJobSeekerFactory(**kwargs)
+        job_app2 = JobApplicationSentByJobSeekerFactory(job_seeker__nir=None, **kwargs)
         user2 = job_app2.job_seeker
 
         self.assertEqual(1, user2.job_applications.count())
         self.assertEqual(job_app2.sender, user2)
 
         # Create `user3` through a job application sent by a prescriber.
-        job_app3 = JobApplicationWithEligibilityDiagnosis(**kwargs)
+        job_app3 = JobApplicationWithEligibilityDiagnosis(job_seeker__nir=None, **kwargs)
         user3 = job_app3.job_seeker
         self.assertNotEqual(job_app3.sender, user3)
         job_app3_sender = job_app3.sender  # The sender is a prescriber.

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -99,17 +99,19 @@ class ManagementCommandsTest(TestCase):
         }
 
         # Create `user1`.
-        job_app1 = JobApplicationWithApprovalFactory(**kwargs)
+        job_app1 = JobApplicationWithApprovalFactory(job_seeker__nir=None, **kwargs)
         user1 = job_app1.job_seeker
 
+        self.assertIsNone(user1.nir)
+        self.assertEqual(1, user1.approvals.count())
         self.assertEqual(1, user1.job_applications.count())
         self.assertEqual(1, user1.eligibility_diagnoses.count())
-        self.assertEqual(1, user1.approvals.count())
 
         # Create `user2`.
-        job_app2 = JobApplicationWithEligibilityDiagnosis(**kwargs)
+        job_app2 = JobApplicationWithEligibilityDiagnosis(job_seeker__nir=None, **kwargs)
         user2 = job_app2.job_seeker
 
+        self.assertIsNone(user2.nir)
         self.assertEqual(0, user2.approvals.count())
         self.assertEqual(1, user2.job_applications.count())
         self.assertEqual(1, user2.eligibility_diagnoses.count())
@@ -117,13 +119,20 @@ class ManagementCommandsTest(TestCase):
         # Create `user3`.
         job_app3 = JobApplicationWithEligibilityDiagnosis(**kwargs)
         user3 = job_app3.job_seeker
+        expected_nir = user3.nir
 
+        self.assertIsNotNone(user3.nir)
         self.assertEqual(0, user3.approvals.count())
         self.assertEqual(1, user3.job_applications.count())
         self.assertEqual(1, user3.eligibility_diagnoses.count())
 
         # Merge all users into `user1`.
         call_command("deduplicate_job_seekers", verbosity=0)
+
+        # If only one NIR exists for all the duplicates, it should
+        # be reassigned to the target account.
+        user1.refresh_from_db()
+        self.assertEqual(user1.nir, expected_nir)
 
         self.assertEqual(3, user1.job_applications.count())
         self.assertEqual(3, user1.eligibility_diagnoses.count())


### PR DESCRIPTION
### Quoi ?

Prise en compte du NIR dans la déduplication.

### Pourquoi ?

Pour traiter les doublons en tenant compte du NIR.

### Comment ?

Si un seul NIR existe pour un jeu de doublons, il est réaffecté au compte de destination de la fusion.