### PR TITLE
[Admin] demander l'organisation prescriptrice seulement si le prescripteur est lié à une organisation

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -204,6 +204,10 @@ class SuspensionAdmin(admin.ModelAdmin):
     )
     readonly_fields = ("created_at", "created_by", "updated_at", "updated_by")
     date_hierarchy = "start_at"
+    search_fields = (
+        "pk",
+        "approval__number",
+    )
 
     def is_in_progress(self, obj):
         return obj.is_in_progress

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -677,8 +677,6 @@ class Suspension(models.Model):
         # Start at overrides to handle edge cases.
         if approval.last_old_suspension(pk_suspension):
             start_at = approval.last_old_suspension(pk_suspension).end_at + relativedelta(days=1)
-        elif approval.user.last_accepted_job_application.created_from_pe_approval:
-            start_at = referent_date
 
         if with_retroactivity_limitation:
             start_at_threshold = referent_date - datetime.timedelta(days=Suspension.MAX_RETROACTIVITY_DURATION_DAYS)

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -1131,6 +1131,23 @@ class SuspensionModelTest(TestCase):
             result = Suspension.Reason.displayed_choices_for_siae(siae)
             self.assertEqual(len(result), 4)
 
+    def test_next_min_start_date(self):
+        today = timezone.now()
+        start_at = today - relativedelta(days=10)
+
+        job_application_1 = JobApplicationWithApprovalFactory(hiring_start_at=today)
+        job_application_2 = JobApplicationWithApprovalFactory(hiring_start_at=start_at)
+        job_application_3 = JobApplicationWithApprovalFactory(hiring_start_at=start_at, created_from_pe_approval=True)
+
+        min_start_at = Suspension.next_min_start_at(job_application_1.approval)
+        self.assertEqual(min_start_at, today.date())
+
+        # Same rules apply for PE approval and PASS IAE
+        min_start_at = Suspension.next_min_start_at(job_application_2.approval)
+        self.assertEqual(min_start_at, start_at.date())
+        min_start_at = Suspension.next_min_start_at(job_application_3.approval)
+        self.assertEqual(min_start_at, start_at.date())
+
 
 class SuspensionModelTestTrigger(TestCase):
     """

--- a/itou/external_data/admin.py
+++ b/itou/external_data/admin.py
@@ -20,3 +20,4 @@ class JobSeekerExternalDataAdmin(admin.ModelAdmin):
 class RejectedEmailEventDataAdmin(admin.ModelAdmin):
     list_filter = ("reason",)
     list_display = ("pk", "recipient", "reason", "created_at")
+    search_fields = ("recipient",)

--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -32,12 +32,13 @@ class JobApplicationAdminForm(forms.ModelForm):
             raise ValidationError("SIAE émettrice inattendue.")
 
         if sender_kind == JobApplication.SENDER_KIND_PRESCRIBER:
-            if sender_prescriber_organization is None:
-                raise ValidationError("Organisation du prescripteur émettrice manquante.")
-            if sender is not None:
+            if sender:
                 # Sender is optional, but if it exists, check its role.
                 if not sender.is_prescriber:
                     raise ValidationError("Emetteur du mauvais type.")
+                # Request organization only if prescriber is linked to organization
+                if sender.is_prescriber_with_org and sender_prescriber_organization is None:
+                    raise ValidationError("Organisation du prescripteur émettrice manquante.")
         elif sender_prescriber_organization is not None:
             raise ValidationError("Organisation du prescripteur émettrice inattendue.")
 

--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -32,7 +32,10 @@ class JobApplicationAdminForm(forms.ModelForm):
             raise ValidationError("SIAE émettrice inattendue.")
 
         if sender_kind == JobApplication.SENDER_KIND_PRESCRIBER:
-            if sender:
+            # request organization only if prescriber is linked to organization
+            if sender is not None and sender.is_prescriber_with_org and sender_prescriber_organization is None:
+                raise ValidationError("Organisation du prescripteur émettrice manquante.")
+            if sender is not None:
                 # Sender is optional, but if it exists, check its role.
                 if not sender.is_prescriber:
                     raise ValidationError("Emetteur du mauvais type.")

--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -39,6 +39,9 @@ class JobApplicationAdminForm(forms.ModelForm):
                 # Request organization only if prescriber is linked to organization
                 if sender.is_prescriber_with_org and sender_prescriber_organization is None:
                     raise ValidationError("Organisation du prescripteur émettrice manquante.")
+            else:
+                # to be checked with support team
+                raise ValidationError("Emetteur prescripteur manquant.")
         elif sender_prescriber_organization is not None:
             raise ValidationError("Organisation du prescripteur émettrice inattendue.")
 

--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -43,6 +43,9 @@ class JobApplicationAdminForm(forms.ModelForm):
                 # to be checked with support team
                 raise ValidationError("Emetteur prescripteur manquant.")
         elif sender_prescriber_organization is not None:
+            # this part cannot be executed. catched by previous test on sender_kind
+            # as long as sender_kind can only be SENDER_KIND_JOB_SEEKER,
+            # SENDER_KIND_SIAE_STAFF or SENDER_KIND_PRESCRIBER (see models.py)
             raise ValidationError("Organisation du prescripteur émettrice inattendue.")
 
         return

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY, PropertyMock, patch
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core import mail
+from django.forms.models import model_to_dict
 from django.template.defaultfilters import title
 from django.test import TestCase
 from django.urls import reverse
@@ -16,6 +17,7 @@ from itou.eligibility.factories import EligibilityDiagnosisFactory, EligibilityD
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.employee_record.factories import EmployeeRecordFactory
 from itou.employee_record.models import EmployeeRecord
+from itou.job_applications.admin_forms import JobApplicationAdminForm
 from itou.job_applications.csv_export import generate_csv_export
 from itou.job_applications.factories import (
     JobApplicationFactory,
@@ -38,7 +40,7 @@ from itou.jobs.factories import create_test_romes_and_appellations
 from itou.jobs.models import Appellation
 from itou.siaes.factories import SiaeFactory, SiaeWithMembershipAndJobsFactory
 from itou.siaes.models import Siae
-from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, SiaeStaffFactory, UserFactory
+from itou.users.factories import JobSeekerFactory, SiaeStaffFactory, UserFactory
 from itou.users.models import User
 from itou.utils.apis.pole_emploi import (
     POLE_EMPLOI_PASS_APPROVED,
@@ -1404,51 +1406,69 @@ class JobApplicationAdminFormTest(TestCase):
     """
 
     def setUp(self):
-        self.user = JobSeekerFactory()
-        self.user.is_superuser = True
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.job_seeker = JobSeekerFactory()
+        self.siae = SiaeFactory()
+
+    #    self.user = UserFactory()
+    #    self.user.is_superuser = True
+    #    self.client.force_login(self.user)
+    #    self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+
+    def test_JobApplicationAdminForm(self):
+        """
+        Job Application sent by a JobSeeker
+        """
+        form = JobApplicationAdminForm()
+
+        self.assertIn("job_seeker", form.fields)
+        self.assertIn("sender", form.fields)
+        self.assertIn("sender_kind", form.fields)
+        self.assertIn("to_siae", form.fields)
+        self.assertIn("state", form.fields)
+        self.assertIn("created_at", form.fields)
+
+    # def test_loggin_to_JobApplicationAdminForm(self):
+    #    """
+    #    Log into Job Application Admin Form
+    #    """
+    #    url = reverse("admin:job_applications_jobapplication_add")
+    #    response = self.client.get(url)
+    #    self.assertEqual(response.status_code, 200)
 
     def test_JobApplicationSentByJobSeeker(self):
         """
         Job Application sent by a JobSeeker
         """
-        job_application = JobApplicationSentByJobSeekerFactory()
-        response = self.client.get(
-            reverse("admin:job_applications_jobapplication_change", kwargs={"object_id": str(job_application.id)})
-        )
-        self.assertEqual(response.status_code, 200)
+
+        data = model_to_dict(JobApplicationSentByJobSeekerFactory())
+        form = JobApplicationAdminForm(data)
+        self.assertTrue(form.is_valid())
+
+        data["sender"] = None
+        form = JobApplicationAdminForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("Emetteur candidat manquant.", form.errors["__all__"])
+
+        data = model_to_dict(JobApplicationSentByJobSeekerFactory())
+        data["sender_kind"] = JobApplication.SENDER_KIND_PRESCRIBER
+        form = JobApplicationAdminForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("Emetteur du mauvais type.", form.errors["__all__"])
 
     def test_applications_sent_by_siae(self):
         """
         Job Application sent by a SIAE
         """
-        job_application = JobApplicationSentBySiaeFactory()
-        self.display_job_application(job_application)
         self.assertEqual(True, True)
 
     def test_applications_sent_by_prescriber_without_organization(self):
         """
         Job Application sent by a prescriber not linked to an organization
         """
-        job_application = JobApplicationSentByPrescriberFactory()
-        self.display_job_application(job_application)
         self.assertEqual(True, True)
 
     def test_applications_sent_by_prescriber_with_organization(self):
         """
         Job Application sent by a prescriber linked to an organization
         """
-        job_application = JobApplicationSentByPrescriberOrganizationFactory()
-        self.display_job_application(job_application)
         self.assertEqual(True, True)
-
-    def display_job_application(self, obj):
-        print(
-            f"id: {obj.id}\n\
-            state: {obj.state}\n\
-            to_siae: {obj.to_siae}\n\
-            sender_kind: {obj.sender_kind}\n\
-            sender.email: {obj.sender.email}\n\
-            sender_siae: {obj.sender_siae}\n\
-            sender_prescriber_organization: {obj.sender_prescriber_organization}"
-        )

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -201,14 +201,15 @@ class SuspensionForm(forms.ModelForm):
     def clean(self):
         super().clean()
 
-        set_default_end_date = self.cleaned_data["set_default_end_date"]
+        set_default_end_date = self.cleaned_data.get("set_default_end_date")
+        start_at = self.cleaned_data.get("start_at")
 
         # If the end date of the suspension is not known,
         # it is set to `start_date` + 12 months.
         # If `set_default_end_date` is not checked, `end_at` field is required.
         # See Suspension model clean/validation.
-        if set_default_end_date:
-            self.cleaned_data["end_at"] = Suspension.get_max_end_at(self.cleaned_data["start_at"])
+        if set_default_end_date and start_at:
+            self.cleaned_data["end_at"] = Suspension.get_max_end_at(start_at)
 
 
 class PoleEmploiApprovalSearchForm(forms.Form):

--- a/itou/www/approvals_views/tests/test_suspend.py
+++ b/itou/www/approvals_views/tests/test_suspend.py
@@ -88,12 +88,10 @@ class ApprovalSuspendViewTest(TestCase):
         # Ensure that the job_application cannot be canceled.
         EmployeeRecordFactory(job_application=job_application, status=EmployeeRecord.Status.PROCESSED)
 
-        start_at = today
-
         # Fill all form data:
         # do not forget to fill `end_at` field with None (or model init will override with a default value)
         post_data = {
-            "start_at": start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
+            "start_at": today.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
             "end_at": None,
             "set_default_end_date": False,
             "reason": Suspension.Reason.SUSPENDED_CONTRACT,
@@ -112,6 +110,27 @@ class ApprovalSuspendViewTest(TestCase):
 
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data["end_at"], Suspension.get_max_end_at(today))
+
+    def test_clean_form(self):
+        # Ensure `clean()` is running OK in case of `start_at` error (Sentry issue):
+        today = timezone.localdate()
+        start_at = today + relativedelta(days=1)
+
+        job_application = JobApplicationWithApprovalFactory(
+            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            hiring_start_at=today - relativedelta(days=Suspension.MAX_RETROACTIVITY_DURATION_DAYS + 1),
+        )
+
+        post_data = {
+            "start_at": start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
+            "end_at": None,
+            "set_default_end_date": False,
+            "reason": Suspension.Reason.SUSPENDED_CONTRACT,
+            "reason_explanation": "",
+            "preview": "1",
+        }
+        form = SuspensionForm(approval=job_application.approval, siae=job_application.to_siae, data=post_data)
+        self.assertFalse(form.is_valid())
 
     def test_update_suspension(self):
         """


### PR DESCRIPTION
## Quoi ?

L’interface admin force l’identification de l’organisation du prescripteur lors du dépôt de candidatures, même par les prescripteurs sans orga.

## Pourquoi ?

Le dépôt de candidatures par des prescripteurs sans orga est désormais autorisée.
(date d’évolution de cette règle : ? récente)

## Comment ?

Modification de l’interface admin pour ne plus afficher le message bloquant `Organisation du prescripteur émettrice manquante` si le prescripteur n’est pas lié à une orga.