### PR TITLE
Fix filtre d'exclusion des SIAE de même ASP ID

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -208,7 +208,11 @@ class JobApplicationQuerySet(models.QuerySet):
             # Exclude flagged approvals (batch creation or import of approvals)
             .exclude(approval__create_employee_record=False)
             # Exclude existing employee records with the same PASS IAE and to_siae.asp_id (considered as dups by ASP)
-            .exclude(employee_record__asp_id=siae.asp_id, employee_record__approval_number=F("approval__number"))
+            .exclude(
+                ~Q(to_siae=siae),
+                employee_record__asp_id=siae.asp_id,
+                employee_record__approval_number=F("approval__number"),
+            )
             # Only ACCEPTED job applications can be transformed into employee records
             .accepted()
             # Accept only job applications without linked or processed employee record

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -6,7 +6,7 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core import mail
 from django.db import models
-from django.db.models import BooleanField, Case, Count, Exists, F, Max, OuterRef, Q, Subquery, When
+from django.db.models import BooleanField, Case, Count, Exists, Max, OuterRef, Q, Subquery, When
 from django.db.models.functions import Greatest, TruncMonth
 from django.urls import reverse
 from django.utils import timezone


### PR DESCRIPTION
### Quoi ?

Disparition de l'affichage de certaines fiches valides

### Pourquoi ?

Dans le cas ou la création de la fiche salarié ne va pas jusqu'au bout (interruption par l'utilisateur),
un retour à la liste des fiches salarié à saisir n'affiche plus la fiche modifié.

=> Filtre mal foutu

### Comment ?

Modification du filtre : ajout d'une condition (bloque l'affichage des fiches pour une SIAE différente de l'actuelle et pas simplement avec le même `asp_id`).

### Autre

Pas de revue : HOTFIX
