### PR TITLE
Les candidatures issues du script des salariés ASP ne peuvent pas être annulées

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -479,6 +479,7 @@ ASP_ITOU_PREFIX = "99999"
 # On November 30th, 2021, we delivered approvals for AI structures.
 # See itou.users.management.commands.import_ai_employees
 AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL = os.environ.get("AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL", "")
+AI_EMPLOYEES_STOCK_IMPORT_DATE = datetime.datetime(2021, 11, 30, tzinfo=pytz.utc)
 
 # Metabase
 # ------------------------------------------------------------------------------

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -270,8 +270,9 @@ class Approval(CommonApprovalMixin):
         if not developer_qs:
             return False
         developer = developer_qs.first()
-        approval_creation_date = datetime.date(2021, 11, 30)
-        return self.created_by == developer and self.created_at.date() == approval_creation_date
+        return (
+            self.created_by == developer and self.created_at.date() == settings.AI_EMPLOYEES_STOCK_IMPORT_DATE.date()
+        )
 
     def can_be_suspended_by_siae(self, siae):
         return (

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -422,8 +422,7 @@ class ApprovalModelTest(TestCase):
         self.assertEqual(approval.end_at, end_at)  # Should NOT extended.
 
     def test_is_from_ai_stock(self):
-        approval_created_at = timezone.datetime(2021, 11, 30)
-        approval_created_at = timezone.make_aware(approval_created_at)
+        approval_created_at = settings.AI_EMPLOYEES_STOCK_IMPORT_DATE
         developer = UserFactory(email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL)
 
         approval = ApprovalFactory()

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -513,6 +513,8 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
 
     @property
     def can_be_cancelled(self):
+        if self.is_from_ai_stock:
+            return False
         if self.hiring_start_at:
             # A job application can be canceled provided that
             # there is no employee record linked with a status:

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -175,6 +175,24 @@ class JobApplicationModelTest(TestCase):
             job_application = JobApplicationFactory(state=state)
             self.assertTrue(job_application.can_be_archived)
 
+    def test_is_from_ai_stock(self):
+        job_application_created_at = settings.AI_EMPLOYEES_STOCK_IMPORT_DATE
+        developer = UserFactory(email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL)
+
+        job_application = JobApplicationFactory.build()
+        self.assertFalse(job_application.is_from_ai_stock)
+
+        job_application = JobApplicationFactory.build(created_at=job_application_created_at)
+        self.assertFalse(job_application.is_from_ai_stock)
+
+        job_application = JobApplicationFactory.build(approval_manually_delivered_by=developer)
+        self.assertFalse(job_application.is_from_ai_stock)
+
+        job_application = JobApplicationFactory.build(
+            created_at=job_application_created_at, approval_manually_delivered_by=developer
+        )
+        self.assertTrue(job_application.is_from_ai_stock)
+
 
 class JobApplicationQuerySetTest(TestCase):
     def test_created_in_past(self):

--- a/itou/www/approvals_views/tests/test_download.py
+++ b/itou/www/approvals_views/tests/test_download.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from django.urls import reverse
-from django.utils import timezone
 
 from itou.job_applications.factories import JobApplicationFactory, JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication
@@ -81,7 +80,7 @@ class TestDownloadApprovalAsPDF(TestCase):
 
         # On November 30th, 2021, AI were delivered approvals without a diagnosis.
         # See itou.users.management.commands.import_ai_employees.
-        approval_created_at = timezone.datetime(2021, 11, 30, tzinfo=timezone.utc)
+        approval_created_at = settings.AI_EMPLOYEES_STOCK_IMPORT_DATE
         approval_created_by = UserFactory(email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL)
         job_application = JobApplicationWithApprovalFactory(
             eligibility_diagnosis=None,


### PR DESCRIPTION
### Quoi ?

Les employés annulent des candidatures et donc les PASS qui ont été délivrés. Cela ne doit pas être possible automatiquement.
