### PR TITLE
Suppression de la commande setup_git_pre_commit_hook dans Makeflie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # =============================================================================
 PYTHON_VERSION := python3.9
 
-.PHONY: run clean cdsitepackages quality style setup_git_pre_commit_hook
+.PHONY: run clean cdsitepackages quality style
 
 # Run Docker images
 run:


### PR DESCRIPTION
### Quoi ?

La commande `make setup_git_pre_commit_hook` ne pointe vers aucune cible.

### Pourquoi ?

Vermeer / 29.01.2022 / canal slack #tech :  "Bien vu le setup_git_pre_commit_hook est un vestige, tu peux le virer du repo public stp."

### Comment ?

Suppression de la commande dans la liste des cibles dans .PHONY 
