### PR TITLE
Permettre de lever une suspension au moment de l'embauche [En attente de la PR #983]

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -235,6 +235,13 @@ class Approval(CommonApprovalMixin):
         return self.jobapplication_set.get().state == state_accepted
 
     @cached_property
+    def can_update_suspension(self):
+        return self.is_suspended and self.suspension_set.in_progress().last().reason in [
+            Suspension.Reason.BROKEN_CONTRACT.value,
+            Suspension.Reason.FINISHED_CONTRACT.value,
+        ]
+
+    @cached_property
     def is_last_for_user(self):
         """
         Returns True if the current Approval is the most recent for the user, False otherwise.

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -288,10 +288,7 @@ class Approval(CommonApprovalMixin):
     @cached_property
     def can_be_unsuspended(self):
         if self.is_suspended:
-            return self.last_in_progress_suspension.reason in [
-                Suspension.Reason.BROKEN_CONTRACT.value,
-                Suspension.Reason.FINISHED_CONTRACT.value,
-            ]
+            return self.last_in_progress_suspension.reason in Suspension.REASONS_TO_UNSUSPEND
         return False
 
     def unsuspend(self, hiring_start_at):
@@ -470,6 +467,11 @@ class Suspension(models.Model):
             """
             reasons = [cls.SUSPENDED_CONTRACT, cls.BROKEN_CONTRACT, cls.FINISHED_CONTRACT]
             return [(reason.value, reason.label) for reason in reasons]
+
+    REASONS_TO_UNSUSPEND = [
+        Reason.BROKEN_CONTRACT.value,
+        Reason.FINISHED_CONTRACT.value,
+    ]
 
     approval = models.ForeignKey(Approval, verbose_name="PASS IAE", on_delete=models.CASCADE)
     start_at = models.DateField(verbose_name="Date de début", default=timezone.localdate, db_index=True)

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -283,9 +283,6 @@ class Approval(CommonApprovalMixin):
 
     @cached_property
     def last_in_progress_suspension(self):
-        """
-        Returns the last in progress suspension if exists else
-        """
         return self.suspension_set.in_progress().order_by("start_at").last()
 
     @cached_property
@@ -295,13 +292,12 @@ class Approval(CommonApprovalMixin):
                 Suspension.Reason.BROKEN_CONTRACT.value,
                 Suspension.Reason.FINISHED_CONTRACT.value,
             ]
-        return True
+        return False
 
     def unsuspend(self, hiring_start_at):
         """
-        An SIAE can reduce the delay of a suspension when they hired job seeker.
-        So, if approval is open to application process and have an active suspension,
-        We save the end date to the d-1 hiring start.
+        When a job application is accepted, the approval is "unsuspended":
+        we do it by setting its end_date to JobApplication.hiring_start_at - 1 day.
         """
         active_suspension = self.last_in_progress_suspension
         if active_suspension and self.can_be_unsuspended:

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -283,6 +283,9 @@ class Approval(CommonApprovalMixin):
 
     @cached_property
     def last_in_progress_suspension(self):
+        """
+        Returns the last in progress suspension if exists else None
+        """
         if self.is_suspended:
             return self.suspensions_by_start_date_asc.last()
 
@@ -296,6 +299,11 @@ class Approval(CommonApprovalMixin):
         return True
 
     def update_last_suspension(self, hiring_start_at):
+        """
+        An SIAE can reduce the delay of a suspension when they hired job seeker.
+        So, if approval is open to application process and have an active suspension,
+        We save the end date to the d-1 hiring start.
+        """
         active_suspension = self.last_in_progress_suspension
         if self.is_open_to_application_process and active_suspension:
             active_suspension.end_at = hiring_start_at - relativedelta(days=1)

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -438,9 +438,8 @@ class ApprovalModelTest(TestCase):
     def test_is_open_to_application_process_with_suspension(self):
         today = timezone.now().date()
         approval_start_at = today - relativedelta(months=3)
-        reasons_to_open_process = [Suspension.Reason.BROKEN_CONTRACT.value, Suspension.Reason.FINISHED_CONTRACT.value]
         reasons_to_not_open_process = [
-            reason.value for reason in Suspension.Reason if reason not in reasons_to_open_process
+            reason.value for reason in Suspension.Reason if reason.value not in Suspension.REASONS_TO_UNSUSPEND
         ]
 
         for reason_to_refuse in reasons_to_not_open_process:
@@ -455,7 +454,7 @@ class ApprovalModelTest(TestCase):
             suspension.delete()
             approval.delete()
 
-        for reason in reasons_to_open_process:
+        for reason in Suspension.REASONS_TO_UNSUSPEND:
             approval = ApprovalFactory(start_at=approval_start_at)
             suspension = SuspensionFactory(
                 approval=approval,

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -472,7 +472,7 @@ class ApprovalModelTest(TestCase):
         today = timezone.now().date()
         approval_start_at = today - relativedelta(months=3)
         approval = ApprovalFactory(start_at=approval_start_at)
-        self.assertTrue(approval.can_be_unsuspended)
+        self.assertFalse(approval.can_be_unsuspended)
 
     def test_last_in_progress_suspension(self):
         today = timezone.now().date()

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -451,7 +451,7 @@ class ApprovalModelTest(TestCase):
                 end_at=today + relativedelta(months=1),
                 reason=reason_to_refuse,
             )
-            self.assertFalse(approval.is_open_to_application_process)
+            self.assertFalse(approval.can_be_unsuspended)
             suspension.delete()
             approval.delete()
 
@@ -464,15 +464,15 @@ class ApprovalModelTest(TestCase):
                 reason=reason,
             )
 
-            self.assertTrue(approval.is_open_to_application_process)
+            self.assertTrue(approval.can_be_unsuspended)
             suspension.delete()
             approval.delete()
 
-    def test_is_open_to_application_process_without_suspension(self):
+    def test_can_be_unsuspended_without_suspension(self):
         today = timezone.now().date()
         approval_start_at = today - relativedelta(months=3)
         approval = ApprovalFactory(start_at=approval_start_at)
-        self.assertTrue(approval.is_open_to_application_process)
+        self.assertTrue(approval.can_be_unsuspended)
 
     def test_last_in_progress_suspension(self):
         today = timezone.now().date()
@@ -502,7 +502,7 @@ class ApprovalModelTest(TestCase):
         )
         self.assertIsNone(approval.last_in_progress_suspension)
 
-    def test_update_last_suspension(self):
+    def test_unsuspend(self):
         today = timezone.now().date()
         approval_start_at = today - relativedelta(months=3)
         approval = ApprovalFactory(start_at=approval_start_at)
@@ -512,11 +512,11 @@ class ApprovalModelTest(TestCase):
             end_at=today + relativedelta(months=2),
             reason=Suspension.Reason.BROKEN_CONTRACT.value,
         )
-        approval.update_last_suspension(hiring_start_at=today)
+        approval.unsuspend(hiring_start_at=today)
         suspension.refresh_from_db()
         self.assertEquals(suspension.end_at, today - relativedelta(days=1))
 
-    def test_update_last_suspension_invalid(self):
+    def test_unsuspend_invalid(self):
         today = timezone.now().date()
         approval_start_at = today - relativedelta(months=3)
         approval = ApprovalFactory(start_at=approval_start_at)
@@ -527,7 +527,7 @@ class ApprovalModelTest(TestCase):
             end_at=suspension_end_at,
             reason=Suspension.Reason.SUSPENDED_CONTRACT.value,
         )
-        approval.update_last_suspension(hiring_start_at=today)
+        approval.unsuspend(hiring_start_at=today)
         suspension.refresh_from_db()
         self.assertEquals(suspension.end_at, suspension_end_at)
 

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -667,10 +667,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             self.approval_number_sent_by_email = True
             self.approval_number_sent_at = timezone.now()
             self.approval_delivery_mode = self.APPROVAL_DELIVERY_MODE_AUTOMATIC
-            if self.approval.can_update_suspension:
-                active_suspension = self.approval.suspension_set.in_progress().last()
-                active_suspension.end_at = self.hiring_start_at - relativedelta(days=1)
-                active_suspension.save()
+            self.approval.update_last_suspension(self.hiring_start_at)
 
     @xwf_models.transition()
     def refuse(self, *args, **kwargs):

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -667,7 +667,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             self.approval_number_sent_by_email = True
             self.approval_number_sent_at = timezone.now()
             self.approval_delivery_mode = self.APPROVAL_DELIVERY_MODE_AUTOMATIC
-            self.approval.update_last_suspension(self.hiring_start_at)
+            self.approval.unsuspend(self.hiring_start_at)
 
     @xwf_models.transition()
     def refuse(self, *args, **kwargs):

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -667,6 +667,10 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             self.approval_number_sent_by_email = True
             self.approval_number_sent_at = timezone.now()
             self.approval_delivery_mode = self.APPROVAL_DELIVERY_MODE_AUTOMATIC
+            if self.approval.can_update_suspension:
+                active_suspension = self.approval.suspension_set.in_progress().last()
+                active_suspension.end_at = self.hiring_start_at - relativedelta(days=1)
+                active_suspension.save()
 
     @xwf_models.transition()
     def refuse(self, *args, **kwargs):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -511,7 +511,7 @@ class User(AbstractUser, AddressMixin):
     def last_hire_was_made_by_siae(self, siae):
         if not self.is_job_seeker:
             return False
-        return self.last_accepted_job_application.to_siae == siae
+        return self.last_accepted_job_application and self.last_accepted_job_application.to_siae == siae
 
     @classmethod
     def create_job_seeker_by_proxy(cls, proxy_user, **fields):

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -338,9 +338,9 @@ class ProcessViewsTest(TestCase):
             "city_slug": city.slug,
         }
         response = self.client.post(url, data=post_data)
-
+        self.assertEqual(response.status_code, 302)
         get_job_application = JobApplication.objects.get(pk=job_application.pk)
-        user_job_seeker = get_job_application.job_seeker
+        # user_job_seeker = get_job_application.job_seeker
         g_suspension = get_job_application.approval.suspension_set.in_progress().last()
 
         # Le pass IAE n'est plus suspendu

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -289,10 +289,7 @@ class ProcessViewsTest(TestCase):
             state=JobApplicationWorkflow.STATE_ACCEPTED,
             job_seeker=job_seeker_user,
             # Ensure that the old_job_application cannot be canceled.
-            hiring_start_at=today
-            - relativedelta(days=100)
-            - relativedelta(days=JobApplication.CANCELLATION_DAYS_AFTER_HIRING_STARTED)
-            - relativedelta(days=1),
+            hiring_start_at=today - relativedelta(days=100),
         )
         # create suspension for the job seeker
         approval_job_seeker = old_job_application.approval

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -340,27 +340,20 @@ class ProcessViewsTest(TestCase):
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
         get_job_application = JobApplication.objects.get(pk=job_application.pk)
-        # user_job_seeker = get_job_application.job_seeker
         g_suspension = get_job_application.approval.suspension_set.in_progress().last()
 
-        # Le pass IAE n'est plus suspendu
-        # self.assertFalse(get_job_application.approval.is_suspended)
-        # La date de fin de suspension est égale à j-1 de la date de début du nouvel emploi
+        # The end date of suspension is set to d-1 of hiring start day
         self.assertEqual(g_suspension.end_at, get_job_application.hiring_start_at - relativedelta(days=1))
-        # La durée du PASS IAE est rallongé de la durée de suspension
+        # Check if the duration of approval was updated correctly
         self.assertEqual(
             get_job_application.approval.end_at,
             approval_job_seeker.end_at + relativedelta(days=(g_suspension.end_at - g_suspension.start_at).days),
         )
-        # gestion du cas de l'annulation d'embauche
-        # annulation
-        # assertEqual old Date = new Date de fin de suspension et de Pass IAE
-        # assertEqual old Date = new Date du Pass IAE
+        # for know, we dont manage the cancel case
 
     def test_accept_with_manual_approval_delivery(self):
         """
         Test the "manual approval delivery mode" path of the view.
-        update maybe
         """
         create_test_cities(["57"], num_per_department=1)
         city = City.objects.first()

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -279,7 +279,7 @@ class ProcessViewsTest(TestCase):
         self.assertFormError(response, "form_user_address", "post_code", "Ce champ est obligatoire.")
 
     def test_accept_with_active_suspension(self):
-        """Test the `accept` transition with suspension for active user"""
+        """Test the `accept` transition with active suspension for active user"""
         create_test_cities(["54", "57"], num_per_department=2)
         city = City.objects.first()
         today = timezone.localdate()
@@ -308,7 +308,7 @@ class ProcessViewsTest(TestCase):
             reason=Suspension.Reason.BROKEN_CONTRACT.value,
         )
 
-        # Now, other Siae want to hired the job seeker
+        # Now, another Siae wants to hire the job seeker
         other_siae = SiaeWithMembershipFactory()
         job_application = JobApplicationSentByJobSeekerFactory(
             approval=approval_job_seeker,
@@ -349,7 +349,7 @@ class ProcessViewsTest(TestCase):
             get_job_application.approval.end_at,
             approval_job_seeker.end_at + relativedelta(days=(g_suspension.end_at - g_suspension.start_at).days),
         )
-        # for know, we dont manage the cancel case
+        # for now, we don't manage the cancel case
 
     def test_accept_with_manual_approval_delivery(self):
         """

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -349,7 +349,6 @@ class ProcessViewsTest(TestCase):
             get_job_application.approval.end_at,
             approval_job_seeker.end_at + relativedelta(days=(g_suspension.end_at - g_suspension.start_at).days),
         )
-        # for now, we don't manage the cancel case
 
     def test_accept_with_manual_approval_delivery(self):
         """

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -254,9 +254,6 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
                     form_user_address.save()
                 # After each successful transition, a save() is performed by django-xworkflows,
                 # so use `commit=False` to avoid a double save.
-                import ipdb
-
-                ipdb.set_trace()
                 job_application = form_accept.save(commit=False)
                 job_application.accept(user=request.user)
         except xwf_models.InvalidTransitionError:

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -254,6 +254,9 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
                     form_user_address.save()
                 # After each successful transition, a save() is performed by django-xworkflows,
                 # so use `commit=False` to avoid a double save.
+                import ipdb
+
+                ipdb.set_trace()
                 job_application = form_accept.save(commit=False)
                 job_application.accept(user=request.user)
         except xwf_models.InvalidTransitionError:

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -59,7 +59,7 @@ def get_approvals_wrapper(request, job_seeker, siae):
 
     if approvals_wrapper.has_valid and approvals_wrapper.latest_approval.is_pass_iae:
 
-        # Ensure that an existing approval is can be unsuspended.
+        # Ensure that an existing approval can be unsuspended.
         if not approvals_wrapper.latest_approval.can_update_suspension:
             error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_PROXY
             if user_info.user == job_seeker:

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -63,7 +63,7 @@ def get_approvals_wrapper(request, job_seeker, siae):
         if not approvals_wrapper.latest_approval.can_update_suspension:
             error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_PROXY
             if user_info.user == job_seeker:
-                error = Approval.ERRROR_PASS_IAE_SUSPENDED_FOR_USER
+                error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_USER
             raise PermissionDenied(error)
 
     return approvals_wrapper

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -57,15 +57,14 @@ def get_approvals_wrapper(request, job_seeker, siae):
             error = approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER
         raise PermissionDenied(error)
 
-    # if approvals_wrapper.has_valid and approvals_wrapper.latest_approval.is_pass_iae:
+    if approvals_wrapper.has_valid and approvals_wrapper.latest_approval.is_pass_iae:
 
-    #     # Ensure that an existing approval is not suspended.
-    #     # + si suspension pour un autre que motif ("contrat de travail terminé ou contrat de travail rompu")
-    #     if approvals_wrapper.latest_approval.is_suspended:
-    #         error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_PROXY
-    #         if user_info.user == job_seeker:
-    #             error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_USER
-    #         raise PermissionDenied(error)
+        # Ensure that an existing approval is can be unsuspended.
+        if not approvals_wrapper.latest_approval.can_update_suspension:
+            error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_PROXY
+            if user_info.user == job_seeker:
+                error = Approval.ERRROR_PASS_IAE_SUSPENDED_FOR_USER
+            raise PermissionDenied(error)
 
     return approvals_wrapper
 

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -60,7 +60,7 @@ def get_approvals_wrapper(request, job_seeker, siae):
     if approvals_wrapper.has_valid and approvals_wrapper.latest_approval.is_pass_iae:
 
         # Ensure that an existing approval can be unsuspended.
-        if not approvals_wrapper.latest_approval.can_update_suspension:
+        if not approvals_wrapper.latest_approval.is_open_to_application_process:
             error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_PROXY
             if user_info.user == job_seeker:
                 error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_USER

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -57,14 +57,15 @@ def get_approvals_wrapper(request, job_seeker, siae):
             error = approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER
         raise PermissionDenied(error)
 
-    if approvals_wrapper.has_valid and approvals_wrapper.latest_approval.is_pass_iae:
+    # if approvals_wrapper.has_valid and approvals_wrapper.latest_approval.is_pass_iae:
 
-        # Ensure that an existing approval is not suspended.
-        if approvals_wrapper.latest_approval.is_suspended:
-            error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_PROXY
-            if user_info.user == job_seeker:
-                error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_USER
-            raise PermissionDenied(error)
+    #     # Ensure that an existing approval is not suspended.
+    #     # + si suspension pour un autre que motif ("contrat de travail terminé ou contrat de travail rompu")
+    #     if approvals_wrapper.latest_approval.is_suspended:
+    #         error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_PROXY
+    #         if user_info.user == job_seeker:
+    #             error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_USER
+    #         raise PermissionDenied(error)
 
     return approvals_wrapper
 

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -59,8 +59,9 @@ def get_approvals_wrapper(request, job_seeker, siae):
 
     if approvals_wrapper.has_valid and approvals_wrapper.latest_approval.is_pass_iae:
 
+        latest_approval = approvals_wrapper.latest_approval
         # Ensure that an existing approval can be unsuspended.
-        if not approvals_wrapper.latest_approval.can_be_unsuspended:
+        if latest_approval.is_suspended and not latest_approval.can_be_unsuspended:
             error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_PROXY
             if user_info.user == job_seeker:
                 error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_USER

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -60,7 +60,7 @@ def get_approvals_wrapper(request, job_seeker, siae):
     if approvals_wrapper.has_valid and approvals_wrapper.latest_approval.is_pass_iae:
 
         # Ensure that an existing approval can be unsuspended.
-        if not approvals_wrapper.latest_approval.is_open_to_application_process:
+        if not approvals_wrapper.latest_approval.can_be_unsuspended:
             error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_PROXY
             if user_info.user == job_seeker:
                 error = Approval.ERROR_PASS_IAE_SUSPENDED_FOR_USER


### PR DESCRIPTION
### Quoi ?
Permettre la levée anticipée d'une suspension dès lors qu'un employeur valide une embauche

UNIQUEMENT POUR LES SUSPENSIONS POUR MOTIF "contrat de travail terminé ou contrat de travail rompu"

Date de fin de suspension = J-1

### Pourquoi ?
Actuellement seul l'auteur de la suspension peut la lever/modifier
C'est bloquant pour une nouvelle embauche

### Comment ?
    # Personne A : salarié chez ETTI_A
    # Personne A termine son contrat chez ETTI_A
    # ETTI_A enregistre une suspension -> Personne A
    # 1 mois plus tard ...
    # ETTI_B -> Décide de recruter personne A
    # Pas de diag, car existance de PASS
    # L'employeur valide la candidature 
    # => Suspension est levée: date de fin est égale à j-1 de la date de début de contrat
    # =============> Quid du cas de l'annulation de l'embauche et qu'il a une suspension ? 
    # ===============> Changement de la date de fin du PASS IAE, à la durée réel de suspension (début +)
    # ===============> Quid de la date de fin de suspension ? -> Pour l'instant on ne le gère pas car très peu de cas et ajoute pas mal de complexité
    # 1 an plus tard ...
    # L'employeur B suspend Personne A
    # => Création d'une nouvelle suspension

### Scénario de tests
1. Se connecter comme `EI` sur la structure par défaut (`EI Garage Martinet Siège`)
2. Suspendre le PASS IAE de `**Jacques Henry**` pour un an avec l'un des deux motifs suivants : Contrat de travail rompu, Contrat de travail terminé
3. Soit :
    1. Se connecter avec le compte candidat 
    2. Se connecter avec le compte de prescripteur et postuler pour `test+de@inclusion.beta.gouv.fr`
4. Choisir une offre d'emploi, comme par exemple : [https://c1-review-madjid-asa-permit-other-siae-update-suspensions.cleverapps.io/siae/job_description/5/card](https://c1-review-madjid-asa-permit-other-siae-update-suspensions.cleverapps.io/siae/job_description/5/card) 
5. Postuler 
6. Se connecter à nouveau sur `EI` en choisissant cette fois la structure `EI Job Insertion 90`
7. Etudier et accepter la candidature de Jack Henry  
8. Vérifier que la date de fin de suspension du PASS de Jack Henry correspond à j-1 de la date d'embauche 

### Autre (optionnel)
[Lien vers la carte trello](https://trello.com/c/g46PX9gV/2360-lever-une-suspension-au-moment-de-lembauche)