### PR TITLE
Mise à jour du suivi de la consommation des etp

### DIFF
--- a/itou/metabase/management/commands/sql/007_suivi_consommation_etp.sql
+++ b/itou/metabase/management/commands/sql/007_suivi_consommation_etp.sql
@@ -5,29 +5,20 @@ les etp par rapport à ce qui est conventionné.
 Les DDETS pourront donc redistribuer les aides aux postes en se basant sur la consommation réelle des etp 
   
 */
-with constantes as (
-    select 
-        case 
-            when (max(emi.emi_sme_annee) = date_part('year', current_date )- 1) then 1
-            else 0 
-        end pas_donnees_annee_en_cours
-    from  
-        "fluxIAE_EtatMensuelIndiv" as emi
-),
-calcul_ETP as (
+with calcul_ETP as (
     select 
         /* En Janvier de l'année en cours, moyenne_nb_etp_depuis_debut_annee = (consommé sur l'année n-1) / (le dernier mois travaillé sur l'année n-1) */
         case 
-            when pas_donnees_annee_en_cours = 1 then (sum(emi.emi_part_etp) / max(emi.emi_sme_mois))
+            when (max(emi.emi_sme_annee) = date_part('year', current_date )- 1) then (sum(emi.emi_part_etp) / max(emi.emi_sme_mois))
             else (sum(emi.emi_part_etp) filter (where emi.emi_sme_annee = (date_part('year', current_date)))) 
                     / (max(emi.emi_sme_mois) filter (where emi.emi_sme_annee = (date_part('year', current_date))))
         end moyenne_nb_etp_depuis_debut_annee,
         case 
-           when pas_donnees_annee_en_cours = 1 then max(af.af_etp_postes_insertion)
+           when (max(emi.emi_sme_annee) = date_part('year', current_date )- 1) then max(af.af_etp_postes_insertion)
            else max(af.af_etp_postes_insertion) filter (where emi.emi_sme_annee = (date_part('year', current_date)))
         end nb_etp_subventionne,
         case 
-           when pas_donnees_annee_en_cours = 1 then sum(emi.emi_nb_heures_travail)
+           when (max(emi.emi_sme_annee) = date_part('year', current_date )- 1) then sum(emi.emi_nb_heures_travail)
            else sum(emi.emi_nb_heures_travail)  filter (where emi.emi_sme_annee = (date_part('year', current_date))) 
         end nb_heures_travaillees_depuis_debut_annee,
         saisie_asp.dernier_mois_saisi_asp,
@@ -43,25 +34,18 @@ calcul_ETP as (
         af.af_numero_convention,
         af.nom_departement_af,
         af.nom_region_af
-    from 
-        constantes 
-    cross join 
-        suivi_saisies_dans_asp saisie_asp 
-    left join 
-        "fluxIAE_EtatMensuelIndiv" emi 
+    from suivi_saisies_dans_asp saisie_asp 
+    left join "fluxIAE_EtatMensuelIndiv" emi 
         on saisie_asp.af_id_annexe_financiere = emi_afi_id  
-    left join 
-        "fluxIAE_AnnexeFinanciere_v2" as af
-            on saisie_asp.af_id_annexe_financiere = af.af_id_annexe_financiere  
-            and af_etat_annexe_financiere_code in ('VALIDE')
-            /*On prend les déclarations mensuelles de l'année en cours + l'année n-1 */
-            and emi.emi_sme_annee >= (date_part('year', current_date) - 1)
-            and date_part('year', to_date(af.af_date_debut_effet, 'dd/mm/yyyy')) >= (date_part('year', current_date) - 1)
-    left join 
-        "fluxIAE_Structure_v2" as structure
-            on af.af_id_structure = structure.structure_id_siae
+    left join "fluxIAE_AnnexeFinanciere_v2" as af
+        on saisie_asp.af_id_annexe_financiere = af.af_id_annexe_financiere  
+        and af_etat_annexe_financiere_code in ('VALIDE'/*, 'SAISI'*/)
+        /*On prend les déclarations mensuelles de l'année en cours + l'année n-1 */
+        and emi.emi_sme_annee >= (date_part('year', current_date) - 1)
+        and date_part('year', to_date(af.af_date_debut_effet, 'dd/mm/yyyy')) >= (date_part('year', current_date) - 1)
+    left join "fluxIAE_Structure_v2" as structure
+        on af.af_id_structure = structure.structure_id_siae
     group by 
-        pas_donnees_annee_en_cours,
         dernier_mois_saisi_asp,
         structure.structure_denomination,
         structure.structure_id_siae,


### PR DESCRIPTION
### Quoi ?

Mise à jour du script qui alimente le suivi de la consommation des ETP

### Pourquoi ?

Afficher la consommation des ETP de l'année n-1 tant que les données de l'année n ne sont pas saisies dans l'ASP