### PR TITLE
Modification de la cohérence de la date de départ des suspensions

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -204,6 +204,10 @@ class SuspensionAdmin(admin.ModelAdmin):
     )
     readonly_fields = ("created_at", "created_by", "updated_at", "updated_by")
     date_hierarchy = "start_at"
+    search_fields = (
+        "pk",
+        "approval__number",
+    )
 
     def is_in_progress(self, obj):
         return obj.is_in_progress

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -677,8 +677,6 @@ class Suspension(models.Model):
         # Start at overrides to handle edge cases.
         if approval.last_old_suspension(pk_suspension):
             start_at = approval.last_old_suspension(pk_suspension).end_at + relativedelta(days=1)
-        elif approval.user.last_accepted_job_application.created_from_pe_approval:
-            start_at = referent_date
 
         if with_retroactivity_limitation:
             start_at_threshold = referent_date - datetime.timedelta(days=Suspension.MAX_RETROACTIVITY_DURATION_DAYS)

--- a/itou/approvals/tests.py
+++ b/itou/approvals/tests.py
@@ -1131,6 +1131,23 @@ class SuspensionModelTest(TestCase):
             result = Suspension.Reason.displayed_choices_for_siae(siae)
             self.assertEqual(len(result), 4)
 
+    def test_next_min_start_date(self):
+        today = timezone.now()
+        start_at = today - relativedelta(days=10)
+
+        job_application_1 = JobApplicationWithApprovalFactory(hiring_start_at=today)
+        job_application_2 = JobApplicationWithApprovalFactory(hiring_start_at=start_at)
+        job_application_3 = JobApplicationWithApprovalFactory(hiring_start_at=start_at, created_from_pe_approval=True)
+
+        min_start_at = Suspension.next_min_start_at(job_application_1.approval)
+        self.assertEqual(min_start_at, today.date())
+
+        # Same rules apply for PE approval and PASS IAE
+        min_start_at = Suspension.next_min_start_at(job_application_2.approval)
+        self.assertEqual(min_start_at, start_at.date())
+        min_start_at = Suspension.next_min_start_at(job_application_3.approval)
+        self.assertEqual(min_start_at, start_at.date())
+
 
 class SuspensionModelTestTrigger(TestCase):
     """


### PR DESCRIPTION
### Quoi ?

Modifications mineures et tests ajoutés pour border les calculs de date minimum de départ des suspensions.

### Pourquoi ?

Les règles de calcul de la date de départ de la suspension ont été modifiées, mais non-testées.

Pour l'admin, il est parfois difficile de retrouver une suspension quand on part du numéro de PASS IAE.

### Comment ?

- ajout de tests unitaires pour `Suspension.next_min_start_date`.
- ajout de champs de recherche dans l'admin des suspensions (ID, numéro de PASS IAE).