### PR TITLE
enrichissement log de controle du script move_data_siae

### DIFF
--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -115,6 +115,12 @@ def move_siae_data(from_id, to_id, dry_run=False, only_job_applications=False):
         to_siae.display_name,
     )
 
+    dest_siae_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=to_id)
+    logger.info("| Job applications sent: %s", dest_siae_job_applications_sent.count())
+
+    dest_siae_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=to_id)
+    logger.info("| Job applications received: %s", dest_siae_job_applications_received.count())
+
     if dry_run:
         logger.info("Nothing to do in dry run mode.")
         return
@@ -154,6 +160,27 @@ def move_siae_data(from_id, to_id, dry_run=False, only_job_applications=False):
                 geocoding_score=None,
             )
 
+    logger.info(
+        "MOVE %s OF siae.id=%s FINISHED",
+        "DATA" if move_all_data else "JOB APPLICATIONS",
+        from_siae.pk
+    )
+    orig_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=from_id)
+    logger.info("| Job applications sent: %s", orig_job_applications_sent.count())
+
+    orig_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=from_id)
+    logger.info("| Job applications received: %s", orig_job_applications_received.count())
+
+    logger.info(
+        "INTO siae.id=%s",
+        to_siae.pk
+    )
+
+    dest_siae_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=to_id)
+    logger.info("| Job applications sent: %s", dest_siae_job_applications_sent.count())
+
+    dest_siae_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=to_id)
+    logger.info("| Job applications received: %s", dest_siae_job_applications_received.count())
 
 class Command(BaseCommand):
     help = HELP_TEXT

--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -160,27 +160,21 @@ def move_siae_data(from_id, to_id, dry_run=False, only_job_applications=False):
                 geocoding_score=None,
             )
 
-    logger.info(
-        "MOVE %s OF siae.id=%s FINISHED",
-        "DATA" if move_all_data else "JOB APPLICATIONS",
-        from_siae.pk
-    )
+    logger.info("MOVE %s OF siae.id=%s FINISHED", "DATA" if move_all_data else "JOB APPLICATIONS", from_siae.pk)
     orig_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=from_id)
     logger.info("| Job applications sent: %s", orig_job_applications_sent.count())
 
     orig_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=from_id)
     logger.info("| Job applications received: %s", orig_job_applications_received.count())
 
-    logger.info(
-        "INTO siae.id=%s",
-        to_siae.pk
-    )
+    logger.info("INTO siae.id=%s", to_siae.pk)
 
     dest_siae_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=to_id)
     logger.info("| Job applications sent: %s", dest_siae_job_applications_sent.count())
 
     dest_siae_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=to_id)
     logger.info("| Job applications received: %s", dest_siae_job_applications_received.count())
+
 
 class Command(BaseCommand):
     help = HELP_TEXT


### PR DESCRIPTION
## Quoi

Le script move_data_siae option job_applications_only, transfère les candidatures d'une SIAE à une autre de même type.

## Pourquoi

- Les logs du traitement annoncent le nombre de candidatures transférées, mais rien sur le nombre de candidatures de la SIAE de destination, ni sur les décomptes post migration.

    MOVE JOB APPLICATIONS OF siae.id=3852 - EI 34445638900019 - Job insertion 90
    | Job applications sent: 0
    | Job applications received: 6
    INTO siae.id=3850 - EI 34445638900016 - EI Garage Martinet Siège

- le champ job_application.updated_at n'est pas mis à jour par le traitement de migration

## Comment

-    ajout de compteurs AVANT/APRÈS la migration dans le logger
-    proposition d'evolution en mode dry-run

    MOVE JOB APPLICATIONS OF siae.id=3852 - EI 34445638900019 - Job insertion 90
    | Job applications sent: 0
    | Job applications received: 6
    INTO siae.id=3850 - EI 34445638900016 - EI Garage Martinet Siège
    | Job applications sent: 0
    | Job applications received: 0
    Nothing to do in dry run mode.

-    proposition d'evolution en mode mise à jour

    MOVE JOB APPLICATIONS OF siae.id=3852 - EI 34445638900019 - Job insertion 90
    | Job applications sent: 0
    | Job applications received: 6
    INTO siae.id=3850 - EI 34445638900016 - EI Garage Martinet Siège
    | Job applications sent: 0
    | Job applications received: 0
    MOVE JOB APPLICATIONS OF siae.id=3852 FINISHED
    | Job applications sent: 0
    | Job applications received: 0
    INTO siae.id=3850
    | Job applications sent: 0
    | Job applications received: 6

