### PR TITLE
BOOST : Sprint 34

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -104,7 +104,7 @@ class IsValidFilter(admin.SimpleListFilter):
 @admin.register(models.Approval)
 class ApprovalAdmin(admin.ModelAdmin):
     form = ApprovalAdminForm
-    list_display = ("pk", "number", "user", "start_at", "end_at", "is_valid", "created_at")
+    list_display = ("pk", "number", "user", "birthdate", "start_at", "end_at", "is_valid", "created_at")
     search_fields = ("pk", "number", "user__first_name", "user__last_name", "user__email")
     list_filter = (IsValidFilter,)
     list_display_links = ("pk", "number")
@@ -166,6 +166,15 @@ class ApprovalAdmin(admin.ModelAdmin):
             ),
         ]
         return additional_urls + super().get_urls()
+
+    def birthdate(self, obj):
+        """
+        User birthdate as custom value in display
+
+        """
+        return obj.user.birthdate
+
+    birthdate.short_description = "Date de naissance"
 
 
 class IsInProgressFilter(admin.SimpleListFilter):

--- a/itou/templates/account/login.html
+++ b/itou/templates/account/login.html
@@ -11,7 +11,7 @@
         {% if show_sign_in_providers %}
             <b class="mb-4">Connectez-vous avec un service tiers</b>
             {% if show_france_connect %}
-            <div>
+            <div class="mt-4">
                 {% include "signup/includes/france_connect_button.html" %}
             </div>
             <div class="mt-4 mb-3">

--- a/itou/templates/siaes/includes/_list_siae_actives_jobs.html
+++ b/itou/templates/siaes/includes/_list_siae_actives_jobs.html
@@ -1,6 +1,15 @@
 {% comment %} takes 2 argument siae<Siae> and jobs_descriptions <List of SiaeJobDescription> {% endcomment %}
 <h4 class="pb-2">Recrutement(s) en cours</h4>
 {% for job in jobs_descriptions %}
+    {# Collapsing block start (more than 5 jobs descriptions) #}
+    {% if forloop.counter0 == 5 and not forloop.last %}
+      <div class="pt-2">
+        <button class="btn collapsed collapse-caret p-0" data-toggle="collapse" data-target="#collapse_{{ forloop.parentloop.counter0 }}" type="button" aria-expanded="false" aria-controls="collapse_{{ forloop.parentloop.counter0 }}">
+          <h6>Voir tous les recrutements en cours ({{ jobs_descriptions.count }})</h6>
+        </button>
+      </div>
+      <div class="collapse" id="collapse_{{forloop.parentloop.counter0}}">
+    {% endif %}
     {% if job.is_active and not siae.block_job_applications %}
         <a class="matomo-event btn btn-outline-primary mb-2"
             href="{% if job.pk %}{{job.get_absolute_url}}{% else %}#{% endif %}?back_url={{ request.get_full_path|urlencode }}"
@@ -16,5 +25,9 @@
             </small>
         {% endif %}
         <br >
+    {% endif %}
+    {# Collapsing block end #}
+    {% if forloop.last and forloop.counter0 > 5 %}
+      </div>
     {% endif %}
 {% endfor %}

--- a/itou/templates/siaes/includes/_list_siae_actives_jobs.html
+++ b/itou/templates/siaes/includes/_list_siae_actives_jobs.html
@@ -1,15 +1,6 @@
 {% comment %} takes 2 argument siae<Siae> and jobs_descriptions <List of SiaeJobDescription> {% endcomment %}
-<h4 class="pb-2">Recrutement(s) en cours</h4>
+<h4 class="pb-2">Recrutement{{ jobs_descriptions|pluralize }} en cours</h4>
 {% for job in jobs_descriptions %}
-    {# Collapsing block start (more than 5 jobs descriptions) #}
-    {% if forloop.counter0 == 5 and not forloop.last %}
-      <div class="pt-2">
-        <button class="btn collapsed collapse-caret p-0" data-toggle="collapse" data-target="#collapse_{{ forloop.parentloop.counter0 }}" type="button" aria-expanded="false" aria-controls="collapse_{{ forloop.parentloop.counter0 }}">
-          <h6>Voir tous les recrutements en cours ({{ jobs_descriptions.count }})</h6>
-        </button>
-      </div>
-      <div class="collapse" id="collapse_{{forloop.parentloop.counter0}}">
-    {% endif %}
     {% if job.is_active and not siae.block_job_applications %}
         <a class="matomo-event btn btn-outline-primary mb-2"
             href="{% if job.pk %}{{job.get_absolute_url}}{% else %}#{% endif %}?back_url={{ request.get_full_path|urlencode }}"
@@ -21,13 +12,21 @@
                 <span class="ml-3">
                         {% include "includes/icon.html" with icon="layers" size=15 class="mr-1 text-danger" %}
                         Plus de {{ job.POPULAR_THRESHOLD }} candidatures reçues
-                    </span>
+                </span>
             </small>
         {% endif %}
         <br >
     {% endif %}
-    {# Collapsing block end #}
-    {% if forloop.last and forloop.counter0 > 5 %}
+    {# Collapsing block start (more than 5 jobs descriptions) #}
+    {% if forloop.counter == 5 and not forloop.last %}
+      <div class="pt-2">
+        <button class="btn collapsed collapse-caret p-0" data-toggle="collapse" data-target="#collapse_{{ forloop.parentloop.counter0 }}" type="button" aria-expanded="false" aria-controls="collapse_{{ forloop.parentloop.counter0 }}">
+          <h6>Voir tous les recrutements en cours ({{ jobs_descriptions.count }})</h6>
+        </button>
+      </div>
+      <div class="collapse" id="collapse_{{forloop.parentloop.counter0}}">
+    {% elif forloop.last and forloop.counter > 5 %}
+      {# Collapsing block end #}
       </div>
     {% endif %}
 {% endfor %}

--- a/itou/templates/siaes/includes/_list_siae_actives_jobs.html
+++ b/itou/templates/siaes/includes/_list_siae_actives_jobs.html
@@ -1,5 +1,5 @@
 {% comment %} takes 2 argument siae<Siae> and jobs_descriptions <List of SiaeJobDescription> {% endcomment %}
-<h4 class="pb-2">Recrutement en cours</h4>
+<h4 class="pb-2">Recrutement(s) en cours</h4>
 {% for job in jobs_descriptions %}
     {% if job.is_active and not siae.block_job_applications %}
         <a class="matomo-event btn btn-outline-primary mb-2"

--- a/itou/templates/siaes/includes/_list_siae_actives_jobs.html
+++ b/itou/templates/siaes/includes/_list_siae_actives_jobs.html
@@ -21,7 +21,7 @@
     {% if forloop.counter == 5 and not forloop.last %}
       <div class="pt-2">
         <button class="btn collapsed collapse-caret p-0" data-toggle="collapse" data-target="#collapse_{{ forloop.parentloop.counter0 }}" type="button" aria-expanded="false" aria-controls="collapse_{{ forloop.parentloop.counter0 }}">
-          <h6>Voir tous les recrutements en cours ({{ jobs_descriptions.count }})</h6>
+          <h6>Voir tous les recrutements en cours ({{ forloop.revcounter0 }} de plus)</h6>
         </button>
       </div>
       <div class="collapse" id="collapse_{{forloop.parentloop.counter0}}">

--- a/itou/templates/siaes/job_description_card.html
+++ b/itou/templates/siaes/job_description_card.html
@@ -24,7 +24,7 @@
             </div>
             <div class="pt-5">
                 {% if job.is_active and not siae.block_job_applications %}
-                    <span class="badge badge-pill badge-success">Recrutement(s) en cours</span>
+                    <span class="badge badge-pill badge-success">Recrutement en cours</span>
                 {% else %}
                     <span class="badge badge-pill badge-warning">Pas de recrutement en cours</span>
                 {% endif %}

--- a/itou/templates/siaes/job_description_card.html
+++ b/itou/templates/siaes/job_description_card.html
@@ -24,7 +24,7 @@
             </div>
             <div class="pt-5">
                 {% if job.is_active and not siae.block_job_applications %}
-                    <span class="badge badge-pill badge-success">Recrutement en cours</span>
+                    <span class="badge badge-pill badge-success">Recrutement(s) en cours</span>
                 {% else %}
                     <span class="badge badge-pill badge-warning">Pas de recrutement en cours</span>
                 {% endif %}

--- a/itou/templates/signup/includes/france_connect_button.html
+++ b/itou/templates/signup/includes/france_connect_button.html
@@ -1,19 +1,23 @@
 {% load static %}
 
 
-<p class="text-center">
+<div class="text-center">
     <b>Utilisez FranceConnect pour vous connecter ou créer un compte</b>
     <br>
     FranceConnect est la solution proposée par l’État pour sécuriser et simplifier la connexion à vos services en ligne.
     <br>
-    <a
-        href="{% url 'france_connect:authorize' %}"
-        aria-label="S'identifier avec FranceConnect"
-        class="matomo-event"
-        data-matomo-category="inscription-candidat"
-        data-matomo-action="clic"
-        data-matomo-option="se-connecter-avec-france-connect">
-        <img class="img-fluid mb-1 itou-france-connect" alt="">
-    </a>
-    <br>
-    <a class="small font-italic d-inline-block" href="https://app.franceconnect.gouv.fr/en-savoir-plus">Qu’est-ce que FranceConnect ?</a>
+    <p class="mt-4">
+        <a
+            href="{% url 'france_connect:authorize' %}"
+            aria-label="S'identifier avec FranceConnect"
+            class="matomo-event"
+            data-matomo-category="inscription-candidat"
+            data-matomo-action="clic"
+            data-matomo-option="se-connecter-avec-france-connect">
+            <img class="img-fluid mb-1 itou-france-connect" alt="">
+        </a>
+        <br>
+        <a class="small font-italic d-inline-block" href="https://app.franceconnect.gouv.fr/en-savoir-plus">Qu’est-ce que FranceConnect ?</a>
+    </p>
+</div>
+

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -161,6 +161,7 @@ class ItouUserAdmin(UserAdmin):
         "email",
         "first_name",
         "last_name",
+        "birthdate",
         "is_staff",
         "is_peamu",
         "is_created_by_a_proxy",

--- a/itou/www/siaes_views/tests.py
+++ b/itou/www/siaes_views/tests.py
@@ -327,7 +327,7 @@ class ConfigureJobsViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["siae"], self.siae)
         response_content = str(response.content)
-        self.assertIn("Recrutement(s) en cours", response_content)
+        self.assertIn("Recrutements en cours", response_content)
 
         # get job description
         url = reverse("siaes_views:job_description_card", kwargs={"job_description_id": job_description.pk})
@@ -335,7 +335,7 @@ class ConfigureJobsViewTest(TestCase):
         response_content = str(response.content)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["job"], job_description)
-        self.assertIn("Recrutement(s) en cours", response_content)
+        self.assertIn("Recrutement en cours", response_content)
 
 
 class ShowAndSelectFinancialAnnexTest(TestCase):

--- a/itou/www/siaes_views/tests.py
+++ b/itou/www/siaes_views/tests.py
@@ -327,7 +327,7 @@ class ConfigureJobsViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["siae"], self.siae)
         response_content = str(response.content)
-        self.assertIn("Recrutement en cours", response_content)
+        self.assertIn("Recrutement(s) en cours", response_content)
 
         # get job description
         url = reverse("siaes_views:job_description_card", kwargs={"job_description_id": job_description.pk})
@@ -335,7 +335,7 @@ class ConfigureJobsViewTest(TestCase):
         response_content = str(response.content)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["job"], job_description)
-        self.assertIn("Recrutement en cours", response_content)
+        self.assertIn("Recrutement(s) en cours", response_content)
 
 
 class ShowAndSelectFinancialAnnexTest(TestCase):


### PR DESCRIPTION
### Quoi ?

Les modifications boost demandées pour le sprint / release 34 :
- ajout de la date de naissance dans l'affichage en liste des PASS IAE et des utilisateurs.
- modification des marges pour les boutons de login.
- affichage des 5 derniers recrutements avec une option pour afficher les suivants (recherche de SIAE).
- corrections mineures (typos).

### Pourquoi ?

Session de boost classique

### Comment ?

En retard

### Captures d'écran (optionnel)

Recherche SIAE / recrutement :

![image](https://user-images.githubusercontent.com/147232/149974080-18127594-d9d9-477b-aa6b-6cfb625a88a7.png)

![image](https://user-images.githubusercontent.com/147232/149974200-ebe169bb-9a0d-488b-b1e6-fd4ba2bcd6f9.png)
