### PR TITLE
Correction des erreurs a11y sur les scripts 

### DIFF
--- a/itou/templates/403.html
+++ b/itou/templates/403.html
@@ -7,7 +7,7 @@
     <h1 class="h1-hero-c1">Vous ne pouvez pas continuer</h1>
 
     {% if exception %}
-        <div class="lead alert alert-warning" role="alert">
+        <div class="lead alert alert-warning" role="status">
             <p class="mb-0">{{ exception }}</p>
         </div>
     {% else %}

--- a/itou/templates/account/account_inactive.html
+++ b/itou/templates/account/account_inactive.html
@@ -7,7 +7,7 @@
 
     <h1 class="h1-hero-c1">Compte inactif</h1>
 
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-warning" role="status">
         Ce compte est inactif.
     </div>
 

--- a/itou/templates/account/email_confirm.html
+++ b/itou/templates/account/email_confirm.html
@@ -34,7 +34,7 @@
 
     {% url 'account_email' as email_url %}
 
-    <div class="alert alert-danger" role="alert">
+    <div class="alert alert-danger" role="status">
         Ce lien de confirmation d'adresse e-mail a expiré ou n'est pas valide.
         <br>
         Veuillez lancer <a href="{{ email_url }}">une nouvelle demande de confirmation</a>.

--- a/itou/templates/account/logout.html
+++ b/itou/templates/account/logout.html
@@ -6,11 +6,11 @@
 
 {% block content %}
 
-<div class="alert alert-info" role="alert">
+<div class="alert alert-info" role="status">
 
     <h1 class="h1-hero-c1">Déconnexion</h1>
 
-    <p>Voulez-vous vraiment vous déconnecter ?</p>
+    <p>Voulez-vous vraiment vous déconnecter ?</p>
 
     <form method="post" action="{% url 'account_logout' %}" class="js-prevent-multiple-submit">
 

--- a/itou/templates/account/password_change.html
+++ b/itou/templates/account/password_change.html
@@ -9,7 +9,7 @@
 {% block content %}
 <h1 class="h1-hero-c1">Modifier votre mot de passe</h1>
 {% if request|user_is_france_connected %}
-<div class="alert alert-info" role="alert">
+<div class="alert alert-info" role="status">
     {{ password_change_message }}
     <br>
     Si vous venez d’utiliser FranceConnect pour créer votre compte, vous ne connaissez pas votre votre mot de passe. Merci d’utiliser la fonctionnalité « <a href="{% url 'account_reset_password' %}">Mot de passe oublié</a> » pour le réinitialiser.

--- a/itou/templates/apply/includes/eligibility_diagnosis.html
+++ b/itou/templates/apply/includes/eligibility_diagnosis.html
@@ -115,7 +115,7 @@
     {% elif expired_eligibility_diagnosis %}
         <hr>
         <h3 class="h2 font-weight-normal text-muted">Éligibilité IAE</h3>
-        <div class="alert alert-warning" role="alert">
+        <div class="alert alert-warning" role="status">
             Le diagnostic d'éligibilité IAE de ce candidat a expiré le {{ expired_eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}, 
             vous devez valider les critères d'éligibilité.
         </div>

--- a/itou/templates/apply/includes/job_applications_filters.html
+++ b/itou/templates/apply/includes/job_applications_filters.html
@@ -14,14 +14,17 @@
     {% endfor %}
     {% if user.is_prescriber or user.is_siae_staff %}
         <li class="list-group-item border-0 ml-md-auto p-0">
-            <span class="btn btn-outline-primary">
-                {% include "includes/icon.html" with icon="download" %}
-                {% if user.is_prescriber %}
-                    <a href="{% url 'apply:list_for_prescriber_exports' %}" class="text-decoration-none">Exporter</a>
+            {% if user.is_prescriber %}
+            <a href="{% url 'apply:list_for_prescriber_exports' %}" class="btn btn-ico btn-outline-primary">
+                    {% include "includes/icon.html" with icon="download" %}
+                    <span>Exporter</span>
+                </a>
                 {% elif user.is_siae_staff %}
-                    <a href="{% url 'apply:list_for_siae_exports' %}" class="text-decoration-none">Exporter</a>
-                {% endif %}
-            </span>
+                <a href="{% url 'apply:list_for_siae_exports' %}" class="btn btn-ico btn-outline-primary">
+                    {% include "includes/icon.html" with icon="download" %}
+                    <span>Exporter</span>
+                </a>
+            {% endif %}
         </li>
     {% endif %}
 </ul>

--- a/itou/templates/apply/includes/job_applications_filters.html
+++ b/itou/templates/apply/includes/job_applications_filters.html
@@ -15,11 +15,11 @@
     {% if user.is_prescriber or user.is_siae_staff %}
         <li class="list-group-item border-0 ml-md-auto p-0">
             {% if user.is_prescriber %}
-            <a href="{% url 'apply:list_for_prescriber_exports' %}" class="btn btn-ico btn-outline-primary">
+                <a href="{% url 'apply:list_for_prescriber_exports' %}" class="btn btn-ico btn-outline-primary">
                     {% include "includes/icon.html" with icon="download" %}
                     <span>Exporter</span>
                 </a>
-                {% elif user.is_siae_staff %}
+            {% elif user.is_siae_staff %}
                 <a href="{% url 'apply:list_for_siae_exports' %}" class="btn btn-ico btn-outline-primary">
                     {% include "includes/icon.html" with icon="download" %}
                     <span>Exporter</span>

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -12,7 +12,7 @@
     <h2 class="h1 text-muted">{{ siae.display_name }}</h2>
 
     {% if siae.is_subject_to_eligibility_rules %}
-        <div class="alert alert-emploi mt-3" role="alert">
+        <div class="alert alert-emploi mt-3">
             Toute demande de PASS IAE doit être effectuée <b>au plus tard le jour de l'embauche</b>.<br>
             Les demandes rétroactives ne sont pas autorisées.
         </div>

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -35,7 +35,7 @@
                         <td>
                         {% if export_for == "siae" %}
                             <a
-                                class="matomo-event"
+                                class="matomo-event text-decoration-none"
                                 data-matomo-category="candidatures"
                                 data-matomo-action="exports"
                                 data-matomo-option="export-siae"
@@ -45,7 +45,7 @@
                             </a>
                         {% else %}
                             <a
-                                class="matomo-event"
+                                class="matomo-event text-decoration-none"
                                 data-matomo-category="candidatures"
                                 data-matomo-action="exports"
                                 data-matomo-option="export-prescripteur"

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -5,7 +5,7 @@
 
     {{ block.super }}
 
-    <div class="alert alert-info" role="alert">
+    <div class="alert alert-info">
         Confirmez votre choix en renseignant quelques informations supplémentaires.
     </div>
 
@@ -19,7 +19,7 @@
 
         {% if form_pe_status %}
             {% if not job_application.approval_not_needed %}
-                <div class="alert alert-warning" role="alert">
+                <div class="alert alert-warning" role="status">
                     Pour obtenir un PASS IAE dans les meilleurs délais, assurez-vous de l'exactitude de la date de naissance et du statut Pôle emploi du candidat.
                 </div>
             {% endif %}

--- a/itou/templates/apply/process_cancel.html
+++ b/itou/templates/apply/process_cancel.html
@@ -5,7 +5,7 @@
 
     {{ block.super }}
 
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-warning" role="status">
         Confirmez votre choix.
     </div>
 

--- a/itou/templates/apply/process_eligibility.html
+++ b/itou/templates/apply/process_eligibility.html
@@ -32,7 +32,7 @@
         Si le candidat ne remplit pas les conditions administratives, <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite/derogation-criteres" target="_blank" rel="noreferrer noopener">orientez-le vers un prescripteur habilité</a>.
     </p>
 
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-warning">
         <i>Dans le cadre de l'expérimentation actuelle, nous vous informons que la liste des critères d'éligibilité à l'IAE est susceptible d'évoluer à la marge.</i>
     </div>
 
@@ -43,7 +43,7 @@
     {% url 'apply:details_for_siae' job_application_id=job_application.id as cancel_url %}
     {% include "eligibility/includes/form.html" with cancel_url=cancel_url %}
 
-    <div class="alert alert-emploi" role="alert">
+    <div class="alert alert-emploi">
         <p>
             Si le candidat n'est pas éligible à l'insertion par l'activité économique, vous pouvez décliner sa candidature :
         </p>

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -5,7 +5,7 @@
 
     {{ block.super }}
 
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-warning" role="status">
         Confirmez votre choix.
     </div>
 

--- a/itou/templates/apply/submit_step_check_prev_applications.html
+++ b/itou/templates/apply/submit_step_check_prev_applications.html
@@ -5,7 +5,7 @@
 
     {{ block.super }}
 
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-warning" role="status">
 
         {% with prev_application.created_at|date:"d F Y à H:i" as prev_created_at %}
             {% if request.user == job_seeker %}

--- a/itou/templates/apply/submit_step_job_seeker_check_info.html
+++ b/itou/templates/apply/submit_step_job_seeker_check_info.html
@@ -5,7 +5,7 @@
 
     {{ block.super }}
 
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-warning" role="status">
         La date de naissance et les informations Pôle emploi sont obligatoires pour continuer.
     </div>
 

--- a/itou/templates/apply/submit_step_job_seeker_create.html
+++ b/itou/templates/apply/submit_step_job_seeker_create.html
@@ -6,7 +6,7 @@
 
     {{ block.super }}
 
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-warning" role="status">
         Cet email n'existe pas dans notre base de données. Vous devez créer un compte pour votre candidat en utilisant le formulaire ci-dessous afin de pouvoir continuer.
     </div>
 

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -100,7 +100,7 @@
                 </div>
             </div>
 
-            <div class="alert alert-warning" role="alert">
+            <div class="alert alert-warning" role="status">
                 <p>
                     En confirmant cette déclaration je certifie sur l'honneur que le motif de prolongation choisi correspond à la situation du salarié.
                 </p>

--- a/itou/templates/approvals/pe_approval_search.html
+++ b/itou/templates/approvals/pe_approval_search.html
@@ -14,7 +14,7 @@
 
     {% if number %}
 
-        <div class="alert alert-danger pb-0" role="alert">
+        <div class="alert alert-danger pb-0" role="status">
             <p>
                 Nous n'avons pas trouvé d'agrément en cours de validité avec le numéro <strong>{{ number }}</strong>.
             </p>

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -8,7 +8,7 @@
 
     {% if approval.is_valid %}
         {% if approval.originates_from_itou %}
-            <div class="alert alert-danger pb-0" role="alert">
+            <div class="alert alert-danger pb-0" role="status">
                 <p>Le numéro <strong>{{ approval.number|slice:12 }}</strong> correspond à un PASS IAE.</p>
             </div>
             <p>
@@ -23,7 +23,7 @@
                     A redirection is made upstream if the current SIAE can prolong or suspend it.
                     It means another SIAE is using it right now.
                 {% endcomment %}
-                <div class="alert alert-danger pb-0" role="alert">
+                <div class="alert alert-danger pb-0" role="status">
                     <p>L'agrément <strong>{{ approval.number|slice:12 }}</strong> a déjà été converti en PASS IAE.</p>
                 </div>
                 <p>
@@ -48,7 +48,7 @@
         {% endif %}
 
     {% else %}
-        <div class="alert alert-danger pb-0" role="alert">
+        <div class="alert alert-danger pb-0" role="status">
             <p>L'agrément <strong>{{ approval.number|slice:12 }}</strong> est expiré depuis le {{ approval.end_at|date:"d/m/Y" }}. Vous ne pouvez pas le prolonger ou le suspendre.
             </p>
         </div>

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -82,7 +82,7 @@
                 </div>
             </div>
 
-            <div class="alert alert-warning" role="alert">
+            <div class="alert alert-warning" role="status">
                 <p>
                     En confirmant cette demande je certifie sur l'honneur que le motif de suspension choisi correspond à la situation du salarié.
                 </p>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -7,7 +7,7 @@
 
     {# Alerte pour gérer les cas d'exception lors de l'importation des AI. #}
     {% if current_siae and current_siae.kind == current_siae.KIND_AI %}
-        <div class="alert alert-warning" role="alert">
+        <div class="alert alert-warning">
             <p>Tous les salariés déclarés auprès de l'ASP avant le 1er décembre ont été ajoutés au tableau de bord de la SIAE porteuse de l’annexe financière. Nous travaillons à vous permettre de les transférer dans le tableau de bord d’une structure fille.</p>
             <p>Pour les salariés qui ne seraient plus en poste, il vous est demandé de procéder à une suspension d’un an au motif « contrat de travail terminé ». Dans la mesure où ces salariés sont connus dans l’Extranet IAE 2.0 de l'ASP, ces PASS IAE ne peuvent pas être annulés.</p>
             <p>Pour les salariés entrés en parcours avant le 1er décembre 2021 qui n’auraient pas été déclarés dans l’Extranet avant le 1er décembre 2021, vous devez procéder à une déclaration d’éligibilité sur la plateforme de l’inclusion.</p>
@@ -16,14 +16,14 @@
     {% endif %}
 
     {% if current_siae and not current_siae.jobs.exists %}
-        <div class="alert alert-warning" role="alert">
+        <div class="alert alert-warning">
             Pour optimiser la réception de vos candidatures, pensez à renseigner le descriptif de vos postes et leurs prérequis.
         </div>
     {% endif %}
 
     {# Alerte pour les employeurs en cas d'absence ou de mauvais score de geocoding. #}
     {% if current_siae and not current_siae.has_reliable_coords %}
-        <div class="alert alert-warning mb-0" role="alert">
+        <div class="alert alert-warning mb-0" role="status">
             Nous n'avons pas pu géolocaliser votre établissement.<br>
             Cela peut affecter sa position dans les résultats de recherche.<br>
             {% if user_is_siae_admin %}
@@ -40,7 +40,7 @@
     {# Alerte pour les prescripteurs en cas d'absence ou de mauvais score de geocoding. #}
     {# Seuls les prescripteurs habilités apparaissent dans le moteur de recherche. #}
     {% if current_prescriber_organization and current_prescriber_organization.is_authorized and not current_prescriber_organization.has_reliable_coords %}
-        <div class="alert alert-warning mb-0" role="alert">
+        <div class="alert alert-warning mb-0" role="status">
             Nous n'avons pas pu géolocaliser votre établissement.<br>
             Cela peut affecter sa position dans les résultats de recherche.<br>
             {% if user_is_prescriber_org_admin %}
@@ -55,7 +55,7 @@
     {% endif %}
 
     {% if current_siae and not current_siae.is_active %}
-        <div class="alert alert-warning mb-0" role="alert">
+        <div class="alert alert-warning mb-0" role="status">
             La DGEFP nous indique que votre structure {% if current_siae.siret %}(inscrite avec le numéro SIRET : {{ current_siae.siret }}) {% endif %}n'est plus conventionnée.<br>
             Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.<br>
             À compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
@@ -72,7 +72,7 @@
     {% endif %}
 
     {% if current_prescriber_organization and current_prescriber_organization.has_pending_authorization %}
-        <div class="alert alert-warning pb-0" role="alert">
+        <div class="alert alert-warning pb-0" role="status">
             <p>
                 Votre habilitation à valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique est en cours de vérification par nos équipes. Vous ne pouvez pas encore réaliser le diagnostic d'éligibilité des candidats.
             </p>

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -6,7 +6,7 @@
 {% block content %}
 <h1 class="h1-hero-c1">Informations personnelles de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
 
-<div class="alert alert-warning" role="alert">
+<div class="alert alert-warning">
   <b>Vous allez modifier des informations sensibles</b> concernant ce candidat ou cette candidate.<br>
   Tout changement entraînera une modification définitive dans notre base de données. <b>Les informations
   supprimées seront perdues.</b>

--- a/itou/templates/dashboard/edit_user_email.html
+++ b/itou/templates/dashboard/edit_user_email.html
@@ -6,7 +6,7 @@
 {% block content %}
 <h1 class="h1-hero-c1">Modifier votre adresse e-mail</h1>
 
-<div class="alert alert-warning" role="alert">
+<div class="alert alert-warning">
     Ce changement entraînera une <b>déconnexion</b>.<br>
     Veuillez alors vous reconnecter avec votre nouvelle adresse e-mail.
 </div>

--- a/itou/templates/institutions/members.html
+++ b/itou/templates/institutions/members.html
@@ -10,7 +10,7 @@
     {{ institution.display_name }}
 </h2>
 
-<div class="alert alert-info" role="alert">
+<div class="alert alert-info">
     Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
 </div>
 

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -6,7 +6,7 @@
 
 {% block content %}
     <h1 class="h1-hero-c1">Envoyer une invitation</h1>
-    <div class="alert alert-info my-3" role="alert">
+    <div class="alert alert-info my-3">
         <p class="mb-0">Une fois vos invitations envoyées, vos invités recevront un e-mail contenant un lien de validation.</p>
     </div>
 

--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -38,7 +38,7 @@
             </tbody>
         </table>
     </div>
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-warning">
         Chaque collaborateur invité reçoit son propre lien d'invitation, ce lien est valable 15 jours
         (lorsque le lien expire, l'invitation n'est plus affichée ci-dessus). 
         Ce lien d'invitation est transmis automatiquement par e-mail.

--- a/itou/templates/layout/_nav_btn_items.html
+++ b/itou/templates/layout/_nav_btn_items.html
@@ -99,10 +99,10 @@
 
     {% if user.is_labor_inspector and user_institutions|length > 1 %}
         <li class="dropdown">
-            <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="switchDropdown" aria-expanded="false">
                 Changer de structure
             </button>
-            <div class="dropdown-menu dropdown-menu-left">
+            <div class="dropdown-menu dropdown-menu-left" id="switchDropdown">
                 <form action="{% url 'dashboard:switch_institution' %}" method="post">
                     {% csrf_token %}
                     {% for i in user_institutions %}
@@ -120,10 +120,10 @@
 
 {% else %}
     <li class="dropdown mr-2">
-        <button type="button" class="btn btn-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button type="button" class="btn btn-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="loginDropdown" aria-expanded="false">
             S'inscrire | Se connecter
         </button>
-        <div class="dropdown-menu">
+        <div class="dropdown-menu" id="loginDropdown">
             <a class="dropdown-item" href="{% url 'account_login' %}?account_type=job_seeker{% if redirect_field_value %}&{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
                 Candidat
             </a>

--- a/itou/templates/layout/_nav_btn_items.html
+++ b/itou/templates/layout/_nav_btn_items.html
@@ -6,10 +6,11 @@
             class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle"
             data-toggle="dropdown"
             aria-haspopup="true"
-            aria-expanded="false" >
+            aria-controls="dashboardUserDropdown"
+            aria-expanded="false">
             Mon espace
         </button>
-        <div class="dropdown-menu dropdown-menu-left">
+        <div class="dropdown-menu dropdown-menu-left" id="dashboardUserDropdown">
             <div class="dropdown-item media">
                 {% include "includes/icon.html" with icon="user" size="40" class="mr-3 icon align-self-center" %}
                 <div class="media-body align-self-center text-wrap">
@@ -56,11 +57,11 @@
     </li>
 
     {% if user.is_siae_staff and user_siaes|length > 1 %}
-        <li  class="dropdown">
-            <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-display="static">
+        <li class="dropdown">
+            <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="switchUserDropdown" aria-expanded="false" data-display="static">
                 Changer de structure
             </button>
-            <div class="dropdown-menu dropdown-menu-left">
+            <div class="dropdown-menu dropdown-menu-left" id="switchUserDropdown">
                 <form action="{% url 'dashboard:switch_siae' %}" method="post">
                     {% csrf_token %}
                     {% for s in user_siaes %}
@@ -77,11 +78,11 @@
     {% endif %}
 
     {% if user.is_prescriber and user_prescriberorganizations|length > 1 %}
-        <li  class="dropdown">
-            <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <li class="dropdown">
+            <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="switchUserDropdown" aria-expanded="false">
                 Changer de structure
             </button>
-            <div class="dropdown-menu dropdown-menu-left">
+            <div class="dropdown-menu dropdown-menu-left" id="switchUserDropdown">
                 <form action="{% url 'dashboard:switch_prescriber_organization' %}" method="post">
                     {% csrf_token %}
                     {% for po in user_prescriberorganizations %}
@@ -99,10 +100,10 @@
 
     {% if user.is_labor_inspector and user_institutions|length > 1 %}
         <li class="dropdown">
-            <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="switchDropdown" aria-expanded="false">
+            <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="switchUserDropdown" aria-expanded="false">
                 Changer de structure
             </button>
-            <div class="dropdown-menu dropdown-menu-left" id="switchDropdown">
+            <div class="dropdown-menu dropdown-menu-left" id="switchUserDropdown">
                 <form action="{% url 'dashboard:switch_institution' %}" method="post">
                     {% csrf_token %}
                     {% for i in user_institutions %}
@@ -120,10 +121,10 @@
 
 {% else %}
     <li class="dropdown mr-2">
-        <button type="button" class="btn btn-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="loginDropdown" aria-expanded="false">
+        <button type="button" class="btn btn-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="loginUserDropdown" aria-expanded="false">
             S'inscrire | Se connecter
         </button>
-        <div class="dropdown-menu" id="loginDropdown">
+        <div class="dropdown-menu" id="loginUserDropdown">
             <a class="dropdown-item" href="{% url 'account_login' %}?account_type=job_seeker{% if redirect_field_value %}&{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
                 Candidat
             </a>

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -51,7 +51,7 @@
                 {% bootstrap_messages %}
 
                 {# Display an alert for old browsers #}
-                <div class="alert alert-secondary alert-old-browser" role="alert">
+                <div class="alert alert-secondary alert-old-browser" role="status">
                     La version de votre navigateur n'est plus supportée. Veuillez utiliser une version plus récente pour améliorer votre expérience sur notre site.
                 </div>
 

--- a/itou/templates/prescribers/edit_organization.html
+++ b/itou/templates/prescribers/edit_organization.html
@@ -11,7 +11,7 @@
     {{ organization.display_name }}
 </h2>
 
-<div class="alert alert-info" role="alert">
+<div class="alert alert-info">
     Les coordonnées de contact de votre organisation sont visibles par tous les utilisateurs connectés.
 </div>
 

--- a/itou/templates/prescribers/list_accredited_organizations.html
+++ b/itou/templates/prescribers/list_accredited_organizations.html
@@ -12,7 +12,7 @@
          <span class="text-muted">{{ prescriber_org.display_name }}</span>
     </h2>
 
-    <div class="alert alert-info" role="alert">
+    <div class="alert alert-info">
         Seuls les administrateurs peuvent voir cette liste.
     </div>
 

--- a/itou/templates/prescribers/members.html
+++ b/itou/templates/prescribers/members.html
@@ -10,7 +10,7 @@
     {{ organization.display_name }}
 </h2>
 
-<div class="alert alert-info" role="alert">
+<div class="alert alert-info">
     Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
 </div>
 

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -43,7 +43,7 @@
             </small>
         </p>
 
-        <p class="font-weight-bold text-muted mb-0 h3" id="siae-number-results">
+        <p class="font-weight-bold text-muted mb-0 h3" id="siae-number-results" role="status">
             {% with siaes_page.number as current_page and siaes_page.paginator.num_pages as total_pages and siaes_page.paginator.count as counter %}
                 <b>{{ counter }}</b> résultat{% if counter > 1 %}s{% endif %}
                 {% if siaes_page.paginator.num_pages > 1 %}

--- a/itou/templates/siaes/configure_jobs.html
+++ b/itou/templates/siaes/configure_jobs.html
@@ -33,7 +33,7 @@
             {% include "siaes/includes/_alert_configure_job.html" with errors=errors%}
 
             <div class="form-group mb-4">
-                <label for="job-autocomplete-input">Ajouter un métier :</label>
+                <label for="job-autocomplete-input">Ajouter un métier :</label>
                 <div class="input-group bg-white">
                     {# Loading #}
                     <span class="input-group-text js-job-autocomplete-loading d-none">

--- a/itou/templates/siaes/create_siae.html
+++ b/itou/templates/siaes/create_siae.html
@@ -9,7 +9,7 @@
 
 <form method="post" action="" class="js-prevent-multiple-submit">
 
-    <div class="alert alert-info" role="alert">
+    <div class="alert alert-info">
         <p>Vous souhaitez rejoindre une structure :</p>
         <ul>
             <li>ayant déjà un ou plusieurs membres, <b>demandez à l’un de ces membres de vous inviter depuis son tableau de bord</b></li>

--- a/itou/templates/siaes/edit_siae.html
+++ b/itou/templates/siaes/edit_siae.html
@@ -18,7 +18,7 @@
 
 <form method="post" action="" class="js-prevent-multiple-submit">
 
-    <div class="alert alert-emploi" role="alert">
+    <div class="alert alert-emploi">
         <i>Laisser les champs vides pour ne rien afficher.</i>
     </div>
 

--- a/itou/templates/siaes/members.html
+++ b/itou/templates/siaes/members.html
@@ -7,7 +7,7 @@
     <h1 class="h1-hero-c1">Collaborateurs</h1>
     <h2 class="h1 text-muted">{{ siae.display_name }}</h2>
 
-    <div class="alert alert-info" role="alert">
+    <div class="alert alert-info">
         Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
     </div>
 

--- a/itou/templates/siaes/show_financial_annexes.html
+++ b/itou/templates/siaes/show_financial_annexes.html
@@ -5,22 +5,22 @@
 {% block messages %}
     {{ block.super }}
 
-    <div class="alert alert-success" role="alert">
+    <div class="alert alert-success">
         Cette interface vous permet de vous assurer que votre structure est associée aux bonnes annexes financières. La gestion de vos annexes financières continue de se faire dans l'extranet 2.0 de l'ASP.
     </div>
 
     {% if current_siae.is_active %}
-        <div class="alert alert-success" role="alert">
+        <div class="alert alert-success" role="status">
             Votre structure est active car elle est associée à au moins une annexe financière valide listée ci-dessous ou bien elle a été manuellement activée par notre support. Vous n'avez rien à faire.
         </div>
     {% elif current_siae_is_asp %}
-        <div class="alert alert-danger" role="alert">
+        <div class="alert alert-danger" role="status">
             {# Inactive siaes of ASP source cannot be fixed by user. #}
             Votre structure est inactive car elle n'est associée à aucune annexe financière valide. Contactez nous via la rubrique votre structure sur
             <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
         </div>
     {% elif current_siae_is_user_created %}
-        <div class="alert alert-danger" role="alert">
+        <div class="alert alert-danger" role="status">
             {# Inactive user created siaes can be fixed by the user. #}
             Votre structure sera prochainement désactivée car elle n'est associée à aucune annexe financière valide. Veuillez dès que possible procéder à la sélection d'une annexe financière valide ci-dessous.
         </div>

--- a/itou/templates/signup/includes/authorization_proof.html
+++ b/itou/templates/signup/includes/authorization_proof.html
@@ -1,4 +1,4 @@
 
-<div class="alert alert-warning" role="alert">
+<div class="alert alert-warning" role="status">
     Afin d'enregistrer votre habilitation à valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique, <b>nous vous demanderons de nous transmettre l'arrêté préfectoral</b> portant mention de cette habilitation.
 </div>

--- a/itou/templates/signup/includes/submit_rgpd.html
+++ b/itou/templates/signup/includes/submit_rgpd.html
@@ -1,6 +1,6 @@
 {% load bootstrap4 %}
 
-<div class="alert alert-warning" role="alert">
+<div class="alert alert-warning">
 
     <p>
         <small>

--- a/itou/templates/signup/prescriber_check_already_exists.html
+++ b/itou/templates/signup/prescriber_check_already_exists.html
@@ -67,7 +67,7 @@
         <h3 class="h2">Ajouter mon organisation</h3>
 
         {% if prescriber_orgs_with_members_same_siret %}
-        <div class="alert alert-warning pb-0" role="alert">
+        <div class="alert alert-warning pb-0" role="status">
             <p>
                 <small>
                     Attention une ou plusieurs organisations existent déjà avec ce SIRET.<br>

--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -11,7 +11,7 @@
         <small class="text-muted">Prescripteur/Orienteur</small>
     </h1>
 
-    <div class="alert alert-warning pb-0" role="alert">
+    <div class="alert alert-warning pb-0">
         <p>
             Les organisations habilitées permettent à leurs collaborateurs de valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique. Cette habilitation est officialisée par arrêté préfectoral.
         </p>

--- a/itou/templates/signup/prescriber_choose_org.html
+++ b/itou/templates/signup/prescriber_choose_org.html
@@ -11,7 +11,7 @@
         <small class="text-muted">Prescripteur/Orienteur</small>
     </h1>
 
-    <div class="alert alert-secondary" role="alert">
+    <div class="alert alert-secondary">
         Votre organisation n'est pas encore inscrite.
     </div>
 

--- a/itou/templates/signup/prescriber_pole_emploi_user.html
+++ b/itou/templates/signup/prescriber_pole_emploi_user.html
@@ -10,7 +10,7 @@
         <small class="text-muted">Prescripteur Pôle emploi</small>
     </h1>
 
-    <div class="alert alert-emploi" role="alert">
+    <div class="alert alert-emploi">
         <p class="lead mb-0">
             Vous allez rejoindre <b>{{ pole_emploi_org.display_name }}</b>
         </p>

--- a/itou/templates/signup/prescriber_request_invitation.html
+++ b/itou/templates/signup/prescriber_request_invitation.html
@@ -12,7 +12,7 @@
         <small class="text-muted">Prescripteur/Orienteur</small>
     </h1>
 
-    <div class="alert alert-info" role="alert">
+    <div class="alert alert-info">
         Renseignez vos coordonnées afin d'être invité par {{ prescriber.first_name|title }} {{ prescriber.last_name|slice:1 }} de l'organisation « {{ organization.display_name }} ».
     </div>
 

--- a/itou/templates/signup/prescriber_signup.html
+++ b/itou/templates/signup/prescriber_signup.html
@@ -13,13 +13,13 @@
 
     {% if join_authorized_org and kind_label and not kind_is_other %}
         {# Display kind's full name if known. #}
-        <div class="alert alert-emploi pb-0" role="alert">
+        <div class="alert alert-emploi pb-0" role="status">
             <p class="lead">{{ kind_label }}</p>
         </div>
     {% endif %}
 
     {% if prescriber_org_data %}
-        <div class="alert alert-emploi pb-0" role="alert">
+        <div class="alert alert-emploi pb-0" role="status">
             <p>
                 <b>{{ prescriber_org_data.name }}</b> - {{ prescriber_org_data.siret|format_siret }}<br>
                 {% if prescriber_org_data.address_line_1 %}{{ prescriber_org_data.address_line_1 }}<br>{% endif %}

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -91,7 +91,7 @@
                 {% endfor %}
             </ul>
 
-            <div class="alert alert-warning pb-0" role="alert">
+            <div class="alert alert-warning pb-0">
                 <p>
                     Pour sécuriser l'inscription, un e-mail de confirmation sera envoyé au correspondant technique référencé dans l'extranet IAE 2.0 de l'ASP. Il permettra de poursuivre la procédure.
                 </p>

--- a/itou/templates/storage/s3_upload_form.html
+++ b/itou/templates/storage/s3_upload_form.html
@@ -28,7 +28,7 @@
     </p>
 </div>
 <noscript>
-    <div class="alert alert-danger" role="alert">
+    <div class="alert alert-danger" role="status">
         JavaScript n'est pas activé. Il est nécessaire de réactiver JavaScript pour activer la fonctionnalité envoi de CV.
     </div>
 </noscript>

--- a/itou/templates/welcoming_tour/includes/message.html
+++ b/itou/templates/welcoming_tour/includes/message.html
@@ -1,4 +1,4 @@
-<div class="alert alert-success alert-dismissible" role="alert">
+<div class="alert alert-success alert-dismissible" role="status">
     👋 Bienvenue sur les emplois de l'inclusion ! 👉 <a href="{% url 'welcoming_tour:index' %}" class="alert-link">Revoir le message de bienvenue</a>
     <button type="button" class="close" data-dismiss="alert" aria-label="Fermer">
         <i class="ri-close-line"></i>


### PR DESCRIPTION
### Quoi ?

Correction des erreurs a11y sur les scripts, les roles boutons d'ouverture des dropdowns, des modals.
Replacement ou suppression des role="alert"

### Pourquoi ?

Pour mettre en conformité le site avec les règles d'accessibilité et respecter les recommandations de l'audit

### Comment ?

En respectant ces règles 
https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html
https://www.w3.org/TR/wai-aria/#combobox
https://developer.mozilla.org/fr/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_status_role
