### PR TITLE
Django passe de 4.0.1 à 4.0.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.3.2  # https://github.com/avian2/unidecode
 # Django
 # ------------------------------------------------------------------------------
 
-django==4.0.1  # https://www.djangoproject.com/
+django==4.0.2  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.46.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
### Quoi ?

Montée de version suite à une [mise à jour de sécurité](https://www.djangoproject.com/weblog/2022/feb/01/security-releases/). Les failles ne nous concernent probablement pas.

### Pourquoi ?

Cette montée de version corrige 2 problèmes concernant:
 1) la **gestion de `debug` dans les template**. Nous ne somme sans doute pas concernés (`rg debug -t html` ne renvoie aucun résultat)
  2) la **gestion des formulaires multipart**. [La faille](https://github.com/django/django/commit/f9c7d48fdd6f198a6494a9202f90242f176e4fc9) consiste à envoyer une requête malicieuse afin de déclencher une boucle infinie. Si je comprends bien nous ne sommes pas concernés, car:
   - le composant impacté est utilisé dans les modèles
   - notre seul upload public passe par S3 (via `boto3`, cf `utils/storage/s3.py` et a lieu dans `itou/www/apply/views/submit_views.py`)
   - nous avons également de l’upload via `employee_record`, mais c’est dans la management command `process_asp_report_file`.



