### PR TITLE
Transfert de candidatures d'une SIAE à une autre

### DIFF
--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -160,7 +160,12 @@ class Command(BaseCommand):
             help="ID of the the siae to move data to.",
             required=True,
         )
-        parser.add_argument("--only-job-applications", action=argparse.BooleanOptionalAction, default=False)
+        parser.add_argument(
+            "--only-job-applications",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+            help="Set to True to move only job applications and job descriptions, nothing else!",
+        )
         parser.add_argument("--dry-run", action=argparse.BooleanOptionalAction, default=False)
 
     def handle(self, *args, **options):

--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -30,8 +30,9 @@ HELP_TEXT = """
     same convention. So be sure to read your trello ticket instructions thoroughly and don't assume this command
     does everything.
 
-    Example of use in local dev:
+    Examples of use in local dev:
     $ make django_admin COMMAND="move_siae_data --from 3243 --to 9612 --dry-run"
+    $ make django_admin COMMAND="move_siae_data --from 3243 --to 9612 --only-job-applications --dry-run"
 
     And in production:
     $ cd && cd app_* && django-admin move_siae_data --from 3243 --to 9612 --dry-run

--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -16,7 +16,8 @@ from itou.users import models as users_models
 logger = logging.getLogger(__name__)
 
 HELP_TEXT = """
-    Move all data from siae A to siae B. After this move siae A is no longer supposed to be used or even accessible.
+    Move all data from siae A to siae B (or only the job applications if `only-job-applications` option is set).
+    After this move siae A is no longer supposed to be used or even accessible.
     Members of siae A are detached, geolocalization is removed and new job applications are blocked.
 
     This command should be used when users have been using the wrong siae A instead of using the correct siae B.


### PR DESCRIPTION
### Quoi ?

Modification du script permettant de déplacer les données d'une SIAE à une autre pour permettre de déplacer uniquement les candidatures.

### Pourquoi ?

Pour pouvoir juste basculer les candidatures dans le cas d'un changement de SIRET (déménagement).

### Comment ?

En ajoutant une option pour ne déplacer que les candidatures. Les fiches de poste ne sont pas déplacer dans ce cas. Les candidatures déplacées apparaissent alors comme "Candidatures spontanées".


