### PR TITLE
Augmentation du délai de l'autocomplétion

### DIFF
--- a/itou/static/js/city_autocomplete_field.js
+++ b/itou/static/js/city_autocomplete_field.js
@@ -17,7 +17,7 @@ $(document).ready(() => {
   citySearchInput
     // https://api.jqueryui.com/autocomplete/
     .autocomplete({
-      delay: 150,
+      delay: 300,
       minLength: 1,
       source: citySearchInput.data('autocomplete-source-url'),
       autoFocus: true,

--- a/itou/static/js/commune_autocomplete_field.js
+++ b/itou/static/js/commune_autocomplete_field.js
@@ -21,7 +21,7 @@ $(document).ready(() => {
   communeSearchInput
     // https://api.jqueryui.com/autocomplete/
     .autocomplete({
-      delay: 150,
+      delay: 300,
       minLength: 1,
       // Use a callback to add custom parameter 'date':
       source: function(request, response) {


### PR DESCRIPTION
### Quoi ?

Augmentation du délai de l'autocomplétion

### Pourquoi ?

L'URL de destination est en top impact de L'APM (pas lente mais très sollicitée).

### Comment ?

Augmentation du délai dans le javascript qui déclenche l'appel.

