### PR TITLE
Les candidatures PE peuvent être importées 3 mois après leur expiration

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -945,6 +945,8 @@ class PoleEmploiApproval(CommonApprovalMixin):
     at the time of issuance.
     """
 
+    SUPPORT_EXTENSION_DELAY_MONTHS = 3
+
     # Matches prescriber_organization.code_safir_pole_emploi.
     pe_structure_code = models.CharField("Code structure Pôle emploi", max_length=5)
 
@@ -1032,6 +1034,11 @@ class PoleEmploiApproval(CommonApprovalMixin):
         end_at = self.end_at
         if self.overlaps_covid_lockdown:
             end_at = self.get_extended_covid_end_at(end_at)
+
+        # On top of a potential lockdown, we want to add a few extra months in order to reduce
+        # the issues of importing expired PE approvals that fill our support
+        end_at = end_at + relativedelta(months=PoleEmploiApproval.SUPPORT_EXTENSION_DELAY_MONTHS)
+
         return end_at
 
     @property

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -256,7 +256,7 @@ class ApplyAsJobSeekerTest(TestCase):
         with mock.patch("django.utils.timezone.now", side_effect=lambda: now):
             siae = SiaeWithMembershipAndJobsFactory(romes=("N1101", "N1105"))
             user = JobSeekerFactory()
-            end_at = now_date - relativedelta(days=30)
+            end_at = now_date - relativedelta(days=30, months=PoleEmploiApproval.SUPPORT_EXTENSION_DELAY_MONTHS)
             start_at = end_at - relativedelta(years=2)
             PoleEmploiApprovalFactory(
                 pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate, start_at=start_at, end_at=end_at


### PR DESCRIPTION
## Quoi ?

https://trello.com/c/ARkraF5B/2371-c1-pouvoir-r%C3%A9cup%C3%A9rer-un-agr%C3%A9ment-expir%C3%A9-depuis-moins-de-3-mois

Je veux prolonger un agrément expiré, mais je ne peux pas le récupérer via le module "Prolonger/suspendre un agrément Pole Emploi"

## Pourquoi ?

Pour limiter la charge support, on a récemment donné la possibilité aux employeurs de prolonger un PASS IAE même s'il est expiré depuis 3 mois. 
Toutefois, ils n'ont pas la possibilité de récupérer un agrément Pole Emploi expiré, donc ils ne peuvent pas prolonger cet agrément

## Comment ?

Donner la possibilité aux employeurs de récupérer un agrément expiré depuis moins de 3 mois dans le module "Prolonger/suspendre un agrément Pole Emploi"

 - introduction d’une constante pour gérer ce délai demandé par le support
 - modification de la logique d’extension de délai de validité d’un agrément PE
 - le Pass conserve les dates de début/fin prévues, et reste invalide une fois importé
 - on peut quand même le prolonger

### Captures d'écran (optionnel)
![Sélection_151](https://user-images.githubusercontent.com/1223316/141816174-a8a45bde-18e9-4112-848b-9f53065dc080.png)
![Sélection_152](https://user-images.githubusercontent.com/1223316/141816177-bc2952f9-6616-4a55-9994-132ae35ede74.png)
![Sélection_153](https://user-images.githubusercontent.com/1223316/141816180-4748e72d-b96a-4df4-af2a-7fd222a83d44.png)


