### PR TITLE
Ajout de la colonne `is_from_ai_stock` (`injection_ai`) aux tables Candidatures et Agréments dans Metabase

### DIFF
--- a/itou/metabase/management/commands/_approvals.py
+++ b/itou/metabase/management/commands/_approvals.py
@@ -95,3 +95,12 @@ TABLE_COLUMNS += get_department_and_region_columns(
     comment_suffix=(" de la structure qui a embauché si PASS IAE ou du PE qui a délivré l agrément si Agrément PE"),
     custom_fn=get_siae_or_pe_org_from_approval,
 )
+
+TABLE_COLUMNS += [
+    {
+        "name": "injection_ai",
+        "type": "boolean",
+        "comment": "Provient des injections AI",
+        "fn": lambda o: o.is_from_ai_stock if isinstance(o, Approval) else False,
+    },
+]

--- a/itou/metabase/management/commands/_job_applications.py
+++ b/itou/metabase/management/commands/_job_applications.py
@@ -206,4 +206,10 @@ TABLE_COLUMNS += [
         "comment": "Date embauche le cas échéant",
         "fn": get_ja_hiring_date,
     },
+    {
+        "name": "injection_ai",
+        "type": "boolean",
+        "comment": "Provient des injections AI",
+        "fn": lambda o: o.approval.is_from_ai_stock if o.approval else False,
+    },
 ]


### PR DESCRIPTION
### Quoi ?

Ajout de la colonne is_from_ai_stock (injection_ai) aux tables Candidatures et Agréments dans Metabase

### Pourquoi ?

L'import des AI a créé beaucoup de candidatures fantômes qui polluent les stats Metabase. Cette nouvelle colonne va permettre à Soumia de les filtrer.