### PR TITLE
Le bouton "Besoin d'aide" envoie dorénavant vers une page d'aide C2 et non C1 si on est sur une page stats.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -549,6 +549,7 @@ METABASE_DASHBOARD_IDS = {
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(os.environ.get("PILOTAGE_DASHBOARDS_WHITELIST", "[]"))
 
 PILOTAGE_SITE_URL = "https://pilotage.inclusion.beta.gouv.fr"
+PILOTAGE_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/aide/pilotage"
 
 # Slack notifications sent by Metabase cronjobs.
 SLACK_CRON_WEBHOOK_URL = os.environ.get("SLACK_CRON_WEBHOOK_URL", None)

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -7,9 +7,17 @@ def expose_settings(request):
     https://docs.djangoproject.com/en/2.1/ref/templates/api/#using-requestcontext
     """
 
+    full_view_name = request.resolver_match.view_name  # e.g. "home:hp" or "stats:stats_public"
+
+    if full_view_name.startswith("stats:"):
+        # On all stats pages the help button should redirect to the C2 help page instead of the C1 help page.
+        assistance_url = settings.PILOTAGE_ASSISTANCE_URL
+    else:
+        assistance_url = settings.ITOU_ASSISTANCE_URL
+
     return {
         "ALLOWED_HOSTS": settings.ALLOWED_HOSTS,
-        "ITOU_ASSISTANCE_URL": settings.ITOU_ASSISTANCE_URL,
+        "ITOU_ASSISTANCE_URL": assistance_url,
         "ITOU_COMMUNITY_URL": settings.ITOU_COMMUNITY_URL,
         "ITOU_DOC_URL": settings.ITOU_DOC_URL,
         "ITOU_EMAIL_CONTACT": settings.ITOU_EMAIL_CONTACT,


### PR DESCRIPTION
### Quoi ?

Le bouton "Besoin d'aide" envoie maintenant vers une page d'aide C2 et non C1 si on est sur une page stats.

Lien C1 : https://communaute.inclusion.beta.gouv.fr/aide/emplois

Lien C2 : https://communaute.inclusion.beta.gouv.fr/aide/pilotage

La tête du bouton : 
![image](https://user-images.githubusercontent.com/10533583/150809695-4ca564eb-7fd8-4f13-be5e-1f7b910db992.png)


### Pourquoi ?

Pas mal d'utilisateurs C2 viennent sur le C1 uniquement pour avoir accès aux TDB privés (DDETS, DREETS...). Du coup il est pertinent que le bouton "Besoin d'aide" renvoit vers la page d'aide C2 et non C1 si on consulte une page stats.