### PR TITLE
Résolution d'une erreur obscure `AttributeError: 'NoneType' object has no attribute 'total_seconds'` dans l'import SIAE depuis la MAJ django 4.

### DIFF
--- a/itou/siaes/management/commands/_import_siae/vue_af.py
+++ b/itou/siaes/management/commands/_import_siae/vue_af.py
@@ -79,10 +79,7 @@ def get_vue_af_df():
         assert row.kind in Siae.ASP_MANAGED_KINDS
         validate_af_number(row.number)
 
-    df["start_at"] = df.start_at.apply(timezone.make_aware)
-    df["end_date"] = df.end_date.apply(timezone.make_aware)
-
-    df["ends_in_the_future"] = df.end_date > timezone.now()
+    df["ends_in_the_future"] = df.end_date.apply(timezone.make_aware) > timezone.now()
     df["has_active_state"] = df.state.isin(SiaeFinancialAnnex.STATES_ACTIVE)
     df["is_active"] = df.has_active_state & df.ends_in_the_future
 
@@ -169,5 +166,5 @@ def get_siae_key_to_convention_end_date():
 ACTIVE_SIAE_KEYS = [
     siae_key
     for siae_key, convention_end_date in get_siae_key_to_convention_end_date().items()
-    if timezone.now() < convention_end_date
+    if timezone.now() < timezone.make_aware(convention_end_date)
 ]


### PR DESCRIPTION
### Quoi ?

Résolution d'une erreur obscure `AttributeError: 'NoneType' object has no attribute 'total_seconds'` dans l'import SIAE depuis la MAJ django 4.

### Pourquoi ?

L'erreur se produit depuis la récente MAJ django 4 et dépendances. Elle se produit même avec pandas `1.3.5` (nous sommes actuellement sur la `1.3.4`).

Le bug semble connu côté pandas et non résolu : https://github.com/pandas-dev/pandas/issues/43516

Il semble se produire quand on itère sur les rows d'une df contenant des timezone aware datetimes.

### Comment ?

La source de l'erreur fut difficile à trouver car l'erreur se produit au moment de l'itération sur la df et non au moment où les datetimes problématiques sont créées dans la df.

La solution est un pur contournement : on transforme les datetimes en "timezone aware" datetimes uniquement à la volée, sans jamais les restocker dans la df pour éviter l'erreur.

J'avoue ne pas avoir complètement compris les tenants et les aboutissements mais ce fix me parait suffisant, surtout parce qu'il me débloque sur un autre sujet.