### PR TITLE
Modification du contrôle de la dernière embauche pour les suspensions

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -542,7 +542,10 @@ class User(AbstractUser, AddressMixin):
     def last_accepted_job_application(self):
         if not self.is_job_seeker:
             return None
-        return self.job_applications.accepted().order_by("created_at").last()
+        # Last accepted job application is based on creation and hiring dates.
+        # There were cases of identical job application creation dates in production,
+        # leading to bad ordering (listed in DB natural "insertion" order).
+        return self.job_applications.accepted().latest("created_at", "hiring_start_at")
 
     @cached_property
     def jobseeker_hash_id(self):


### PR DESCRIPTION
### Quoi ?

Changement des critères de sélection de la dernière embauche pour un candidat.

### Pourquoi ?

Dans certains cas (limites), la date de création de la candidature n'est pas discriminante pour savoir quelle SIAE a effectuée la dernière embauche pour un candidat donné.

### Comment ?

On se base désormais sur 2 champs, la date de création de la candidature et la date d'embauche.