### PR TITLE
Revert "Les candidatures PE peuvent être importées 3 mois après leur expiration"

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1027,8 +1027,6 @@ class PoleEmploiApproval(CommonApprovalMixin):
     at the time of issuance.
     """
 
-    SUPPORT_EXTENSION_DELAY_MONTHS = 3
-
     # Matches prescriber_organization.code_safir_pole_emploi.
     pe_structure_code = models.CharField("Code structure Pôle emploi", max_length=5)
 
@@ -1116,11 +1114,6 @@ class PoleEmploiApproval(CommonApprovalMixin):
         end_at = self.end_at
         if self.overlaps_covid_lockdown:
             end_at = self.get_extended_covid_end_at(end_at)
-
-        # On top of a potential lockdown, we want to add a few extra months in order to reduce
-        # the issues of importing expired PE approvals that fill our support
-        end_at = end_at + relativedelta(months=PoleEmploiApproval.SUPPORT_EXTENSION_DELAY_MONTHS)
-
         return end_at
 
     @property

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -575,25 +575,13 @@ class PoleEmploiApprovalModelTest(TestCase):
             end_at = now_date - relativedelta(days=1)
             start_at = end_at - relativedelta(years=2)
             approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
-            self.assertTrue(approval.is_valid())
+            self.assertFalse(approval.is_valid())
 
             # Starts tomorrow.
             start_at = now_date + relativedelta(days=1)
             end_at = start_at + relativedelta(years=2)
             approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
             self.assertTrue(approval.is_valid())
-
-            # Ended last month
-            end_at = now_date - relativedelta(months=1)
-            start_at = end_at - relativedelta(years=2)
-            approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
-            self.assertTrue(approval.is_valid())
-
-            # Ended 3 months and a day ago
-            end_at = now_date - relativedelta(days=1, months=3)
-            start_at = end_at - relativedelta(years=2)
-            approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
-            self.assertFalse(approval.is_valid())
 
     def test_is_valid_overlaps_covid_lockdown(self):
         now_date = PoleEmploiApproval.LOCKDOWN_END_AT + relativedelta(months=6)
@@ -608,17 +596,10 @@ class PoleEmploiApprovalModelTest(TestCase):
 
         # Overlaps COVID lockdown but is expired even with the prolongation
         with mock.patch("django.utils.timezone.now", side_effect=lambda: now):
-            end_at = now_date - relativedelta(months=PoleEmploiApproval.LOCKDOWN_EXTENSION_DELAY_MONTHS + 3, days=1)
-            start_at = end_at - relativedelta(years=2)
-            approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
-            self.assertFalse(approval.is_valid())
-
-        # Overlaps COVID lockdown but is not expired even with the prolongation thanks to the 3 month extension
-        with mock.patch("django.utils.timezone.now", side_effect=lambda: now):
             end_at = now_date - relativedelta(months=PoleEmploiApproval.LOCKDOWN_EXTENSION_DELAY_MONTHS, days=1)
             start_at = end_at - relativedelta(years=2)
             approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
-            self.assertTrue(approval.is_valid())
+            self.assertFalse(approval.is_valid())
 
         # Does not overlap COVID lockdown: should not be prolonged
         end_at = PoleEmploiApproval.LOCKDOWN_START_AT - relativedelta(days=1)

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -256,7 +256,7 @@ class ApplyAsJobSeekerTest(TestCase):
         with mock.patch("django.utils.timezone.now", side_effect=lambda: now):
             siae = SiaeWithMembershipAndJobsFactory(romes=("N1101", "N1105"))
             user = JobSeekerFactory()
-            end_at = now_date - relativedelta(days=30, months=PoleEmploiApproval.SUPPORT_EXTENSION_DELAY_MONTHS)
+            end_at = now_date - relativedelta(days=30)
             start_at = end_at - relativedelta(years=2)
             PoleEmploiApprovalFactory(
                 pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate, start_at=start_at, end_at=end_at


### PR DESCRIPTION
Reverts betagouv/itou#977

Des agréments expirés sont récupérer hors du module de prolongation.