### PR TITLE
Ajout de paramètres non obligatoires dans les appels aux API pole emploi

### DIFF
--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -309,6 +309,8 @@ def _mise_a_jour_parameters(encrypted_identifier: str, job_application, pass_app
         # The necessary parameters to notify Pole Emploi of a refusal
         return {
             "idNational": encrypted_identifier,
+            "typeSIAE": _mise_a_jour_siae_kind_param(siae),
+            "numSIRETsiae": siae.siret,
             "statutReponsePassIAE": POLE_EMPLOI_PASS_REFUSED,
             "origineCandidature": _mise_a_jour_sender_kind_param(job_application.sender_kind),
         }


### PR DESCRIPTION
### Quoi ?

Certains paramètres sont censés −d’après la documentation− être non obligatoires en cas de pass décliné. C’est le cas du type de SIAE et de son SIRET. Il sont en fait obligatoires.

### Pourquoi ?

J’ai évité de mettre des données non obligatoires pour éviter de faire du zèle inutile et surtout éviter des problèmes de données incompatibles mais visiblement c’est l’inverse qui s’est produit.

### Comment

Ajout de données manquantes.