### PR TITLE
Amélioration de l’utilisation de France Connect

### DIFF
--- a/itou/templates/layout/_nav_btn_items.html
+++ b/itou/templates/layout/_nav_btn_items.html
@@ -1,3 +1,4 @@
+{% load france_connect %}
 {% if user.is_authenticated %}
     <li class="dropdown mr-2">
         <button
@@ -35,9 +36,11 @@
             </a>
 
             {% if not user.is_peamu %}
+                {% if not request|user_is_france_connected %}
                 <a class="dropdown-item text-primary" href="{% url 'account_change_password' %}">
                     Modifier mon mot de passe
                 </a>
+                {% endif %}
                 
                 <a class="dropdown-item text-primary" href="{% url 'dashboard:edit_user_email' %}">
                     Modifier mon adresse e-mail


### PR DESCRIPTION
- Masquage du bouton "Modifier mon mot de passe" quand on est connecté avec France Connect (mais pas pour les autres!)
- Correction: Si un utilisateur existe déjà avec l’email transmis par France Connect, on le prend (corrige [cette erreur](https://sentry.io/organizations/betagouv-f7/issues/2867133906/?project=5671910&query=is%3Aunresolved))
