### PR TITLE
Correction des erreurs a11y sur les tableaux

### DIFF
--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -20,6 +20,7 @@
 
         <div class="table-responsive">
             <table class="table table-striped table-bordered">
+                <caption>Liste de candidatures reçues</caption>
                 <thead>
                     <tr>
                         <th scope="col">Mois</th>
@@ -35,7 +36,7 @@
                         <td>
                         {% if export_for == "siae" %}
                             <a
-                                class="matomo-event"
+                                class="matomo-event text-decoration-none"
                                 data-matomo-category="candidatures"
                                 data-matomo-action="exports"
                                 data-matomo-option="export-siae"
@@ -45,7 +46,7 @@
                             </a>
                         {% else %}
                             <a
-                                class="matomo-event"
+                                class="matomo-event text-decoration-none"
                                 data-matomo-category="candidatures"
                                 data-matomo-action="exports"
                                 data-matomo-option="export-prescripteur"

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -20,7 +20,7 @@
 
         <div class="table-responsive">
             <table class="table table-striped table-bordered">
-                <caption>Liste de candidatures reçues</caption>
+                <caption>Liste des candidatures reçues par mois</caption>
                 <thead>
                     <tr>
                         <th scope="col">Mois</th>

--- a/itou/templates/includes/members.html
+++ b/itou/templates/includes/members.html
@@ -1,6 +1,7 @@
 
 <div class="table-responsive">
     <table class="table table-striped table-bordered">
+        <caption>Liste des collaborateurs</caption>
         <thead>
             <tr>
                 <th scope="col">#</th>

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -40,6 +40,7 @@
         <h1 class="h1-hero-c1 mt-5">Invitations en attente</h1>
         <div class="table-responsive">
             <table class="table table-striped">
+              <caption>Liste des invitations en attente</caption>
               <thead>
                 <tr>
                   <th scope="col">Prénom</th>

--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -2,6 +2,7 @@
 {% if pending_invitations %}
     <h1 class="h1-hero-c1 mt-5 mb-3">Invitations en attente</h1>
     <div class="table-responsive">
+        <caption>Liste des invitations en attente</caption>
         <table class="table table-striped table-bordered">
             <thead>
                 <tr>

--- a/itou/templates/prescribers/list_accredited_organizations.html
+++ b/itou/templates/prescribers/list_accredited_organizations.html
@@ -52,6 +52,7 @@
 
                         <div class="table-responsive">
                             <table class="table table-striped table-bordered">
+                                <caption>Liste des organisations conventionnées</caption>
                                 <thead>
                                     <tr>
                                         <th scope="col">#</th>

--- a/itou/templates/prescribers/list_accredited_organizations.html
+++ b/itou/templates/prescribers/list_accredited_organizations.html
@@ -20,7 +20,7 @@
 
     {% if not accredited_orgs %}
 
-        <div class="alert alert-emploi" role="info">
+        <div class="alert alert-emploi" role="status">
             Aucun résultat.
         </div>
 

--- a/itou/templates/siaes/includes/_configure_jobs_list.html
+++ b/itou/templates/siaes/includes/_configure_jobs_list.html
@@ -1,5 +1,6 @@
 {% load bootstrap4 %}
 <table class="js-jobs-table table table-bordered table-striped table-responsive-sm text-center{% if not job_descriptions %} d-none{% endif %}">
+    <caption>Liste de métiers(s) exercé(s) dans votre structure</caption>
     <thead>
         <tr>
             <th scope="col">ROME</th>

--- a/itou/templates/siaes/includes/_configure_jobs_list.html
+++ b/itou/templates/siaes/includes/_configure_jobs_list.html
@@ -1,6 +1,6 @@
 {% load bootstrap4 %}
 <table class="js-jobs-table table table-bordered table-striped table-responsive-sm text-center{% if not job_descriptions %} d-none{% endif %}">
-    <caption>Liste de métiers(s) exercé(s) dans votre structure</caption>
+    <caption>Liste des métiers exercés dans votre structure</caption>
     <thead>
         <tr>
             <th scope="col">ROME</th>

--- a/itou/templates/siaes/show_financial_annexes.html
+++ b/itou/templates/siaes/show_financial_annexes.html
@@ -35,6 +35,7 @@
 
 <div class="table-responsive">
     <table class="table table-striped table-bordered">
+        <caption>Liste des annexes financières</caption>
         <thead>
             <tr>
                 <th scope="col">Numéro d'annexe financière</th>

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -25,11 +25,11 @@
 
 
 {% if siren_form.cleaned_data and not siaes_without_members and not siaes_with_members %}
-    <div class="alert alert-emploi mt-5" role="info">
+    <div class="alert alert-emploi mt-5" role="status">
         Aucun résultat pour <b>{{ siren_form.cleaned_data.siren }}</b>.
     </div>
 
-    <div class="alert alert-danger mt-2" role="info">
+    <div class="alert alert-danger mt-2" role="status">
         <p>
             <b>Si votre conventionnement est récent</b>, nous vous invitons à renouveler votre inscription dans une semaine.
         </p>
@@ -50,7 +50,7 @@
 
         <h3 class="h2">Entreprises disponibles</h3>
 
-        <div class="alert alert-emploi" role="info">
+        <div class="alert alert-emploi" role="status">
             <i>Les données sont fournies par l'extranet IAE 2.0 de l'ASP.</i>
         </div>
 
@@ -111,7 +111,7 @@
 
         <h3 class="h2">Entreprises déjà inscrites</h3>
 
-        <div class="alert alert-emploi" role="info">
+        <div class="alert alert-emploi" role="status">
             <i>Par sécurité vous devez obtenir une invitation pour rejoindre ces structures.</i>
         </div>
 


### PR DESCRIPTION
### Quoi ?

Correction des erreurs a11y sur les tableaux

### Pourquoi ?

Pour mettre en conformité le site avec les règles d'accessibilité et respecter les recommandations de l'audit

### Comment ?

En respectant les règles RGAA 5.1/5.2 et en ajoutant un titre aux `<table>` via la balise `<caption>`
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-5-1

### Bonus

Remplacement des role aria info (qui n'existent pas) par des role status


