### PR TITLE
Suppression des infos liées au PASS IAE sur les candidatures annulées

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -684,6 +684,12 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             self.approval.delete()
             self.approval = None
 
+            # Remove flags on the job application about approval
+            self.approval_number_sent_by_email = False
+            self.approval_number_sent_at = None
+            self.approval_delivery_mode = ""
+            self.approval_manually_delivered_by = None
+
         # Send notification.
         user = kwargs.get("user")
         connection = mail.get_connection()


### PR DESCRIPTION
### Quoi ?

Remise à zéro des champs concernant l'attribution du PASS IAE lors qu'une candidature est annulée.

### Pourquoi ?

Lorsqu'une embauche est de nouveau acceptée après une annulation, le Pass IAE ne peut pas être généré ([carte Trello](https://trello.com/c/ZQBiFsQV)).

### Comment ?

Lors de l'annulation de l'embauche, les champs sont remis à 0.