### PR TITLE
Réactivation du téléchargement des PASS IAE

### DIFF
--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -41,6 +41,13 @@
                             Gérer la candidature
                         </a>
                     </div>
+                    {% if job_application.can_download_approval_as_pdf %}
+                        <div class="col-sm-3">
+                            <a class="btn btn-link text-decoration-none disable-on-click matomo-event hidden" href="{% url 'approvals:approval_as_pdf' job_application_id=job_application.id %}" data-matomo-category="agrement" data-matomo-action="telechargement-pdf" data-matomo-option="liste-candidatures">
+                                Télécharger le PASS IAE
+                            </a>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
 

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -51,6 +51,16 @@
                                     Prolonger
                             </a>
                         {% endif %}
+                        {% if job_application.can_download_approval_as_pdf %}
+                            <a
+                                href="{% url 'approvals:approval_as_pdf' job_application_id=job_application.id %}"
+                                class="btn btn-outline-primary float-right disable-on-click matomo-event"
+                                data-matomo-category="agrement"
+                                data-matomo-action="telechargement-pdf"
+                                data-matomo-option="details-candidature">
+                                    Télécharger le PASS IAE
+                            </a>
+                        {% endif %}
                     {% endif %}
 
                 </div>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -5,12 +5,6 @@
 {% block messages %}
     {{ block.super }}
 
-    {% if current_siae and current_siae.is_subject_to_eligibility_rules %}
-        <div class="alert alert-danger" role="alert">
-            Le téléchargement des PASS IAE en PDF est momentanément indisponible. Nous nous excusons pour la gêne occasionnée.
-        </div>
-    {% endif %}
-
     {# Alerte pour gérer les cas d'exception lors de l'importation des AI. #}
     {% if current_siae and current_siae.kind == current_siae.KIND_AI %}
         <div class="alert alert-warning" role="alert">


### PR DESCRIPTION
### Quoi ?

Retour des boutons de téléchargement des PASS IAE et suppression du message d'information sur le tableau de bord.

### Pourquoi ?

PDF Shift, le service que nous utilisons pour générer les PDF, est de nouveau disponible. 