### PR TITLE
Permettre la suspension d'un PASS IAE même si la candidature est annulable

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -279,7 +279,6 @@ class Approval(CommonApprovalMixin):
             self.can_be_suspended
             # Only the SIAE currently hiring the job seeker can suspend a PASS IAE.
             and self.user.last_hire_was_made_by_siae(siae)
-            and not self.user.last_accepted_job_application.can_be_cancelled
         )
 
     @cached_property

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -43,7 +43,7 @@
                     </div>
                     {% if job_application.can_download_approval_as_pdf %}
                         <div class="col-sm-3">
-                            <a href="{% url 'approvals:approval_as_pdf' job_application_id=job_application.id %}" class="text-decoration-none disable-on-click matomo-event" data-matomo-category="agrement" data-matomo-action="telechargement-pdf" data-matomo-option="liste-candidatures">
+                            <a class="btn btn-link" href="{% url 'approvals:approval_as_pdf' job_application_id=job_application.id %}" class="text-decoration-none disable-on-click matomo-event" data-matomo-category="agrement" data-matomo-action="telechargement-pdf" data-matomo-option="liste-candidatures">
                                 Télécharger le PASS IAE
                             </a>
                         </div>

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -48,13 +48,6 @@
                             </a>
                         </div>
                     {% endif %}
-                    {% if siae.is_subject_to_eligibility_rules and job_application.approval and job_application.can_be_cancelled %}
-                        <div class="col-sm-3">
-                            <span class="text-muted text-nowrap">
-                                PASS IAE disponible au téléchargement après le {{ job_application.hiring_start_at|date:"d/m/Y" }}
-                            </span>
-                        </div>
-                    {% endif %}
                 </div>
             </div>
 


### PR DESCRIPTION
### Quoi ?

Permettre la suspension d'un PASS IAE même si la candidature associée peut encore être annulée.

### Pourquoi ?

Suite aux dernières modifications notamment la suppression du délai des 96 heures, les candidatures peuvent être annulée à tout moment et par conséquent, la suspension n'est plus proposée.

### Comment ?

En retirant la condition bloquante au niveau du modèle Approval.