### PR TITLE
Filtre lien retour candidatures

### DIFF
--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -37,7 +37,7 @@
             <div class="card-footer bg-white">
                 <div class="row">
                     <div class="col-sm-3">
-                        <a class="btn btn-emploi" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">
+                        <a class="btn btn-emploi" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}">
                             Gérer la candidature
                         </a>
                     </div>


### PR DESCRIPTION
### Quoi ?

Le lien retour depuis la carte candidature vers la liste des candidatures reçues, intègre les filtres de recherche utilisés
url de la carte candidature : /apply/_job_application_id_/siae/details
url de la liste des candidatures : /apply/siae/list

### Pourquoi ?

Lorsque l'utilisateur utilisait des filtres pour sa recherche de candidatures, ces filtres etaient perdus après la consulation d'une candidature: 
Scénario :
* J'applique un filtre sur les candidatures.
* Je consulte la candidature
* Je clique sur retour
* Le filtre s'est désactivé et j'ai de nouveau toutes les candidatures

### Comment ?

Ajout du parametre `?back_url={{ request.get_full_path|urlencode }}` dans le template `apply/list_for_siae.html`

Ce parametre est interprété par `get_safe_url(request, "back_url", fallback_url=reverse_lazy("apply:list_for_siae"))` dans `itou/www/apply/views/process_views.py` function `details_for_siae` 

L'url du lien de retour, après application des filtres est désormais du style `/apply/siae/list?states=new&states=processing`


