### PR TITLE
Ajout d'une date de suspension de PASS IAE par défaut

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -558,9 +558,12 @@ class Suspension(models.Model):
         super().save(*args, **kwargs)
 
     def clean(self):
-
         if self.reason == self.Reason.FORCE_MAJEURE and not self.reason_explanation:
             raise ValidationError({"reason_explanation": "En cas de force majeure, veuillez préciser le motif."})
+
+        # This can happen in forms when no default/end date is entered
+        if not self.end_at:
+            raise ValidationError({"end_at": "La date de fin de la suspension est obligatoire."})
 
         # No min duration: a suspension may last only 1 day.
         if self.end_at < self.start_at:

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -28,7 +28,16 @@
 
             {% bootstrap_form_errors form alert_error_type="all" %}
 
-            {% bootstrap_form form %}
+            {# Split form fields for easier collapsible behaviour #}
+            {% bootstrap_field form.start_at %}
+            <div id="collapse_end_at" class="collapse{% if not form.set_default_end_date.value %} show{% endif %}">
+                {% bootstrap_field form.end_at %}
+            </div> 
+            <div role="button" data-toggle="collapse" data-target="#collapse_end_at" aria-controls="#collapse_end_at">
+                {% bootstrap_field form.set_default_end_date %}
+            </div>
+            {% bootstrap_field form.reason %}
+            {% bootstrap_field form.reason_explanation %}
 
             {% buttons %}
                 <a class="btn btn-outline-primary" href="{{ back_url }}">


### PR DESCRIPTION
### Quoi ?

Modification du formulaire de suspension des PASS IAE

### Pourquoi ?

Pour permettre à l'utilisateur de ne pas saisir de date de fin de suspension.

### Comment ?

A l'aide d'une case à cocher dans le formulaire, permettant :
- de fixer la date de fin de suspension le plus loin possible (+12 mois actuellement),
- de masquer le champ de saisie de la date de fin si l'on choisi cette option.  
- 
### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/147232/152775824-aefb5d71-1f85-414e-aa94-fdcdd21c11fe.png)

![image](https://user-images.githubusercontent.com/147232/152775895-a47a2e65-ce95-43bc-83a1-9663350dea7e.png)
