### PR TITLE
Migration locale de docker vers PostgreSQL 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     services:
       postgres:
         # Docker Hub image
-        image: postgis/postgis:12-master
+        image: postgis/postgis:14-master
         env:
           POSTGRES_PASSWORD: password
         ports:

--- a/docker/dev/postgres/Dockerfile
+++ b/docker/dev/postgres/Dockerfile
@@ -1,5 +1,5 @@
 # https://registry.hub.docker.com/r/postgis/postgis
-FROM postgis/postgis:12-master
+FROM postgis/postgis:14-master
 
 COPY ./docker/dev/postgres/maintenance /usr/local/bin/maintenance
 


### PR DESCRIPTION
# Quoi ?

 - Montée de version locale à postgres 14
 - Infos de migration

# Pourquoi ?

On souhaite passer à la version 14

# Comment

Les répertoires locaux sont incompatibles d’une version à une autre. Si on monte juste la version de postgres, on ne peut plus démarrer docker:

```
The data directory was initialized by PostgreSQL version 12, which is not compatible with this version 14.1 (Debian 14.1-1.pgdg110+1).
```

Il faut donc bien supprimer les volumes, forcer le rebuild et refaire un import de base:

```
$ docker-compose down
$ docker rm -f $(docker ps -a -q)
$ docker volume rm $(docker volume ls -q)
$ docker-compose up --build --force-recreate

# On réimporte la base:
$ make postgres_restore_latest_backup

# On peut ensuite lancer l’app:
$ make run
# Dans un autre terminal:
$ make django_admin COMMAND=set_fake_passwords

# Constater qu’on est bien sur la version 14:
$ make shell_on_postgres_container 
docker exec -ti itou_postgres /bin/bash
root@eed2a76be90c:/# psql --version
psql (PostgreSQL) 14.1 (Debian 14.1-1.pgdg110+1)

# et que l’appli tourne bien sur localhost:8080, avec les bonnes données dans l’admin par ex
```
