### PR TITLE
Bugfix de la pagination des candidatures

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -176,7 +176,11 @@ class JobApplicationQuerySet(models.QuerySet):
             "to_siae__convention",
         ).prefetch_related("selected_jobs__appellation")
 
-        return qs.with_has_suspended_approval().with_is_pending_for_too_long().order_by("-created_at")
+        # Many job applications from AI exports share the exact same `created_at` value thus we secondarily order
+        # by pk to prevent flakyness in the resulting pagination (a same job application appearing both on page 1
+        # and page 2). Note that pk is a hash and not the usual incrementing integer, thus ordering by it does not
+        # make any other sense than being deterministic for pagination purposes.
+        return qs.with_has_suspended_approval().with_is_pending_for_too_long().order_by("-created_at", "pk")
 
     def with_monthly_counts(self):
         """


### PR DESCRIPTION
### Quoi ?

Bugfix de la pagination des candidatures.

### Pourquoi ?

Avant ce bugfix, une même candidature pouvait remonter sur la page 1 et la page 2.

### Comment ?

En utilisant un tri secondaire sur la clé primaire, qui permet de rendre la pagination déterministique. Avant cela, en raison des exports AI, de nombreuses candidatures avaient exactement la même date de création et la pagination n'était donc pas déterministique.
