### PR TITLE
Permettre aux EA et GEIQ de créer à nouveau leurs antennes

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -333,7 +333,7 @@
                             {% endif %}
                         </p>
                     {% endif %}
-                    {% if current_siae.is_active and user_is_siae_admin and current_siae.convention %}
+                    {% if can_create_siae_antenna %}
                         <p class="card-text">
                             {% include "includes/icon.html" with icon="plus-square" %}
                             <a href="{% url 'siaes_views:create_siae' %}">Créer/rejoindre une autre structure</a>

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -372,6 +372,24 @@ class User(AbstractUser, AddressMixin):
         """
         return self.is_siae_staff and self.siaemembership_set.filter(is_active=True).exists()
 
+    def can_create_siae_antenna(self, parent_siae):
+        """
+        Only admin employers can create an antenna for their SIAE.
+
+        For non SIAE structures (GEIQ, EA...) the convention logic is not implemented thus no convention ever exists.
+        Antennas can be freely created and technically are not rigorously linked to the parent structure.
+
+        For SIAE structures (AI, ACI...) the convention has to be present to link the parent SIAE and its antenna.
+        In some edge cases (e.g. SIAE created by staff and not yet officialized) the convention is absent,
+        in that case we must absolutely not allow any antenna to be created.
+        """
+        return (
+            self.is_siae_staff
+            and parent_siae.is_active
+            and parent_siae.has_admin(self)
+            and (parent_siae.convention is not None or not parent_siae.is_asp_managed)
+        )
+
     def can_view_stats_dashboard_widget(self, current_org):
         """
         Whether a stats section should be displayed on the user's dashboard.

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -79,6 +79,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
     context = {
         "lemarche_regions": settings.LEMARCHE_OPEN_REGIONS,
         "job_applications_categories": job_applications_categories,
+        "can_create_siae_antenna": request.user.can_create_siae_antenna(parent_siae=current_org),
         "can_show_financial_annexes": can_show_financial_annexes,
         "can_show_employee_records": can_show_employee_records,
         "can_view_stats_dashboard_widget": request.user.can_view_stats_dashboard_widget(current_org=current_org),

--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -240,12 +240,9 @@ def create_siae(request, template_name="siaes/create_siae.html"):
     Create a new SIAE (Antenne in French).
     """
     current_siae = get_current_siae_or_404(request)
-    if not current_siae.is_active or not current_siae.has_admin(request.user):
+    if not request.user.can_create_siae_antenna(parent_siae=current_siae):
         raise PermissionDenied
-    if current_siae.convention is None:
-        # We need a convention to exist in order to link the mother siae and its antenna.
-        # In some edge cases (e.g. siae created by staff) the convention might not be present yet.
-        raise PermissionDenied
+
     form = CreateSiaeForm(
         current_siae=current_siae,
         current_user=request.user,


### PR DESCRIPTION
### Quoi ?

Permettre aux EA et GEIQ de créer à nouveau leurs antennes.

### Pourquoi ?

Suite à un [récent hotfix pas beau](https://github.com/betagouv/itou/commit/5c139c5151e36e34a6f6c356d7cfa17e8658d925) de période de fête, les EA/GEIQ ne pouvaient plus créer leurs antennes.

### Comment ?

Refactorisation avec une méthode bien propre dans le modèle et des tests.