### PR TITLE
Montée de version du client Postgres dans le container django

### DIFF
--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME"; \
     apt-key list;
 
-ENV PG_MAJOR="12"
+ENV PG_MAJOR="14"
 
 # Add PostgreSQL's repository. It contains the most recent stable release.
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list


### PR DESCRIPTION
## Quoi 

Mise à jour de la version du client PostgreSQL pour le container Django

## Pourquoi

Suite à la [montée de version de PostgreSQL](https://github.com/betagouv/itou/pull/1084), le container postgres est bien en v14, mais le client psql dans le container django n’a pas suivi la montée de version:

```bash
# Container postgres:
$ docker exec -ti itou_postgres /bin/bash
root@774124155de5:/# psql --version
psql (PostgreSQL) 14.1 (Debian 14.1-1.pgdg110+1)

# Le container django est resté en version 12:
$ make shell_on_django_container
docker exec -ti itou_django /bin/bash
app@43144ba6846c:~$ ./manage.py dbshell
psql (12.9 (Debian 12.9-1.pgdg100+1), server 14.1 (Debian 14.1-1.pgdg110+1))
WARNING: psql major version 12, server major version 14.
         Some psql features might not work.
```

Cette PR corrige ce problème. Une fois le container recréé:

```bash
docker-compose down
docker rm -f $(docker ps -a -q)
docker-compose up --build --force-recreate
```

le container django est bien sur la bonne version:

```bash
# container django: on est bien sur la 14
$ make shell_on_django_container
docker exec -ti itou_django /bin/bash
app@10d10921a3ea:~$ ./manage.py dbshell
psql (14.2 (Debian 14.2-1.pgdg100+1), server 14.1 (Debian 14.1-1.pgdg110+1))
```

## Comment

MAJ du `Dockerfile` django