### PR TITLE
Augmentation de la mémoire disponible pour le conteneur PostgreSQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     container_name: itou_postgres
     env_file:
       - ./envs/dev.env
+    # The default memory setting (64M) is not enough anymore due to the size of the database we import
     # https://stackoverflow.com/questions/56839975/docker-shm-size-dev-shm-resizing-shared-memory
     shm_size: 1g
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     container_name: itou_postgres
     env_file:
       - ./envs/dev.env
+    # https://stackoverflow.com/questions/56839975/docker-shm-size-dev-shm-resizing-shared-memory
+    shm_size: 1g
     build:
       context: .
       dockerfile: ./docker/dev/postgres/Dockerfile


### PR DESCRIPTION
### Quoi ?

Augmentation de la mémoire disponible pour le conteneur PostgreSQL.

### Pourquoi ?

Je ne pouvais plus utiliser la base de prod localement car sa taille était trop importante.

### Comment ?

Mise à jour de `docker-compose.yml`.