### PR TITLE
Analyse des heures travaillées par les salariés en IAE à l'échelle infra-départementale

### DIFF
--- a/itou/metabase/management/commands/sql/006_heures_etp_salaries.sql
+++ b/itou/metabase/management/commands/sql/006_heures_etp_salaries.sql
@@ -10,10 +10,10 @@ Ces indicateurs sont déclinés par type de public cible:
     - niveau de formation du salarié
     - commune de la structure
     - établissement public territorial
+    - établissements publics de coopération intercommunale
     - département et région de l'annexe financière
   
 Un filtre est appliqué pour récupérer un historique de 2 ans en plus de l'année en cours
-
 */
     
 select 
@@ -21,7 +21,8 @@ select
     sum(nombre_etp_consommes)/12 as nombre_etp,
     sum(nombre_heures_travaillees) as nombre_heures_travaillees, 
     date_part('year', date_saisie) as annee_saisie,
-    etablissement_Public_Territorial, 
+    etablissement_Public_Territorial,
+    nom_epci,
     niveau_formation_salarie,
     genre_salarie,
     rsa, 
@@ -41,7 +42,8 @@ where nombre_heures_travaillees > 0
       and date_part('year', date_saisie) >= (date_part('year', current_date) - 2)
 group by 
     annee_saisie,
-    etablissement_Public_Territorial, 
+    etablissement_Public_Territorial,
+    nom_epci,
     niveau_formation_salarie,
     genre_salarie,
     rsa, 


### PR DESCRIPTION
Quoi ?
Ajouter la colonne établissements publics de coopération intercommunale (EPCI) à la table

Pourquoi ?
Donner la possibilité aux DDETS, DREETS et CD la possibilité de filtrer les ETP à l'échelle infra-départementale