### PR TITLE
Erreur sur le formatage de certains NIR

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1,4 +1,3 @@
-import re
 import uuid
 from collections import Counter
 
@@ -336,12 +335,6 @@ class User(AbstractUser, AddressMixin):
             self.is_prescriber
             and self.prescriberorganization_set.filter(is_authorized=True, members__is_active=True).exists()
         )
-
-    @property
-    def nir_with_spaces(self):
-        nir_regex = r"^([12])([0-9]{2})([0-1][0-9])(2[AB]|[0-9]{2})([0-9]{3})([0-9]{3})([0-9]{2})$"
-        match = re.match(nir_regex, self.nir)
-        return " ".join(match.groups())
 
     def is_prescriber_of_authorized_organization(self, organization_id):
         return self.prescriberorganization_set.filter(

--- a/itou/users/tests.py
+++ b/itou/users/tests.py
@@ -423,10 +423,6 @@ class ModelTest(TestCase):
         self.assertTrue(siae_staff.can_add_nir(job_seeker_no_nir))
         self.assertFalse(authorized_prescriber.can_add_nir(job_seeker_with_nir))
 
-    def test_nir_with_spaces(self):
-        job_seeker = JobSeekerFactory.build(nir="141068078200557")
-        self.assertEqual(job_seeker.nir_with_spaces, "1 41 06 80 782 005 57")
-
     def test_is_account_creator(self):
         user = UserFactory()
 

--- a/itou/utils/templatetags/format_filters.py
+++ b/itou/utils/templatetags/format_filters.py
@@ -46,6 +46,6 @@ def format_siret(siret):
 @stringfilter
 def format_nir(nir):
     nir = nir.replace(" ", "")
-    nir_regex = r"^([12])([0-9]{2})([0-1][0-9])(2[AB]|[0-9]{2})([0-9]{3})([0-9]{3})([0-9]{2})$"
+    nir_regex = r"^([12])([0-9]{2})([0-9]{2})(2[AB]|[0-9]{2})([0-9]{3})([0-9]{3})([0-9]{2})$"
     match = re.match(nir_regex, nir)
     return " ".join(match.groups())

--- a/itou/utils/validators.py
+++ b/itou/utils/validators.py
@@ -53,7 +53,7 @@ def validate_nir(nir):
         raise ValidationError("Le numéro de sécurité sociale est trop long (15 caractères autorisés).")
     if len(nir) < 15:
         raise ValidationError("Le numéro de sécurité sociale est trop court (15 caractères autorisés).")
-    # God bless forums.
+    # Warning : any change to this regex must be reflected on format filter "format_nir"
     nir_regex = r"^[12][0-9]{2}[0-9]{2}(2[AB]|[0-9]{2})[0-9]{3}[0-9]{3}[0-9]{2}$"
 
     match = re.match(nir_regex, nir)


### PR DESCRIPTION
### Quoi ?

Prise en compte de subtilités dans le formatage du NIR

### Pourquoi ?

Suite à une modification de la validation du NIR, des erreurs apparaissent ensuite lors de l'affichage de certains NIRs qui passent désormais la validation.

### Comment ?

Ajustement de l'expression régulière au niveau du filtre de formatage du gabarit.

### Captures d'écran

![Exemple de page affichant le NIR](https://user-images.githubusercontent.com/17601807/146163307-43238b91-b0a7-4623-b96a-536e301e2f25.png)


