### PR TITLE
Le message n'est pas destiné aux candidates

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -6,7 +6,7 @@
     {{ block.super }}
 
     {# Alerte pour gérer les cas d'exception lors de l'importation des AI. #}
-    {% if current_siae.kind == current_siae.KIND_AI %}
+    {% if current_siae and current_siae.kind == current_siae.KIND_AI %}
         <div class="alert alert-warning" role="alert">
             <p>Tous les salariés déclarés auprès de l'ASP avant le 1er décembre ont été ajoutés au tableau de bord de la SIAE porteuse de l’annexe financière. Nous travaillons à vous permettre de les transférer dans le tableau de bord d’une structure fille.</p>
             <p>Pour les salariés qui ne seraient plus en poste, il vous est demandé de procéder à une suspension d’un an au motif « contrat de travail terminé ». Dans la mesure où ces salariés sont connus dans l’Extranet IAE 2.0 de l'ASP, ces PASS IAE ne peuvent pas être annulés.</p>


### PR DESCRIPTION
### Quoi ?

Restriction de l'affichage du message d'information.

### Pourquoi ?

Le message apparaît sur le tableau de bord des candidats alors qu'il ne devrait pas.

### Comment ?

Ajout d'un test pour identifier si on est bien sur le tableau de bord d'une SIAE
