### PR TITLE
Boost

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -53,3 +53,8 @@ ELASTIC_APM = {
 
 # Overrides base settings, only PROD should be allowed to do this
 EMPLOYEE_RECORD_TRANSFER_ENABLED = True
+
+# Enable HTTP Strict Transport Security
+# see https://docs.djangoproject.com/en/4.0/ref/middleware/#http-strict-transport-security
+SECURE_HSTS_SECONDS = 3600  # We set this to a small value initially
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -50,9 +50,21 @@
                     <button type="submit" class="btn btn-success btn-block">
                         Oui, j'ai besoin d'une aide au poste
                     </button>
+                    {% comment %}
+## Contexte :
+les AI et les ETTI sont tenues de recruter des personnes dans le cadre de l’IAE,
+elles n’ont pas le droit de recruter des personnes en dehors du conventionnement.
+Aussi, il ne faudrait pas permettre aux AI et ETTI de recruter « sans PASS IAE ».
+## Solution boost
+**On retire le bouton “je n’ai pas besoin d’une aide au poste” pour toutes les SIAE .**
+On laisse le mécanisme au cas où il soit nécessaire e le remettre en
+place (notamment du fait de demande arrivant au support)
+                    {% endcomment%}
+                    {% comment%}
                     <button type="submit" name="without_approval" class="btn btn-outline-success btn-block">
                         Non, je n'ai pas besoin d'aide au poste
                     </button>
+                    {% endcomment %}
                 </div>
                 <div class="my-4 mx-5 justify-content-center">
                     <p class="text-center">


### PR DESCRIPTION
### Quoi ?

Tickets boost

 - retirer le bouton "je n'ai pas besoin d'aide au poste"  (https://www.notion.so/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=b63a2d5015554ac2afc04eb9c2659ee9)
 - ajout de la directive HSTS, sur 1H pour tester que ca ne casse rien (https://www.notion.so/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=825a95359d8e4f4699d086007afcda2f), comme des dépendances tierces par ex

### Pourquoi ?

 - les AI et les ETTI sont tenues de recruter des personnes dans le cadre de l’IAE, elles n’ont pas le droit de recruter des personnes en dehors du conventionnement. Aussi, il ne faudrait pas permettre aux AI et ETTI de recruter « sans PASS IAE ».
  - HSTS est une préconisation suite à audit de sécu.