### PR TITLE
Rendre l'annexe financière optionnelle pour les fiches salarié

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -154,7 +154,7 @@ class EmployeeRecord(models.Model):
         related_name="employee_record",
     )
 
-    # Employee records must be linked to a valid financial annex
+    # Employee records may be linked to a valid financial annex
     # This field can't be automatically filled, the user will be asked
     # to select a valid one manually
     financial_annex = models.ForeignKey(

--- a/itou/templates/employee_record/includes/create_step_4.html
+++ b/itou/templates/employee_record/includes/create_step_4.html
@@ -3,6 +3,10 @@
 
 <h4>Annexe financière</h4>
 
+<div class="alert alert-info">
+  Le choix d'une annexe financière est <b>optionnel</b>, et dans tous les cas, l'information n'est pas transmise à l'ASP.
+</div>
+
 <form method="post" action="{% url "employee_record_views:create_step_4" job_application.id %}" class="js-prevent-multiple-submit">
         
     {% csrf_token %}
@@ -15,4 +19,3 @@
     {% endbuttons %}
 
 </form>
-

--- a/itou/templates/employee_record/includes/employee_record_summary.html
+++ b/itou/templates/employee_record/includes/employee_record_summary.html
@@ -76,7 +76,11 @@
         <h5>Annexe financière </h5>
 
         <div>    
-            {{ employee_record.financial_annex.number }} ({{ employee_record.financial_annex.get_state_display|lower }})
+            {% if employee_record.financial_annex %}
+              {{ employee_record.financial_annex.number }} ({{ employee_record.financial_annex.get_state_display|lower }})
+            {% else %}
+              Aucune annexe financière n'a été selectionnée.
+            {% endif %}
         </div>
 
     </div>

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -350,6 +350,7 @@ class NewEmployeeRecordStep4(forms.Form):
             state__in=SiaeFinancialAnnex.STATES_ACTIVE, end_at__gt=timezone.now()
         )
         self.fields["financial_annex"].initial = employee_record.financial_annex
+        self.fields["financial_annex"].required = False
 
     def clean(self):
         super().clean()

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -336,7 +336,7 @@ class NewEmployeeRecordStep4(forms.Form):
     financial_annex = forms.ModelChoiceField(
         queryset=None,
         label="Annexe financière",
-        help_text="Vous devez rattacher la fiche salarié à une annexe financière validée ou provisoire",
+        help_text="Vous pouvez rattacher la fiche salarié à une annexe financière validée ou provisoire",
     )
 
     def __init__(self, employee_record, *args, **kwargs):


### PR DESCRIPTION
### Quoi ?

Permettre de ne pas saisir l'annexe financière dans le parcours de création / modification de la fiche salarié.

### Pourquoi ?

Beaucoup de friction à cause de possible décalages de validité de l'annexe / convention (imports hebdomadaires).

Pour au final une info dont l'ASP ne fait rien.

### Comment ?

Permettre de ne rien saisir à l'étape 4 du tunnel de création des fiches salarié.

### Captures d'écran

![image](https://user-images.githubusercontent.com/147232/141810368-936224e3-cd80-48d9-b3c4-a3756218fa31.png)



