### PR TITLE
Afficher par défaut la bannières des comptes de test en environnement de dev

### DIFF
--- a/config/settings/dev.py.template
+++ b/config/settings/dev.py.template
@@ -7,6 +7,7 @@ ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1", "192.168.0.1"]
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 ITOU_ENVIRONMENT = "DEV"
+SHOW_TEST_ACCOUNTS_BANNER  = True
 
 # Security.
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
### Quoi ?

Mise à jour des variables environnement de dev dans le fichier de config de template.

### Pourquoi ?

Afficher par défaut l'écran de sélection des comptes de test sur la home en localhost.


### Comment ?

Ajout de la variable SHOW_TEST_ACCOUNTS_BANNER  à True.
