### PR TITLE
Niveau de log Huey

### DIFF
--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import textwrap
 
@@ -10,6 +11,10 @@ from django.template.loader import get_template
 from huey.contrib.djhuey import task
 
 from itou.utils.iterators import chunks
+
+
+# Reduce verbosity of huey logs (INFO by default)
+logging.getLogger("huey").setLevel(logging.WARNING)
 
 
 # This is the "real" email backend used by the async wrapper / email backend

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,5 +1,5 @@
 -r ./base.txt
 
 uwsgi==2.0.20  # https://github.com/unbit/uwsgi
-sentry-sdk==1.5.1  # https://github.com/getsentry/sentry-python
+sentry-sdk==1.5.3  # https://github.com/getsentry/sentry-python
 elastic-apm==6.7.2  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html


### PR DESCRIPTION
### Quoi ?

Modification du niveau de log de Huey.

Bonus : upgrade de sentry en v1.5.3

### Pourquoi ?

Pour éviter de polluer les logs avec tous les messages d'actions asynchrones.

### Comment ?

Passage du niveau de logs de Huey de `INFO` à `WARNING`.