### PR TITLE
[Admin] demander l'organisation prescriptrice seulement si le prescripteur est lié à une organisation

### DIFF
--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -24,20 +24,26 @@ class JobApplicationAdminForm(forms.ModelForm):
         if sender_kind == JobApplication.SENDER_KIND_SIAE_STAFF:
             if sender_siae is None:
                 raise ValidationError("SIAE émettrice manquante.")
-            if sender is not None:
+            if sender is None:
+                raise ValidationError("Emetteur SIAE manquant.")
+            else:
                 # Sender is optional, but if it exists, check its role.
                 if not sender.is_siae_staff:
                     raise ValidationError("Emetteur du mauvais type.")
+
         elif sender_siae is not None:
             raise ValidationError("SIAE émettrice inattendue.")
 
         if sender_kind == JobApplication.SENDER_KIND_PRESCRIBER:
-            if sender_prescriber_organization is None:
-                raise ValidationError("Organisation du prescripteur émettrice manquante.")
-            if sender is not None:
+            if sender:
                 # Sender is optional, but if it exists, check its role.
                 if not sender.is_prescriber:
                     raise ValidationError("Emetteur du mauvais type.")
+                # Request organization only if prescriber is linked to organization
+                if sender.is_prescriber_with_org and sender_prescriber_organization is None:
+                    raise ValidationError("Organisation du prescripteur émettrice manquante.")
+            else:
+                raise ValidationError("Emetteur prescripteur manquant.")
         elif sender_prescriber_organization is not None:
             raise ValidationError("Organisation du prescripteur émettrice inattendue.")
 


### PR DESCRIPTION
reprise de la PR 1109

## Quoi ?

1. L'ajout de l’organisation du prescripteur est obligatoire dans l'admin, lors de l'enregistrement d'une candidature, même par si le prescripteur est sans orga.
1. La présence de l'émetteur n'est pas systématiquement vérifiée. Une candidature peut être enregistrée à tord sans émetteur.

## Pourquoi ?

1. Permettre l'enregistrement de candidatures par les prescripteurs sans organisation, y compris par le support.
1. Eviter que des candidatures de type `Prescripteur` et `Employeurs` soient enregistrées sans émetteur.

## Comment ?

1. Modification du formulaire de l'admin Candidatures (job_applications) pour ne plus afficher le message bloquant  `Organisation du prescripteur émettrice manquante` si le prescripteur n’est pas lié à une orga.
1. Ajout des contrôles sur la présence de l'emetteur