### PR TITLE
Boostdev S33

### DIFF
--- a/config/settings/_sentry.py
+++ b/config/settings/_sentry.py
@@ -3,7 +3,7 @@ import os
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
-from sentry_sdk.integrations.logging import ignore_logger, LoggingIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 
 
 def strip_sentry_sensitive_data(event, hint):
@@ -40,7 +40,7 @@ def sentry_init(dsn):
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.
-        traces_sample_rate=1.0,
+        traces_sample_rate=0,
         # Associate users (ID+email+username+IP) to errors.
         # https://docs.sentry.io/platforms/python/django/
         send_default_pii=True,

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -335,6 +335,8 @@ class UtilsValidatorsTest(TestCase):
         validate_nir("141062a78200555")
         # Haute-Corse
         validate_nir("141062B78200582")
+        # Valid number with fictitious month
+        validate_nir("141208078200587")
         self.assertRaises(ValidationError, validate_nir, "123456789")
         self.assertRaises(ValidationError, validate_nir, "141068078200557123")
         # Should start with 1 or 2.

--- a/itou/utils/validators.py
+++ b/itou/utils/validators.py
@@ -54,9 +54,17 @@ def validate_nir(nir):
     if len(nir) < 15:
         raise ValidationError("Le numéro de sécurité sociale est trop court (15 caractères autorisés).")
     # God bless forums.
-    nir_regex = r"^[12][0-9]{2}[0-1][0-9](2[AB]|[0-9]{2})[0-9]{3}[0-9]{3}[0-9]{2}$"
+    nir_regex = r"^[12][0-9]{2}[0-9]{2}(2[AB]|[0-9]{2})[0-9]{3}[0-9]{3}[0-9]{2}$"
+
     match = re.match(nir_regex, nir)
     if not match:
+        raise ValidationError("Ce numéro n'est pas valide.")
+
+    # For the month of birth, fictitious codes are assigned for persons registered on the basis of an incomplete civil
+    # status certificate. A valid month can also be between 20 and 42 or between 50 and 99.
+    # Source : https://fr.wikipedia.org/wiki/Num%C3%A9ro_de_s%C3%A9curit%C3%A9_sociale_en_France#ancrage_B
+    month = int(nir[3:5])
+    if (month > 12 and month < 20) or (month > 42 and month < 50):
         raise ValidationError("Ce numéro n'est pas valide.")
 
     # Last 2 digits validate previous 13 characters.


### PR DESCRIPTION
### Quoi ?

Mise à jour des règles de validation du NIR
Désactivation de l'envoi de transactions à Sentry

### Pourquoi ?

Des NIR valide ne sont pas considéré comme tel.
Le quota Sentry est dépassé.

### Comment ?

Ajustement de la regex
Modification de la conf pour Sentry