### PR TITLE
config: Set ITOU app log level to INFO by default

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -283,7 +283,7 @@ LOGGING = {
         },
         "itou": {
             "handlers": ["console"],
-            "level": os.getenv("DJANGO_LOG_LEVEL", "DEBUG"),
+            "level": os.getenv("ITOU_LOG_LEVEL", "INFO"),
         },
         # Logger for DRF API application
         # Will be "log-drained": may need to adjust format

--- a/envs/dev.env.template
+++ b/envs/dev.env.template
@@ -27,6 +27,7 @@ METABASE_PASSWORD=password
 
 DJANGO_SETTINGS_MODULE=config.settings.dev
 DJANGO_DEBUG=True
+ITOU_LOG_LEVEL=DEBUG
 DJANGO_SECRET_KEY=******************dev_secret_key******************
 
 API_ESD_MISE_A_JOUR_PASS_MODE="sandbox"


### PR DESCRIPTION
The default should be the production ones, in order to avoid having
debug values in production.

Since we don't want to set the loglevel to DEBUG for DRF, Django base
logs, etc in development, introduce a new specialized env var for the
application logs.

### Quoi ?

Faire en sorte que sans configuration spéciale, le niveau des logs applicatifs soit INFO.

### Pourquoi ?

On avait DEBUG par défaut ce qui est assez dangereux.

### Comment ?

En ontroduisant une nouvelle variable d'env avec une valeur par défaut plus raisonnable.

