### PR TITLE
Sentry : stop warnings

### DIFF
--- a/config/settings/_sentry.py
+++ b/config/settings/_sentry.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -29,7 +28,7 @@ def strip_sentry_sensitive_data(event, hint):
 
 sentry_logging = LoggingIntegration(
     level=logging.INFO,  # Capture info and above as breadcrumbs.
-    event_level=logging.WARNING,  # Send warnings as events.
+    event_level=logging.ERROR,  # Send only errors as events.
 )
 
 


### PR DESCRIPTION
### Quoi ?

Ne pas remonter les informations du niveau `WARNING` en tant qu’événement Sentry.

### Pourquoi ?

Génère un volume trop élevé d'information qui explose le seuil du Sentry proposé par Beta. 

### Comment ?

- retour à la valeur par défaut pour les événements Sentry  (`ERROR`).
- passage à une instance Sentry gérée par Itou.