### PR TITLE
Gestion plus propre des logs des doublons avec export en CSV

### DIFF
--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db.models import Case, F, Value, When
 from django.urls import reverse
+from tqdm import tqdm
 
 from itou.job_applications.models import JobApplication
 from itou.users.models import User
@@ -187,7 +188,11 @@ class Command(BaseCommand):
             prefetch_related_lookups=["approvals", "eligibility_diagnoses"]
         )
 
+        pbar = tqdm(total=len(duplicates_dict.items()))
+
         for pe_id, duplicates in duplicates_dict.items():
+
+            pbar.update(1)
 
             users_with_approval = [u for u in duplicates if u.approvals.exists()]
 

--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
 
     To run the command without any change in DB and have a preview of which
     accounts will be merged:
-        django-admin deduplicate_job_seekers --dry-run
+        django-admin deduplicate_job_seekers --dry-run --no-csv
 
     To merge duplicates job seekers in the database:
         django-admin deduplicate_job_seekers
@@ -46,6 +46,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="Only display data to deduplicate")
+        parser.add_argument("--no-csv", dest="no_csv", action="store_true", help="Do not export results in CSV")
 
     def set_logger(self, verbosity):
         """
@@ -138,11 +139,12 @@ class Command(BaseCommand):
 
             self.HARD_CASES_LOGS.append(log_info)
 
-    def handle(self, dry_run=False, **options):
+    def handle(self, dry_run=False, no_csv=False, **options):
 
         self.set_logger(options.get("verbosity"))
 
         self.dry_run = dry_run
+        self.no_csv = no_csv
 
         self.logger.debug("Starting. Good luck…")
 
@@ -199,7 +201,7 @@ class Command(BaseCommand):
                 count_hard_cases += 1
                 self.handle_hard_cases(duplicates, count_hard_cases)
 
-        if settings.ITOU_ENVIRONMENT != "TEST" and not self.dry_run:
+        if not self.no_csv:
             self.to_csv(
                 "easy-duplicates",
                 [
@@ -213,7 +215,7 @@ class Command(BaseCommand):
             self.to_csv(
                 "hard-duplicates",
                 [
-                    "Numéro",
+                    "Numéro",  # Lines with the same number are duplicates.
                     "Nombre de doublons",
                     "Email",
                     "Numéro PASS IAE",

--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -1,3 +1,5 @@
+import csv
+import datetime
 import logging
 
 from django.conf import settings
@@ -39,6 +41,9 @@ class Command(BaseCommand):
 
     help = "Deduplicate job seekers."
 
+    EASY_CASES_LOGS = []
+    HARD_CASES_LOGS = []
+
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="Only display data to deduplicate")
 
@@ -65,13 +70,19 @@ class Command(BaseCommand):
 
         users_to_delete = [u for u in duplicates if u != target]
 
-        user_admin_path = reverse("admin:users_user_change", args=[target.pk])
-        user_admin_url = f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{user_admin_path}"
-        self.logger.debug("<tr>")
-        self.logger.debug(f'<td><a href="{user_admin_url}">{target.email}</a></td>')
-        self.logger.debug(f"<td>{len(users_to_delete)}</td>")
-        self.logger.debug(f"<td>{' ; '.join([u.email for u in users_to_delete])}</td>")
-        self.logger.debug("</tr>")
+        target_admin_path = reverse("admin:users_user_change", args=[target.pk])
+        target_admin_url = f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{target_admin_path}"
+        self.EASY_CASES_LOGS.append(
+            {
+                "Compte de destination": target.email,
+                "URL admin du compte de destination": target_admin_url,
+                "Nombre de doublons": len(users_to_delete),
+                "Doublons fusionnés": " ; ".join([u.email for u in users_to_delete]),
+            }
+        )
+
+        # Debug info.
+        self.logger.debug(f"[easy] {self.EASY_CASES_LOGS[-1].values()}")
 
         for user in users_to_delete:
 
@@ -97,6 +108,36 @@ class Command(BaseCommand):
             if not self.dry_run:
                 target.save()
 
+    def handle_hard_cases(self, duplicates, num):
+        """
+        Only log hard cases.
+        """
+
+        for duplicate in duplicates:
+            log_info = {
+                "Numéro": num,
+                "Nombre de doublons": len(duplicates),
+                "Email": duplicate.email,
+                "Numéro PASS IAE": "",
+                "Début PASS IAE": "",
+                "Fin PASS IAE": "",
+                "Lien admin PASS IAE": "",
+            }
+
+            approval = duplicate.approvals.last()
+            if approval:
+                approval_admin_path = reverse("admin:approvals_approval_change", args=[approval.pk])
+                approval_admin_url = f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{approval_admin_path}"
+                log_info["Numéro PASS IAE"] = approval.number
+                log_info["Début PASS IAE"] = approval.start_at.strftime("%d/%m/%Y")
+                log_info["Fin PASS IAE"] = approval.end_at.strftime("%d/%m/%Y")
+                log_info["Lien admin PASS IAE"] = approval_admin_url
+
+            # Debug info.
+            self.logger.debug(f"[hard] {log_info.values()}")
+
+            self.HARD_CASES_LOGS.append(log_info)
+
     def handle(self, dry_run=False, **options):
 
         self.set_logger(options.get("verbosity"))
@@ -107,21 +148,10 @@ class Command(BaseCommand):
 
         count_easy_cases = 0
         count_hard_cases = 0
-        hard_cases = []
 
         duplicates_dict = User.objects.get_duplicates_by_pole_emploi_id(
             prefetch_related_lookups=["approvals", "eligibility_diagnoses"]
         )
-
-        self.logger.debug("<table>")
-        self.logger.debug("<thead>")
-        self.logger.debug("<tr>")
-        self.logger.debug("<th>Compte de destination</th>")
-        self.logger.debug("<th>Nombre de doublons</th>")
-        self.logger.debug("<th>Doublons</th>")
-        self.logger.debug("</tr>")
-        self.logger.debug("</thead>")
-        self.logger.debug("<tbody>")
 
         for pe_id, duplicates in duplicates_dict.items():
 
@@ -164,52 +194,47 @@ class Command(BaseCommand):
 
             # Hard cases.
             # More than one PASS IAE was issued for the same person.
-            # We only display logs for the moment, we don't know yet how to merge them.
+            # We only handle logs for the moment, we don't know yet how to merge them.
             elif len(users_with_approval) > 1:
                 count_hard_cases += 1
-                hard_cases.append(duplicates)
+                self.handle_hard_cases(duplicates, count_hard_cases)
 
-        self.logger.debug("</tbody></table>")
+        if settings.ITOU_ENVIRONMENT != "TEST" and not self.dry_run:
+            self.to_csv(
+                "easy-duplicates",
+                [
+                    "Compte de destination",
+                    "URL admin du compte de destination",
+                    "Nombre de doublons",
+                    "Doublons fusionnés",
+                ],
+                self.EASY_CASES_LOGS,
+            )
+            self.to_csv(
+                "hard-duplicates",
+                [
+                    "Numéro",
+                    "Nombre de doublons",
+                    "Email",
+                    "Numéro PASS IAE",
+                    "Début PASS IAE",
+                    "Fin PASS IAE",
+                    "Lien admin PASS IAE",
+                ],
+                self.HARD_CASES_LOGS,
+            )
 
         self.logger.debug("-" * 80)
         self.logger.debug(f"{count_easy_cases} easy cases merged.")
-
-        self.log_hard_cases(count_hard_cases, hard_cases)
+        self.logger.debug(f"{count_hard_cases} hard cases found.")
 
         self.logger.debug("-" * 80)
         self.logger.debug("Done.")
 
-    def log_hard_cases(self, count_hard_cases, hard_cases):
-        self.logger.debug("-" * 80)
-        self.logger.debug(f"{count_hard_cases} hard cases with more than one PASS IAE issued for the same person:")
-        self.logger.debug("<table>")
-        self.logger.debug("<thead>")
-        self.logger.debug("<tr>")
-        self.logger.debug("<th>Numéro</th>")
-        self.logger.debug("<th>Nombre de doublons</th>")
-        self.logger.debug("<th>Email</th>")
-        self.logger.debug("<th>Numéro PASS IAE</th>")
-        self.logger.debug("<th>Début PASS IAE</th>")
-        self.logger.debug("<th>Fin PASS IAE</th>")
-        self.logger.debug("</tr>")
-        self.logger.debug("</thead>")
-        self.logger.debug("<tbody>")
-        for i, duplicates in enumerate(hard_cases, 1):
-            for u in duplicates:
-                self.logger.debug("<tr>")
-                self.logger.debug(f"<td>{i}</td>")
-                self.logger.debug(f"<td>{len(duplicates)}</td>")
-                user_admin_path = reverse("admin:users_user_change", args=[u.pk])
-                user_admin_url = f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{user_admin_path}"
-                debug_msg = f'<td><a href="{user_admin_url}">{u.email}</a></td>'
-                if approval := u.approvals.last():
-                    approval_admin_path = reverse("admin:approvals_approval_change", args=[approval.pk])
-                    approval_admin_url = f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{approval_admin_path}"
-                    debug_msg += f'<td><a href="{approval_admin_url}">{approval.number}</a> </td>'
-                    debug_msg += f"<td>{approval.start_at.strftime('%d/%m/%Y')}</td>"
-                    debug_msg += f"<td>{approval.end_at.strftime('%d/%m/%Y')}</td>"
-                else:
-                    debug_msg += '<td colspan="3"> </td>'
-                self.logger.debug(debug_msg)
-                self.logger.debug("</tr>")
-        self.logger.debug("</tbody></table>")
+    def to_csv(self, filename, fieldnames, data):
+        log_datetime = datetime.datetime.now().strftime("%d-%m-%Y-%H-%M-%S")
+        path = f"{settings.EXPORT_DIR}/{log_datetime}-{filename}-{settings.ITOU_ENVIRONMENT.lower()}.csv"
+        with open(path, "w") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames, quoting=csv.QUOTE_ALL)
+            writer.writeheader()
+            writer.writerows(data)

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -127,7 +127,7 @@ class ManagementCommandsTest(TestCase):
         self.assertEqual(1, user3.eligibility_diagnoses.count())
 
         # Merge all users into `user1`.
-        call_command("deduplicate_job_seekers", verbosity=0)
+        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True)
 
         # If only one NIR exists for all the duplicates, it should
         # be reassigned to the target account.
@@ -188,7 +188,7 @@ class ManagementCommandsTest(TestCase):
         ApprovalFactory(user=user1)
 
         # Merge all users into `user1`.
-        call_command("deduplicate_job_seekers", verbosity=0)
+        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True)
 
         self.assertEqual(3, user1.job_applications.count())
 


### PR DESCRIPTION
### Quoi ?

- Gestion plus propre des logs des doublons avec export en CSV
- Export des candidats en doublon avec plusieurs NIR pour la même personne

### Pourquoi ?

Pour faciliter la tache de Supportix qui, sinon, aurait eu à copier-coller l'output HTML dans la console.