### PR TITLE
Mise à jour de Django, Elastic APM et Sentry

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.2.0  # https://github.com/avian2/unidecode
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.2.9  # pyup: < 4.0  # https://www.djangoproject.com/
+django==3.2.10  # pyup: < 4.0  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.45.0  # https://github.com/pennersr/django-allauth

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,5 +1,5 @@
 -r ./base.txt
 
 uwsgi==2.0.19.1  # https://github.com/unbit/uwsgi
-sentry-sdk==1.4.3  # https://github.com/getsentry/sentry-python
-elastic-apm==6.6.0  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html
+sentry-sdk==1.5.0  # https://github.com/getsentry/sentry-python
+elastic-apm==6.7.1  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html


### PR DESCRIPTION
### Quoi ?

Mise à jour de Django, Elastic APM et Sentry

### Pourquoi ?

Une CVE a été publiée sur Django : 
https://www.djangoproject.com/weblog/2021/dec/07/security-releases/

### Comment ?

Mise à jour des paquets Python.
