### PR TITLE
Correction du script qui importe les salariés des AI

### DIFF
--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -331,12 +331,12 @@ class Command(BaseCommand):
                     if not self.dry_run:
                         # In production, it can raise an IntegrityError if another PASS has just been delivered a few seconds ago.
                         # Try to save with another number until it succeeds.
-                        succedded = None
-                        while succedded is None:
+                        succeeded = None
+                        while succeeded is None:
                             try:
                                 # `Approval.save()` delivers an automatic number.
                                 approval.save()
-                                succedded = True
+                                succeeded = True
                             except IntegrityError:
                                 pass
                     created_approvals += 1

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -420,6 +420,7 @@ class Command(BaseCommand):
                 "approval_id": approval.pk,
                 "approval_manually_delivered_by": approval_manually_delivered_by,
                 "created_at": settings.AI_EMPLOYEES_STOCK_IMPORT_DATE,
+                "approval_number_sent_by_email": True,
             }
             job_application = JobApplication(**job_app_dict)
             if not self.dry_run:

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -300,11 +300,11 @@ class Command(BaseCommand):
 
                 # Create a job seeker.
                 if not job_seeker:
-                    created_users += 1
                     if self.dry_run:
                         job_seeker = User(**user_data)
                     else:
                         job_seeker = User.create_job_seeker_by_proxy(developer, **user_data)
+                    created_users += 1
 
                 # If job seeker has already a valid approval: don't redeliver it.
                 if job_seeker.approvals.valid().exists():
@@ -318,7 +318,6 @@ class Command(BaseCommand):
                         created_by=developer,
                         created_at=objects_created_at,
                     )
-                    created_approvals += 1
                     if not self.dry_run:
                         # In production, it can raise an IntegrityError if another PASS has just been delivered a few seconds ago.
                         # Try to save with another number until it succeeds.
@@ -330,6 +329,7 @@ class Command(BaseCommand):
                                 succedded = True
                             except IntegrityError:
                                 pass
+                    created_approvals += 1
 
                 # Create a new job application.
                 siae = Siae.objects.get(kind=Siae.KIND_AI, siret=row[SIRET_COL])

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -347,8 +347,6 @@ class Command(BaseCommand):
                 redelivered_approval = True
             elif count > 1:
                 self.logger.info(f"Multiple accepted job applications linked to this approval: {approval.pk}.")
-                if not self.dry_run:
-                    raise NotImplementedError()
 
         if not approval:
             # `create_employee_record` prevents "Fiche salariés" from being created.

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -360,7 +360,6 @@ class Command(BaseCommand):
                 end_at=datetime.date(2023, 11, 30),
                 user_id=job_seeker.pk,
                 created_by=created_by,
-                create_employee_record=False,
                 created_at=settings.AI_EMPLOYEES_STOCK_IMPORT_DATE,
             )
             if not self.dry_run:

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -282,10 +282,11 @@ class Command(BaseCommand):
                 # See `self.clean_nir`.
                 if not row.nir_is_valid:
                     ignored_nirs += 1
+                    user_data["nir"] = None
 
-                job_seeker = User.objects.filter(nir=row[NIR_COL]).exclude(nir="").first()
+                job_seeker = User.objects.filter(nir=user_data["nir"]).exclude(nir__isnull=True).first()
                 if not job_seeker:
-                    job_seeker = User.objects.filter(email=row[EMAIL_COL]).first()
+                    job_seeker = User.objects.filter(email=user_data["email"]).first()
 
                 # Some e-mail addresses belong to prescribers!
                 if job_seeker and not job_seeker.is_job_seeker:

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -412,6 +412,12 @@ class Command(BaseCommand):
                     )
 
         job_application = job_application_qs.first()
+
+        # Previously create job applications may still allow employee records creation.
+        if job_application and job_application.create_employee_record:
+            job_application.create_employee_record = False
+            if not self.dry_run:
+                job_application.save()
         if not job_application:
             job_app_dict = {
                 "sender": siae.active_admin_members.first(),
@@ -425,6 +431,7 @@ class Command(BaseCommand):
                 "approval_id": approval.pk,
                 "approval_manually_delivered_by": approval_manually_delivered_by,
                 "created_at": settings.AI_EMPLOYEES_STOCK_IMPORT_DATE,
+                "create_employee_record": False,
                 "approval_number_sent_by_email": True,
             }
             job_application = JobApplication(**job_app_dict)

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -8,6 +8,7 @@ import uuid
 from pathlib import Path
 
 import pandas as pd
+import pytz
 import unidecode
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -326,6 +327,7 @@ class Command(BaseCommand):
 
                 # Create a new job application.
                 siae = Siae.objects.get(kind=Siae.KIND_AI, siret=row[SIRET_COL])
+                job_app_created_at = datetime.datetime(2021, 11, 30, 20, 50, 00, tzinfo=pytz.utc)
                 job_app_dict = {
                     "sender": siae.active_admin_members.first(),
                     "sender_kind": JobApplication.SENDER_KIND_SIAE_STAFF,
@@ -338,6 +340,7 @@ class Command(BaseCommand):
                     "approval_id": approval.pk,
                     "approval_manually_delivered_by": developer,
                     "create_employee_record": False,
+                    "created_at": job_app_created_at,
                 }
                 job_application = JobApplication(**job_app_dict)
                 created_job_applications += 1

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -9,7 +9,6 @@ import uuid
 from pathlib import Path
 
 import pandas as pd
-import pytz
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -47,11 +47,15 @@ SIRET_COL = "pmo_siret"
 COMMENTS_COL = "commentaire"
 USER_PK_COL = "salarie_id_pour_asp"
 USER_ITOU_EMAIL_COL = "salarie_itou_email"
-PASS_IAE_NUMBER_COL = "pass_iaa_numero"
+PASS_IAE_NUMBER_COL = "pass_iae_numero"
 PASS_IAE_START_DATE_COL = "pass_iae_date_debut"
 PASS_IAE_END_DATE_COL = "pass_iae_date_fin"
 
+# First file.
 DATE_FORMAT = "%Y-%m-%d"
+
+# Second file.
+DATE_FORMAT = "%d/%m/%Y"
 
 
 class Command(BaseCommand):
@@ -536,10 +540,12 @@ class Command(BaseCommand):
         # Exclude ended contracts.
         total_df = total_df.copy()
         filtered_df = total_df.copy()
-        ended_contracts = total_df[total_df[CONTRACT_ENDDATE_COL] != ""]
-        filtered_df = filtered_df.drop(ended_contracts.index)
-        self.logger.info(f"Ended contract: excluding {len(ended_contracts)} rows.")
-        total_df.loc[ended_contracts.index, COMMENTS_COL] = "Ligne ignorée : contrat terminé."
+
+        if CONTRACT_ENDDATE_COL in total_df.columns:
+            ended_contracts = total_df[total_df[CONTRACT_ENDDATE_COL] != ""]
+            filtered_df = filtered_df.drop(ended_contracts.index)
+            self.logger.info(f"Ended contract: excluding {len(ended_contracts)} rows.")
+            total_df.loc[ended_contracts.index, COMMENTS_COL] = "Ligne ignorée : contrat terminé."
 
         # List provided by the ASP.
         excluded_structures_df = filtered_df[~filtered_df.siret_validated_by_asp]
@@ -578,9 +584,9 @@ class Command(BaseCommand):
         self.logger.info("-" * 80)
 
         if sample_size:
-            df = pd.read_csv(file_path, dtype=str, encoding="latin_1").sample(int(sample_size))
+            df = pd.read_csv(file_path, dtype=str, encoding="latin_1", sep=";").sample(int(sample_size))
         else:
-            df = pd.read_csv(file_path, dtype=str, encoding="latin_1")
+            df = pd.read_csv(file_path, dtype=str, encoding="latin_1", sep=";")
 
         # Add columns to share data with the ASP.
         df = self.add_columns_for_asp(df)

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -92,6 +92,14 @@ class Command(BaseCommand):
             dest="sample_size",
             help="Sample size to run this script with (instead of the whole file).",
         )
+
+        parser.add_argument(
+            "--invalid-nirs-only",
+            dest="invalid_nirs_only",
+            action="store_true",
+            help="Only save users whose NIR is invalid.",
+        )
+
         parser.add_argument(
             "--file-path",
             dest="file_path",
@@ -382,7 +390,7 @@ class Command(BaseCommand):
 
         self.log_to_csv("emailing", emailing_rows)
 
-    def handle(self, file_path, developer_email, dry_run=False, **options):
+    def handle(self, file_path, developer_email, dry_run=False, invalid_nirs_only=False, **options):
         """
         Each line represents a contract.
         1/ Read the file and clean data.
@@ -428,6 +436,9 @@ class Command(BaseCommand):
         self.logger.info(f"Invalid nirs: {len(invalid_nirs)}.")
 
         self.logger.info("🚮 STEP 2: remove rows!")
+        if invalid_nirs_only:
+            df = invalid_nirs
+
         cleaned_df = df.copy()
 
         # Exclude ended contracts.

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -274,7 +274,7 @@ class Command(BaseCommand):
                 if not row.nir_is_valid:
                     ignored_nirs += 1
 
-                job_seeker = User.objects.filter(nir=row[NIR_COL]).first()
+                job_seeker = User.objects.filter(nir=row[NIR_COL]).exclude(nir="").first()
                 if not job_seeker:
                     job_seeker = User.objects.filter(email=row[EMAIL_COL]).first()
 
@@ -421,12 +421,13 @@ class Command(BaseCommand):
         df["nir_is_valid"] = ~df[NIR_COL].isnull()
         df["siret_is_valid"] = df.apply(self.siret_is_valid, axis=1)
 
+        # Replace empty values by "" instead of NaN.
+        df = df.fillna("")
+
         # Users with invalid NIRS are stored but without a NIR.
         invalid_nirs = df[~df.nir_is_valid]
         df.loc[invalid_nirs.index, "Commentaire"] = "NIR invalide. Utilisateur potentiellement créé sans NIR."
-
-        # Replace empty values by "" instead of NaN.
-        df = df.fillna("")
+        self.logger.info(f"Invalid nirs: {len(invalid_nirs)}.")
 
         self.logger.info("🚮 STEP 2: remove rows!")
         cleaned_df = df.copy()

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -237,9 +237,9 @@ class Command(BaseCommand):
         created_job_applications = 0
 
         # A fixed creation date allows us to retrieve objects
-        # created by  this script.
+        # created by this script.
         # See Approval.is_from_ai_stock for example.
-        objects_created_at = datetime.datetime(2021, 11, 30, 20, 50, 00, tzinfo=pytz.utc)
+        objects_created_at = settings.AI_EMPLOYEES_STOCK_IMPORT_DATE
 
         # Get developer account by email.
         # Used to store who created the following users, approvals and job applications.

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -44,9 +44,12 @@ PHONE_COL = "adr_telephone"
 POST_CODE_COL = "codepostalcedex"
 SIAE_NAME_COL = "pmo_denom_soc"
 SIRET_COL = "pmo_siret"
-PASS_IAE_NUMBER_COL = "Numéro de PASS IAE"
-USER_PK_COL = "ID salarié"
-COMMENTS_COL = "Commentaire"
+COMMENTS_COL = "commentaire"
+USER_PK_COL = "salarie_id_pour_asp"
+USER_ITOU_EMAIL_COL = "salarie_itou_email"
+PASS_IAE_NUMBER_COL = "pass_iaa_numero"
+PASS_IAE_START_DATE_COL = "pass_iae_date_debut"
+PASS_IAE_END_DATE_COL = "pass_iae_date_fin"
 
 DATE_FORMAT = "%Y-%m-%d"
 
@@ -483,8 +486,11 @@ class Command(BaseCommand):
 
             # Update dataframe values.
             # https://stackoverflow.com/questions/25478528/updating-value-in-iterrow-for-pandas
-            df.loc[i, USER_PK_COL] = job_seeker.jobseeker_hash_id
             df.loc[i, PASS_IAE_NUMBER_COL] = approval.number
+            df.loc[i, PASS_IAE_START_DATE_COL] = approval.start_at.strftime(DATE_FORMAT)
+            df.loc[i, PASS_IAE_END_DATE_COL] = approval.end_at.strftime(DATE_FORMAT)
+            df.loc[i, USER_PK_COL] = job_seeker.jobseeker_hash_id
+            df.loc[i, USER_ITOU_EMAIL_COL] = job_seeker.email
 
         self.logger.info("Import is over!")
         self.logger.info(f"Already existing users: {found_users}.")
@@ -513,17 +519,12 @@ class Command(BaseCommand):
 
     def add_columns_for_asp(self, df):
         df[COMMENTS_COL] = ""
-        df[PASS_IAE_NUMBER_COL] = ""
         df[USER_PK_COL] = ""
+        df[USER_ITOU_EMAIL_COL] = ""
+        df[PASS_IAE_NUMBER_COL] = ""
+        df[PASS_IAE_START_DATE_COL] = ""
+        df[PASS_IAE_END_DATE_COL] = ""
         return df
-
-    def assert_asp_columns(self, df):
-        expected_columns = [
-            COMMENTS_COL,
-            PASS_IAE_NUMBER_COL,
-            USER_PK_COL,
-        ]
-        assert all(item in df.columns for item in expected_columns)
 
     def filter_invalid_nirs(self, df):
         total_df = df.copy()
@@ -610,8 +611,6 @@ class Command(BaseCommand):
         # Step 4: create a CSV file including comments to be shared with the ASP.
         df = df.drop(["nir_is_valid", "siret_validated_by_asp"], axis=1)  # Remove useless columns.
 
-        # Make sure expected columns are present.
-        self.assert_asp_columns(df)
         self.log_to_csv("fichier_final", df)
         self.logger.info("📖 STEP 4: log final results.")
         self.logger.info("You can transfer this file to the ASP: /exports/import_ai_bilan.csv")

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -43,7 +43,7 @@ POST_CODE_COL = "codepostalcedex"
 SIAE_NAME_COL = "pmo_denom_soc"
 SIRET_COL = "pmo_siret"
 PASS_IAE_NUMBER_COL = "Numéro de PASS IAE"
-USER_PK = "ID utilisateur"
+USER_PK = "ID salarié"
 
 DATE_FORMAT = "%Y-%m-%d"
 
@@ -384,7 +384,7 @@ class Command(BaseCommand):
             # Update dataframe values.
             # https://stackoverflow.com/questions/25478528/updating-value-in-iterrow-for-pandas
             cleaned_df.loc[i, PASS_IAE_NUMBER_COL] = approval.number
-            cleaned_df.loc[i, USER_PK] = job_seeker.pk
+            original_df.loc[i, USER_PK] = job_seeker.jobseeker_hash_id
             original_df.loc[i, PASS_IAE_NUMBER_COL] = approval.number
 
         self.logger.info("Import is over!")
@@ -453,7 +453,7 @@ class Command(BaseCommand):
         # Will be shared with the ASP.
         df["Commentaire"] = ""
 
-        # Add an "approval" column to share with the ASP the PASS IAE number.
+        # Add columns to share data with the ASP.
         df[PASS_IAE_NUMBER_COL] = ""
         df[USER_PK] = ""
 
@@ -504,7 +504,7 @@ class Command(BaseCommand):
         df, cleaned_df = self.import_data_into_itou(original_df=df, cleaned_df=cleaned_df)
 
         # Step 4: create a CSV file including comments to be shared with the ASP.
-        df = df.drop([USER_PK, "nir_is_valid", "siret_is_valid"], axis=1)  # Remove useless columns.
+        df = df.drop(["nir_is_valid", "siret_is_valid"], axis=1)  # Remove useless columns.
         self.log_to_csv("fichier_final", df)
         self.logger.info("📖 STEP 4: log final results.")
         self.logger.info("You can transfer this file to the ASP: /exports/import_ai_bilan.csv")

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -9,13 +9,11 @@ from pathlib import Path
 
 import pandas as pd
 import pytz
-import unidecode
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.db.utils import IntegrityError
-from django.utils.text import slugify
 from tqdm import tqdm
 
 from itou.approvals.models import Approval

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -591,9 +591,9 @@ class Command(BaseCommand):
         self.logger.info("-" * 80)
 
         if sample_size:
-            df = pd.read_csv(file_path, dtype=str, encoding="latin_1", sep=";").sample(int(sample_size))
+            df = pd.read_csv(file_path, dtype=str, encoding="latin_1", sep=",").sample(int(sample_size))
         else:
-            df = pd.read_csv(file_path, dtype=str, encoding="latin_1", sep=";")
+            df = pd.read_csv(file_path, dtype=str, encoding="latin_1", sep=",")
 
         # Add columns to share data with the ASP.
         df = self.add_columns_for_asp(df)

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -315,8 +315,6 @@ class Command(BaseCommand):
                                 succedded = True
                             except IntegrityError:
                                 pass
-                        # Make sure approval.pk is set.
-                        approval.refresh_from_db()
 
                 # Create a new job application.
                 siae = Siae.objects.get(kind=Siae.KIND_AI, siret=row[SIRET_COL])

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -54,7 +54,7 @@ PASS_IAE_END_DATE_COL = "pass_iae_date_fin"
 DATE_FORMAT = "%Y-%m-%d"
 
 # Second file.
-DATE_FORMAT = "%d/%m/%Y"
+# DATE_FORMAT = "%d/%m/%Y"
 
 
 class Command(BaseCommand):
@@ -288,7 +288,9 @@ class Command(BaseCommand):
         if not row.nir_is_valid:
             user_data["nir"] = None
 
-        job_seeker = User.objects.filter(nir=user_data["nir"]).exclude(Q(nir__isnull=True) | Q(nir="")).first()
+        job_seeker = None
+        if row.nir_is_valid:
+            job_seeker = User.objects.filter(nir=user_data["nir"]).exclude(Q(nir__isnull=True) | Q(nir="")).first()
 
         if not job_seeker:
             job_seeker = User.objects.filter(email=user_data["email"]).first()

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -1,0 +1,146 @@
+import datetime
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from itou.approvals.factories import ApprovalFactory
+from itou.eligibility.models import EligibilityDiagnosis
+from itou.job_applications.factories import (
+    JobApplicationSentByJobSeekerFactory,
+    JobApplicationWithApprovalFactory,
+    JobApplicationWithEligibilityDiagnosis,
+)
+from itou.job_applications.models import JobApplication
+from itou.users.models import User
+
+
+class ManagementCommandsTest(TestCase):
+    """
+    Test the deduplication of several users.
+
+    This is temporary and should be deleted after the release of the NIR
+    which should prevent duplication.
+    """
+
+    def test_deduplicate_job_seekers(self):
+        """
+        Easy case : among all the duplicates, only one has a PASS IAE.
+        """
+
+        # Attributes shared by all users.
+        # Deduplication is based on these values.
+        kwargs = {
+            "job_seeker__pole_emploi_id": "6666666B",
+            "job_seeker__birthdate": datetime.date(2002, 12, 12),
+        }
+
+        # Create `user1`.
+        job_app1 = JobApplicationWithApprovalFactory(job_seeker__nir=None, **kwargs)
+        user1 = job_app1.job_seeker
+
+        self.assertIsNone(user1.nir)
+        self.assertEqual(1, user1.approvals.count())
+        self.assertEqual(1, user1.job_applications.count())
+        self.assertEqual(1, user1.eligibility_diagnoses.count())
+
+        # Create `user2`.
+        job_app2 = JobApplicationWithEligibilityDiagnosis(job_seeker__nir=None, **kwargs)
+        user2 = job_app2.job_seeker
+
+        self.assertIsNone(user2.nir)
+        self.assertEqual(0, user2.approvals.count())
+        self.assertEqual(1, user2.job_applications.count())
+        self.assertEqual(1, user2.eligibility_diagnoses.count())
+
+        # Create `user3`.
+        job_app3 = JobApplicationWithEligibilityDiagnosis(**kwargs)
+        user3 = job_app3.job_seeker
+        expected_nir = user3.nir
+
+        self.assertIsNotNone(user3.nir)
+        self.assertEqual(0, user3.approvals.count())
+        self.assertEqual(1, user3.job_applications.count())
+        self.assertEqual(1, user3.eligibility_diagnoses.count())
+
+        # Merge all users into `user1`.
+        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True)
+
+        # If only one NIR exists for all the duplicates, it should
+        # be reassigned to the target account.
+        user1.refresh_from_db()
+        self.assertEqual(user1.nir, expected_nir)
+
+        self.assertEqual(3, user1.job_applications.count())
+        self.assertEqual(3, user1.eligibility_diagnoses.count())
+        self.assertEqual(1, user1.approvals.count())
+
+        self.assertEqual(0, User.objects.filter(email=user2.email).count())
+        self.assertEqual(0, User.objects.filter(email=user3.email).count())
+
+        self.assertEqual(0, JobApplication.objects.filter(job_seeker=user2).count())
+        self.assertEqual(0, JobApplication.objects.filter(job_seeker=user3).count())
+
+        self.assertEqual(0, EligibilityDiagnosis.objects.filter(job_seeker=user2).count())
+        self.assertEqual(0, EligibilityDiagnosis.objects.filter(job_seeker=user3).count())
+
+    def test_deduplicate_job_seekers_without_empty_sender_field(self):
+        """
+        Easy case: among all the duplicates, only one has a PASS IAE.
+        Ensure that the `sender` field is never left empty.
+        """
+
+        # Attributes shared by all users.
+        # Deduplication is based on these values.
+        kwargs = {
+            "job_seeker__pole_emploi_id": "6666666B",
+            "job_seeker__birthdate": datetime.date(2002, 12, 12),
+        }
+
+        # Create `user1` through a job application sent by him.
+        job_app1 = JobApplicationSentByJobSeekerFactory(job_seeker__nir=None, **kwargs)
+        user1 = job_app1.job_seeker
+
+        self.assertEqual(1, user1.job_applications.count())
+        self.assertEqual(job_app1.sender, user1)
+
+        # Create `user2` through a job application sent by him.
+        job_app2 = JobApplicationSentByJobSeekerFactory(job_seeker__nir=None, **kwargs)
+        user2 = job_app2.job_seeker
+
+        self.assertEqual(1, user2.job_applications.count())
+        self.assertEqual(job_app2.sender, user2)
+
+        # Create `user3` through a job application sent by a prescriber.
+        job_app3 = JobApplicationWithEligibilityDiagnosis(job_seeker__nir=None, **kwargs)
+        user3 = job_app3.job_seeker
+        self.assertNotEqual(job_app3.sender, user3)
+        job_app3_sender = job_app3.sender  # The sender is a prescriber.
+
+        # Ensure that `user1` will always be the target into which duplicates will be merged
+        # by attaching a PASS IAE to him.
+        self.assertEqual(0, user1.approvals.count())
+        self.assertEqual(0, user2.approvals.count())
+        self.assertEqual(0, user3.approvals.count())
+        ApprovalFactory(user=user1)
+
+        # Merge all users into `user1`.
+        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True)
+
+        self.assertEqual(3, user1.job_applications.count())
+
+        job_app1.refresh_from_db()
+        job_app2.refresh_from_db()
+        job_app3.refresh_from_db()
+
+        self.assertEqual(job_app1.sender, user1)
+        self.assertEqual(job_app2.sender, user1)  # The sender must now be user1.
+        self.assertEqual(job_app3.sender, job_app3_sender)  # The sender must still be a prescriber.
+
+        self.assertEqual(0, User.objects.filter(email=user2.email).count())
+        self.assertEqual(0, User.objects.filter(email=user3.email).count())
+
+        self.assertEqual(0, JobApplication.objects.filter(job_seeker=user2).count())
+        self.assertEqual(0, JobApplication.objects.filter(job_seeker=user3).count())
+
+        self.assertEqual(0, EligibilityDiagnosis.objects.filter(job_seeker=user2).count())
+        self.assertEqual(0, EligibilityDiagnosis.objects.filter(job_seeker=user3).count())

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -282,7 +282,6 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
         row = df.iloc[0]
         self.assertEqual(row[EMAIL_COL], "colette@gmail.fr")
 
-    # Test added comments.
     def test_filter_invalid_nirs(self):
         # Create a dataframe with one valid and one invalid NIR.
         command = self.command
@@ -302,7 +301,6 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
         self.assertEqual(df.iloc[1][COMMENTS_COL], expected_comment)
         self.assertEqual(invalid_nirs_df.iloc[0][COMMENTS_COL], expected_comment)
 
-    # Test excluded rows.
     def test_remove_ignored_rows(self):
         command = self.command
         SiaeFactory(kind=Siae.KIND_AI, siret=getattr(CleanedAiCsvFileMock(), SIRET_COL))
@@ -350,8 +348,6 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
         self.assertEqual(len(filtered_df), 1)
         expected_comment = "Ligne ignorée : agrément ou PASS IAE renseigné."
         self.assertEqual(total_df.iloc[1][COMMENTS_COL], expected_comment)
-
-    # Test importing data to Itou.
 
     def test_find_or_create_job_seeker__find(self):
         developer = UserFactory(email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL)
@@ -484,7 +480,6 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
         self.assertTrue(job_seeker.email.endswith("@email-temp.com"))
         job_seeker.delete()
 
-    # - Test find_or_create_approval
     def test_find_or_create_approval__find(self):
         developer = UserFactory(email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL)
         command = self.command
@@ -522,7 +517,6 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
         # Clean
         existing_approval.user.delete()
 
-    # - Test find_or_create_job_applications
     def test_find_or_create_approval__create(self):
         developer = UserFactory(email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL)
         command = self.command
@@ -631,7 +625,6 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
         self.assertTrue(previous_approval.pk, approval.pk)
         job_seeker.delete()
 
-    # Find or create job applications.
     def test_find_or_create_job_application__find(self):
         # Find job applications created previously by this script.
         developer = UserFactory(email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL)

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -608,11 +608,6 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
             approval_delivery_mode=JobApplication.APPROVAL_DELIVERY_MODE_AUTOMATIC,
         )
 
-        # Only if dry_run is False.
-        with self.assertRaises(NotImplementedError):
-            command.find_or_create_approval(job_seeker=job_seeker, created_by=developer)
-
-        command.dry_run = True
         created, approval, redelivered_approval = command.find_or_create_approval(
             job_seeker=job_seeker, created_by=developer
         )

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -1,9 +1,13 @@
 import datetime
+from dataclasses import dataclass
 
+import pandas
+from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
 from itou.approvals.factories import ApprovalFactory
+from itou.asp.factories import CommuneFactory
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.factories import (
     JobApplicationSentByJobSeekerFactory,
@@ -11,6 +15,24 @@ from itou.job_applications.factories import (
     JobApplicationWithEligibilityDiagnosis,
 )
 from itou.job_applications.models import JobApplication
+from itou.siaes.factories import SiaeFactory
+from itou.siaes.models import Siae
+from itou.users.factories import JobSeekerFactory, UserFactory
+from itou.users.management.commands.import_ai_employees import (
+    APPROVAL_COL,
+    BIRTHDATE_COL,
+    CITY_INSEE_COL,
+    COMMENTS_COL,
+    CONTRACT_ENDDATE_COL,
+    CONTRACT_STARTDATE_COL,
+    DATE_FORMAT,
+    EMAIL_COL,
+    FIRST_NAME_COL,
+    LAST_NAME_COL,
+    NIR_COL,
+    SIRET_COL,
+    Command as ImportAiEmployeesCommand,
+)
 from itou.users.models import User
 
 
@@ -144,3 +166,217 @@ class DeduplicateJobSeekersManagementCommandsTest(TestCase):
 
         self.assertEqual(0, EligibilityDiagnosis.objects.filter(job_seeker=user2).count())
         self.assertEqual(0, EligibilityDiagnosis.objects.filter(job_seeker=user3).count())
+
+
+@dataclass
+class AiCSVFile:
+    """Mock the CSV file transmitted by the AFP."""
+
+    pmo_siret: str = "33491262300058"
+    pmo_denom_soc: str = "UNE NOUVELLE CHANCE"
+    ppn_numero_inscription: str = "141068078200557"
+    pph_nom_usage: str = "CHAMADE"
+    pph_prenom: str = "SYLIA"
+    pph_date_naissance: str = "1983-07-11"
+    agr_numero_agrement: str = ""
+    adr_point_remise: str = "app 14"
+    adr_cplt_point_geo: str = "Cat's Eyes"
+    codetypevoie: str = "RUE"
+    adr_numero_voie: str = "5"
+    codeextensionvoie: str = "B"
+    adr_libelle_voie: str = "du Louvre"
+    adr_cplt_distribution: str = ""
+    codepostalcedex: str = "75001"
+    codeinseecom: str = "75101"
+    adr_telephone: str = "0622568941"
+    adr_mail: str = "sylia@chamade.fr"
+    ctr_date_embauche: str = "2021-08-12"
+    ctr_date_fin_reelle: str = ""
+
+
+@dataclass
+class CleanedAiCsvFile(AiCSVFile):
+    """Add expected cleaned values."""
+
+    pph_date_naissance: datetime.datetime = datetime.datetime(1983, 7, 11)
+    ctr_date_embauche: datetime.datetime = datetime.datetime(2021, 8, 12)
+    nir_is_valid: bool = True
+    siret_validated_by_asp: bool = True
+    Commentaire: str = ""
+
+
+class ImportAiEmployeesManagementCommandTest(TestCase):
+    """November 30th we imported AI employees.
+    See users.management.commands.import_ai_employees.
+    """
+
+    def test_cleaning(self):
+        """Test dataframe cleaning: rows formatting and validation."""
+        command = ImportAiEmployeesCommand()
+
+        # Perfect data.
+        df = pandas.DataFrame([AiCSVFile()])
+        df = command.clean_df(df)
+        row = df.iloc[0]
+        self.assertTrue(isinstance(row[BIRTHDATE_COL], datetime.datetime))
+        self.assertTrue(isinstance(row[CONTRACT_STARTDATE_COL], datetime.datetime))
+        self.assertTrue(row["nir_is_valid"])
+        self.assertTrue(row["siret_validated_by_asp"])
+
+        # Invalid birth date.
+        df = pandas.DataFrame([AiCSVFile(**{BIRTHDATE_COL: "1668-11-09"})])
+        df = command.clean_df(df)
+        row = df.iloc[0]
+        self.assertEqual(row[BIRTHDATE_COL].strftime(DATE_FORMAT), "1968-11-09")
+        self.assertTrue(isinstance(row[BIRTHDATE_COL], datetime.datetime))
+
+        # Invalid NIR.
+        df = pandas.DataFrame([AiCSVFile(**{NIR_COL: "56987534"})])
+        df = command.clean_df(df)
+        row = df.iloc[0]
+        self.assertEqual(row[NIR_COL], "")
+        self.assertFalse(row["nir_is_valid"])
+
+        # Excluded SIRET from the ASP.
+        siret = "33491197100029"
+        df = pandas.DataFrame([AiCSVFile(**{SIRET_COL: siret})])
+        df = command.clean_df(df)
+        row = df.iloc[0]
+        self.assertEqual(row[SIRET_COL], siret)
+        self.assertFalse(row["siret_validated_by_asp"])
+
+    # Test added comments.
+    def test_filter_invalid_nirs(self):
+        # Create a dataframe with one valid and one invalid NIR.
+        command = ImportAiEmployeesCommand()
+        df = pandas.DataFrame([CleanedAiCsvFile(), CleanedAiCsvFile(**{NIR_COL: "56987534", "nir_is_valid": False})])
+        df, invalid_nirs_df = command.filter_invalid_nirs(df)
+
+        # Filtered rows.
+        self.assertEqual(len(df), 2)
+        self.assertEqual(len(invalid_nirs_df), 1)
+        self.assertFalse(invalid_nirs_df.iloc[0]["nir_is_valid"])
+
+        # A comment has been added to invalid rows.
+        expected_comment = "NIR invalide. Utilisateur potentiellement créé sans NIR."
+        self.assertEqual(df.iloc[0][COMMENTS_COL], "")
+        self.assertEqual(df.iloc[1][COMMENTS_COL], expected_comment)
+        self.assertEqual(invalid_nirs_df.iloc[0][COMMENTS_COL], expected_comment)
+
+    # Test excluded rows.
+    def test_remove_ignored_rows(self):
+        command = ImportAiEmployeesCommand()
+        command.set_logger(verbosity=0)
+        SiaeFactory(kind=Siae.KIND_AI, siret=getattr(CleanedAiCsvFile(), SIRET_COL))
+
+        # Ended contracts are removed.
+        df = pandas.DataFrame([CleanedAiCsvFile(), CleanedAiCsvFile(**{CONTRACT_ENDDATE_COL: "2020-11-30"})])
+        total_df, filtered_df = command.remove_ignored_rows(df)
+        self.assertEqual(len(total_df), 2)
+        self.assertEqual(len(filtered_df), 1)
+        expected_comment = "Ligne ignorée : contrat terminé."
+        self.assertEqual(total_df.iloc[1][COMMENTS_COL], expected_comment)
+
+        # SIRET provided by the ASP are removed.
+        df = pandas.DataFrame(
+            [CleanedAiCsvFile(), CleanedAiCsvFile(**{SIRET_COL: "33491197100029", "siret_validated_by_asp": False})]
+        )
+        total_df, filtered_df = command.remove_ignored_rows(df)
+        self.assertEqual(len(total_df), 2)
+        self.assertEqual(len(filtered_df), 1)
+        expected_comment = "Ligne ignorée : entreprise inexistante communiquée par l'ASP."
+        self.assertEqual(total_df.iloc[1][COMMENTS_COL], expected_comment)
+
+        # Inexistent structures are removed.
+        df = pandas.DataFrame([CleanedAiCsvFile(), CleanedAiCsvFile(**{SIRET_COL: "202020202"})])
+        total_df, filtered_df = command.remove_ignored_rows(df)
+        self.assertEqual(len(total_df), 2)
+        self.assertEqual(len(filtered_df), 1)
+        expected_comment = "Ligne ignorée : entreprise inexistante."
+        self.assertEqual(total_df.iloc[1][COMMENTS_COL], expected_comment)
+
+        # Rows with approvals are removed.
+        df = pandas.DataFrame([CleanedAiCsvFile(), CleanedAiCsvFile(**{APPROVAL_COL: "670929"})])
+        total_df, filtered_df = command.remove_ignored_rows(df)
+        self.assertEqual(len(total_df), 2)
+        self.assertEqual(len(filtered_df), 1)
+        expected_comment = "Ligne ignorée : agrément ou PASS IAE renseigné."
+        self.assertEqual(total_df.iloc[1][COMMENTS_COL], expected_comment)
+
+    # Test importing data to Itou.
+
+    def test_find_or_create_job_seeker__find(self):
+        developer = UserFactory(email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL)
+        CommuneFactory(code=getattr(CleanedAiCsvFile, CITY_INSEE_COL))
+        command = ImportAiEmployeesCommand()
+        command.set_logger(verbosity=0)
+        command.dry_run = False
+
+        # Find existing user with NIR.
+        nir = getattr(CleanedAiCsvFile(), NIR_COL)
+        JobSeekerFactory(nir=nir)
+        df = pandas.DataFrame([CleanedAiCsvFile()])
+        created, job_seeker = command.find_or_create_job_seeker(row=df.iloc[0], created_by=developer)
+        self.assertFalse(created)
+        self.assertTrue(job_seeker)
+        self.assertEqual(job_seeker.nir, nir)
+        self.assertEqual(User.objects.all().count(), 2)
+        # Clean
+        job_seeker.delete()
+
+        # Find existing user with email address.
+        email = getattr(CleanedAiCsvFile(), EMAIL_COL)
+        JobSeekerFactory(nir="", email=email)
+        df = pandas.DataFrame([CleanedAiCsvFile()])
+        created, job_seeker = command.find_or_create_job_seeker(row=df.iloc[0], created_by=developer)
+        self.assertFalse(created)
+        self.assertTrue(job_seeker)
+        self.assertEqual(job_seeker.email, email)
+        self.assertEqual(User.objects.all().count(), 2)
+        # Clean
+        job_seeker.delete()
+
+        # Find existing user created previously by this script.
+        base_data = CleanedAiCsvFile()
+        first_name = getattr(base_data, FIRST_NAME_COL).title()
+        last_name = getattr(base_data, LAST_NAME_COL).title()
+        birthdate = getattr(base_data, BIRTHDATE_COL)
+        JobSeekerFactory(
+            first_name=first_name,
+            last_name=last_name,
+            birthdate=birthdate,
+            created_by=developer,
+            date_joined=settings.AI_EMPLOYEES_STOCK_IMPORT_DATE,
+        )
+        df = pandas.DataFrame([CleanedAiCsvFile()])
+        created, job_seeker = command.find_or_create_job_seeker(row=df.iloc[0], created_by=developer)
+        self.assertFalse(created)
+        self.assertTrue(job_seeker)
+        self.assertEqual(job_seeker.birthdate, birthdate.date())
+        self.assertEqual(User.objects.all().count(), 2)
+        # Clean
+        job_seeker.delete()
+
+    def test_find_or_create_job_seeker__create(self):
+        # Job seeker not found: create user.
+
+        # NIR is empty: create user with NIR None, even if another one exists.
+
+        # If found job_seeker is not a job seeker: create one with no NIR and a fake email address.
+
+        # Check expected attributes.
+        # Perfect path: NIR, email, ...
+        # Created by developer on XX date.
+
+        # If no email provided: fake email.
+
+        #
+        pass
+
+    # - Test find_or_create_approval
+
+    # - Test find_or_create_job_applications
+
+    # Test calling the management command.
+
+    # Test calling command with option `--invalid-nirs-only`.

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -511,7 +511,6 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
             user__nir=getattr(CleanedAiCsvFileMock(), NIR_COL),
             start_at=datetime.date(2021, 12, 1),
             created_by=developer,
-            create_employee_record=False,
             created_at=settings.AI_EMPLOYEES_STOCK_IMPORT_DATE,
         )
         created, expected_approval, _ = command.find_or_create_approval(

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -266,7 +266,7 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
         self.assertEqual(row[SIRET_COL], siret)
         self.assertFalse(row["siret_validated_by_asp"])
 
-        # # Employer email.
+        # Employer email.
         domain = "unenouvellechance.fr"
         siae = SiaeFactory(auth_email=f"accueil@{domain}", kind=Siae.KIND_AI)
         df = pandas.DataFrame([AiCSVFileMock(**{EMAIL_COL: f"colette@{domain}", SIRET_COL: siae.siret})])

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -14,7 +14,7 @@ from itou.job_applications.models import JobApplication
 from itou.users.models import User
 
 
-class ManagementCommandsTest(TestCase):
+class DeduplicateJobSeekersManagementCommandsTest(TestCase):
     """
     Test the deduplication of several users.
 

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -313,6 +313,13 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
         expected_comment = "Ligne ignorée : contrat terminé."
         self.assertEqual(total_df.iloc[1][COMMENTS_COL], expected_comment)
 
+        # Continue even if df.CONTRACT_ENDDATE_COL does not exists.
+        df = pandas.DataFrame([CleanedAiCsvFile(), CleanedAiCsvFile(**{CONTRACT_ENDDATE_COL: "2020-11-30"})])
+        df = df.drop(columns=[CONTRACT_ENDDATE_COL])
+        total_df, filtered_df = command.remove_ignored_rows(df)
+        self.assertEqual(len(total_df), 2)
+        self.assertEqual(len(filtered_df), 2)
+
         # SIRET provided by the ASP are removed.
         df = pandas.DataFrame(
             [CleanedAiCsvFile(), CleanedAiCsvFile(**{SIRET_COL: "33491197100029", "siret_validated_by_asp": False})]

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -34,10 +34,13 @@ from itou.users.management.commands.import_ai_employees import (
     FIRST_NAME_COL,
     LAST_NAME_COL,
     NIR_COL,
+    PASS_IAE_END_DATE_COL,
     PASS_IAE_NUMBER_COL,
+    PASS_IAE_START_DATE_COL,
     PHONE_COL,
     POST_CODE_COL,
     SIRET_COL,
+    USER_ITOU_EMAIL_COL,
     USER_PK_COL,
     Command as ImportAiEmployeesCommand,
 )
@@ -210,7 +213,7 @@ class CleanedAiCsvFile(AiCSVFile):
     ctr_date_embauche: datetime.datetime = datetime.datetime(2021, 8, 12)
     nir_is_valid: bool = True
     siret_validated_by_asp: bool = True
-    Commentaire: str = ""
+    commentaire: str = ""
 
 
 class ImportAiEmployeesManagementCommandTest(TestCase):
@@ -780,4 +783,7 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
             job_seeker = User.objects.get(nir=row[NIR_COL])
             approval = job_seeker.approvals.first()
             self.assertEqual(row[PASS_IAE_NUMBER_COL], approval.number)
+            self.assertEqual(row[PASS_IAE_START_DATE_COL], approval.start_at.strftime(DATE_FORMAT))
+            self.assertEqual(row[PASS_IAE_END_DATE_COL], approval.end_at.strftime(DATE_FORMAT))
             self.assertEqual(row[USER_PK_COL], job_seeker.jobseeker_hash_id)
+            self.assertEqual(row[USER_ITOU_EMAIL_COL], job_seeker.email)

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -3,22 +3,15 @@ import uuid
 from unittest import mock
 
 from django.core.exceptions import ValidationError
-from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
 import itou.asp.factories as asp
-from itou.approvals.factories import ApprovalFactory
 from itou.asp.models import AllocationDuration, EmployerType
-from itou.eligibility.models import EligibilityDiagnosis
 from itou.institutions.factories import InstitutionWithMembershipFactory
 from itou.institutions.models import Institution
-from itou.job_applications.factories import (
-    JobApplicationSentByJobSeekerFactory,
-    JobApplicationWithApprovalFactory,
-    JobApplicationWithEligibilityDiagnosis,
-)
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.factories import JobApplicationSentByJobSeekerFactory
+from itou.job_applications.models import JobApplicationWorkflow
 from itou.prescribers.factories import (
     AuthorizedPrescriberOrganizationWithMembershipFactory,
     PrescriberMembershipFactory,
@@ -75,138 +68,6 @@ class ManagerTest(TestCase):
             "8888888C": [user3, user4, user5],
         }
         self.assertCountEqual(duplicated_users, expected_result)
-
-
-class ManagementCommandsTest(TestCase):
-    """
-    Test the deduplication of several users.
-
-    This is temporary and should be deleted after the release of the NIR
-    which should prevent duplication.
-    """
-
-    def test_deduplicate_job_seekers(self):
-        """
-        Easy case : among all the duplicates, only one has a PASS IAE.
-        """
-
-        # Attributes shared by all users.
-        # Deduplication is based on these values.
-        kwargs = {
-            "job_seeker__pole_emploi_id": "6666666B",
-            "job_seeker__birthdate": datetime.date(2002, 12, 12),
-        }
-
-        # Create `user1`.
-        job_app1 = JobApplicationWithApprovalFactory(job_seeker__nir=None, **kwargs)
-        user1 = job_app1.job_seeker
-
-        self.assertIsNone(user1.nir)
-        self.assertEqual(1, user1.approvals.count())
-        self.assertEqual(1, user1.job_applications.count())
-        self.assertEqual(1, user1.eligibility_diagnoses.count())
-
-        # Create `user2`.
-        job_app2 = JobApplicationWithEligibilityDiagnosis(job_seeker__nir=None, **kwargs)
-        user2 = job_app2.job_seeker
-
-        self.assertIsNone(user2.nir)
-        self.assertEqual(0, user2.approvals.count())
-        self.assertEqual(1, user2.job_applications.count())
-        self.assertEqual(1, user2.eligibility_diagnoses.count())
-
-        # Create `user3`.
-        job_app3 = JobApplicationWithEligibilityDiagnosis(**kwargs)
-        user3 = job_app3.job_seeker
-        expected_nir = user3.nir
-
-        self.assertIsNotNone(user3.nir)
-        self.assertEqual(0, user3.approvals.count())
-        self.assertEqual(1, user3.job_applications.count())
-        self.assertEqual(1, user3.eligibility_diagnoses.count())
-
-        # Merge all users into `user1`.
-        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True)
-
-        # If only one NIR exists for all the duplicates, it should
-        # be reassigned to the target account.
-        user1.refresh_from_db()
-        self.assertEqual(user1.nir, expected_nir)
-
-        self.assertEqual(3, user1.job_applications.count())
-        self.assertEqual(3, user1.eligibility_diagnoses.count())
-        self.assertEqual(1, user1.approvals.count())
-
-        self.assertEqual(0, User.objects.filter(email=user2.email).count())
-        self.assertEqual(0, User.objects.filter(email=user3.email).count())
-
-        self.assertEqual(0, JobApplication.objects.filter(job_seeker=user2).count())
-        self.assertEqual(0, JobApplication.objects.filter(job_seeker=user3).count())
-
-        self.assertEqual(0, EligibilityDiagnosis.objects.filter(job_seeker=user2).count())
-        self.assertEqual(0, EligibilityDiagnosis.objects.filter(job_seeker=user3).count())
-
-    def test_deduplicate_job_seekers_without_empty_sender_field(self):
-        """
-        Easy case: among all the duplicates, only one has a PASS IAE.
-        Ensure that the `sender` field is never left empty.
-        """
-
-        # Attributes shared by all users.
-        # Deduplication is based on these values.
-        kwargs = {
-            "job_seeker__pole_emploi_id": "6666666B",
-            "job_seeker__birthdate": datetime.date(2002, 12, 12),
-        }
-
-        # Create `user1` through a job application sent by him.
-        job_app1 = JobApplicationSentByJobSeekerFactory(job_seeker__nir=None, **kwargs)
-        user1 = job_app1.job_seeker
-
-        self.assertEqual(1, user1.job_applications.count())
-        self.assertEqual(job_app1.sender, user1)
-
-        # Create `user2` through a job application sent by him.
-        job_app2 = JobApplicationSentByJobSeekerFactory(job_seeker__nir=None, **kwargs)
-        user2 = job_app2.job_seeker
-
-        self.assertEqual(1, user2.job_applications.count())
-        self.assertEqual(job_app2.sender, user2)
-
-        # Create `user3` through a job application sent by a prescriber.
-        job_app3 = JobApplicationWithEligibilityDiagnosis(job_seeker__nir=None, **kwargs)
-        user3 = job_app3.job_seeker
-        self.assertNotEqual(job_app3.sender, user3)
-        job_app3_sender = job_app3.sender  # The sender is a prescriber.
-
-        # Ensure that `user1` will always be the target into which duplicates will be merged
-        # by attaching a PASS IAE to him.
-        self.assertEqual(0, user1.approvals.count())
-        self.assertEqual(0, user2.approvals.count())
-        self.assertEqual(0, user3.approvals.count())
-        ApprovalFactory(user=user1)
-
-        # Merge all users into `user1`.
-        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True)
-
-        self.assertEqual(3, user1.job_applications.count())
-
-        job_app1.refresh_from_db()
-        job_app2.refresh_from_db()
-        job_app3.refresh_from_db()
-
-        self.assertEqual(job_app1.sender, user1)
-        self.assertEqual(job_app2.sender, user1)  # The sender must now be user1.
-        self.assertEqual(job_app3.sender, job_app3_sender)  # The sender must still be a prescriber.
-
-        self.assertEqual(0, User.objects.filter(email=user2.email).count())
-        self.assertEqual(0, User.objects.filter(email=user3.email).count())
-
-        self.assertEqual(0, JobApplication.objects.filter(job_seeker=user2).count())
-        self.assertEqual(0, JobApplication.objects.filter(job_seeker=user3).count())
-
-        self.assertEqual(0, EligibilityDiagnosis.objects.filter(job_seeker=user2).count())
-        self.assertEqual(0, EligibilityDiagnosis.objects.filter(job_seeker=user3).count())
 
 
 class ModelTest(TestCase):


### PR DESCRIPTION
### Quoi ?

Prise en compte des NIR invalides.

### Pourquoi ?

À la suite d'un bug dans le code, nous avons créé 842 candidatures pour le même candidat. Les AI ont donc vu sur leur tableau de bord des candidatures acceptées pour un candidat qui leur était inconnu. De nombreuses plaintes sont remontées au support.

D'où provenait ce bug ?
- [Ligne 121](https://github.com/betagouv/itou/blob/master/itou/users/management/commands/import_ai_employees.py#L421), les nir invalides sont remplacés par "". C'est implicite. :see_no_evil: 
-  [Ligne 277](https://github.com/betagouv/itou/blob/master/itou/users/management/commands/import_ai_employees.py#L277), le script effectue une boucle : il trouve un User en utilisant le NIR de la ligne (`User.objects.filter(nir=row[NIR_COL])`). Mais si le NIR est vide, il trouve le premier User dont le NIR est vide... et voilà comment on crée 842 candidatures pour le mauvais candidat. :weary: 

Un simple `User.objects.exclude(nir="")` aurait évité le problème. Mais je ne l'ai pas vu pour les raisons suivantes :
- le script n'est pas testé. C'est mal, surtout compte tenu du nombre de cas d'usage différents. Je ne l'ai pas fait car on a pris la mauvaise habitude de peu tester les _management commands_, car j'étais un peu perdue avec Pandas et car j'ai bossé dans l'urgence. C'est donc ajouté des tests.
- Pandas est difficile à lire et donc source d'erreurs. Il faut très bien connaître la librairie pour en comprendre les subtilités. La « magie » des méthodes rend les PR difficilement compréhensibles et c'est pourquoi cette erreur, pourtant évidente, a passé la revue. J'aurais dû me cantonner à Python.

Enfin, rappelons ces quelques règles du _Zen of Python_ :
- _Explicit is better than implicit_.
- _Readability counts_. 

### Comment ?

- Correction de la requête source d'erreur. Tentative de simplification du script.
- Ajout de tests.
- Ajout d'un identifiant unique des salariés pour l'ASP, des dates de début et de fin des PASS et de l'e-mail utilisé chez Itou.
- Ajout d'un mécanisme pour éviter de créer deux fois des candidatures ou des PASS.. Détection des doublons éventuels. 