### PR TITLE
Blocage du transfert des fiches salarié sur un environnement autre que PROD

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -675,3 +675,8 @@ EMPLOYEE_RECORD_ARCHIVING_DELAY_IN_DAYS = int(os.environ.get("EMPLOYEE_RECORD_AR
 # It is used as parameter to filter the eligible job applications for the feature.
 # (no job application before this date can be used for this feature)
 EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 7, 1, tzinfo=timezone.utc)
+
+# Only PROD or temporary tests environments are able to transfer employee records data to ASP 
+# This is disabled by default, overidden in prod settings, and can be set 
+# via local dev settings or env vars for a temporary environment.
+EMPLOYEE_RECORD_TRANSFER_ENABLED = bool(os.environ.get("EMPLOYEE_RECORD_TRANSFER_ENABLED", False))

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -50,3 +50,6 @@ ELASTIC_APM = {
     "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
     "TRANSACTION_SAMPLE_RATE": 0.1,
 }
+
+# Overrides base settings, only PROD should be allowed to do this
+EMPLOYEE_RECORD_TRANSFER_ENABLED = True

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -31,6 +31,8 @@ ASP_FS_KNOWN_HOSTS = None
 
 # Employee record production deployment
 EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 1, 1, tzinfo=timezone.utc)
+# Allow for testing
+EMPLOYEE_RECORD_TRANSFER_ENABLED = True
 
 FRANCE_CONNECT_CLIENT_ID = "FC_CLIENT_ID_123"
 FRANCE_CONNECT_CLIENT_SECRET = "FC_CLIENT_SECRET_123"

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -354,6 +354,13 @@ class Command(BaseCommand):
         """
         Employee Record Management Command
         """
+        if not settings.EMPLOYEE_RECORD_TRANSFER_ENABLED:
+            self.logger.info(
+                "This management command can't be used in this environment. Update Django settings if needed."
+            )
+            # Goodbye Marylou
+            return
+
         if verbosity > 1:
             self.logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
### Quoi ?

Bloquer les interactions avec l'ASP pour les environnements autres que PROD.

### Pourquoi ?

Suite à diverses erreurs de manipulations et de configuration, des environnements autres que PROD ont pu transférer des lots de fiches salarié vers l'ASP sans le contexte nécessaire, créant des conflits et des retours d'erreurs (3436) chez les usagers.

### Comment ?

En ne permettant l'utilisation de la `management command` permettant le transfert des fiches salarié : 
- que sur l'environnement de production (par défaut),
- que si l'environnement est **explicitement autorisé** à utiliser cette commande (par les `settings` Django pour un poste de dev ou via une variable d'environnement `EMPLOYEE_RECORD_TRANSFER_ENABLED` pour les instances cloud).
