### PR TITLE
Correction du calcul de la fin des agréments reportés pendant les années bissextiles

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -308,10 +308,15 @@ class Approval(CommonApprovalMixin):
 
         Returns True if date has been updated, False otherwise
         """
+        # Only approvals which are not started yet can be postponed.
         if self.can_postpone_start_date:
-            delay = new_start_date - self.start_at
             self.start_at = new_start_date
-            self.end_at = self.end_at + delay
+            # At first, we computed the end date applying a delay like this:
+            # delay = new_start_date - self.start_at
+            # self.end_at = self.end_at + delay
+            # But this is error-prone on leap years!
+            # Instead, set the default end date.
+            self.end_at = self.get_default_end_date(new_start_date)
             self.save()
             return True
         return False


### PR DESCRIPTION
### Quoi ?

Correction d'une méthode qui faisait casser les tests uniquement pendant les années bissextiles.

### Pourquoi ?

Il est possible de décaler le début d'un PASS IAE s'il n'a pas encore commencé. Cela modifie la date de début et de fin. Or la manière dont nous calculions la nouvelle date de fin était inexacte.
Comme l'a bien expliqué @SebastienReuiller qui a trouvé l'origine du problème :

>  On vient récupérer un Pass IAE existant et on met à jour la date de début par rapport à la date de début du dernier contrat. Sauf que pour faire ça, quand on fait ça, on veut aussi décaler la date de fin en conséquence et pour ça on calcul l’intervalle de temps entre la nouvelle date de début et l'ancienne (qui est de 28 en ce moment dans le test qui foire car on revient un mois en arrière en chevauchant février !! ) et surprise, la date de fin est en 2024 qui est une année.. bissextile !! On applique donc un délai de 28 jours sur cette date de fin alors qu'à cette période, un décalage de 29 jours est nécessaire..


### Comment ?

Remplacement de l'ancienne date de fin par une nouvelle calculée automatiquement à partir de la date de début.
À valider avec le métier !