### PR TITLE
Améliorations diverses de la mise à jour quotidienne de Metabase avec les données C1

### DIFF
--- a/.github/workflows/imports-asp.yml
+++ b/.github/workflows/imports-asp.yml
@@ -23,7 +23,7 @@ env:
   CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
   CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
   ITOU_ORGANIZATION_NAME: ${{ secrets.CLEVER_ORGANIZATION_NAME }}
-  DEPLOY_BRANCH: master_clever
+  DEPLOY_BRANCH: ${{ github.head_ref }}
   PYTHON_VERSION: 3.9
 
 jobs:

--- a/.github/workflows/populate-metabase.yml
+++ b/.github/workflows/populate-metabase.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: 🏷 Setup app name
       run:
-        echo "CRON_TASK_APP_NAME=`echo \"c1-cron-populate-$(date +%y-%m-%d-%Hh-%M)"`" >> $GITHUB_ENV
+        echo "CRON_TASK_APP_NAME=`echo \"c1-cron-daily-$(date +%y-%m-%d-%Hh-%M)"`" >> $GITHUB_ENV
 
     - name: 🏷 Setup worker command
       run:

--- a/.github/workflows/populate-metabase.yml
+++ b/.github/workflows/populate-metabase.yml
@@ -3,7 +3,8 @@ name: Populate metabase
 # Runs "populate_itou_metabase".
 # A github action takes care of the cron task that:
 # - creates a machine on demand
-# - runs the desired command through CC_RUN_SUCCEEDED_HOOK
+# - runs the desired command via a worker
+# - waits a reasonable amount of time for the script to complete
 # - destroys the machine once the update is done
 on:
   workflow_dispatch: # allows us to run this action manually
@@ -46,13 +47,9 @@ jobs:
       run:
         echo "CRON_TASK_APP_NAME=`echo \"c1-cron-populate-$(date +%y-%m-%d-%Hh-%M)"`" >> $GITHUB_ENV
 
-    # CC_RUN_SUCCEEDED_HOOK is a clever-cloud-specific environment variable.
-    # We set the command we want to run once the app is started
-    # The goal of this entire file relies on this variable !
-    # https://www.clever-cloud.com/doc/develop/build-hooks/
-    - name: 🏷 Setup post-deployment hook
+    - name: 🏷 Setup worker command
       run:
-        echo 'CC_RUN_SUCCEEDED_HOOK=./manage.py populate_metabase_itou --verbosity 2' >> $GITHUB_ENV
+        echo 'CC_WORKER_COMMAND=./manage.py populate_metabase_itou --verbosity 2' >> $GITHUB_ENV
 
     - name: 🧫 Create a cron app on Clever Cloud on a strong machine
       run: |
@@ -80,18 +77,16 @@ jobs:
         $CLEVER_CLI service link-addon c1-prod-database-encrypted
         $CLEVER_CLI service link-addon c1-itou-redis
 
-    - name: "🚀 Deploy post-deploy hook to Clever"
+    - name: 🚀 Deploy worker command to Clever
       run:
-        $CLEVER_CLI env import-vars CC_RUN_SUCCEEDED_HOOK
+        $CLEVER_CLI env import-vars CC_WORKER_COMMAND
 
-# OK, here is the tricky part: we use a hook, so in the following 2 tasks
-# we deploy and destroy the app, but in fact we sequentially:
-# - deploy the application
-# - run what’s in CC_RUN_SUCCEEDED_HOOK
-# - destroy the app once the task is over
-    - name: 🚀 Deploy to Clever Cloud
+    - name: 🚀 Deploy app to Clever Cloud
       run: $CLEVER_CLI deploy --alias $CRON_TASK_APP_NAME --branch $DEPLOY_BRANCH --force
 
-    - name: 🗑 Delete the app once the work is done
+    - name: 🕒 Wait one hour which should be more than enough for the script to complete
+      run: sleep 3600
+
+    - name: 🔪 Delete the app once the work is done
       run:
         $CLEVER_CLI delete --yes

--- a/.github/workflows/populate-metabase.yml
+++ b/.github/workflows/populate-metabase.yml
@@ -27,7 +27,7 @@ env:
   CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
   CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
   CRON_APPS_ORGANIZATION_NAME: ${{ secrets.CLEVER_CRON_APPS_ORGANIZATION_NAME }}
-  DEPLOY_BRANCH: master_clever
+  DEPLOY_BRANCH: ${{ github.head_ref }}
   PYTHON_VERSION: 3.9
 
 jobs:

--- a/itou/metabase/management/commands/_database_psycopg2.py
+++ b/itou/metabase/management/commands/_database_psycopg2.py
@@ -14,6 +14,10 @@ class MetabaseDatabaseCursor:
             dbname=settings.METABASE_DATABASE,
             user=settings.METABASE_USER,
             password=settings.METABASE_PASSWORD,
+            keepalives=1,
+            keepalives_idle=30,
+            keepalives_interval=5,
+            keepalives_count=5,
         )
         self.cursor = self.connection.cursor()
         return self.cursor, self.connection

--- a/itou/metabase/management/commands/_job_descriptions.py
+++ b/itou/metabase/management/commands/_job_descriptions.py
@@ -16,9 +16,9 @@ TABLE_COLUMNS = [
         "fn": lambda o: o.appellation.rome.name,
     },
     {
-        "name": "active",
+        "name": "recrutement_ouvert",
         "type": "boolean",
-        "comment": "Fiche de poste active à ce jour",
+        "comment": "Recrutement ouvert à ce jour",
         "fn": lambda o: o.is_active,
     },
     {"name": "id_employeur", "type": "integer", "comment": "ID employeur", "fn": lambda o: o.siae.id},

--- a/itou/metabase/management/commands/_job_descriptions.py
+++ b/itou/metabase/management/commands/_job_descriptions.py
@@ -51,4 +51,10 @@ TABLE_COLUMNS += [
         "comment": "Date de création",
         "fn": lambda o: o.created_at,
     },
+    {
+        "name": "date_dernière_modification",
+        "type": "date",
+        "comment": "Date de dernière modification",
+        "fn": lambda o: o.updated_at,
+    },
 ]

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -165,7 +165,9 @@ class Command(BaseCommand):
                     "name": "date_mise_à_jour_metabase",
                     "type": "date",
                     "comment": "Date de dernière mise à jour de Metabase",
-                    "fn": lambda o: timezone.now(),
+                    # As metabase daily updates run typically every night after midnight, the last day with
+                    # complete data is yesterday, not today.
+                    "fn": lambda o: timezone.now() + timezone.timedelta(days=-1),
                 },
             ]
 

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -147,94 +147,100 @@ class Command(BaseCommand):
         new_table_name = f"{table_name}_new"
         old_table_name = f"{table_name}_old"
 
-        self.cleanup_tables(table_name)
+        with MetabaseDatabaseCursor() as (cur, conn):
+            self.cur = cur
+            self.conn = conn
 
-        if self.dry_run:
-            total_rows = sum(
-                [min(queryset.count(), settings.METABASE_DRY_RUN_ROWS_PER_QUERYSET) for queryset in querysets]
-            )
-        else:
-            total_rows = sum([queryset.count() for queryset in querysets])
+            self.cleanup_tables(table_name)
 
-        table_columns += [
-            {
-                "name": "date_mise_à_jour_metabase",
-                "type": "date",
-                "comment": "Date de dernière mise à jour de Metabase",
-                "fn": lambda o: timezone.now(),
-            },
-        ]
+            if self.dry_run:
+                total_rows = sum(
+                    [min(queryset.count(), settings.METABASE_DRY_RUN_ROWS_PER_QUERYSET) for queryset in querysets]
+                )
+            else:
+                total_rows = sum([queryset.count() for queryset in querysets])
 
-        # Transform boolean fields into 0-1 integer fields as
-        # metabase cannot sum or average boolean columns ¯\_(ツ)_/¯
-        for c in table_columns:
-            if c["type"] == "boolean":
-                c["type"] = "integer"
-                c["fn"] = compose(convert_boolean_to_int, c["fn"])
+            table_columns += [
+                {
+                    "name": "date_mise_à_jour_metabase",
+                    "type": "date",
+                    "comment": "Date de dernière mise à jour de Metabase",
+                    "fn": lambda o: timezone.now(),
+                },
+            ]
 
-        self.log(f"Injecting {total_rows} rows with {len(table_columns)} columns into table {table_name}:")
+            # Transform boolean fields into 0-1 integer fields as
+            # metabase cannot sum or average boolean columns ¯\_(ツ)_/¯
+            for c in table_columns:
+                if c["type"] == "boolean":
+                    c["type"] = "integer"
+                    c["fn"] = compose(convert_boolean_to_int, c["fn"])
 
-        # Create table.
-        create_table_query = sql.SQL("CREATE TABLE {new_table_name} ({fields_with_type})").format(
-            new_table_name=sql.Identifier(new_table_name),
-            fields_with_type=sql.SQL(",").join(
-                [sql.SQL(" ").join([sql.Identifier(c["name"]), sql.SQL(c["type"])]) for c in table_columns]
-            ),
-        )
-        self.cur.execute(create_table_query)
+            self.log(f"Injecting {total_rows} rows with {len(table_columns)} columns into table {table_name}:")
 
-        self.commit()
-
-        # Add comments on table columns.
-        for c in table_columns:
-            assert set(c.keys()) == set(["name", "type", "comment", "fn"])
-            column_name = c["name"]
-            column_comment = c["comment"]
-            comment_query = sql.SQL("comment on column {new_table_name}.{column_name} is {column_comment}").format(
+            # Create table.
+            create_table_query = sql.SQL("CREATE TABLE {new_table_name} ({fields_with_type})").format(
                 new_table_name=sql.Identifier(new_table_name),
-                column_name=sql.Identifier(column_name),
-                column_comment=sql.Literal(column_comment),
+                fields_with_type=sql.SQL(",").join(
+                    [sql.SQL(" ").join([sql.Identifier(c["name"]), sql.SQL(c["type"])]) for c in table_columns]
+                ),
             )
-            self.cur.execute(comment_query)
+            self.cur.execute(create_table_query)
 
-        self.commit()
+            self.commit()
 
-        if extra_object:
-            # Insert extra object without counter/tqdm for simplicity.
-            self.inject_chunk(table_columns=table_columns, chunk=[extra_object], new_table_name=new_table_name)
+            # Add comments on table columns.
+            for c in table_columns:
+                assert set(c.keys()) == set(["name", "type", "comment", "fn"])
+                column_name = c["name"]
+                column_comment = c["comment"]
+                comment_query = sql.SQL("comment on column {new_table_name}.{column_name} is {column_comment}").format(
+                    new_table_name=sql.Identifier(new_table_name),
+                    column_name=sql.Identifier(column_name),
+                    column_comment=sql.Literal(column_comment),
+                )
+                self.cur.execute(comment_query)
 
-        with tqdm(total=total_rows) as progress_bar:
-            for queryset in querysets:
-                injections = 0
-                total_injections = queryset.count()
-                if self.dry_run:
-                    total_injections = min(total_injections, settings.METABASE_DRY_RUN_ROWS_PER_QUERYSET)
+            self.commit()
 
-                # Insert rows by batch of settings.METABASE_INSERT_BATCH_SIZE.
-                for chunk_qs in chunked_queryset(queryset, chunk_size=settings.METABASE_INSERT_BATCH_SIZE):
-                    injections_left = total_injections - injections
-                    if chunk_qs.count() > injections_left:
-                        chunk_qs = chunk_qs[:injections_left]
-                    self.inject_chunk(table_columns=table_columns, chunk=chunk_qs, new_table_name=new_table_name)
-                    injections += chunk_qs.count()
-                    progress_bar.update(chunk_qs.count())
+            if extra_object:
+                # Insert extra object without counter/tqdm for simplicity.
+                self.inject_chunk(table_columns=table_columns, chunk=[extra_object], new_table_name=new_table_name)
 
-                # Trigger garbage collection to optimize memory use.
-                gc.collect()
+            with tqdm(total=total_rows) as progress_bar:
+                for queryset in querysets:
+                    injections = 0
+                    total_injections = queryset.count()
+                    if self.dry_run:
+                        total_injections = min(total_injections, settings.METABASE_DRY_RUN_ROWS_PER_QUERYSET)
 
-        # Swap new and old table nicely to minimize downtime.
-        self.cur.execute(
-            sql.SQL("ALTER TABLE IF EXISTS {} RENAME TO {}").format(
-                sql.Identifier(table_name), sql.Identifier(old_table_name)
+                    # Insert rows by batch of settings.METABASE_INSERT_BATCH_SIZE.
+                    for chunk_qs in chunked_queryset(queryset, chunk_size=settings.METABASE_INSERT_BATCH_SIZE):
+                        injections_left = total_injections - injections
+                        if chunk_qs.count() > injections_left:
+                            chunk_qs = chunk_qs[:injections_left]
+                        self.inject_chunk(table_columns=table_columns, chunk=chunk_qs, new_table_name=new_table_name)
+                        injections += chunk_qs.count()
+                        progress_bar.update(chunk_qs.count())
+
+                    # Trigger garbage collection to optimize memory use.
+                    gc.collect()
+
+            # Swap new and old table nicely to minimize downtime.
+            self.cur.execute(
+                sql.SQL("ALTER TABLE IF EXISTS {} RENAME TO {}").format(
+                    sql.Identifier(table_name), sql.Identifier(old_table_name)
+                )
             )
-        )
-        self.cur.execute(
-            sql.SQL("ALTER TABLE {} RENAME TO {}").format(sql.Identifier(new_table_name), sql.Identifier(table_name))
-        )
-        self.commit()
-        self.cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(old_table_name)))
-        self.commit()
-        self.log("")
+            self.cur.execute(
+                sql.SQL("ALTER TABLE {} RENAME TO {}").format(
+                    sql.Identifier(new_table_name), sql.Identifier(table_name)
+                )
+            )
+            self.commit()
+            self.cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(old_table_name)))
+            self.commit()
+            self.log("")
 
     def populate_siaes(self):
         """
@@ -434,21 +440,19 @@ class Command(BaseCommand):
         if not settings.ALLOW_POPULATING_METABASE:
             self.log("Populating metabase is not allowed in this environment.")
             return
-        with MetabaseDatabaseCursor() as (cur, conn):
-            self.cur = cur
-            self.conn = conn
-            self.populate_siaes()
-            self.populate_job_descriptions()
-            self.populate_organizations()
-            self.populate_job_seekers()
-            self.populate_job_applications()
-            self.populate_selected_jobs()
-            self.populate_approvals()
-            self.populate_rome_codes()
-            self.populate_insee_codes()
-            self.populate_departments()
 
-            self.report_data_inconsistencies()
+        self.populate_siaes()
+        self.populate_job_descriptions()
+        self.populate_organizations()
+        self.populate_job_seekers()
+        self.populate_job_applications()
+        self.populate_selected_jobs()
+        self.populate_approvals()
+        self.populate_rome_codes()
+        self.populate_insee_codes()
+        self.populate_departments()
+
+        self.report_data_inconsistencies()
 
     def handle(self, dry_run=False, **options):
         self.set_logger(options.get("verbosity"))


### PR DESCRIPTION
## Quoi ?

Améliorations diverses de la mise à jour quotidienne de Metabase avec les données C1.

Au menu :

### Investigation du timeout de 47 minutes (chez clever uniquement, pas en local dev)

Toutes nos github actions qui lancent une instance clever et un script dessus via un `CC_RUN_SUCCEEDED_HOOK` se heurtent à un timeout non documenté de 47 minutes. Même un `CC_RUN_SUCCEEDED_HOOK=sleep 3600` suffit à reproduire systématiquement le problème.

Clever reconnait que ce hook n'est pas fait pour des scripts longs. A la place, ils recommendent d'utiliser soit un worker, soit un cron, soit du ssh programmatique.

Le SSH programmatique est techniquement possible (e.g. `echo sleep 300 | $CLEVER_CLI ssh --alias $CRON_TASK_APP_NAME`) mais risque d'ajouter pas mal de complexité et de soucis de sécurité pour déployer une clé SSH dans la github action.  Cette clé SSH donnant accès SSH à toutes nos instances o_O. Du coup le SSH programmatique n'est pas ma direction favorite pour le moment.

Le cron serait similaire au worker avec de la complexité en plus pour rien, donc autant utiliser un worker.

Cette PR contient une V0.1 de worker fonctionnel.

![image](https://user-images.githubusercontent.com/10533583/141472761-7dd55fad-0d19-4b75-b706-d0fb70c10ae5.png)

[Documentation des workers clever.](https://github.com/CleverCloud/doc.clever-cloud.com/blob/ea0db321909e9a3473075681011d9d31fbd1a06c/develop/workers.md)

On lance le worker puis on attend un temps suffisant (60 minutes) puis on kill l'instance.

C'est très moche pour plein de raisons mais au moins ça débloque.

Dans la PR qui va venir juste après, je vais bosser deux axes d'amélioration :

- rajouter des notifs slack en début et fin de script pour qu'on soit moins aveugles
- au lieu d'attendre à l'aveugle, faire que le script utilise lui-même la CLI clever pour tuer sa propre instance en fin de job

### Investigation d'erreurs de connection db (en local dev uniquement, pas chez clever)

En local dev uniquement j'ai eu plusieurs fois un `psycopg2.OperationalError: SSL SYSCALL error: EOF detected`.

J'ai fait ces 2 changements et depuis plus de problème en local dev :

![image](https://user-images.githubusercontent.com/10533583/141473594-a08fee74-b3f2-4ff7-af70-63ed859e9b56.png)

### Rendre la branche du cronjob plus dynamique

Avant ce changement, si on lancait la github action à la main sur une branche custom, cela tournait en fait quand même sur master car il fallait aussi aller changer la branche dans le code. Avec ce fix, la branche est choisie dynamiquement.

![image](https://user-images.githubusercontent.com/10533583/141473707-0e301eaa-4eff-4e41-8975-c90834b4a7d8.png)

### Renommage de l'instance clever du cron quotidien

`cron-populate` était très ambigüe (populate itou ou populate fluxiae ?)

`cron-daily` est succint et non ambigüe

### Trois tickets du C2

- renommage d'un champ
- ajout d'un champ date de dernière modification
- correctif de la date de mise à jour Metabase

![image](https://user-images.githubusercontent.com/10533583/141473992-01e6e13d-d508-4056-9fae-8936ef2d47ec.png)


