### PR TITLE
Mise à jour de la documentation dans le Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ populate_db_venv:
 COMMAND_GRAPH_MODELS := graph_models --group-models jobs users siaes prescribers job_applications approvals eligibility invitations asp --pygraphviz -o itou-graph-models.png
 
 graph_models_itou:
+	# Install these packages first:
+	# apt-get install gcc graphviz graphviz-dev
+	# pip install pygraphviz
 	docker exec -ti itou_django django-admin $(COMMAND_GRAPH_MODELS)
 
 graph_models_itou_venv:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ populate_db_venv:
 	pg_restore -d itou --if-exists --clean --no-owner --no-privileges itou/fixtures/postgres/cities.sql
 	ls -d itou/fixtures/django/* | xargs ./manage.py loaddata
 
-COMMAND_GRAPH_MODELS := graph_models --group-models jobs users siaes prescribers job_applications approvals eligibility invitations asp --pygraphviz -o itou-graph-models.png
+COMMAND_GRAPH_MODELS := graph_models --group-models jobs users siaes prescribers job_applications approvals eligibility invitations asp cities employee_record external_data institutions --pygraphviz -o itou-graph-models.png
 
 graph_models_itou:
 	# Install these packages first:


### PR DESCRIPTION
### Quoi ?

- Ajout de documentation précisant les librairies nécessaires à l'utilisation de cette commande. Elles ne sont pas installées par défaut car cette commande, bien que très utile, est rarement utilisée.
- Mise à jour des modèles générés sur le graphique.

### Pourquoi ?

La commande `make graph_models_itou` permet de générer un graphique représentant le schéma de données.
