### PR TITLE
Mise à jour du lien vers le portail d'assistance

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -441,7 +441,7 @@ ITOU_PROTOCOL = "https"
 ITOU_FQDN = "emplois.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact@inclusion.beta.gouv.fr"
 ITOU_EMAIL_PROLONGATION = "prolongation@inclusion.beta.gouv.fr"
-ITOU_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/assistance/"
+ITOU_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/assistance"
 
 DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -3,8 +3,8 @@ Base settings to build other settings files upon.
 https://docs.djangoproject.com/en/dev/ref/settings
 """
 import datetime
-import os
 import json
+import os
 
 import pytz
 from django.utils import timezone
@@ -441,7 +441,7 @@ ITOU_PROTOCOL = "https"
 ITOU_FQDN = "emplois.inclusion.beta.gouv.fr"
 ITOU_EMAIL_CONTACT = "contact@inclusion.beta.gouv.fr"
 ITOU_EMAIL_PROLONGATION = "prolongation@inclusion.beta.gouv.fr"
-ITOU_ASSISTANCE_URL = "https://assistance.inclusion.beta.gouv.fr"
+ITOU_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/assistance/"
 
 DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"
 

--- a/itou/templates/500.html
+++ b/itou/templates/500.html
@@ -11,7 +11,7 @@
     {# Using ITOU_ASSISTANCE_URL would have required a custom error handler. #}
     <p>
         Toutefois, nous vous invitons à contacter
-        <a href="https://assistance.inclusion.beta.gouv.fr/accueil/support/"> l'assistance de la Plateforme de l'inclusion</a>
+        <a href="https://communaute.inclusion.beta.gouv.fr/assistance/"> l'assistance de la Plateforme de l'inclusion</a>
         afin que nous disposions de toutes les informations nécessaires à la résolution du problème.
     </p>
 

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -56,7 +56,7 @@
             S'il s'agit d'un nouveau contrat, vous pouvez solliciter <a href="{% url 'search:prescribers_home' %}">un prescripteur habilité</a> pour qu'il puisse vous orienter le candidat.
         </p>
         <p>
-            Si le salarié travaille actuellement dans votre structure, <a href="{{ ITOU_ASSISTANCE_URL }}/accueil/support" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet">contactez-nous {% include "includes/icon.html" with icon="external-link" %}</a>.
+            Si le salarié travaille actuellement dans votre structure, <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet">contactez-nous {% include "includes/icon.html" with icon="external-link" %}</a>.
         </p>
         <a class="btn btn-primary" href="{{ back_url }}">Nouvelle recherche</a>
     {% endif %}


### PR DESCRIPTION
### Quoi ?

Le lien était cassé (affichage d'une page blanche). Il dirige désormais vers la page d'assistance du portail de la Communauté.