### PR TITLE
Ajout d'une page de stats à charger dans une iframe 2

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -528,6 +528,7 @@ DDETS_STATS_ALLOWED_DEPARTMENTS = ["38", "62", "67", "93"]
 DREETS_STATS_DASHBOARD_ID = 117
 DGEFP_STATS_DASHBOARD_ID = 117
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(os.environ.get("PILOTAGE_DASHBOARDS_WHITELIST", "[]"))
+PILOTAGE_SITE_URL = "https://pilotage.inclusion.beta.gouv.fr"
 
 # Slack notifications sent by Metabase cronjobs.
 SLACK_CRON_WEBHOOK_URL = os.environ.get("SLACK_CRON_WEBHOOK_URL", None)

--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -95,7 +95,7 @@
               <ul>
                 <li><a href="https://emplois.inclusion.beta.gouv.fr" rel="noopener" target="_blank">Les emplois</a></li>
                 <li><a href="https://communaute.inclusion.beta.gouv.fr" rel="noopener" target="_blank">La communauté</a></li>
-                <li><a href="https://pilotage.inclusion.beta.gouv.fr" rel="noopener" target="_blank">Le pilotage</a></li>
+                <li><a href="{{ ITOU_PILOTAGE_URL }}" rel="noopener" target="_blank">Le pilotage</a></li>
                 <li><a href="https://lemarche.inclusion.beta.gouv.fr" rel="noopener" target="_blank">Le marché</a></li>
               </ul>
             </nav>

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -12,7 +12,7 @@
         </div>
         <div class="mb-4">
             {% include "includes/icon.html" with icon="arrow-right" %}
-            <a href="https://pilotage.inclusion.beta.gouv.fr/" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet">
+            <a href="{{ ITOU_PILOTAGE_URL }}" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet">
                 Accès au site pilotage de l'inclusion
             </a>
         </div>

--- a/itou/templates/stats/stats_pilotage.html
+++ b/itou/templates/stats/stats_pilotage.html
@@ -17,7 +17,6 @@
       body {
         width: 100%;
         height: 100vh;
-        overflow: hidden;
       }
 ​
       iframe {

--- a/itou/templates/stats/stats_pilotage.html
+++ b/itou/templates/stats/stats_pilotage.html
@@ -32,11 +32,11 @@
     {% block content %}
         <script>
             window.iFrameResizer = {
-                targetOrigin: "{{ pilotage_base_url }}"
+                targetOrigin: "{{ ITOU_PILOTAGE_URL }}"
             }
         </script>
         <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.2/js/iframeResizer.contentWindow.min.js"></script>
-        {% comment %} we took the scripts from {{stats_base_url}} to have always the same version than metabase{% endcomment %}
+        {% comment %} we took the scripts from {{stats_base_url}} to always use the same version{% endcomment %}
         <script src="{{ stats_base_url }}/app/iframeResizer.js"></script>
         <iframe
             src="{{ iframeurl }}"

--- a/itou/templates/stats/stats_pilotage.html
+++ b/itou/templates/stats/stats_pilotage.html
@@ -3,6 +3,8 @@
 <html lang="fr">
 ​
   <head>
+    <meta name="robots" content="noindex, nofollow">
+
     <style>
       html,
       body,
@@ -27,24 +29,22 @@
   </head>
 ​
   <body>
-    <div id="embedMetabase">
-        {% block content %}
-            <script>
-                window.iFrameResizer = {
-                    targetOrigin: "{{ pilotage_base_url }}"
-                }
-            </script>
-            <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.2/js/iframeResizer.contentWindow.min.js"></script>
-            {% comment %} we took the scripts from {{stats_base_url}} to have always the same version than metabase{% endcomment %}
-            <script src="{{ stats_base_url }}/app/iframeResizer.js"></script>
-            <iframe
-                src="{{ iframeurl }}"
-                width="100%"
-                onload="iFrameResize({}, this)"
-                frameborder="0">
-            </iframe>
-        {% endblock %}
-    </div>
+    {% block content %}
+        <script>
+            window.iFrameResizer = {
+                targetOrigin: "{{ pilotage_base_url }}"
+            }
+        </script>
+        <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.2/js/iframeResizer.contentWindow.min.js"></script>
+        {% comment %} we took the scripts from {{stats_base_url}} to have always the same version than metabase{% endcomment %}
+        <script src="{{ stats_base_url }}/app/iframeResizer.js"></script>
+        <iframe
+            src="{{ iframeurl }}"
+            width="100%"
+            onload="iFrameResize({}, this)"
+            frameborder="0">
+        </iframe>
+    {% endblock %}
   </body>
 ​
 </html>

--- a/itou/templates/stats/stats_pilotage.html
+++ b/itou/templates/stats/stats_pilotage.html
@@ -29,6 +29,13 @@
   <body>
     <div id="embedMetabase">
         {% block content %}
+            <script>
+                window.iFrameResizer = {
+                    targetOrigin: "{{ pilotage_base_url }}"
+                }
+            </script>
+            <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.2/js/iframeResizer.contentWindow.min.js"></script>
+            {% comment %} we took the scripts from {{stats_base_url}} to have always the same version than metabase{% endcomment %}
             <script src="{{ stats_base_url }}/app/iframeResizer.js"></script>
             <iframe
                 src="{{ iframeurl }}"

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -18,7 +18,7 @@ def _get_token(payload):
     return jwt.encode(payload, settings.METABASE_SECRET_KEY, algorithm="HS256")
 
 
-def metabase_embedded_url(dashboard_id, params={}):
+def metabase_embedded_url(dashboard_id, params={}, with_title=False):
     """
     Creates an embed/signed URL for embedded Metabase dashboards:
     * expiration delay of token set at 10 minutes, kept short on purpose due to the fact that during this short time
@@ -27,4 +27,5 @@ def metabase_embedded_url(dashboard_id, params={}):
     * optional parameters typically for locked filters (e.g. allow viewing data of one departement only)
     """
     payload = {"resource": {"dashboard": dashboard_id}, "params": params, "exp": round(time.time()) + (10 * 60)}
-    return settings.METABASE_SITE_URL + "/embed/dashboard/" + _get_token(payload) + "#titled=false"
+    is_titled = "true" if with_title else "false"
+    return settings.METABASE_SITE_URL + "/embed/dashboard/" + _get_token(payload) + f"#titled={is_titled}"

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -16,6 +16,7 @@ def expose_settings(request):
         "ITOU_EMAIL_PROLONGATION": settings.ITOU_EMAIL_PROLONGATION,
         "ITOU_ENVIRONMENT": settings.ITOU_ENVIRONMENT,
         "ITOU_FQDN": settings.ITOU_FQDN,
+        "ITOU_PILOTAGE_URL": settings.PILOTAGE_SITE_URL,
         "ITOU_PROTOCOL": settings.ITOU_PROTOCOL,
         "SHOW_TEST_ACCOUNTS_BANNER": settings.SHOW_TEST_ACCOUNTS_BANNER,
         "TYPEFORM_URL": settings.TYPEFORM_URL,

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -72,7 +72,7 @@ def public_pilotage_stats(request, dashboard_id, template_name="stats/stats_pilo
         raise PermissionDenied
 
     context = {
-        "iframeurl": metabase_embedded_url(dashboard_id),
+        "iframeurl": metabase_embedded_url(dashboard_id, with_title=True),
         "stats_base_url": settings.METABASE_SITE_URL,
     }
     return render(request, template_name, context)

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -58,6 +58,7 @@ def public_advanced_stats(request, template_name=_STATS_HTML_TEMPLATE):
         "related_link": "stats:public_basic_stats",
         "related_title": "Vers les statistiques simplifiées",
         "stats_base_url": settings.METABASE_SITE_URL,
+        "pilotage_base_url": settings.PILOTAGE_SITE_URL,
     }
     return render(request, template_name, context)
 

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -58,7 +58,6 @@ def public_advanced_stats(request, template_name=_STATS_HTML_TEMPLATE):
         "related_link": "stats:public_basic_stats",
         "related_title": "Vers les statistiques simplifiées",
         "stats_base_url": settings.METABASE_SITE_URL,
-        "pilotage_base_url": settings.PILOTAGE_SITE_URL,
     }
     return render(request, template_name, context)
 


### PR DESCRIPTION
### Quoi ?

Ajout d'une url pour pouvoir visualiser des dashboards avec des ids particuliers.

Suite à la précédente [pr](https://github.com/betagouv/itou/pull/974) nous avons constaté un problème de scroll sur la page et que les titres de dashboards n'étaient plus affichés.

### Pourquoi ?
#### Problème de scroll
Ce fonctionnement est dû au fait que la bibliothèque iframeResizer a besoin d'être implémenté dans les deux sens (le parent et l'iframe) 👉👉 [voir la doc d'iframe-resizer](https://github.com/davidjbradshaw/iframe-resizer/blob/master/src/iframeResizer.js#L4)

#### Problèmes des titres de dashboards
L'appel par défaut de l'url de metabase ajoute l'argument `#titled=false`

### Comment ?

![image](https://user-images.githubusercontent.com/12339682/143562744-87ce5ce7-5833-4798-9c7d-71e9ad50ffa6.png)

### Autre (optionnel)

- [Pour aller plus loin dans la communication cross iframes](https://benohead.com/blog/2015/12/07/cross-document-communication-with-iframes/)