### PR TITLE
Empêcher notre support d'entrer dans l'admin certaines données incohérentes.

### DIFF
--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from itou.job_applications import models
+from itou.job_applications.admin_forms import JobApplicationAdminForm
 
 
 class TransitionLogInline(admin.TabularInline):
@@ -38,6 +39,7 @@ class ManualApprovalDeliveryRequiredFilter(admin.SimpleListFilter):
 
 @admin.register(models.JobApplication)
 class JobApplicationAdmin(admin.ModelAdmin):
+    form = JobApplicationAdminForm
     date_hierarchy = "created_at"
     list_display = ("pk", "state", "sender_kind", "created_at")
     raw_id_fields = (

--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -1,0 +1,48 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from itou.job_applications.models import JobApplication
+
+
+class JobApplicationAdminForm(forms.ModelForm):
+    class Meta:
+        model = JobApplication
+        fields = "__all__"
+
+    def clean(self):
+        sender = self.cleaned_data["sender"]
+        sender_kind = self.cleaned_data["sender_kind"]
+        sender_siae = self.cleaned_data["sender_siae"]
+        sender_prescriber_organization = self.cleaned_data["sender_prescriber_organization"]
+
+        if sender_kind == JobApplication.SENDER_KIND_JOB_SEEKER:
+            if sender is None:
+                raise ValidationError("Emetteur candidat manquant.")
+            if not sender.is_job_seeker:
+                raise ValidationError("Emetteur du mauvais type.")
+            if sender_prescriber_organization is not None:
+                raise ValidationError("Organisation du prescripteur émettrice inattendue.")
+            if sender_siae is not None:
+                raise ValidationError("SIAE émettrice inattendue.")
+
+        if sender_kind == JobApplication.SENDER_KIND_SIAE_STAFF:
+            if sender_siae is None:
+                raise ValidationError("SIAE émettrice manquante.")
+            if sender is not None:
+                # Sender is optional, but if it exists, check its role.
+                if not sender.is_siae_staff:
+                    raise ValidationError("Emetteur du mauvais type.")
+            if sender_prescriber_organization is not None:
+                raise ValidationError("Organisation du prescripteur émettrice inattendue.")
+
+        if sender_kind == JobApplication.SENDER_KIND_PRESCRIBER:
+            if sender_prescriber_organization is None:
+                raise ValidationError("Organisation du prescripteur émettrice manquante.")
+            if sender is not None:
+                # Sender is optional, but if it exists, check its role.
+                if not sender.is_prescriber:
+                    raise ValidationError("Emetteur du mauvais type.")
+            if sender_siae is not None:
+                raise ValidationError("SIAE émettrice inattendue.")
+
+        return

--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -28,9 +28,8 @@ class JobApplicationAdminForm(forms.ModelForm):
                 # Sender is optional, but if it exists, check its role.
                 if not sender.is_siae_staff:
                     raise ValidationError("Emetteur du mauvais type.")
-        else:
-            if sender_siae is not None:
-                raise ValidationError("SIAE émettrice inattendue.")
+        elif sender_siae is not None:
+            raise ValidationError("SIAE émettrice inattendue.")
 
         if sender_kind == JobApplication.SENDER_KIND_PRESCRIBER:
             if sender_prescriber_organization is None:
@@ -39,8 +38,7 @@ class JobApplicationAdminForm(forms.ModelForm):
                 # Sender is optional, but if it exists, check its role.
                 if not sender.is_prescriber:
                     raise ValidationError("Emetteur du mauvais type.")
-        else:
-            if sender_prescriber_organization is not None:
-                raise ValidationError("Organisation du prescripteur émettrice inattendue.")
+        elif sender_prescriber_organization is not None:
+            raise ValidationError("Organisation du prescripteur émettrice inattendue.")
 
         return

--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -20,10 +20,6 @@ class JobApplicationAdminForm(forms.ModelForm):
                 raise ValidationError("Emetteur candidat manquant.")
             if not sender.is_job_seeker:
                 raise ValidationError("Emetteur du mauvais type.")
-            if sender_prescriber_organization is not None:
-                raise ValidationError("Organisation du prescripteur émettrice inattendue.")
-            if sender_siae is not None:
-                raise ValidationError("SIAE émettrice inattendue.")
 
         if sender_kind == JobApplication.SENDER_KIND_SIAE_STAFF:
             if sender_siae is None:
@@ -32,8 +28,9 @@ class JobApplicationAdminForm(forms.ModelForm):
                 # Sender is optional, but if it exists, check its role.
                 if not sender.is_siae_staff:
                     raise ValidationError("Emetteur du mauvais type.")
-            if sender_prescriber_organization is not None:
-                raise ValidationError("Organisation du prescripteur émettrice inattendue.")
+        else:
+            if sender_siae is not None:
+                raise ValidationError("SIAE émettrice inattendue.")
 
         if sender_kind == JobApplication.SENDER_KIND_PRESCRIBER:
             if sender_prescriber_organization is None:
@@ -42,7 +39,8 @@ class JobApplicationAdminForm(forms.ModelForm):
                 # Sender is optional, but if it exists, check its role.
                 if not sender.is_prescriber:
                     raise ValidationError("Emetteur du mauvais type.")
-            if sender_siae is not None:
-                raise ValidationError("SIAE émettrice inattendue.")
+        else:
+            if sender_prescriber_organization is not None:
+                raise ValidationError("Organisation du prescripteur émettrice inattendue.")
 
         return


### PR DESCRIPTION
### Quoi ?

Empêcher notre support d'entrer dans l'admin certaines données incohérentes.

### Pourquoi ?

Récemment Zohra et Eric, chacun de leur côté, ont entré manuellement une candidature avec une SIAE émettrice manquante. Cela a provoqué des erreurs 500 dans le script Metabase quotidien, et aurait très bien pu causer des erreurs 500 ailleurs dans le code C1, puisqu'une candidature avec un `sender_kind` employeur est supposée toujours avoir une `sender_siae`.

### Comment ?

En bétonnant l'admin.