### PR TITLE
[Admin] gestion du status "fiche salarié en attente" dans la page "Pass IAE"

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -52,6 +52,9 @@ class JobApplicationInline(admin.StackedInline):
             display = employee_record.get_status_display()
             return format_html(f"<a href='{url}'><b>{display} (ID : {employee_record.id})</b></a>")
 
+        elif obj.is_waiting_for_employee_record_creation and obj.to_siae.can_use_employee_record:
+            return "Fiche salarié en attente de creation"
+
         return "Pas de fiche salarié crée pour cette candidature"
 
 

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -606,6 +606,20 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
                 kind = "Prescripteur habilité"
         return kind
 
+    @property
+    def is_waiting_for_employee_record_creation(self):
+        """
+        Check if EmployeeRecord does not exist and can be created for this JobApplication.
+        """
+        is_application_valid = (
+            self.hiring_start_at >= settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE.date()
+            and not self.hiring_without_approval
+            and self.state == JobApplicationWorkflow.STATE_ACCEPTED
+            and self.approval.is_valid()
+        )
+
+        return is_application_valid and not self.employee_record.all() and self.to_siae.can_use_employee_record
+
     def get_eligibility_diagnosis(self):
         """
         Returns the eligibility diagnosis linked to this job application or None.

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -214,6 +214,65 @@ class JobApplicationModelTest(TestCase):
         )
         self.assertTrue(job_application.is_from_ai_stock)
 
+    def test_is_waiting_for_employee_record_creation(self, *args, **kwargs):
+        today = datetime.date.today()
+        job_application = JobApplicationWithApprovalFactory()
+        to_siae = job_application.to_siae
+
+        # test application before EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE
+        day_in_the_past = settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE.date() - relativedelta(months=2)
+        job_application.hiring_start_at = day_in_the_past
+        self.assertFalse(job_application.is_waiting_for_employee_record_creation)
+
+        # test application between EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE and today
+        recent_day_in_the_past = (
+            datetime.date.today() - relativedelta(settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE.date(), today) / 2
+        )
+        job_application.hiring_start_at = recent_day_in_the_past
+        self.assertTrue(job_application.is_waiting_for_employee_record_creation)
+
+        # test application today
+        job_application.hiring_start_at = today
+        self.assertTrue(job_application.is_waiting_for_employee_record_creation)
+
+        # test hiring without approval
+        job_application_without_approval = JobApplicationWithoutApprovalFactory()
+        self.assertFalse(job_application_without_approval.is_waiting_for_employee_record_creation)
+
+        # test state not STATE_ACCEPTED
+        states_transition_not_possible = [
+            JobApplicationWorkflow.STATE_NEW,
+            JobApplicationWorkflow.STATE_PROCESSING,
+            JobApplicationWorkflow.STATE_POSTPONED,
+            JobApplicationWorkflow.STATE_CANCELLED,
+            JobApplicationWorkflow.STATE_REFUSED,
+            JobApplicationWorkflow.STATE_OBSOLETE,
+        ]
+
+        for state in states_transition_not_possible:
+            job_application.state = state
+            self.assertFalse(job_application.is_waiting_for_employee_record_creation)
+
+        # test approval is invalid
+        job_application.state = JobApplicationWorkflow.STATE_ACCEPTED
+        job_application.approval.start_at = timezone.now().date() - relativedelta(year=1)
+        job_application.approval.end_at = timezone.now().date() - relativedelta(month=1)
+        self.assertFalse(job_application.is_waiting_for_employee_record_creation)
+
+        # test SIAE cannot use Employee_Record
+        job_application.hiring_start_at = today
+        for siae_kind in [
+            siae_kind for siae_kind, _ in Siae.KIND_CHOICES if siae_kind not in Siae.ASP_EMPLOYEE_RECORD_KINDS
+        ]:
+            not_eligible_siae = SiaeFactory(kind=siae_kind)
+            job_application.to_siae = not_eligible_siae
+            self.assertFalse(job_application.is_waiting_for_employee_record_creation)
+
+        # test Employee_Record already exists
+        job_application.to_siae = to_siae
+        EmployeeRecordFactory(job_application=job_application)
+        self.assertFalse(job_application.is_waiting_for_employee_record_creation)
+
 
 class JobApplicationQuerySetTest(TestCase):
     def test_created_in_past(self):


### PR DESCRIPTION
reprise de la PR #1096 

## Quoi ?

Modifier le texte affiché dans le champ "Statut de la fiche salarié", de la page 'Modification des Pass IAE' de l'admin.

## Pourquoi ?

Dans l'admin 'Modification des Pass IAE', le champ "Statut de la fiche salarié" affiche "Pas de fiche salarié crée pour cette candidature" si la fiche est en attente de création OU si elle ne doit pas être créée.
Demande Métier : différencier les cas de fiches en attente de création et de fiches à ne pas créer car les conditions ne sont pas réunies


## Comment ?

Ajout de la propriété `can_have_employee_record` dans le model JobApplication.
Cette propriété determine si la candidature est éligible à une fiche salariée

Utilisation de cette propriété dans `employee_record_status` de l'admin Approval
