### PR TITLE
Ajout d'un message d'information temporaire

### DIFF
--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -21,8 +21,8 @@
 
 {# Message temporaire : dysfonctionnement ASP #}
 <div class="alert alert-warning">
-  <p>Suite à un dysfonctionnement d'interface serveur entre la plate-forme de l'inclusion et l'extranet IAE, la transmission des fiches salarié est interrompue le temps de la correction.</p>
-  <p>Vous pouvez initialiser la création de vos fiches salariés dans la plate-forme de l'inclusion, elles resteront à l'état <b>"fiche complétée"</b> en attendant la résolution du problème.</p>
+  <p>Suite à un dysfonctionnement d'interface serveur entre les emplois de l'inclusion et l'extranet IAE, la transmission des fiches salarié est interrompue le temps de la correction.</p>
+  <p>Vous pouvez initialiser la création de vos fiches salariés dans les emplois de l'inclusion, elles resteront à l'état <b>"fiche complétée"</b> en attendant la résolution du problème.</p>
 </div>
 {# Fin message #}
 

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -19,6 +19,13 @@
 
 <h1>Fiches salarié ASP - <span class="text-muted">{{ current_siae.display_name }}</span></h1>
 
+{# Message temporaire : dysfonctionnement ASP #}
+<div class="alert alert-warning">
+  <p>Suite à un dysfonctionnement d'interface serveur entre la plate-forme de l'inclusion et l'extranet IAE, la transmission des fiches salarié est interrompue le temps de la correction.</p>
+  <p>Vous pouvez initialiser la création de vos fiches salariés dans la plate-forme de l'inclusion, elles resteront à l'état <b>"fiche complétée"</b> en attendant la résolution du problème.</p>
+</div>
+{# Fin message #}
+
 <div class="mt-3">
     <form method="get" class="form" id="status-filter-form">
         <div class="row">


### PR DESCRIPTION
### Quoi ?

Ajout d'un message d'erreur concernant les problèmes de tranfert vers l'ASP.

### Pourquoi ?

Depuis le 27 décembre à midi, suite à une modification technique des serveurs ASP, les connexions sont impossibles.

### Comment ?

Dans l'attente d'un rétablissement de la connexion, un message informatif est affiché dans la rubrique fiche salarié.

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/147232/147830227-2ee61d15-9291-4065-952e-084639e013e8.png)
