### PR TITLE
Boostdev pour limiter les erreurs Sentry

### DIFF
--- a/itou/utils/pdf.py
+++ b/itou/utils/pdf.py
@@ -59,7 +59,7 @@ class HtmlToPdf:
             "auth": ("api", settings.PDFSHIFT_API_KEY),
             "json": {"source": html, "sandbox": settings.PDFSHIFT_SANDBOX_MODE},
         }
-        with httpx.stream("POST", self.url, **kwargs) as response:
+        with httpx.stream("POST", self.url, timeout=10.0, **kwargs) as response:
             response.raise_for_status()
             result = io.BytesIO()
             for chunk in response.iter_bytes(1024):

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,5 +1,5 @@
 -r ./base.txt
 
 uwsgi==2.0.20  # https://github.com/unbit/uwsgi
-sentry-sdk==1.5.0  # https://github.com/getsentry/sentry-python
+sentry-sdk==1.5.1  # https://github.com/getsentry/sentry-python
 elastic-apm==6.7.2  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html


### PR DESCRIPTION
### Quoi ?

Boostdev pour limiter les erreurs Sentry

### Pourquoi ?

Il y a des erreurs de type OSError et Timeout qui surviennent régulièrement.

### Comment ?

Mise à jour du SDK Sentry
Augmentation du délai pour les requêtes vers l'API de génération de PDF
