### PR TITLE
HOTFIX - date de suspension 

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -542,7 +542,10 @@ class User(AbstractUser, AddressMixin):
     def last_accepted_job_application(self):
         if not self.is_job_seeker:
             return None
-        return self.job_applications.accepted().order_by("created_at").last()
+        # Last accepted job application is based on creation and hiring dates.
+        # There were cases of identical job application creation dates in production,
+        # leading to bad ordering (listed in DB natural "insertion" order).
+        return self.job_applications.accepted().latest("created_at", "hiring_start_at")
 
     @cached_property
     def jobseeker_hash_id(self):

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -201,14 +201,15 @@ class SuspensionForm(forms.ModelForm):
     def clean(self):
         super().clean()
 
-        set_default_end_date = self.cleaned_data["set_default_end_date"]
+        set_default_end_date = self.cleaned_data.get("set_default_end_date")
+        start_at = self.cleaned_data.get("start_at")
 
         # If the end date of the suspension is not known,
         # it is set to `start_date` + 12 months.
         # If `set_default_end_date` is not checked, `end_at` field is required.
         # See Suspension model clean/validation.
-        if set_default_end_date:
-            self.cleaned_data["end_at"] = Suspension.get_max_end_at(self.cleaned_data["start_at"])
+        if set_default_end_date and start_at:
+            self.cleaned_data["end_at"] = Suspension.get_max_end_at(start_at)
 
 
 class PoleEmploiApprovalSearchForm(forms.Form):

--- a/itou/www/approvals_views/tests/test_suspend.py
+++ b/itou/www/approvals_views/tests/test_suspend.py
@@ -88,12 +88,10 @@ class ApprovalSuspendViewTest(TestCase):
         # Ensure that the job_application cannot be canceled.
         EmployeeRecordFactory(job_application=job_application, status=EmployeeRecord.Status.PROCESSED)
 
-        start_at = today
-
         # Fill all form data:
         # do not forget to fill `end_at` field with None (or model init will override with a default value)
         post_data = {
-            "start_at": start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
+            "start_at": today.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
             "end_at": None,
             "set_default_end_date": False,
             "reason": Suspension.Reason.SUSPENDED_CONTRACT,
@@ -112,6 +110,27 @@ class ApprovalSuspendViewTest(TestCase):
 
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data["end_at"], Suspension.get_max_end_at(today))
+
+    def test_clean_form(self):
+        # Ensure `clean()` is running OK in case of `start_at` error (Sentry issue):
+        today = timezone.localdate()
+        start_at = today + relativedelta(days=1)
+
+        job_application = JobApplicationWithApprovalFactory(
+            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            hiring_start_at=today - relativedelta(days=Suspension.MAX_RETROACTIVITY_DURATION_DAYS + 1),
+        )
+
+        post_data = {
+            "start_at": start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
+            "end_at": None,
+            "set_default_end_date": False,
+            "reason": Suspension.Reason.SUSPENDED_CONTRACT,
+            "reason_explanation": "",
+            "preview": "1",
+        }
+        form = SuspensionForm(approval=job_application.approval, siae=job_application.to_siae, data=post_data)
+        self.assertFalse(form.is_valid())
 
     def test_update_suspension(self):
         """


### PR DESCRIPTION
### Quoi ?

`keyerror`dans Sentry, `clean`, pas assez testé

### Pourquoi ?

Fixer le fix : ajout d'un test

### Comment ?

Défensif sur la lecture de `cleaned_data`
