### PR TITLE
Evolutions de la mise à jour quotidienne de Metabase avec les données C1

### DIFF
--- a/.github/workflows/imports-asp.yml
+++ b/.github/workflows/imports-asp.yml
@@ -1,4 +1,4 @@
-name: Imports ASP
+name: 🐡 Imports ASP
 
 # Runs the various ASP data imports.
 # A github action takes care of the cron task that:

--- a/.github/workflows/populate-metabase-itou.yml
+++ b/.github/workflows/populate-metabase-itou.yml
@@ -1,4 +1,4 @@
-name: Populate metabase itou
+name: 🌈 Populate metabase itou
 
 # Runs "populate_metabase_itou".
 # A github action takes care of the cron task that:

--- a/.github/workflows/populate-metabase-itou.yml
+++ b/.github/workflows/populate-metabase-itou.yml
@@ -50,6 +50,7 @@ jobs:
     - name: 🏷 Setup worker to run django command
       run: |
         echo 'CC_WORKER_COMMAND=./manage.py populate_metabase_itou --verbosity 2' >> $GITHUB_ENV
+        # By default, workers always restart on failure. We want to avoid an infinite loop if it happens.
         echo 'CC_WORKER_RESTART=no' >> $GITHUB_ENV
 
     - name: 🧫 Create a cron app on Clever Cloud on a strong machine

--- a/.github/workflows/populate-metabase-itou.yml
+++ b/.github/workflows/populate-metabase-itou.yml
@@ -1,6 +1,6 @@
-name: Populate metabase
+name: Populate metabase itou
 
-# Runs "populate_itou_metabase".
+# Runs "populate_metabase_itou".
 # A github action takes care of the cron task that:
 # - creates a machine on demand
 # - runs the desired command via a worker

--- a/.github/workflows/populate-metabase.yml
+++ b/.github/workflows/populate-metabase.yml
@@ -86,8 +86,8 @@ jobs:
     - name: 🚀 Deploy app to Clever Cloud
       run: $CLEVER_CLI deploy --alias $CRON_TASK_APP_NAME --branch $DEPLOY_BRANCH --force
 
-    - name: 🕒 Wait one hour which should be more than enough for the script to complete
-      run: sleep 3600
+    - name: 🕒 Wait a reasonable amount of time for the script to complete
+      run: sleep 5400
 
     - name: 🔪 Delete the app once the work is done
       run:

--- a/.github/workflows/populate-metabase.yml
+++ b/.github/workflows/populate-metabase.yml
@@ -47,9 +47,10 @@ jobs:
       run:
         echo "CRON_TASK_APP_NAME=`echo \"c1-cron-daily-$(date +%y-%m-%d-%Hh-%M)"`" >> $GITHUB_ENV
 
-    - name: 🏷 Setup worker command
-      run:
+    - name: 🏷 Setup worker to run django command
+      run: |
         echo 'CC_WORKER_COMMAND=./manage.py populate_metabase_itou --verbosity 2' >> $GITHUB_ENV
+        echo 'CC_WORKER_RESTART=no' >> $GITHUB_ENV
 
     - name: 🧫 Create a cron app on Clever Cloud on a strong machine
       run: |
@@ -77,9 +78,10 @@ jobs:
         $CLEVER_CLI service link-addon c1-prod-database-encrypted
         $CLEVER_CLI service link-addon c1-itou-redis
 
-    - name: 🚀 Deploy worker command to Clever
-      run:
+    - name: 🚀 Deploy worker configuration to Clever
+      run: |
         $CLEVER_CLI env import-vars CC_WORKER_COMMAND
+        $CLEVER_CLI env import-vars CC_WORKER_RESTART
 
     - name: 🚀 Deploy app to Clever Cloud
       run: $CLEVER_CLI deploy --alias $CRON_TASK_APP_NAME --branch $DEPLOY_BRANCH --force

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -529,6 +529,9 @@ DREETS_STATS_DASHBOARD_ID = 117
 DGEFP_STATS_DASHBOARD_ID = 117
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(os.environ.get("PILOTAGE_DASHBOARDS_WHITELIST", "[]"))
 
+# Slack notifications sent by Metabase cronjobs.
+SLACK_CRON_WEBHOOK_URL = os.environ.get("SLACK_CRON_WEBHOOK_URL", None)
+
 # Huey / async
 # Workers are run in prod via `CC_WORKER_COMMAND = django-admin run_huey`.
 # ------------------------------------------------------------------------------

--- a/itou/metabase/management/commands/_database_tables.py
+++ b/itou/metabase/management/commands/_database_tables.py
@@ -7,15 +7,24 @@ from itou.metabase.management.commands._database_psycopg2 import MetabaseDatabas
 
 
 def get_new_table_name(table_name):
-    return f"{table_name}_new"
+    """
+    We use the `z` prefix so that temporary tables are listed last and do not get in the way of Metabase power users.
+    """
+    return f"z_new_{table_name}"
 
 
 def get_old_table_name(table_name):
-    return f"{table_name}_old"
+    """
+    We use the `z` prefix so that temporary tables are listed last and do not get in the way of Metabase power users.
+    """
+    return f"z_old_{table_name}"
 
 
 def get_dry_table_name(table_name):
-    return f"{table_name}_dry_run"
+    """
+    We use the `z` prefix so that temporary tables are listed last and do not get in the way of Metabase power users.
+    """
+    return f"z_dry_{table_name}"
 
 
 def switch_table_atomically(table_name):

--- a/itou/metabase/management/commands/_database_tables.py
+++ b/itou/metabase/management/commands/_database_tables.py
@@ -1,6 +1,9 @@
 """
 Helper methods for manipulating tables used by both populate_metabase_itou and populate_metabase_fluxiae scripts.
 """
+from psycopg2 import sql
+
+from itou.metabase.management.commands._database_psycopg2 import MetabaseDatabaseCursor
 
 
 def get_new_table_name(table_name):
@@ -13,3 +16,24 @@ def get_old_table_name(table_name):
 
 def get_dry_table_name(table_name):
     return f"{table_name}_dry_run"
+
+
+def switch_table_atomically(table_name):
+    with MetabaseDatabaseCursor() as (cur, conn):
+        cur.execute(
+            sql.SQL("ALTER TABLE IF EXISTS {} RENAME TO {}").format(
+                sql.Identifier(table_name),
+                sql.Identifier(get_old_table_name(table_name)),
+            )
+        )
+        cur.execute(
+            sql.SQL("ALTER TABLE {} RENAME TO {}").format(
+                sql.Identifier(get_new_table_name(table_name)),
+                sql.Identifier(table_name),
+            )
+        )
+        conn.commit()
+        cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(get_old_table_name(table_name))))
+        # Dry run tables are periodically dropped by wet runs.
+        cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(get_dry_table_name(table_name))))
+        conn.commit()

--- a/itou/metabase/management/commands/_database_tables.py
+++ b/itou/metabase/management/commands/_database_tables.py
@@ -1,0 +1,15 @@
+"""
+Helper methods for manipulating tables used by both populate_metabase_itou and populate_metabase_fluxiae scripts.
+"""
+
+
+def get_new_table_name(table_name):
+    return f"{table_name}_new"
+
+
+def get_old_table_name(table_name):
+    return f"{table_name}_old"
+
+
+def get_dry_table_name(table_name):
+    return f"{table_name}_dry_run"

--- a/itou/metabase/management/commands/_dataframes.py
+++ b/itou/metabase/management/commands/_dataframes.py
@@ -8,22 +8,31 @@ from tqdm import tqdm
 
 from itou.metabase.management.commands._database_psycopg2 import MetabaseDatabaseCursor
 from itou.metabase.management.commands._database_sqlalchemy import get_pg_engine
+from itou.metabase.management.commands._database_tables import (
+    get_dry_table_name,
+    get_new_table_name,
+    get_old_table_name,
+)
 
 
 def switch_table_atomically(table_name):
     with MetabaseDatabaseCursor() as (cur, conn):
         cur.execute(
             sql.SQL("ALTER TABLE IF EXISTS {} RENAME TO {}").format(
-                sql.Identifier(table_name), sql.Identifier(f"{table_name}_old")
+                sql.Identifier(table_name),
+                sql.Identifier(get_old_table_name(table_name)),
             )
         )
         cur.execute(
             sql.SQL("ALTER TABLE {} RENAME TO {}").format(
-                sql.Identifier(f"{table_name}_new"), sql.Identifier(table_name)
+                sql.Identifier(get_new_table_name(table_name)),
+                sql.Identifier(table_name),
             )
         )
         conn.commit()
-        cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(f"{table_name}_old")))
+        cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(get_old_table_name(table_name))))
+        # Dry run tables are periodically dropped by wet runs.
+        cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(get_dry_table_name(table_name))))
         conn.commit()
 
 
@@ -37,7 +46,7 @@ def store_df(df, table_name, dry_run, max_attempts=5):
     Try up to `max_attempts` times.
     """
     if dry_run:
-        table_name += "_dry_run"
+        table_name = get_dry_table_name(table_name)
         df = df.head(1000)
 
     # Recipe from https://stackoverflow.com/questions/44729727/pandas-slice-large-dataframe-in-chunks
@@ -54,7 +63,7 @@ def store_df(df, table_name, dry_run, max_attempts=5):
             for df_chunk in tqdm(df_chunks):
                 pg_engine = get_pg_engine()
                 df_chunk.to_sql(
-                    name=f"{table_name}_new",
+                    name=get_new_table_name(table_name),
                     # Use a new connection for each chunk to avoid random disconnections.
                     con=pg_engine,
                     if_exists=if_exists,

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -59,23 +59,13 @@ An EMI does not necessarily have a mission.
 
 """
 import logging
-import os
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from psycopg2 import sql
 
-from itou.metabase.management.commands._database_psycopg2 import MetabaseDatabaseCursor
-from itou.metabase.management.commands._database_tables import (
-    get_dry_table_name,
-    get_new_table_name,
-    switch_table_atomically,
-)
 from itou.metabase.management.commands._dataframes import store_df
+from itou.metabase.management.commands._utils import build_custom_tables
 from itou.siaes.management.commands._import_siae.utils import get_fluxiae_df, get_fluxiae_referential_filenames, timeit
-
-
-CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 if settings.METABASE_SHOW_SQL_REQUESTS:
@@ -133,52 +123,6 @@ class Command(BaseCommand):
         for filename in get_fluxiae_referential_filenames():
             self.populate_fluxiae_view(vue_name=filename)
 
-    def build_custom_table(self, table_name, sql_request):
-        """
-        Build a new table with given sql_request.
-        Minimize downtime by building a temporary table first then swap the two tables atomically.
-        """
-        if self.dry_run:
-            # Note that during a dry run, the dry run version of the current table will be built
-            # from the wet run version of the underlying tables.
-            table_name = get_dry_table_name(table_name)
-
-        with MetabaseDatabaseCursor() as (cur, conn):
-            cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(get_new_table_name(table_name))))
-            conn.commit()
-            cur.execute(
-                sql.SQL("CREATE TABLE {} AS {}").format(
-                    sql.Identifier(get_new_table_name(table_name)), sql.SQL(sql_request)
-                )
-            )
-            conn.commit()
-
-        switch_table_atomically(table_name=table_name)
-        self.log("Done.")
-
-    @timeit
-    def build_custom_tables(self):
-        """
-        Build custom tables one by one by playing SQL requests in `sql` folder.
-
-        Typically:
-        - 001_fluxIAE_DateDerniereMiseAJour.sql
-        - 002_missions_ai_ehpad.sql
-        - ...
-
-        The numerical prefixes ensure the order of execution is deterministic.
-
-        The name of the table being created with the query is derived from the filename,
-        # e.g. '002_missions_ai_ehpad.sql' => 'missions_ai_ehpad'
-        """
-        path = f"{CURRENT_DIR}/sql"
-        for filename in sorted([f for f in os.listdir(path) if f.endswith(".sql")]):
-            self.log(f"Running {filename} ...")
-            table_name = "_".join(filename.split(".")[0].split("_")[1:])
-            with open(os.path.join(path, filename), "r") as file:
-                sql_request = file.read()
-            self.build_custom_table(table_name=table_name, sql_request=sql_request)
-
     @timeit
     def populate_metabase_fluxiae(self):
         if not settings.ALLOW_POPULATING_METABASE:
@@ -201,7 +145,7 @@ class Command(BaseCommand):
         self.populate_fluxiae_view(vue_name="fluxIAE_Structure")
 
         # Build custom tables by running raw SQL queries on existing tables.
-        self.build_custom_tables()
+        build_custom_tables(dry_run=self.dry_run)
 
     def handle(self, dry_run=False, **options):
         self.set_logger(options.get("verbosity"))

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -66,8 +66,12 @@ from django.core.management.base import BaseCommand
 from psycopg2 import sql
 
 from itou.metabase.management.commands._database_psycopg2 import MetabaseDatabaseCursor
-from itou.metabase.management.commands._database_tables import get_dry_table_name, get_new_table_name
-from itou.metabase.management.commands._dataframes import store_df, switch_table_atomically
+from itou.metabase.management.commands._database_tables import (
+    get_dry_table_name,
+    get_new_table_name,
+    switch_table_atomically,
+)
+from itou.metabase.management.commands._dataframes import store_df
 from itou.siaes.management.commands._import_siae.utils import get_fluxiae_df, get_fluxiae_referential_filenames, timeit
 
 

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -53,7 +53,13 @@ from itou.metabase.management.commands._database_tables import (
     get_old_table_name,
 )
 from itou.metabase.management.commands._dataframes import get_df_from_rows, store_df
-from itou.metabase.management.commands._utils import anonymize, chunked_queryset, compose, convert_boolean_to_int
+from itou.metabase.management.commands._utils import (
+    anonymize,
+    build_custom_tables,
+    chunked_queryset,
+    compose,
+    convert_boolean_to_int,
+)
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae, SiaeJobDescription
 from itou.users.models import User
@@ -449,6 +455,9 @@ class Command(BaseCommand):
                 "manual resolution, see command output"
             )
 
+    def build_custom_tables(self):
+        build_custom_tables(dry_run=self.dry_run)
+
     def populate_metabase_itou(self):
         if not settings.ALLOW_POPULATING_METABASE:
             self.log("Populating metabase is not allowed in this environment.")
@@ -469,6 +478,7 @@ class Command(BaseCommand):
             self.populate_rome_codes,
             self.populate_insee_codes,
             self.populate_departments,
+            self.build_custom_tables,
             self.report_data_inconsistencies,
         ]
 

--- a/itou/utils/slack.py
+++ b/itou/utils/slack.py
@@ -1,0 +1,24 @@
+"""
+Send notifications to Slack.
+
+Thanks to
+https://gist.github.com/devStepsize/b1b795309a217d24566dcc0ad136f784
+"""
+import json
+
+import requests
+from django.conf import settings
+
+
+def send_slack_message(text="Hello world :wave:"):
+    if not settings.SLACK_CRON_WEBHOOK_URL:
+        return
+    response = requests.post(
+        url=settings.SLACK_CRON_WEBHOOK_URL,
+        data=json.dumps({"text": text}),
+        headers={"Content-Type": "application/json"},
+    )
+    if response.status_code != 200:
+        raise ValueError(
+            "Request to slack returned an error %s, the response is:\n%s" % (response.status_code, response.text)
+        )


### PR DESCRIPTION
# Quoi ?

Evolutions de la mise à jour quotidienne de Metabase avec les données C1.

Sont listées ci-dessous les évolutions majeures uniquement. Les mineures sont visibles commit par commit.

## Envoi de notifications slack pour monitorer notre cron quotidien.

Sans ces notifications, nous et la github action sommes incapables de dire si le script s'est bien terminé ou non.

Un flag permet d'afficher ou non toutes les étapes, sorte de log.

![image](https://user-images.githubusercontent.com/10533583/141816446-c558ca26-7f6f-4e31-a593-f105fb5250a4.png)
![image](https://user-images.githubusercontent.com/10533583/141816525-5416d960-7437-40f6-80c0-bc873a17731b.png)
![image](https://user-images.githubusercontent.com/10533583/141816627-ec75ea02-bf14-41f9-ba26-0ef5d8bce237.png)

## Meilleur nommage des tables temporaires

![image](https://user-images.githubusercontent.com/10533583/141817313-f225d6a2-cff8-4d2c-9e27-eeb190880d5b.png)

Les tables temporaires (new/old/dry) ont maintenant un préfixe `Z` qui les place en toute fin de liste. Pratique pour ne pas pertuber nos utilisateurs Metabase avancés.

De plus, les dry tables (celles issues d'un dry run) ne sont plus éternelles. Chaque wet run les supprime maintenant en passant. Moins de bruit.

## Reconstruction des custom tables de Soumia chaque nuit et pas seulement chaque lundi

Soumia commence à croiser des données C1 et des données FluxIAE. Du coup ses tables custom bénéficierons de tourner chaque nuit après chaque mise à jour des données C1.

![image](https://user-images.githubusercontent.com/10533583/141818127-b7bc0648-f236-4a34-816c-b00024b02783.png)
