### PR TITLE
Ajout de la possibilité d’effectuer une recherche par email dans les logs d’erreurs

### DIFF
--- a/itou/external_data/admin.py
+++ b/itou/external_data/admin.py
@@ -20,3 +20,4 @@ class JobSeekerExternalDataAdmin(admin.ModelAdmin):
 class RejectedEmailEventDataAdmin(admin.ModelAdmin):
     list_filter = ("reason",)
     list_display = ("pk", "recipient", "reason", "created_at")
+    search_fields = ("recipient",)


### PR DESCRIPTION
### Quoi ?

Ajout de la possibilité d’effectuer une recherche par email dans les logs d’erreurs d’envoi d’email

### Pourquoi ?

Pour faciliter la recherche, qui se fait actuellement en navigant dans les pages de logs.

### Comment ?

Ajout d’un critère de tri dans l’admin