### PR TITLE
Gestion automatique de la crise annuelle des AF manquantes côté ASP

### DIFF
--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -3,8 +3,6 @@
 SiaeConvention object logic used by the import_siae.py script is gathered here.
 
 """
-from collections import defaultdict
-
 from django.utils import timezone
 
 from itou.siaes.management.commands._import_siae.siae import does_siae_have_an_active_convention
@@ -12,19 +10,12 @@ from itou.siaes.management.commands._import_siae.vue_structure import ASP_ID_TO_
 from itou.siaes.models import Siae, SiaeConvention
 
 
-# In general we deactivate conventions which should be deactivated, but some timings are tricky like the beginning of
-# each year. For example in ASP dataset of Jan 4 2021, no structure had any valid AF for 2021 yet, which means we
-# would have deactivated 4013 conventions o_O. In these cases we temporarily no longer deactivate any convention
-# until AF data catches up several weeks or months later.
-DEACTIVATE_CONVENTIONS = True
-
-
 def update_existing_conventions():
     """
     Update existing conventions, mainly the is_active field,
     and check data integrity on the fly.
     """
-    deactivations = 0
+    conventions_to_deactivate = []
     reactivations = 0
     three_months_ago = timezone.now() - timezone.timedelta(days=90)
 
@@ -75,25 +66,29 @@ def update_existing_conventions():
                 pass
             else:
                 # Active convention should be deactivated.
-                deactivations += 1
-                # Break if too many deactivations have occurred without waiting for the end of the loop.
-                # This way we avoid shutting down 100% of our conventions on January 1st of the year.
-                assert deactivations <= 200
-                if DEACTIVATE_CONVENTIONS:
-                    convention.is_active = False
-                    # Start the grace period now.
-                    convention.deactivated_at = timezone.now()
-                    convention.save()
+                conventions_to_deactivate.append(convention)
 
     print(f"{reactivations} conventions have been reactivated")
 
     total = SiaeConvention.objects.count()
+    deactivation_ratio = len(conventions_to_deactivate) / total
 
-    if DEACTIVATE_CONVENTIONS:
-        print(f"{deactivations} of {total} conventions have been deactivated")
+    if deactivation_ratio >= 0.05:
+        # Early each year, all or most AF for the new year are missing in ASP AF data.
+        # Instead of brutally deactivating all SIAE, we patiently wait until enough AF data is present.
+        # While we wait, no SIAE is deactivated whatsoever.
+        print(
+            f"ERROR: too many conventions should be deactivated ({100*deactivation_ratio}%)"
+            f" thus none will actually be!"
+        )
         return
 
-    print(f"{deactivations} of {total} conventions should have been deactivated but have *not* been")
+    for convention in conventions_to_deactivate:
+        convention.is_active = False
+        # Start the grace period now.
+        convention.deactivated_at = timezone.now()
+        convention.save()
+    print(f"{len(conventions_to_deactivate)} conventions have been deactivated")
 
 
 def get_creatable_conventions():
@@ -116,12 +111,7 @@ def get_creatable_conventions():
 
         siret_signature = ASP_ID_TO_SIRET_SIGNATURE.get(asp_id)
 
-        if DEACTIVATE_CONVENTIONS:
-            is_active = does_siae_have_an_active_convention(siae)
-        else:
-            # At the beginning of each year, when AFs of the new year are not there yet, we temporarily
-            # consider all new conventions as active by default even though they do not have a valid AF yet.
-            is_active = True
+        is_active = does_siae_have_an_active_convention(siae)
 
         assert not SiaeConvention.objects.filter(asp_id=asp_id, kind=siae.kind).exists()
 

--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -25,7 +25,6 @@ def update_existing_conventions():
     and check data integrity on the fly.
     """
     deactivations = 0
-    deactivations_by_kind = defaultdict(int)  # 0 by default
     reactivations = 0
     three_months_ago = timezone.now() - timezone.timedelta(days=90)
 
@@ -80,7 +79,6 @@ def update_existing_conventions():
                 # Break if too many deactivations have occurred without waiting for the end of the loop.
                 # This way we avoid shutting down 100% of our conventions on January 1st of the year.
                 assert deactivations <= 200
-                deactivations_by_kind[convention.kind] += 1
                 if DEACTIVATE_CONVENTIONS:
                     convention.is_active = False
                     # Start the grace period now.
@@ -96,17 +94,6 @@ def update_existing_conventions():
         return
 
     print(f"{deactivations} of {total} conventions should have been deactivated but have *not* been")
-
-    # Text in french ready to be copy/pasted to the DGEFP/ASP.
-    print("=== BEGINNING OF FRENCH TEXT FOR DGEFP/ASP ===")
-    pct_value = round(100 * deactivations / total, 1)
-    print(f"{deactivations} des {total} SIAE ({pct_value}%) n'ont pas d'AF pour la présente année à ce jour")
-    for kind, _ in Siae.KIND_CHOICES:
-        total = SiaeConvention.objects.filter(kind=kind).count()
-        if total >= 1:  # Skip GEIQ etc and avoid division by zero.
-            pct_value = round(100 * deactivations_by_kind[kind] / total, 1)
-            print(f"{deactivations_by_kind[kind]} des {total} {kind} ({pct_value}%) n'ont pas d'AF à ce jour")
-    print("=== END OF FRENCH TEXT FOR DGEFP/ASP ===")
 
 
 def get_creatable_conventions():

--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -70,15 +70,12 @@ def update_existing_conventions():
 
     print(f"{reactivations} conventions have been reactivated")
 
-    total = SiaeConvention.objects.count()
-    deactivation_ratio = len(conventions_to_deactivate) / total
-
-    if deactivation_ratio >= 0.05:
+    if len(conventions_to_deactivate) >= 100:
         # Early each year, all or most AF for the new year are missing in ASP AF data.
         # Instead of brutally deactivating all SIAE, we patiently wait until enough AF data is present.
         # While we wait, no SIAE is deactivated whatsoever.
         print(
-            f"ERROR: too many conventions should be deactivated ({100*deactivation_ratio}%)"
+            f"ERROR: too many conventions would be deactivated ({len(conventions_to_deactivate)})"
             f" thus none will actually be!"
         )
         return

--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -70,7 +70,7 @@ def update_existing_conventions():
 
     print(f"{reactivations} conventions have been reactivated")
 
-    if len(conventions_to_deactivate) >= 100:
+    if len(conventions_to_deactivate) >= 200:
         # Early each year, all or most AF for the new year are missing in ASP AF data.
         # Instead of brutally deactivating all SIAE, we patiently wait until enough AF data is present.
         # While we wait, no SIAE is deactivated whatsoever.

--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -84,7 +84,8 @@ def update_existing_conventions():
         convention.is_active = False
         # Start the grace period now.
         convention.deactivated_at = timezone.now()
-        convention.save()
+    SiaeConvention.objects.bulk_update(conventions_to_deactivate, ["is_active", "deactivated_at"])
+
     print(f"{len(conventions_to_deactivate)} conventions have been deactivated")
 
 

--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -84,7 +84,7 @@ def update_existing_conventions():
         convention.is_active = False
         # Start the grace period now.
         convention.deactivated_at = timezone.now()
-    SiaeConvention.objects.bulk_update(conventions_to_deactivate, ["is_active", "deactivated_at"])
+    SiaeConvention.objects.bulk_update(conventions_to_deactivate, ["is_active", "deactivated_at"], batch_size=200)
 
     print(f"{len(conventions_to_deactivate)} conventions have been deactivated")
 

--- a/itou/siaes/management/commands/_import_siae/financial_annex.py
+++ b/itou/siaes/management/commands/_import_siae/financial_annex.py
@@ -3,6 +3,8 @@
 SiaeFinancialAnnex object logic used by the import_siae.py script is gathered here.
 
 """
+from django.utils import timezone
+
 from itou.siaes.management.commands._import_siae.vue_af import AF_NUMBER_TO_ROW
 from itou.siaes.models import SiaeConvention, SiaeFinancialAnnex
 
@@ -32,13 +34,13 @@ def get_creatable_and_deletable_afs():
         assert af.convention.kind == row.kind
 
         # Sometimes an AF start date changes.
-        if af.start_at != row.start_at:
-            af.start_at = row.start_at
+        if af.start_at != timezone.make_aware(row.start_at):
+            af.start_at = timezone.make_aware(row.start_at)
             af.save()
 
         # Sometimes an AF end date changes.
-        if af.end_at != row.end_date:
-            af.end_at = row.end_date
+        if af.end_at != timezone.make_aware(row.end_date):
+            af.end_at = timezone.make_aware(row.end_date)
             af.save()
 
         # Sometimes an AF state changes.
@@ -77,7 +79,7 @@ def build_financial_annex_from_number(number):
     return SiaeFinancialAnnex(
         number=row.number,
         state=row.state,
-        start_at=row.start_at,
-        end_at=row.end_date,
+        start_at=timezone.make_aware(row.start_at),
+        end_at=timezone.make_aware(row.end_date),
         convention=convention_query.get(),
     )


### PR DESCRIPTION
### Quoi ?

Gestion automatique de la crise annuelle des AF manquantes côté ASP.

### Pourquoi ?

Chaque semaine l'ASP nous envoit ses données. Une SIAE est dite conventionnée si et seulement elle a au moins une AF valide à date. Or chaque début d'année, les AF de la nouvelle année sont très en retard. Le 1er janvier 2022 il n'y aura toujours aucune AF pour 2022, du coup en théorie toutes les SIAE sont déconventionnées.

### Comment ?

Avant :

Un dev C1 devait manuellement mettre un flag pour stopper les déconventionnements, puis quelques mois plus tard retirer ce flag pour reprendre les déconventionnements.

Après :

Tout est automatisé. Le 1er janvier, quand 100% des SIAE devraient être déconventionnées, le script suspend automatiquement tout déconventionnement. Il attend que le nombre de SIAE à déconventionner retombe en dessous de 100 (seuil arbitraire décidé par le support, correspond environ à 2.5% des 4000 conventions) pour reprendre les déconventionnemments.