### PR TITLE
Affichage d'un message d'erreur en cas de doublon DE autonome

### DIFF
--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -10,8 +10,6 @@
 
         {% csrf_token %}
 
-        {% bootstrap_form_errors form type="all" %}
-
         {% bootstrap_form form %}
 
         {% if redirect_field_value %}

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -3,7 +3,7 @@
 {% load static %}
 {% load format_filters %}
 
-{% block title %}Postuler{{ block.super }}{% endblock %}
+{% block title %}{{ block.super }}{% endblock %}
 
 {% block right_column %}
     <form method="post" action="{% url 'apply:step_check_job_seeker_nir' siae_pk=siae.pk %}" class="js-prevent-multiple-submit js-format-nir">

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -10,6 +10,8 @@
 
         {% csrf_token %}
 
+        {% bootstrap_form_errors form type="all" %}
+
         {% bootstrap_form form %}
 
         {% if redirect_field_value %}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -74,7 +74,7 @@ class CheckJobSeekerNirForm(forms.Form):
                 error_message = (
                     "Ce numéro de sécurité sociale est déjà utilisé par un autre compte. "
                     f"Merci de vous reconnecter avec l'adresse e-mail <b>{existing_account.email}</b>. "
-                    "Si vous ne vous souvenez plus de votre mot de passe, vous pouvez "
+                    "Si vous ne vous souvenez plus de votre mot de passe, vous pourrez "
                     "cliquer sur « mot de passe oublié ». "
                     f'En cas de souci, vous pouvez <a href="{settings.ITOU_ASSISTANCE_URL}" rel="noopener" '
                     'target="_blank" aria-label="Ouverture dans un nouvel onglet">nous contacter</a>.'

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 
 from dateutil.relativedelta import relativedelta
 from django import forms
@@ -18,9 +17,6 @@ from itou.siaes.models import Siae
 from itou.users.models import User
 from itou.utils.validators import validate_nir
 from itou.utils.widgets import DuetDatePickerWidget
-
-
-logger = logging.getLogger(__name__)
 
 
 class UserExistsForm(forms.Form):
@@ -82,12 +78,6 @@ class CheckJobSeekerNirForm(forms.Form):
                     "cliquer sur « mot de passe oublié ». "
                     f'En cas de souci, vous pouvez <a href="{settings.ITOU_ASSISTANCE_URL}" rel="noopener" '
                     'target="_blank" aria-label="Ouverture dans un nouvel onglet">nous contacter</a>.'
-                )
-                logger.warning(
-                    forms.ValidationError(
-                        "Un utilisateur avec ce NIR (%s) existe déjà. Email compte connecté: %s"
-                        % (existing_account.nir, self.job_seeker.email)
-                    )
                 )
                 raise forms.ValidationError(mark_safe(error_message))
         else:


### PR DESCRIPTION
### Quoi ?

Affichage d'un message d'erreur au DE autonome en cas de doublon.

### Pourquoi ?

Un DE se connecte avec son compte qui n'a pas de NIR. Il ne sait pas qu'un autre compte existe avec son NIR. Quand il tente de candidater, il est bloqué. Actuellement, une erreur 500 apparaît. Ce n'est pas sympa.

### Comment ?

Message d'erreur.

### Capture d'écran

![image](https://user-images.githubusercontent.com/6150920/141163999-c182826a-0bfe-441e-a2f4-c6b53f5c4fc5.png)

