### PR TITLE
Modification du dashboard : retrait d'un message d'info en double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Modification de l'admin Django pour ajouter plus de visibilité pour les élément `checkbox` et `radio`.
 - Ajout de deux nouveaux motifs de suspension d'un PASS IAE dont un uniquement pour les ACI et EI (Contrat Passerelle). 
-- Ajout de documentation dans le fichier Makefile.
+- Ajout de documentation dans le fichier `Makefile`.
 - Ajout d'un second tableau de bord pour les DDETS.
 
 ### Modifié
@@ -16,6 +16,7 @@
 - Réduction du niveau de log pour l'envoi d'e-mails. 
 - Modification de la date de mise en production des fiches salarié.
 - Modification de l'indexation Google pour les emplois (route `/robots.txt`).
+- Modification du `Makefile` concernant le déploiement en production (script `deploy.sh`).
 
 ## [34] - 2022-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,24 @@
 
 ### Ajouté
 
-- Modification de l'admin Django pour ajouter plus de visibilité pour les élément `checkbox` et `radio`.
 - Ajout de deux nouveaux motifs de suspension d'un PASS IAE dont un uniquement pour les ACI et EI (Contrat Passerelle). 
 - Ajout de documentation dans le fichier `Makefile`.
 - Ajout d'un second tableau de bord pour les DDETS.
+- Ajout de la date de naissance dans l'affichage en liste des PASS IAE et des utilisateurs (admin).
+- L'affichage des recrutements est en 2 parties, avec une option pour montrer la totalité des éléments (recherche de SIAE).
 
 ### Modifié
 
+- Modification de l'admin Django pour ajouter plus de visibilité pour les élément `checkbox` et `radio`.
 - Le bouton "Besoin d'aide" envoie dorénavant vers une page d'aide du pilotage et non des emplois depuis une page stats. 
 - Modification du niveau de log de Sentry.
 - Réduction du niveau de log pour l'envoi d'e-mails. 
 - Modification de la date de mise en production des fiches salarié.
 - Modification de l'indexation Google pour les emplois (route `/robots.txt`).
 - Modification du `Makefile` concernant le déploiement en production (script `deploy.sh`).
+- Modification des marges pour les boutons de connexion.
+- Modification des horaires de transfert des fiches salarié.
+- Corrections mineures (typos).
 
 ## [34] - 2022-01-14
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -122,14 +122,6 @@
         </div>
     {% endif %}
 
-    {# Message d'information temporaire pour les fiches salarié / annexes financières #}
-    {% if can_show_employee_records %}
-        <div class="alert alert-info">
-          <p>La fin de validité des annexes financières de 2021 n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.</p> 
-          <p>Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
-        </div>
-    {% endif %}
-
     <h1 class="h1">
         Tableau de bord
         {% if user.is_job_seeker and user.get_full_name %} - <span class="text-muted">{{ user.get_full_name }}</span>{% endif %}


### PR DESCRIPTION
### Quoi ?

Un message concernant les annexes financières apparaît en double sur le tableau de bord.

### Pourquoi ?

Parce que c'est moche.

### Comment ?

Probablement, un mix entre différentes PR.

### Captures d'écran (optionnel)

Il s'agit de ce message : 

![image](https://user-images.githubusercontent.com/147232/152009276-3ca0a1c8-6249-410b-a9ce-a4dbed69e822.png)

