### PR TITLE
Permettre le téléchargement des pass IAE en staging & démo

### DIFF
--- a/config/settings/dev.py.template
+++ b/config/settings/dev.py.template
@@ -71,7 +71,7 @@ ALLOW_POPULATING_METABASE = True
 # https://www.neilwithdata.com/django-sql-logging
 LOGGING.setdefault("filters", {}).setdefault("require_debug_true", {})["()"] = "django.utils.log.RequireDebugTrue"
 LOGGING.setdefault("loggers", {})["django.db.backends"] = {
-    "level": "DEBUG",
+    "level": os.getenv("SQL_LOG_LEVEL", "DEBUG"),
     "handlers": ["console"],
 }
 

--- a/itou/fixtures/django/10_eligibility_diagnoses.json
+++ b/itou/fixtures/django/10_eligibility_diagnoses.json
@@ -1,0 +1,67 @@
+[
+{
+   "model": "eligibility.eligibilitydiagnosis",
+   "pk": 1,
+   "fields": {
+      "job_seeker": 21,
+      "author": 6,
+      "author_kind": "siae_staff",
+      "author_siae": 3850,
+      "author_prescriber_organization": null,
+      "created_at": "2022-02-08T10:57:46.994Z",
+      "updated_at": "2022-02-08T10:57:47.028Z"
+   }
+},
+{
+   "model": "eligibility.eligibilitydiagnosis",
+   "pk": 2,
+   "fields": {
+      "job_seeker": 20,
+      "author": 6,
+      "author_kind": "siae_staff",
+      "author_siae": 3850,
+      "author_prescriber_organization": 996,
+      "created_at": "2022-02-08T10:59:58.777Z",
+      "updated_at": "2022-02-08T10:59:58.818Z"
+   }
+},
+{
+   "model": "eligibility.eligibilitydiagnosis",
+   "pk": 3,
+   "fields": {
+      "job_seeker": 19,
+      "author": 3,
+      "author_kind": "prescriber",
+      "author_siae": 3850,
+      "author_prescriber_organization": 903,
+      "created_at": "2022-02-08T11:00:49.078Z",
+      "updated_at": "2022-02-08T11:00:49.108Z"
+   }
+},
+{
+   "model": "eligibility.eligibilitydiagnosis",
+   "pk": 4,
+   "fields": {
+      "job_seeker": 18,
+      "author": 3,
+      "author_kind": "prescriber",
+      "author_siae": 3850,
+      "author_prescriber_organization": 996,
+      "created_at": "2022-02-08T11:01:48.331Z",
+      "updated_at": "2022-02-08T11:01:48.364Z"
+   }
+},
+{
+   "model": "eligibility.eligibilitydiagnosis",
+   "pk": 5,
+   "fields": {
+      "job_seeker": 17,
+      "author": 4,
+      "author_kind": "prescriber",
+      "author_siae": 3850,
+      "author_prescriber_organization": 952,
+      "created_at": "2022-02-08T11:02:28.172Z",
+      "updated_at": "2022-02-08T11:02:28.202Z"
+   }
+}
+]

--- a/itou/www/approvals_views/tests/test_download.py
+++ b/itou/www/approvals_views/tests/test_download.py
@@ -1,7 +1,6 @@
 from unittest.mock import PropertyMock, patch
 
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from django.urls import reverse
 
@@ -108,5 +107,5 @@ class TestDownloadApprovalAsPDF(TestCase):
         siae_member = job_application.to_siae.members.first()
         self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
 
-        with self.assertRaises(ObjectDoesNotExist):
+        with self.assertRaisesRegex(Exception, "had no eligibility diagnosis and also was not mass-imported"):
             self.client.get(reverse("approvals:approval_as_pdf", kwargs={"job_application_id": job_application.pk}))


### PR DESCRIPTION
### Quoi ?

Permettre le téléchargement des PASS IAE en dev/staging/demo.

### Pourquoi ?

Ce n'etait plus possible or c'est utile.

### Comment ?

En ajoutant les fixtures de diagnostics d'ligibilité qui sont censés être requis.