### PR TITLE
Evolutions fiches salarié 

### DIFF
--- a/itou/api/employee_record_api/serializers.py
+++ b/itou/api/employee_record_api/serializers.py
@@ -94,14 +94,16 @@ class DummyEmployeeRecordSerializer(serializers.Serializer):
 # Employee record serializer is mostly the same as the one used
 # for serialization transfers.
 # Except some fields are "unobfuscated" and added for third-party
-# software connecting to the API
+# software connecting to the API.
 
 
 class _API_EmployeeAddressSerializer(_EmployeeAddressSerializer):
-    # This class in only useful for compatibilty
-    # We decided not to send phone and email (business concerns and bad ASP address filters)
-    # But we make it available for API for compatibility with original document
-    # (these fiels should really be actual data, not fake, by implicit contract)
+    """
+    This class in only useful for compatibility.
+    We decided not to send phone and email (business concerns and bad ASP address filters).
+    But we make it available in the API for compatibility with original document
+    (these fields should really be actual data, not fake, by implicit contract).
+    """
 
     def _update_address_and_phone_number(self, result, instance) -> OrderedDict:
         """

--- a/itou/api/employee_record_api/serializers.py
+++ b/itou/api/employee_record_api/serializers.py
@@ -4,8 +4,9 @@ from typing import OrderedDict
 from django.conf import settings
 from django.utils.crypto import salted_hmac
 from rest_framework import serializers
-from itou.employee_record.serializers import _EmployeeAddressSerializer, _EmployeeSerializer, EmployeeRecordSerializer
+
 from itou.employee_record.models import EmployeeRecord
+from itou.employee_record.serializers import EmployeeRecordSerializer, _EmployeeAddressSerializer, _EmployeeSerializer
 from itou.users.models import User
 
 

--- a/itou/api/employee_record_api/serializers.py
+++ b/itou/api/employee_record_api/serializers.py
@@ -91,7 +91,7 @@ class DummyEmployeeRecordSerializer(serializers.Serializer):
         return fiche_salarie
 
 
-# Employe record serializer is mostly the same as the one used
+# Employee record serializer is mostly the same as the one used
 # for serialization transfers.
 # Except some fields are "unobfuscated" and added for third-party
 # software connecting to the API

--- a/itou/api/employee_record_api/serializers.py
+++ b/itou/api/employee_record_api/serializers.py
@@ -4,8 +4,9 @@ from typing import OrderedDict
 from django.conf import settings
 from django.utils.crypto import salted_hmac
 from rest_framework import serializers
-from itou.employee_record.serializers import _EmployeeAddress, EmployeeRecordSerializer
+from itou.employee_record.serializers import _EmployeeAddressSerializer, _EmployeeSerializer, EmployeeRecordSerializer
 from itou.employee_record.models import EmployeeRecord
+from itou.users.models import User
 
 
 class DummyEmployeeRecordSerializer(serializers.Serializer):
@@ -95,7 +96,7 @@ class DummyEmployeeRecordSerializer(serializers.Serializer):
 # software connecting to the API
 
 
-class _API_EmployeeAddress(_EmployeeAddress):
+class _API_EmployeeAddressSerializer(_EmployeeAddressSerializer):
     # This class in only useful for compatibilty
     # We decided not to send phone and email (business concerns and bad ASP address filters)
     # But we make it available for API for compatibility with original document
@@ -114,6 +115,30 @@ class _API_EmployeeAddress(_EmployeeAddress):
         return result
 
 
+class _API_EmployeeSerializer(_EmployeeSerializer):
+    """
+    Specific fields added to the API (not used in ASP transfers)
+    """
+
+    NIR = serializers.CharField(source="nir")
+
+    class Meta:
+        model = User
+        fields = [
+            "sufPassIae",
+            "idItou",
+            "NIR",
+            "civilite",
+            "nomUsage",
+            "prenom",
+            "dateNaissance",
+            "codeComInsee",
+            "codeDpt",
+            "codeInseePays",
+            "codeGroupePays",
+        ]
+
+
 class EmployeeRecordAPISerializer(EmployeeRecordSerializer):
     """
     This serializer is a version with the `numeroAnnexe` field added (financial annex number).
@@ -123,7 +148,8 @@ class EmployeeRecordAPISerializer(EmployeeRecordSerializer):
     """
 
     numeroAnnexe = serializers.CharField(source="financial_annex_number")
-    adresse = _API_EmployeeAddress(source="job_application.job_seeker")
+    adresse = _API_EmployeeAddressSerializer(source="job_application.job_seeker")
+    personnePhysique = _API_EmployeeSerializer(source="job_application.job_seeker")
 
     class Meta:
         model = EmployeeRecord

--- a/itou/api/employee_record_api/viewsets.py
+++ b/itou/api/employee_record_api/viewsets.py
@@ -4,11 +4,10 @@ from rest_framework import viewsets
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 
 from itou.employee_record.models import EmployeeRecord
-from itou.employee_record.serializers import EmployeeRecordAPISerializer
 from itou.job_applications.models import JobApplication
 
 from .perms import EmployeeRecordAPIPermission
-from .serializers import DummyEmployeeRecordSerializer
+from .serializers import DummyEmployeeRecordSerializer, EmployeeRecordAPISerializer
 
 
 logger = logging.getLogger("api_drf")

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
 from django.urls import path
+from django.utils.html import format_html
 
 from itou.approvals import models
 from itou.approvals.admin_forms import ApprovalAdminForm
 from itou.approvals.admin_views import manually_add_approval, manually_refuse_approval
 from itou.job_applications.models import JobApplication
+from itou.employee_record.models import EmployeeRecord
 
 
 class JobApplicationInline(admin.StackedInline):
@@ -22,14 +24,34 @@ class JobApplicationInline(admin.StackedInline):
         "approval_number_sent_at",
         "approval_delivery_mode",
         "approval_manually_delivered_by",
+        "employee_record_status",
     )
-    raw_id_fields = ("job_seeker", "to_siae", "approval_manually_delivered_by")
+    raw_id_fields = (
+        "job_seeker",
+        "to_siae",
+        "approval_manually_delivered_by",
+    )
+
+    # Mandatory for "custom" inline fields
+    readonly_fields = ("employee_record_status",)
 
     def has_change_permission(self, request, obj=None):
         return False
 
     def has_add_permission(self, request, obj=None):
         return False
+
+    # Custom read-only fields as workaround :
+    # there is no direct relation between approvals and employee records
+    # (YET...)
+    @admin.display(description="Statut de la fiche salarié")
+    def employee_record_status(self, obj):
+        if employee_record := obj.employee_record.first():
+            url = f"/admin/employee_record/employeerecord/{employee_record.id}"
+            display = employee_record.get_status_display()
+            return format_html(f"<a href='{url}'><b>{display} (ID : {employee_record.id})</b></a>")
+
+        return "Pas de fiche salarié crée pour cette candidature"
 
 
 class SuspensionInline(admin.TabularInline):

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.urls import path
+from django.urls.base import reverse
 from django.utils.html import format_html
 
 from itou.approvals import models
@@ -46,7 +47,7 @@ class JobApplicationInline(admin.StackedInline):
     @admin.display(description="Statut de la fiche salarié")
     def employee_record_status(self, obj):
         if employee_record := obj.employee_record.first():
-            url = f"/admin/employee_record/employeerecord/{employee_record.id}"
+            url = reverse("admin:employee_record_employeerecord_change", args=[employee_record.id])
             display = employee_record.get_status_display()
             return format_html(f"<a href='{url}'><b>{display} (ID : {employee_record.id})</b></a>")
 

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -5,8 +5,8 @@ from django.utils.html import format_html
 from itou.approvals import models
 from itou.approvals.admin_forms import ApprovalAdminForm
 from itou.approvals.admin_views import manually_add_approval, manually_refuse_approval
-from itou.job_applications.models import JobApplication
 from itou.employee_record.models import EmployeeRecord
+from itou.job_applications.models import JobApplication
 
 
 class JobApplicationInline(admin.StackedInline):

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -5,7 +5,6 @@ from django.utils.html import format_html
 from itou.approvals import models
 from itou.approvals.admin_forms import ApprovalAdminForm
 from itou.approvals.admin_views import manually_add_approval, manually_refuse_approval
-from itou.employee_record.models import EmployeeRecord
 from itou.job_applications.models import JobApplication
 
 

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -299,14 +299,15 @@ class Command(BaseCommand):
         """
         ready_employee_records = EmployeeRecord.objects.ready()
 
+        # FIXME: temp disabled, too much impact, must be discussed
         # As requested by ASP, we can now send employee records in bigger batches
-        if len(ready_employee_records) < EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS:
-            self.logger.info(
-                "No enough employee records to initiate a transfer (%s / %s)",
-                len(ready_employee_records),
-                EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS,
-            )
-            return
+        # if len(ready_employee_records) < EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS:
+        #     self.logger.info(
+        #         "Not enough employee records to initiate a transfer (%s / %s)",
+        #        len(ready_employee_records),
+        #         EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS,
+        #     )
+        #     return
 
         self.logger.info("Starting UPLOAD")
 

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -297,9 +297,20 @@ class Command(BaseCommand):
         """
         Upload a file composed of all ready employee records
         """
+        ready_employee_records = EmployeeRecord.objects.ready()
+
+        # As requested by ASP, we can now send employee records in bigger batches
+        if len(ready_employee_records) < EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS:
+            self.logger.info(
+                "No enough employee records to initiate a transfer (%s / %s)",
+                len(ready_employee_records),
+                EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS,
+            )
+            return
+
         self.logger.info("Starting UPLOAD")
 
-        for batch in chunks(EmployeeRecord.objects.ready(), EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS):
+        for batch in chunks(ready_employee_records, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS):
             self._upload_batch_file(sftp, batch, dry_run)
 
     def archive(self, dry_run):

--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -70,7 +70,7 @@ class _EmployeeSerializer(serializers.ModelSerializer):
         return result
 
 
-class _EmployeeAddress(serializers.ModelSerializer):
+class _EmployeeAddressSerializer(serializers.ModelSerializer):
 
     adrTelephone = serializers.CharField(source="phone", allow_blank=True)
     adrMail = serializers.CharField(source="email", allow_blank=True)
@@ -151,7 +151,7 @@ class _EmployeeAddress(serializers.ModelSerializer):
         return result
 
 
-class _EmployeeSituation(serializers.ModelSerializer):
+class _EmployeeSituationSerializer(serializers.ModelSerializer):
 
     # Placeholder: updated at top-level serialization
     orienteur = serializers.CharField(required=False)
@@ -246,8 +246,8 @@ class EmployeeRecordSerializer(serializers.ModelSerializer):
     siret = serializers.CharField()
 
     personnePhysique = _EmployeeSerializer(source="job_application.job_seeker")
-    adresse = _EmployeeAddress(source="job_application.job_seeker")
-    situationSalarie = _EmployeeSituation(source="job_application.job_seeker")
+    adresse = _EmployeeAddressSerializer(source="job_application.job_seeker")
+    situationSalarie = _EmployeeSituationSerializer(source="job_application.job_seeker")
 
     # These fields are null at the beginning of the ASP processing
     codeTraitement = serializers.CharField(source="asp_processing_code", allow_blank=True)

--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -304,56 +304,6 @@ class EmployeeRecordSerializer(serializers.ModelSerializer):
         return result
 
 
-class _API_EmployeeAddress(_EmployeeAddress):
-    # This class in only useful for compatibilty
-    # We decided not to send phone and email (business and bad ASP address filters)
-    # But we make it available for API for compatibility with original document
-    # (these fiels should really be actual data, not fake, by implicit contract)
-
-    def _update_address_and_phone_number(self, result, instance) -> OrderedDict:
-        """
-        Allow overriding these 2 fields:
-        - adrTelephone
-        - adrMail
-        Make data readable again for API users.
-        """
-        result["adrTelephone"] = instance.phone
-        result["adrMail"] = instance.email
-
-        return result
-
-
-class EmployeeRecordAPISerializer(EmployeeRecordSerializer):
-    """
-    This serializer is a version with the `numeroAnnexe` field added (financial annex number).
-
-    This field not needed by ASP was simply ignored in earlier versions of the
-    main SFTP serializer but was removed for RGPD concerns.
-    """
-
-    numeroAnnexe = serializers.CharField(source="financial_annex_number")
-    adresse = _API_EmployeeAddress(source="job_application.job_seeker")
-
-    class Meta:
-        model = EmployeeRecord
-        fields = [
-            "passIae",
-            "passDateDeb",
-            "passDateFin",
-            "numLigne",
-            "typeMouvement",
-            "numeroAnnexe",
-            "mesure",
-            "siret",
-            "personnePhysique",
-            "adresse",
-            "situationSalarie",
-            "codeTraitement",
-            "libelleTraitement",
-        ]
-        read_only_fields = fields
-
-
 class EmployeeRecordBatchSerializer(serializers.Serializer):
     """
     This serializer is a wrapper for a list of employee records

--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -1,5 +1,4 @@
 import re
-from typing import OrderedDict
 
 from rest_framework import serializers
 from unidecode import unidecode

--- a/itou/employee_record/tests.py
+++ b/itou/employee_record/tests.py
@@ -302,6 +302,9 @@ class EmployeeRecordLifeCycleTest(TestCase):
         self.assertIsNone(self.employee_record.archived_json)
 
 
+# There is no need to create 700 employee record for a single batch
+# so this class var is changed to 1 for tests.
+@mock.patch("itou.employee_record.models.EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS", new=1)
 class EmployeeRecordManagementCommandTest(TestCase):
     """
     Employee record management command, testing:

--- a/itou/employee_record/tests.py
+++ b/itou/employee_record/tests.py
@@ -302,8 +302,8 @@ class EmployeeRecordLifeCycleTest(TestCase):
         self.assertIsNone(self.employee_record.archived_json)
 
 
-# There is no need to create 700 employee record for a single batch
-# so this class var is changed to 1 for tests.
+# There is no need to create 700 employee records for a single batch
+# so this class var is changed to 1 for tests, otherwise download operation is not triggered.
 @mock.patch("itou.employee_record.models.EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS", new=1)
 class EmployeeRecordManagementCommandTest(TestCase):
     """


### PR DESCRIPTION
### Quoi ?

Demandes d'évolutions et améliorations sur les fiches salarié.

### Pourquoi ?

- meilleure prise en charge par le support,
- éviter un  message d'information peu clair lors de la saisie des F.S.,
- évolutions de l'API demandées par les éditeurs de logiciel tiers,
- augmentation du nombre de fiches salarié à chaque envoi.

### Comment ?

- blocage préventif de l'affichage et de la possibilité de créer 2 fiches salariés pour deux structures d'une même "entité" ASP (même SIRET mais types de SIAE différents)
- affichage de l'état de la fiche salarié correspondante dans la section "candidature" de l'admin du PASS IAE (si existante)
- ajout d'un champ pour le NIR dans l'API fiche salarié (si disponible)

### Capture d'écrans

#### Admin PASS IAE

![image](https://user-images.githubusercontent.com/147232/143254779-dbf98f5b-7ad2-4971-ae43-eb926c67542f.png)

#### API


