### PR TITLE
Suppression de certains PASS du process de notification Pole Emploi

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -19,7 +19,6 @@ from itou.job_applications.tasks import huey_notify_pole_employ
 from itou.utils.apis.esd import get_access_token
 from itou.utils.apis.pole_emploi import (
     POLE_EMPLOI_PASS_APPROVED,
-    POLE_EMPLOI_PASS_REFUSED,
     PoleEmploiIndividu,
     PoleEmploiMiseAJourPassIAEException,
     mise_a_jour_pass_iae,
@@ -706,7 +705,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         if self.is_sent_by_proxy:
             emails.append(self.email_refuse_for_proxy)
         connection.send_messages(emails)
-        self.notify_pole_emploi_refused()
 
     @xwf_models.transition()
     def cancel(self, *args, **kwargs):
@@ -862,11 +860,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     def notify_pole_emploi_accepted(self) -> bool:
         if settings.API_ESD_SHOULD_PERFORM_MISE_A_JOUR_PASS:
             return huey_notify_pole_employ(self, POLE_EMPLOI_PASS_APPROVED)
-        return False
-
-    def notify_pole_emploi_refused(self) -> bool:
-        if settings.API_ESD_SHOULD_PERFORM_MISE_A_JOUR_PASS:
-            return huey_notify_pole_employ(self, POLE_EMPLOI_PASS_REFUSED)
         return False
 
     def _notify_pole_employ(self, mode: str) -> bool:

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -880,6 +880,11 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
          - we keep logs of the successful/failed attempts
          - when anything break, we quit early
         """
+        # We do not send approvals that start in the future to PE, because the information system in front
+        # can’t handle them. I’ll keep my opinion about this for talks that involve an unreasonnable amount of beer.
+        # Another mechanism will be in charge of sending them on their start date
+        if self.approval.start_at > timezone.now().date():
+            return False
         individual = PoleEmploiIndividu.from_job_seeker(self.job_seeker)
         if individual is None or not individual.is_valid():
             # We may not have a valid user (missing NIR, for instance),

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -42,7 +42,6 @@ from itou.users.factories import JobSeekerFactory, SiaeStaffFactory, UserFactory
 from itou.users.models import User
 from itou.utils.apis.pole_emploi import (
     POLE_EMPLOI_PASS_APPROVED,
-    POLE_EMPLOI_PASS_REFUSED,
     PoleEmploiIndividu,
     PoleEmploiIndividuResult,
     PoleEmploiMiseAJourPassIAEException,
@@ -1085,8 +1084,8 @@ class JobApplicationWorkflowTest(TestCase):
             self.assertEqual(len(mail.outbox), 1)
             self.assertIn("Candidature déclinée", mail.outbox[0].subject)
             mail.outbox = []
-            # Approval refused -> Pole Emploi is notified
-            notify_mock.assert_called()
+            # Approval refused -> Pole Emploi is not notified, because they don’t care
+            notify_mock.assert_not_called()
 
     def test_cancel_delete_linked_approval(self, *args, **kwargs):
         job_application = JobApplicationWithApprovalFactory()
@@ -1252,8 +1251,8 @@ class JobApplicationNotifyPoleEmploiIntegrationTest(TestCase):
     - the possible ways the process can break
     - that all the notification logs are created as expected
 
-    Due to the fact that the core function we want to test (`JobApplication.notify_pole_emploi_accepted` and
-    `JobApplication.notify_pole_emploi_refused`) make use of huey for async, those tests call
+    Due to the fact that the core function we want to test (`JobApplication.notify_pole_emploi_accepted`)
+    make use of huey for async, those tests call
     _notify_pole_employ directly in order to bypass the need for a task runner
     """
 
@@ -1297,30 +1296,6 @@ class JobApplicationNotifyPoleEmploiIntegrationTest(TestCase):
         pe_individual = PoleEmploiIndividu.from_job_seeker(job_application.job_seeker)
         self.assertTrue(pe_individual.is_valid())
         self.assertTrue(job_application._notify_pole_employ(POLE_EMPLOI_PASS_APPROVED))
-
-        access_token_mock.assert_called_with(ANY)
-        nir_mock.assert_called_with(ANY, self.token)
-        maj_mock.assert_called_with(job_application, ANY, self.encrypted_nir, self.token)
-        notification_log = JobApplicationPoleEmploiNotificationLog.objects.get(job_application=job_application)
-        self.assertEqual(notification_log.status, JobApplicationPoleEmploiNotificationLog.STATUS_OK)
-
-    @patch("itou.job_applications.models.mise_a_jour_pass_iae", return_value=True)
-    @patch(
-        "itou.job_applications.models.JobApplicationPoleEmploiNotificationLog.get_encrypted_nir_from_individual",
-        return_value=encrypted_nir,
-    )
-    @patch("itou.job_applications.models.get_access_token", return_value=token)
-    def test_notification_refused_nominal(self, access_token_mock, nir_mock, maj_mock, sleep_mock):
-        """
-        Nominal scenario: we sent a notification for refusal and everything worked
-         - All the APIs should be called
-         - An entry in the notification log should be added with status OK
-        """
-        job_application = JobApplicationWithApprovalFactory()
-        # our job seeker is valid
-        pe_individual = PoleEmploiIndividu.from_job_seeker(job_application.job_seeker)
-        self.assertTrue(pe_individual.is_valid())
-        self.assertTrue(job_application._notify_pole_employ(POLE_EMPLOI_PASS_REFUSED))
 
         access_token_mock.assert_called_with(ANY)
         nir_mock.assert_called_with(ANY, self.token)


### PR DESCRIPTION
# Quoi? 

- Les pass refusés ne sont pas transmis à PE
- Les PASS avec une date de début dans le futur ne sont pas transmis au moment de leur acceptation.

Ils seront transmis au moment de leur début effectif par un développment ultérieur

# Pourquoi ?

Actions décidées suite à la réunion avec PE du 16/12

# Comment

Modification des règles métier en conséquence, ajout de tests.