### PR TITLE
Ajout d’infos prescripteur manquantes dans les notifications à Pole Emploi

### DIFF
--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -331,6 +331,8 @@ def prescriber_kind_param(prescriber_organization):
             return "DEPT_BRSA"
     if kind in mapping:
         return mapping[kind]
+    # The mapping does not entirely matches all the possible prescriber kind we have.
+    # by default (if the prescriber kind is not in PE’s possible list), we send "OTHER"
     return "OTHER"
 
 
@@ -365,9 +367,11 @@ def _mise_a_jour_parameters(encrypted_identifier: str, job_application, pass_app
         "numSIRETsiae": siae.siret,
         "origineCandidature": _mise_a_jour_sender_kind_param(job_application.sender_kind),
     }
+
+    # Whenever possible, we send details about the prescriber
     if job_application.sender_kind == JobApplication.SENDER_KIND_PRESCRIBER:
         organization = job_application.sender_prescriber_organization
         data["numSIRETPrescripteur"] = organization.siret
-        # we are supposed to provide the raison sociale too but… its not documented anywhere how to provide it
         data["typologiePrescripteur"] = prescriber_kind_param(organization)
+
     return data

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -18,7 +18,10 @@ from factory import Faker
 from itou.common_apps.resume.forms import ResumeFormMixin
 from itou.institutions.factories import InstitutionFactory, InstitutionWithMembershipFactory
 from itou.job_applications.factories import JobApplicationFactory, JobApplicationWithApprovalFactory
-from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
+from itou.prescribers.factories import (
+    AuthorizedPrescriberOrganizationWithMembershipFactory,
+    PrescriberOrganizationWithMembershipFactory,
+)
 from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
 from itou.siaes.models import Siae, SiaeMembership
 from itou.users.factories import JobSeekerFactory, PrescriberFactory
@@ -801,6 +804,24 @@ class PoleEmploiTest(TestCase):
                 job_application, POLE_EMPLOI_PASS_APPROVED, "some_valid_encrypted_identifier", "some_valid_token"
             )
             mock_post.assert_called()
+
+    @mock.patch(
+        "httpx.post",
+        return_value=httpx.Response(200, json=POLE_EMPLOI_MISE_A_JOUR_PASS_API_RESULT_OK_MOCK),
+    )
+    def test_mise_a_jour_pass_iae_with_prescriber(self, mock_post):
+        """
+        Our code should be able to call the API even if we provide prescriber information
+        """
+        sender_prescriber_organization = AuthorizedPrescriberOrganizationWithMembershipFactory()
+        sender = sender_prescriber_organization.members.first()
+        job_application = JobApplicationWithApprovalFactory(
+            sender_prescriber_organization=sender_prescriber_organization, sender=sender
+        )
+        mise_a_jour_pass_iae(
+            job_application, POLE_EMPLOI_PASS_APPROVED, "some_valid_encrypted_identifier", "some_valid_token"
+        )
+        mock_post.assert_called()
 
     @mock.patch(
         "httpx.post",


### PR DESCRIPTION
### Quoi ?

 - [x] Ajout de la typologie et du numéro de SIRET prescripteur dans les appels API pour Pole Emploi.

### Pourquoi ?

Ces champs ne sont pas obligatoires techniquement mais le sont fonctionnellement.

### Comment ?

Ajout d’un mapping entre nos données et celles attendus par l’API PE.