### PR TITLE
HOTFIX - Correction RSA pubkey suite à MAJ serveurs ASP

### DIFF
--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -22,6 +22,11 @@ connection_options = None
 if settings.ASP_FS_KNOWN_HOSTS and path.exists(settings.ASP_FS_KNOWN_HOSTS):
     connection_options = pysftp.CnOpts(knownhosts=settings.ASP_FS_KNOWN_HOSTS)
 
+# Fixes transfer issue after ASP SFTP server upgrade (27.12.2021)
+# Apparently, ssh-rsa public keys are not accepted by default anymore
+if connection_options:
+    connection_options.PubkeyAcceptedKeyTypes = "+ssh-rsa"
+
 
 class Command(BaseCommand):
     """


### PR DESCRIPTION
### Quoi ?

Ajout d'options de connexion SSH / SFTP à `paramiko` / `pysftp`

### Pourquoi ?

L'ASP a procédé à une mise à jour de ses serveurs SFTP le 27.12.2021 vers midi.
Depuis aucun transfert de fiches salarié n'est possible.

### Comment ?

Apparement les serveurs MAJ ne considèrent plus une connexion via certificat RSA comme valide par défaut.

Il est nécessaire d'ajouter une option de connexion SSH custom : `PubkeyAcceptedKeyTypes=+ssh-rsa` (via `pysftp` ou dans la config ssh).

Probablement du au fait que `openssh` considère désormais RSA-SHA1 comme `deprecated`

### Note :

RSA sera à terme supprimé de `openssh`. 

Il est nécessaire de passer en ECDSA aussi vite que possible et l'ASP en a été notifié.
