### PR TITLE
Suppression du message GTA du dashboard AI 🔪

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -10,7 +10,6 @@
         <div class="alert alert-warning" role="alert">
             <p>Tous les salariés déclarés auprès de l'ASP avant le 1er décembre ont été ajoutés au tableau de bord de la SIAE porteuse de l’annexe financière. Nous travaillons à vous permettre de les transférer dans le tableau de bord d’une structure fille.</p>
             <p>Pour les salariés qui ne seraient plus en poste, il vous est demandé de procéder à une suspension d’un an au motif « contrat de travail terminé ». Dans la mesure où ces salariés sont connus dans l’Extranet IAE 2.0 de l'ASP, ces PASS IAE ne peuvent pas être annulés.</p>
-            <p>Certains salariés en insertion déclarés dans le logiciel GTA n’ont pas pu être déclarés dans l’Extranet IAE 2.0 de l'ASP avant le 1er décembre 2021. Pour ce cas particulier, des échanges sont en cours pour définir une méthode d’intégration, nous vous tiendrons informés.</p>
             <p>Pour les salariés entrés en parcours avant le 1er décembre 2021 qui n’auraient pas été déclarés dans l’Extranet avant le 1er décembre 2021, vous devez procéder à une déclaration d’éligibilité sur la plateforme de l’inclusion.</p>
             <p>Pour toute question liée à un cas individuel, <a href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/#support" rel="noopener" target="_blank" class="is-external" aria-label="Ouverture dans un nouvel onglet">une assistance est disponible ici {% include "includes/icon.html" with icon="external-link" %}</a>.</p>
         </div>


### PR DESCRIPTION
### Quoi ?

Suppression du message GTA du dashboard AI 🔪

### Pourquoi ?

Sur demande express de Eric.

Trivial donc pas de revue.

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/10533583/147738809-2b16a269-52af-408c-b91d-4c65f97432a5.png)
