### PR TITLE
HOTFIX - Retour des transferts de fiches salarié

### DIFF
--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -22,11 +22,6 @@ connection_options = None
 if settings.ASP_FS_KNOWN_HOSTS and path.exists(settings.ASP_FS_KNOWN_HOSTS):
     connection_options = pysftp.CnOpts(knownhosts=settings.ASP_FS_KNOWN_HOSTS)
 
-# Fixes transfer issue after ASP SFTP server upgrade (27.12.2021)
-# Apparently, ssh-rsa public keys are not accepted by default anymore
-if connection_options:
-    connection_options.PubkeyAcceptedKeyTypes = "+ssh-rsa"
-
 
 class Command(BaseCommand):
     """
@@ -82,6 +77,7 @@ class Command(BaseCommand):
             username=settings.ASP_FS_SFTP_USER,
             private_key=settings.ASP_FS_SFTP_PRIVATE_KEY_PATH,
             cnopts=connection_options,
+            log="pysftp.log",
         )
 
     def _store_processing_report(self, conn, remote_path, content, local_path=settings.ASP_FS_REMOTE_DOWNLOAD_DIR):

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -19,13 +19,6 @@
 
 <h1>Fiches salarié ASP - <span class="text-muted">{{ current_siae.display_name }}</span></h1>
 
-{# Message temporaire : dysfonctionnement ASP #}
-<div class="alert alert-warning">
-  <p>Suite à un dysfonctionnement d'interface serveur entre les emplois de l'inclusion et l'extranet IAE, la transmission des fiches salarié est interrompue le temps de la correction.</p>
-  <p>Vous pouvez initialiser la création de vos fiches salariés dans les emplois de l'inclusion, elles resteront à l'état <b>"fiche complétée"</b> en attendant la résolution du problème.</p>
-</div>
-{# Fin message #}
-
 <div class="mt-3">
     <form method="get" class="form" id="status-filter-form">
         <div class="row">

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -74,6 +74,8 @@ PyJWT==2.3.0  # https://github.com/jpadilla/pyjwt
 httpx==0.21.1  # https://github.com/encode/httpx/
 
 # SFTP file transfer for ASP
+# Paramiko is explicitly defined to solve an "issue" (RSA order) of 2.9.x versions
+paramiko==2.8.1  # https://github.com/paramiko/paramiko
 pysftp==0.2.9  # https://bitbucket.org/dundeemt/pysftp/src/master/
 
 # S3


### PR DESCRIPTION
### Quoi ?

MAJ des serveurs ASP, part 2 : the Revenge of paramiko.

### Pourquoi ?

Le problème de transfert des fiches salarié est en fait double : 
- une MAJ des serveurs ASP le 27/12/2021 parasitant l'échange de clés RSA
- une MAJ d'une dépendance de `pysftp` (`paramiko`) le 23/12/2021 qui modifie la priorité de l'échange en RSA si d'autres options sont disponibles

Lors de la première MEP après le 23/12, l'installation de `pysftp` via `pip` a installé la version 2.9.2 de `paramiko` en dépendance (et mis le bazar).  

### Comment ?

- Downgrade explicite dans les `requirements` de `paramiko` en version 2.8.1 (les versions >= 2.9.0 ont le "problème")
- retrait du message informatif à destination des utilisateurs

### Autre

Voir le changelog de `paramiko`, à la section 2.9.0 :  
https://www.paramiko.org/changelog.html