### PR TITLE
Mise à jour de sécurité django 4.0 -> 4.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.3.2  # https://github.com/avian2/unidecode
 # Django
 # ------------------------------------------------------------------------------
 
-django==4.0  # https://www.djangoproject.com/
+django==4.0.1  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.46.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
### Quoi ?

Passage à django 4.0.1, le composant clé du projet.

### Pourquoi ?

Mise à jour de sécurité [publiée aujourd’hui](https://www.djangoproject.com/weblog/2022/jan/04/security-releases/).

On utilise 2 des 3 éléments concernés, le problème est surtout le risque de DOS:
```bash
$ grep UserAttributeSimilarityValidator
config/settings/base.py
190:    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
```

Ceci dit l’injection dans `dictsort` ne semble pas possible car on hardcode la clé, mais même si c’était le cas le risque serait très localisé donc faible.
```bash
$ grep dictsort
itou/templates/apply/includes/eligibility_diagnosis.html
32:                    {% regroup administrative_criteria|dictsort:"level" by get_level_display as levels %}
80:                        {% regroup administrative_criteria|dictsort:"level" by get_level_display as levels %}
```
