### PR TITLE
Ajout d'un message d'information sur le dashboard - fiches salarié et annexes financières

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -114,6 +114,14 @@
         </div>
     {% endif %}
 
+    {# Message d'information temporaire pour les fiches salarié / annexes financières #}
+    {% if can_show_employee_records %}
+        <div class="alert alert-info">
+          <p>La fin de validité des annexes financières de 2021 n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.</p> 
+          <p>Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
+        </div>
+    {% endif %}
+
     <h1 class="h2">
         Tableau de bord
         {% if user.is_job_seeker and user.get_full_name %} - <span class="text-muted">{{ user.get_full_name }}</span>{% endif %}


### PR DESCRIPTION
### Quoi ?

Ajout d'informations pour les structures utilisant les fiches salarié.

### Pourquoi ?

Pour indiquer que la fin de validité des annexes financières pour l'année 2021 n'a pas d'incidence sur la saisie des fiches salarié.

### Comment ?

![image](https://user-images.githubusercontent.com/147232/148348955-bf571971-dfd3-4202-9209-35e094c36304.png)
