### PR TITLE
On considère une éligibilité valide si un PASS IAE valide existe sans diagnostic

### DIFF
--- a/itou/eligibility/models.py
+++ b/itou/eligibility/models.py
@@ -57,9 +57,23 @@ class EligibilityDiagnosisQuerySet(models.QuerySet):
 class EligibilityDiagnosisManager(models.Manager):
     def has_considered_valid(self, job_seeker, for_siae=None):
         """
-        Returns True if the given job seeker has a considered valid diagnosis, False otherwise.
+        Returns True if the given job seeker has a considered valid diagnosis,
+        False otherwise.
+
+        We consider the eligibility as valid when a PASS IAE is valid but
+        the eligibility diagnosis is missing.
+
+        This can happen when we have to:
+        - import approvals previously issued by Pôle emploi
+        - create PASS IAE manually for AI (16K+)
+        - etc.
+
+        In these cases, the diagnoses have been made outside of Itou.
+
+        Hence the Trello #2604 decision: if a PASS IAE is valid, we do not
+        check the presence of an eligibility diagnosis.
         """
-        return job_seeker.approvals_wrapper.has_valid_pole_emploi_eligibility_diagnosis or bool(
+        return job_seeker.approvals_wrapper.has_valid or bool(
             self.last_considered_valid(job_seeker, for_siae=for_siae)
         )
 

--- a/itou/eligibility/tests.py
+++ b/itou/eligibility/tests.py
@@ -177,7 +177,7 @@ class EligibilityDiagnosisManagerTest(TestCase):
         self.assertEqual(last_considered_valid, prescriber_diagnosis)
         self.assertIsNone(last_expired)
 
-        # Has a expired Itou diagnoses made by an other SIAE
+        # Has an expired Itou diagnoses made by another SIAE.
         job_seeker = JobSeekerFactory()
         siae1 = SiaeWithMembershipFactory()
         siae2 = SiaeWithMembershipFactory()
@@ -189,7 +189,7 @@ class EligibilityDiagnosisManagerTest(TestCase):
         last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=job_seeker, for_siae=siae2)
         self.assertIsNone(last_expired)
 
-        # Has 2 Itou diagnoses: 1 is concidered expired and second is concidered valid
+        # Has 2 Itou diagnoses: 1 is considered expired and the second is considered valid.
         job_seeker = JobSeekerFactory()
         ExpiredEligibilityDiagnosisFactory(job_seeker=job_seeker)
         EligibilityDiagnosisFactory(job_seeker=job_seeker)
@@ -200,7 +200,7 @@ class EligibilityDiagnosisManagerTest(TestCase):
         self.assertIsNotNone(last_considered_valid)
         self.assertIsNone(last_expired)
 
-        # Has 2 Itou diagnoses are concidered expired : the last one expired must be returned
+        # Has 2 Itou diagnoses expired: the last one expired must be returned.
         job_seeker = JobSeekerFactory()
 
         date_6m = (

--- a/itou/eligibility/tests.py
+++ b/itou/eligibility/tests.py
@@ -66,6 +66,17 @@ class EligibilityDiagnosisManagerTest(TestCase):
         self.assertIsNone(last_expired)
         self.assertTrue(has_considered_valid)
 
+        # Has a valid PASS IAE but NO diagnosis.
+        approval = ApprovalFactory()
+        job_seeker = approval.user
+        self.assertEqual(0, job_seeker.eligibility_diagnoses.count())
+        has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(job_seeker=job_seeker)
+        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(job_seeker=job_seeker)
+        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=job_seeker)
+        self.assertTrue(has_considered_valid)
+        self.assertIsNone(last_considered_valid)
+        self.assertIsNone(last_expired)
+
         # Has valid Pôle emploi diagnosis.
         job_seeker = JobSeekerFactory()
         PoleEmploiApprovalFactory(pole_emploi_id=job_seeker.pole_emploi_id, birthdate=job_seeker.birthdate)

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -1154,6 +1154,9 @@ class JobApplicationCsvExportTest(TestCase):
         )
         job_application.accept(user=job_application.to_siae.members.first())
 
+        # The accept transition above will create a valid PASS IAE for the job seeker.
+        self.assertTrue(job_seeker.approvals.last().is_valid)
+
         csv_output = io.StringIO()
         generate_csv_export(JobApplication.objects, csv_output)
         self.maxDiff = None
@@ -1173,7 +1176,7 @@ class JobApplicationCsvExportTest(TestCase):
         self.assertIn(job_application.created_at.strftime("%d/%m/%Y"), csv_output.getvalue())
         self.assertIn(job_application.hiring_start_at.strftime("%d/%m/%Y"), csv_output.getvalue())
         self.assertIn(job_application.hiring_end_at.strftime("%d/%m/%Y"), csv_output.getvalue())
-        self.assertIn("non", csv_output.getvalue())
+        self.assertIn("oui", csv_output.getvalue())  # Eligibility status.
         self.assertIn(job_application.approval.number, csv_output.getvalue())
         self.assertIn(job_application.approval.start_at.strftime("%d/%m/%Y"), csv_output.getvalue())
         self.assertIn(job_application.approval.end_at.strftime("%d/%m/%Y"), csv_output.getvalue())


### PR DESCRIPTION
### Quoi ?

On considère une éligibilité valide si un PASS IAE valide existe sans diagnostic.

### Pourquoi ?

Afin de ne pas forcer les SIAE à repasser par la case "Valider les critères d'éligibilité" pour une nouvelle embauche d'un candidat qui dispose d'un PASS IAE hérité de l'import des AI.