### PR TITLE
[technique] Appliquer djhtml systématiquement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: 🌍 Install spatial libraries
-      run: sudo apt-get update && sudo apt-get install binutils libproj-dev gdal-bin
+      run: sudo apt-get update && sudo apt-get install binutils build-essential libproj-dev gdal-bin
     - name: 💾 Create a database to check migrations
       run: |
         psql <<SQL
@@ -55,11 +55,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements/dev.txt
-    - name: ✨ Black, isort and Flake8
+    - name: ✨ Black, isort, flake8 & djhtml
       run: |
-        black --check itou
-        isort --check-only itou
-        flake8 itou --count --show-source --statistics
+        make quality_venv
     - name: 🤹‍ Django tests
       run: django-admin test --noinput --failfast --parallel=2
       env:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # =============================================================================
 PYTHON_VERSION := python3.9
 
-.PHONY: run clean cdsitepackages quality
+.PHONY: run clean cdsitepackages quality quality_venv fix fix_venv pylint pylint_venv
 
 # Run Docker images
 run:
@@ -15,17 +15,32 @@ cdsitepackages:
 	docker exec -ti -w /usr/local/lib/$(PYTHON_VERSION)/site-packages itou_django /bin/bash
 
 quality:
-	docker exec -ti itou_django black itou
-	docker exec -ti itou_django isort itou
-	docker exec -ti itou_django flake8 itou
+	docker exec -ti itou_django black --check itou
+	docker exec -ti itou_django isort --check itou
+	docker exec -ti itou_django djhtml --check $(shell find itou/templates -name "*.html")
+	docker exec -ti itou_django flake8 itou --count --show-source --statistics
 
 quality_venv:
+	black --check itou
+	isort --check itou
+	djhtml --check $(shell find itou/templates -name "*.html")
+	flake8 itou --count --show-source --statistics
+
+fix:
+	docker exec -ti itou_django black itou
+	docker exec -ti itou_django isort itou
+	docker exec -ti itou_django djhtml --in-place $(shell find itou/templates -name "*.html")
+
+fix_venv:
 	black itou
 	isort itou
-	flake8 itou
+	djhtml --in-place $(shell find itou/templates -name "*.html")
 
 pylint:
 	docker exec -ti itou_django pylint itou
+
+pylint_venv:
+	pylint itou
 
 coverage:
 	docker exec -ti itou_django coverage run ./manage.py test itou --settings=config.settings.test

--- a/itou/templates/account/email_confirm.html
+++ b/itou/templates/account/email_confirm.html
@@ -8,38 +8,38 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Confirmer l'adresse e-mail</h1>
+    <h1 class="h1-hero-c1">Confirmer l'adresse e-mail</h1>
 
-{% if confirmation %}
+    {% if confirmation %}
 
-    <p>Confirmez que <a href="mailto:{{ confirmation.email_address.email }}" title="{{ confirmation.email_address.email }} est bien votre adresse e-mail">{{ confirmation.email_address.email }}</a> est bien votre adresse e-mail en cliquant sur le bouton ci-dessous :</p>
+        <p>Confirmez que <a href="mailto:{{ confirmation.email_address.email }}" title="{{ confirmation.email_address.email }} est bien votre adresse e-mail">{{ confirmation.email_address.email }}</a> est bien votre adresse e-mail en cliquant sur le bouton ci-dessous :</p>
 
-    <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+        <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
 
-        {% csrf_token %}
+            {% csrf_token %}
 
-        {# `is_safe_url` is secure enough to let us use request params here. #}
-        {# See Allauth.account.adapter.DefaultAccountAdapter.is_safe_url #}
-        {% if request.GET.next %}
-            <input type="hidden" name="next" value="{{ request.GET.next }}">
-        {% endif %}
+            {# `is_safe_url` is secure enough to let us use request params here. #}
+            {# See Allauth.account.adapter.DefaultAccountAdapter.is_safe_url #}
+            {% if request.GET.next %}
+                <input type="hidden" name="next" value="{{ request.GET.next }}">
+            {% endif %}
 
-        {% buttons %}
-            <button type="submit" class="btn btn-primary">Confirmer</button>
-        {% endbuttons %}
+            {% buttons %}
+                <button type="submit" class="btn btn-primary">Confirmer</button>
+            {% endbuttons %}
 
-    </form>
+        </form>
 
-{% else %}
+    {% else %}
 
-    {% url 'account_email' as email_url %}
+        {% url 'account_email' as email_url %}
 
-    <div class="alert alert-danger" role="status">
-        Ce lien de confirmation d'adresse e-mail a expiré ou n'est pas valide.
-        <br>
-        Veuillez lancer <a href="{{ email_url }}">une nouvelle demande de confirmation</a>.
-    </div>
+        <div class="alert alert-danger" role="status">
+            Ce lien de confirmation d'adresse e-mail a expiré ou n'est pas valide.
+            <br>
+            Veuillez lancer <a href="{{ email_url }}">une nouvelle demande de confirmation</a>.
+        </div>
 
-{% endif %}
+    {% endif %}
 
 {% endblock %}

--- a/itou/templates/account/login.html
+++ b/itou/templates/account/login.html
@@ -11,14 +11,14 @@
         {% if show_sign_in_providers %}
             <b class="mb-4">Connectez-vous avec un service tiers</b>
             {% if show_france_connect %}
-            <div class="mt-4">
-                {% include "signup/includes/france_connect_button.html" %}
-            </div>
-            <div class="mt-4 mb-3">
-                <p class="text-center">
-                    <b>Ou</b>
-                </p>
-            </div>
+                <div class="mt-4">
+                    {% include "signup/includes/france_connect_button.html" %}
+                </div>
+                <div class="mt-4 mb-3">
+                    <p class="text-center">
+                        <b>Ou</b>
+                    </p>
+                </div>
             {% endif %}
 
             <div class="row mt-3">
@@ -38,7 +38,7 @@
             {% bootstrap_form_errors form type="all" %}
 
             {% if redirect_field_value %}
-            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
+                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
             {% endif %}
 
             {% bootstrap_field form.login form_group_class="form-group" %}
@@ -63,10 +63,10 @@
 
                 <p>
                     <a class="btn btn-outline-primary" href="{{ signup_url }}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}">
-                    Inscription 
-                    {% if account_type_display_name %}
-                        {{ account_type_display_name|lower }}
-                    {% endif %}
+                        Inscription
+                        {% if account_type_display_name %}
+                            {{ account_type_display_name|lower }}
+                        {% endif %}
                     </a>
                 </p>
             </div>

--- a/itou/templates/account/logout.html
+++ b/itou/templates/account/logout.html
@@ -6,26 +6,26 @@
 
 {% block content %}
 
-<div class="alert alert-info" role="status">
+    <div class="alert alert-info" role="status">
 
-    <h1 class="h1-hero-c1">Déconnexion</h1>
+        <h1 class="h1-hero-c1">Déconnexion</h1>
 
-    <p>Voulez-vous vraiment vous déconnecter ?</p>
+        <p>Voulez-vous vraiment vous déconnecter ?</p>
 
-    <form method="post" action="{% url 'account_logout' %}" class="js-prevent-multiple-submit">
+        <form method="post" action="{% url 'account_logout' %}" class="js-prevent-multiple-submit">
 
-        {% csrf_token %}
+            {% csrf_token %}
 
-        {% if redirect_field_value %}
-        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
-        {% endif %}
+            {% if redirect_field_value %}
+                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+            {% endif %}
 
-        {% buttons %}
-            <button type="submit" class="btn btn-primary">Se déconnecter</button>
-        {% endbuttons %}
+            {% buttons %}
+                <button type="submit" class="btn btn-primary">Se déconnecter</button>
+            {% endbuttons %}
 
-    </form>
+        </form>
 
-</div>
+    </div>
 
 {% endblock %}

--- a/itou/templates/account/password_change.html
+++ b/itou/templates/account/password_change.html
@@ -7,24 +7,24 @@
 {% block title %}Modifier votre mot de passe{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1 class="h1-hero-c1">Modifier votre mot de passe</h1>
-{% if request|user_is_france_connected %}
-<div class="alert alert-info" role="status">
-    {{ password_change_message }}
-    <br>
-    Si vous venez d’utiliser FranceConnect pour créer votre compte, vous ne connaissez pas votre votre mot de passe. Merci d’utiliser la fonctionnalité « <a href="{% url 'account_reset_password' %}">Mot de passe oublié</a> » pour le réinitialiser.
-</div>
-{% endif %}
-<form method="post" action="{% url 'account_change_password' %}" class="js-prevent-multiple-submit">
+    <h1 class="h1-hero-c1">Modifier votre mot de passe</h1>
+    {% if request|user_is_france_connected %}
+        <div class="alert alert-info" role="status">
+            {{ password_change_message }}
+            <br>
+            Si vous venez d’utiliser FranceConnect pour créer votre compte, vous ne connaissez pas votre votre mot de passe. Merci d’utiliser la fonctionnalité « <a href="{% url 'account_reset_password' %}">Mot de passe oublié</a> » pour le réinitialiser.
+        </div>
+    {% endif %}
+    <form method="post" action="{% url 'account_change_password' %}" class="js-prevent-multiple-submit">
 
-    {% csrf_token %}
+        {% csrf_token %}
 
-    {% bootstrap_form form alert_error_type="all" %}
+        {% bootstrap_form form alert_error_type="all" %}
 
-    {% buttons %}
-        <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
-        <button type="submit" class="btn btn-primary">Modifier le mot de passe</button>
-    {% endbuttons %}
+        {% buttons %}
+            <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
+            <button type="submit" class="btn btn-primary">Modifier le mot de passe</button>
+        {% endbuttons %}
 
-</form>
+    </form>
 {% endblock %}

--- a/itou/templates/account/password_reset.html
+++ b/itou/templates/account/password_reset.html
@@ -6,23 +6,23 @@
 {% block title %}Réinitialisation du mot de passe{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1 class="h1-hero-c1">Réinitialisation du mot de passe</h1>
+    <h1 class="h1-hero-c1">Réinitialisation du mot de passe</h1>
 
-{% if user.is_authenticated %}
-    {% include "account/snippets/already_logged_in.html" %}
-{% endif %}
+    {% if user.is_authenticated %}
+        {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
 
-<p>Mot de passe oublié ? Indiquez votre adresse e-mail ci-dessous et nous vous enverrons un e-mail pour le réinitialiser.</p>
+    <p>Mot de passe oublié ? Indiquez votre adresse e-mail ci-dessous et nous vous enverrons un e-mail pour le réinitialiser.</p>
 
-<form method="post" action="{% url 'account_reset_password' %}" class="js-prevent-multiple-submit">
+    <form method="post" action="{% url 'account_reset_password' %}" class="js-prevent-multiple-submit">
 
-    {% csrf_token %}
+        {% csrf_token %}
 
-    {% bootstrap_form form alert_error_type="all" %}
+        {% bootstrap_form form alert_error_type="all" %}
 
-    {% buttons %}
-        <button type="submit" class="btn btn-primary">Réinitialiser votre mot de passe</button>
-    {% endbuttons %}
+        {% buttons %}
+            <button type="submit" class="btn btn-primary">Réinitialiser votre mot de passe</button>
+        {% endbuttons %}
 
-</form>
+    </form>
 {% endblock %}

--- a/itou/templates/account/password_reset_done.html
+++ b/itou/templates/account/password_reset_done.html
@@ -7,23 +7,23 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Si un compte existe, vous recevrez un e-mail de réinitialisation</h1>
+    <h1 class="h1-hero-c1">Si un compte existe, vous recevrez un e-mail de réinitialisation</h1>
 
-{% if request.GET.email %}
-    {# Give the user a chance to check that there is no typing error in email before contacting support. #}
-    <h2 class="h1 text-muted">{{ request.GET.email }}</h2>
-{% endif %}
+    {% if request.GET.email %}
+        {# Give the user a chance to check that there is no typing error in email before contacting support. #}
+        <h2 class="h1 text-muted">{{ request.GET.email }}</h2>
+    {% endif %}
 
-{% if user.is_authenticated %}
-    {% include "account/snippets/already_logged_in.html" %}
-{% endif %}
+    {% if user.is_authenticated %}
+        {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
 
-<p>Il contient les instructions pour réinitialiser votre mot de passe.</p>
+    <p>Il contient les instructions pour réinitialiser votre mot de passe.</p>
 
-<p>Si vous le ne recevez pas dans les minutes qui suivent :</p>
+    <p>Si vous le ne recevez pas dans les minutes qui suivent :</p>
 
-<ul>
-    <li>vérifiez votre courrier indésirable</li>
-    <li>vérifiez qu'il n'y a pas d'erreur dans votre e-mail</li>
-</ul>
+    <ul>
+        <li>vérifiez votre courrier indésirable</li>
+        <li>vérifiez qu'il n'y a pas d'erreur dans votre e-mail</li>
+    </ul>
 {% endblock %}

--- a/itou/templates/account/password_reset_from_key.html
+++ b/itou/templates/account/password_reset_from_key.html
@@ -5,37 +5,37 @@
 {% block title %}Modification de votre mot de passe{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1 class="h1-hero-c1">{% if token_fail %}Mauvais jeton d'identification{% else %}Modification de votre mot de passe{% endif %}</h1>
+    <h1 class="h1-hero-c1">{% if token_fail %}Mauvais jeton d'identification{% else %}Modification de votre mot de passe{% endif %}</h1>
 
-{% if token_fail %}
+    {% if token_fail %}
 
-    {% url 'account_reset_password' as passwd_reset_url %}
-    <p>Le lien de réinitialisation du mot de passe est invalide. Il a peut être déjà été utilisé. Veuillez faire une nouvelle <a href="{{ passwd_reset_url }}">demande de réinitialisation de mot de passe</a>.</p>
-
-{% else %}
-
-    {% if form %}
-
-        <form method="post" action="{{ action_url }}" class="js-prevent-multiple-submit">
-
-            {% csrf_token %}
-
-            {% bootstrap_form_errors form type="all" %}
-
-            {% bootstrap_field form.password1 %}
-            {% bootstrap_field form.password2 %}
-
-            {% buttons %}
-                <button type="submit" class="btn btn-primary">Modifier le mot de passe</button>
-            {% endbuttons %}
-
-        </form>
+        {% url 'account_reset_password' as passwd_reset_url %}
+        <p>Le lien de réinitialisation du mot de passe est invalide. Il a peut être déjà été utilisé. Veuillez faire une nouvelle <a href="{{ passwd_reset_url }}">demande de réinitialisation de mot de passe</a>.</p>
 
     {% else %}
 
-        <p>Votre mot de passe a été modifié.</p>
+        {% if form %}
+
+            <form method="post" action="{{ action_url }}" class="js-prevent-multiple-submit">
+
+                {% csrf_token %}
+
+                {% bootstrap_form_errors form type="all" %}
+
+                {% bootstrap_field form.password1 %}
+                {% bootstrap_field form.password2 %}
+
+                {% buttons %}
+                    <button type="submit" class="btn btn-primary">Modifier le mot de passe</button>
+                {% endbuttons %}
+
+            </form>
+
+        {% else %}
+
+            <p>Votre mot de passe a été modifié.</p>
+
+        {% endif %}
 
     {% endif %}
-
-{% endif %}
 {% endblock %}

--- a/itou/templates/account/password_reset_from_key_done.html
+++ b/itou/templates/account/password_reset_from_key_done.html
@@ -5,10 +5,10 @@
 {% block title %}Modification de votre mot de passe{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1 class="h1-hero-c1">Modification de votre mot de passe</h1>
-<p>Votre mot de passe a été modifié !</p>
+    <h1 class="h1-hero-c1">Modification de votre mot de passe</h1>
+    <p>Votre mot de passe a été modifié !</p>
 
-<p>
-    <a href="{% url 'account_login' %}">Connexion</a>
-</p>
+    <p>
+        <a href="{% url 'account_login' %}">Connexion</a>
+    </p>
 {% endblock %}

--- a/itou/templates/account/verification_sent.html
+++ b/itou/templates/account/verification_sent.html
@@ -6,8 +6,8 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Vérifiez votre adresse e-mail</h1>
+    <h1 class="h1-hero-c1">Vérifiez votre adresse e-mail</h1>
 
-<p>Nous vous avons envoyé un e-mail avec un lien pour validation. Cliquez sur le lien fourni pour terminer votre inscription.</p>
+    <p>Nous vous avons envoyé un e-mail avec un lien pour validation. Cliquez sur le lien fourni pour terminer votre inscription.</p>
 
 {% endblock %}

--- a/itou/templates/admin/approvals/includes/job_application_details.html
+++ b/itou/templates/admin/approvals/includes/job_application_details.html
@@ -14,7 +14,7 @@
             {{ job_seeker.last_name }}
             <small>
                 (<a href="{% url "admin:approvals_poleemploiapproval_changelist" %}?q={{ job_seeker.last_name|urlencode }}" target="_blank">
-                rechercher dans les agréments Pôle emploi
+                    rechercher dans les agréments Pôle emploi
                 </a>)
             </small>
         </li>
@@ -42,7 +42,7 @@
                 {{ job_seeker.pole_emploi_id }}
                 <small>
                     (<a href="{% url "admin:approvals_poleemploiapproval_changelist" %}?q={{ job_seeker.pole_emploi_id|urlencode }}" target="_blank">
-                    rechercher dans les agréments Pôle emploi
+                        rechercher dans les agréments Pôle emploi
                     </a>)
                 </small>
             </li>

--- a/itou/templates/admin/approvals/manually_add_approval.html
+++ b/itou/templates/admin/approvals/manually_add_approval.html
@@ -1,45 +1,45 @@
 {% extends "admin/change_form.html" %}
 
 {% block content %}
-<form action="" method="post" id="{{ opts.model_name }}_form" novalidate>
+    <form action="" method="post" id="{{ opts.model_name }}_form" novalidate>
 
-    {% if errors %}
-        <p class="errornote">
-            {% if errors|length == 1 %}
-                Please correct the error below.
-            {% else %}
-                Please correct the errors below.
-            {% endif %}
-        </p>
-        {{ adminform.form.non_field_errors }}
-    {% endif %}
-
-    {% csrf_token %}
-
-    <div>
-
-        {% block field_sets %}
-            {% for fieldset in adminform %}
-                {% include "admin/includes/fieldset.html" %}
-            {% endfor %}
-        {% endblock %}
-
-        <div class="submit-row">
-
-            <p class="deletelink-box">
-                <a class="deletelink" href="{% url "admin:approvals_approval_manually_refuse_approval" job_application.id %}">
-                    Refuser
-                </a>
+        {% if errors %}
+            <p class="errornote">
+                {% if errors|length == 1 %}
+                    Please correct the error below.
+                {% else %}
+                    Please correct the errors below.
+                {% endif %}
             </p>
+            {{ adminform.form.non_field_errors }}
+        {% endif %}
 
-            <input type="submit" value="Enregistrer et envoyer par email" class="default">
+        {% csrf_token %}
+
+        <div>
+
+            {% block field_sets %}
+                {% for fieldset in adminform %}
+                    {% include "admin/includes/fieldset.html" %}
+                {% endfor %}
+            {% endblock %}
+
+            <div class="submit-row">
+
+                <p class="deletelink-box">
+                    <a class="deletelink" href="{% url "admin:approvals_approval_manually_refuse_approval" job_application.id %}">
+                        Refuser
+                    </a>
+                </p>
+
+                <input type="submit" value="Enregistrer et envoyer par email" class="default">
+
+            </div>
 
         </div>
 
-    </div>
+    </form>
 
-</form>
-
-{% include "admin/approvals/includes/job_application_details.html" %}
+    {% include "admin/approvals/includes/job_application_details.html" %}
 
 {% endblock %}

--- a/itou/templates/admin/approvals/manually_refuse_approval.html
+++ b/itou/templates/admin/approvals/manually_refuse_approval.html
@@ -4,23 +4,23 @@
 
 {% block content %}
 
-<p>En confirmant le refus, cet email sera envoyé à la personne ayant accepté la candidature :</p>
+    <p>En confirmant le refus, cet email sera envoyé à la personne ayant accepté la candidature :</p>
 
-<pre>
+    <pre>
 {{ email_subject_template }}<br>
 {{ email_body_template }}
-</pre>
+    </pre>
 
-<form method="post">{% csrf_token %}
+    <form method="post">{% csrf_token %}
 
-    <div>
-        <input type="hidden" name="confirm" value="yes">
-        <input type="submit" value="Oui, je confirme le refus"">
-        <a href="{% url "admin:approvals_approval_manually_add_approval" job_application.id %}" class="button cancel-link">Non, revenir à la page précédente</a>
-    </div>
+        <div>
+            <input type="hidden" name="confirm" value="yes">
+            <input type="submit" value="Oui, je confirme le refus"">
+                <a href="{% url "admin:approvals_approval_manually_add_approval" job_application.id %}" class="button cancel-link">Non, revenir à la page précédente</a>
+            </div>
 
-</form>
+        </form>
 
-{% include "admin/approvals/includes/job_application_details.html" %}
+        {% include "admin/approvals/includes/job_application_details.html" %}
 
 {% endblock %}

--- a/itou/templates/admin/base_site.html
+++ b/itou/templates/admin/base_site.html
@@ -3,9 +3,9 @@
 {% block title %}{{ title }} | Les emplois de l'inclusion{% endblock %}
 
 {% block branding %}
-<h1 id="site-name">
-    <a href="{% url 'admin:index' %}">Admin Itou</a>
-</h1>
+    <h1 id="site-name">
+        <a href="{% url 'admin:index' %}">Admin Itou</a>
+    </h1>
 {% endblock %}
 
 {% block nav-global %}{% endblock %}

--- a/itou/templates/admin/prescribers/change_form.html
+++ b/itou/templates/admin/prescribers/change_form.html
@@ -7,11 +7,11 @@
 
         <div class="submit-row">
             <input class="danger" type="submit" value="Refuser l'habilitation"
-                   name="_authorization_action_refuse"
-                   onclick="return confirm('Êtes vous certain ?')">
+                name="_authorization_action_refuse"
+                onclick="return confirm('Êtes vous certain ?')">
             <input class="default" type="submit" value="Valider l'habilitation"
-                   name="_authorization_action_validate"
-                   onclick="return confirm('Êtes vous certain ?')">
+                name="_authorization_action_validate"
+                onclick="return confirm('Êtes vous certain ?')">
         </div>
 
     {% elif original.has_refused_authorization and not user.is_superuser %}
@@ -19,8 +19,8 @@
 
         <div class="submit-row">
             <input class="default" type="submit" value="Annuler le refus et valider l'habilitation"
-                   name="_authorization_action_validate"
-                   onclick="return confirm('Êtes vous certain ?')">
+                name="_authorization_action_validate"
+                onclick="return confirm('Êtes vous certain ?')">
         </div>
 
     {% endif %}

--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}API Les emplois de l’inclusion{% endblock %}
 
-{% block content %}   
+{% block content %}
     <div class="row">
         <div class="col">
             <div class="row">

--- a/itou/templates/apply/edit_contract_start_date.html
+++ b/itou/templates/apply/edit_contract_start_date.html
@@ -4,21 +4,21 @@
 {% block title %}Modification de la date de contrat{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1 class="h1-hero-c1">Candidature de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
-<h2 class="h1">Modification de la date de contrat</h2>
+    <h1 class="h1-hero-c1">Candidature de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
+    <h2 class="h1">Modification de la date de contrat</h2>
 
-<form method="post" action="" class="js-prevent-multiple-submit">
+    <form method="post" action="" class="js-prevent-multiple-submit">
 
-    {% csrf_token %}
+        {% csrf_token %}
 
-    {% bootstrap_form form alert_error_type="all" %}
+        {% bootstrap_form form alert_error_type="all" %}
 
-    {% buttons %}
-        <a class="btn btn-outline-primary" href="{{ prev_url }}">Annuler</a>
-        <button type="submit" class="btn btn-primary">Enregistrer</button>
-    {% endbuttons %}
+        {% buttons %}
+            <a class="btn btn-outline-primary" href="{{ prev_url }}">Annuler</a>
+            <button type="submit" class="btn btn-primary">Enregistrer</button>
+        {% endbuttons %}
 
-</form>
+    </form>
 {% endblock %}
 
 {% block script %}

--- a/itou/templates/apply/includes/archive_button.html
+++ b/itou/templates/apply/includes/archive_button.html
@@ -18,10 +18,10 @@
                     <h3 class="modal-title" id="no-email-modal-label">
                         {% include "includes/icon.html" with icon="trash-2" %}
                         Supprimer cette candidature de mon tableau de bord
-                    </h3>                
+                    </h3>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
                         <i class="ri-close-line"></i>
-                    </button>            
+                    </button>
                 </div>
                 <div class="modal-body">
                     <div class="container">

--- a/itou/templates/apply/includes/eligibility_diagnosis.html
+++ b/itou/templates/apply/includes/eligibility_diagnosis.html
@@ -42,7 +42,7 @@
 
             <p>
                 <i>
-                    Ce diagnostic est valide du {{ eligibility_diagnosis.created_at|date:"d/m/Y" }} au 
+                    Ce diagnostic est valide du {{ eligibility_diagnosis.created_at|date:"d/m/Y" }} au
                     {{ eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}.
                 </i>
             </p>
@@ -95,7 +95,7 @@
 
                 <p>
                     <i>
-                        Ce diagnostic expire le 
+                        Ce diagnostic expire le
                         {{ eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}.
                     </i>
                 </p>
@@ -116,7 +116,7 @@
         <hr>
         <h3 class="h2 font-weight-normal text-muted">Éligibilité IAE</h3>
         <div class="alert alert-warning" role="status">
-            Le diagnostic d'éligibilité IAE de ce candidat a expiré le {{ expired_eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}, 
+            Le diagnostic d'éligibilité IAE de ce candidat a expiré le {{ expired_eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }},
             vous devez valider les critères d'éligibilité.
         </div>
     {% endif %}

--- a/itou/templates/apply/includes/info_csv.html
+++ b/itou/templates/apply/includes/info_csv.html
@@ -3,7 +3,7 @@
         <p class="card-text">
             {% include "includes/icon.html" with icon="info" %}
             <a href="{{ ITOU_DOC_URL }}/mon-mode-demploi-prescripteur/exporter-mes-candidatures-sur-excel">
-            Consultez le mode d'emploi pour lire le fichier
+                Consultez le mode d'emploi pour lire le fichier
             </a>
         </p>
     </div>

--- a/itou/templates/apply/includes/job_application_info.html
+++ b/itou/templates/apply/includes/job_application_info.html
@@ -1,24 +1,24 @@
-    <ul>
-        {% if request.user.is_prescriber %}
-            <li>Employeur : <b>{{ job_application.to_siae.display_name }}</b></li>
-        {% endif %}
-        <li>Date de la candidature : <b>{{ job_application.created_at|date:"d F Y à H:i" }}</b></li>
+<ul>
+    {% if request.user.is_prescriber %}
+        <li>Employeur : <b>{{ job_application.to_siae.display_name }}</b></li>
+    {% endif %}
+    <li>Date de la candidature : <b>{{ job_application.created_at|date:"d F Y à H:i" }}</b></li>
 
-        {% if job_application.selected_jobs.exists %}
-            <li>
-                Métier(s) recherché(s) :
-                <ul>
-                    {% for job in job_application.selected_jobs.all %}
-                        <li><b>{{ job.display_name }}</b> ({{ job.appellation.rome_id }})</li>
-                    {% endfor %}
-                </ul>
-            </li>
-        {% else %}
-            <li>Candidature spontanée</li>
-        {% endif %}
-    </ul>
+    {% if job_application.selected_jobs.exists %}
+        <li>
+            Métier(s) recherché(s) :
+            <ul>
+                {% for job in job_application.selected_jobs.all %}
+                    <li><b>{{ job.display_name }}</b> ({{ job.appellation.rome_id }})</li>
+                {% endfor %}
+            </ul>
+        </li>
+    {% else %}
+        <li>Candidature spontanée</li>
+    {% endif %}
+</ul>
 
-    <div class="alert alert-emploi">
-        <p><b>Message :</b></p>
-        {{ job_application.message|linebreaks }}
-    </div>
+<div class="alert alert-emploi">
+    <p><b>Message :</b></p>
+    {{ job_application.message|linebreaks }}
+</div>

--- a/itou/templates/apply/includes/job_application_sender_info.html
+++ b/itou/templates/apply/includes/job_application_sender_info.html
@@ -7,7 +7,7 @@
     <li>Type : <b>{{ job_application.get_sender_kind_display }}</b></li>
 
     <li>E-mail : <a
-            href="mailto:{{ job_application.sender.email }}">{{ job_application.sender.email }}</a></li>
+        href="mailto:{{ job_application.sender.email }}">{{ job_application.sender.email }}</a></li>
 
     {% if job_application.sender_prescriber_organization %}
         <li>

--- a/itou/templates/apply/includes/job_applications_filters.html
+++ b/itou/templates/apply/includes/job_applications_filters.html
@@ -4,7 +4,7 @@
 <ul class="d-flex flex-wrap align-items-end mt-sm-5 mb-sm-0 list-group list-group-horizontal align-items-end">
     <li class="list-group-item border-0 p-0">
         <button class="btn btn-primary" type="button" data-toggle="modal" data-target="#filtersModal">
-          Rechercher dans vos candidatures
+            Rechercher dans vos candidatures
         </button>
     </li>
     {% for filter in filters %}

--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -28,13 +28,13 @@
     {% endif %}
 </ul>
 <p>
-{% if job_application.has_editable_job_seeker %}
-    <p>
-        <a href="{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
-            class="btn btn-outline-primary">
-            Modifier les informations personnelles
-        </a>
-    </p>
-{% else %}
-    <p>Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations.<p>
-{% endif %}
+    {% if job_application.has_editable_job_seeker %}
+        <p>
+            <a href="{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
+                class="btn btn-outline-primary">
+                Modifier les informations personnelles
+            </a>
+        </p>
+    {% else %}
+        <p>Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations.<p>
+    {% endif %}

--- a/itou/templates/apply/includes/state_transition_siae.html
+++ b/itou/templates/apply/includes/state_transition_siae.html
@@ -1,194 +1,194 @@
 {% load bootstrap4 %}
 {% load format_filters %}
 
-    {% if job_application.state.is_new %}
+{% if job_application.state.is_new %}
 
-        <hr>
+    <hr>
 
-        <form method="post" action="{% url 'apply:process' job_application_id=job_application.id %}"
-              class="js-prevent-multiple-submit">
-            {% csrf_token %}
-            {% buttons %}
-                <button type="submit" class="btn btn-warning">J'étudie cette candidature</button>
-            {% endbuttons %}
-        </form>
+    <form method="post" action="{% url 'apply:process' job_application_id=job_application.id %}"
+        class="js-prevent-multiple-submit">
+        {% csrf_token %}
+        {% buttons %}
+            <button type="submit" class="btn btn-warning">J'étudie cette candidature</button>
+        {% endbuttons %}
+    </form>
 
+{% endif %}
+
+{# Answer ------------------------------------------------------------------------- #}
+
+{% if job_application.answer or job_application.state.is_refused %}
+
+    <hr>
+
+    <h3 class="h2 font-weight-normal text-muted">Réponse</h3>
+
+    {% if job_application.refusal_reason %}
+        <p>
+            <b>Motif du refus :</b><br>
+            {{ job_application.get_refusal_reason_display }}
+        </p>
     {% endif %}
 
-    {# Answer ------------------------------------------------------------------------- #}
-
-    {% if job_application.answer or job_application.state.is_refused %}
-
-        <hr>
-
-        <h3 class="h2 font-weight-normal text-muted">Réponse</h3>
-
-        {% if job_application.refusal_reason %}
-            <p>
-                <b>Motif du refus :</b><br>
-                {{ job_application.get_refusal_reason_display }}
-            </p>
-        {% endif %}
-
-        {% if job_application.answer %}
-            <div class="alert alert-emploi">
-                <p><b>Réponse :</b></p>
-                {{ job_application.answer|linebreaks }}
-            </div>
-        {% endif %}
-
-        {% if job_application.answer_to_prescriber %}
-            <div class="alert alert-emploi">
-                <p><b>Message pour le prescripteur :</b></p>
-                {{ job_application.answer_to_prescriber|linebreaks }}
-            </div>
-        {% endif %}
-
+    {% if job_application.answer %}
+        <div class="alert alert-emploi">
+            <p><b>Réponse :</b></p>
+            {{ job_application.answer|linebreaks }}
+        </div>
     {% endif %}
 
-    {# Possible next steps when the state is processing ------------------------------------------------------ #}
+    {% if job_application.answer_to_prescriber %}
+        <div class="alert alert-emploi">
+            <p><b>Message pour le prescripteur :</b></p>
+            {{ job_application.answer_to_prescriber|linebreaks }}
+        </div>
+    {% endif %}
 
-    {% if job_application.state.is_processing %}
+{% endif %}
 
-        <hr>
+{# Possible next steps when the state is processing ------------------------------------------------------ #}
 
-        {% if job_application.eligibility_diagnosis_by_siae_required %}
-            <p>
-                {% include "eligibility/includes/new_diagnosis_button.html" %}
-            </p>
-        {% else %}
-            <p>
-                <a href="{% url 'apply:accept' job_application_id=job_application.id %}"
-                   class="btn btn-outline-success btn-block">
-                    Je l'embauche
-                    {% include "includes/icon.html" with icon="arrow-right" %}
-                </a>
-            </p>
+{% if job_application.state.is_processing %}
 
-            <p>
-                <a href="{% url 'apply:postpone' job_application_id=job_application.id %}"
-                   class="btn btn-outline-success btn-block">
-                    Mettre en liste d'attente
-                    {% include "includes/icon.html" with icon="arrow-right" %}
-                </a>
-            </p>
+    <hr>
 
-        {% endif %}
+    {% if job_application.eligibility_diagnosis_by_siae_required %}
+        <p>
+            {% include "eligibility/includes/new_diagnosis_button.html" %}
+        </p>
+    {% else %}
+        <p>
+            <a href="{% url 'apply:accept' job_application_id=job_application.id %}"
+                class="btn btn-outline-success btn-block">
+                Je l'embauche
+                {% include "includes/icon.html" with icon="arrow-right" %}
+            </a>
+        </p>
 
         <p>
-            <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
-               class="btn btn-outline-danger btn-block">
-                Décliner la candidature
+            <a href="{% url 'apply:postpone' job_application_id=job_application.id %}"
+                class="btn btn-outline-success btn-block">
+                Mettre en liste d'attente
                 {% include "includes/icon.html" with icon="arrow-right" %}
             </a>
         </p>
 
     {% endif %}
 
-    {# Possible next steps when the state is postponed ------------------------------------------------------ #}
+    <p>
+        <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
+            class="btn btn-outline-danger btn-block">
+            Décliner la candidature
+            {% include "includes/icon.html" with icon="arrow-right" %}
+        </a>
+    </p>
 
-    {% if job_application.state.is_postponed %}
+{% endif %}
 
-        <hr>
+{# Possible next steps when the state is postponed ------------------------------------------------------ #}
 
-        {% if job_application.eligibility_diagnosis_by_siae_required %}
-            <p>
-                {% include "eligibility/includes/new_diagnosis_button.html" %}
-            </p>
-        {% else %}
-            <p>
-                <a href="{% url 'apply:accept' job_application_id=job_application.id %}"
-                   class="btn btn-outline-success btn-block">
-                    Je l'embauche
-                    {% include "includes/icon.html" with icon="arrow-right" %}
-                </a>
-            </p>
-        {% endif %}
+{% if job_application.state.is_postponed %}
 
+    <hr>
+
+    {% if job_application.eligibility_diagnosis_by_siae_required %}
         <p>
-            <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
-               class="btn btn-outline-danger btn-block">
-                Décliner la candidature
+            {% include "eligibility/includes/new_diagnosis_button.html" %}
+        </p>
+    {% else %}
+        <p>
+            <a href="{% url 'apply:accept' job_application_id=job_application.id %}"
+                class="btn btn-outline-success btn-block">
+                Je l'embauche
                 {% include "includes/icon.html" with icon="arrow-right" %}
             </a>
         </p>
-
     {% endif %}
 
+    <p>
+        <a href="{% url 'apply:refuse' job_application_id=job_application.id %}"
+            class="btn btn-outline-danger btn-block">
+            Décliner la candidature
+            {% include "includes/icon.html" with icon="arrow-right" %}
+        </a>
+    </p>
 
-    {# Possible next steps when the state is obsolete, refused or cancelled --------------------------------- #}
+{% endif %}
 
-    {% if job_application.state.is_obsolete or job_application.state.is_refused or job_application.state.is_cancelled %}
 
-        <hr>
+{# Possible next steps when the state is obsolete, refused or cancelled --------------------------------- #}
 
-        {% if job_application.eligibility_diagnosis_by_siae_required %}
-            <p>
-                {% include "eligibility/includes/new_diagnosis_button.html" %}
-            </p>
-        {% else %}
-            <p>
-                <a href="{% url 'apply:accept' job_application_id=job_application.id %}"
-                   class="btn btn-outline-success btn-block">
-                    Je l'embauche
-                    {% include "includes/icon.html" with icon="arrow-right" %}
-                </a>
-            </p>
-        {% endif %}
+{% if job_application.state.is_obsolete or job_application.state.is_refused or job_application.state.is_cancelled %}
 
-    {% endif %}
+    <hr>
 
-    {# Job application accepted: details -------------------------------------------------------------------- #}
-
-    {% if job_application.state.is_accepted %}
-        <hr>
-
-        <h3 class="h2 font-weight-normal text-muted">Détails du contrat de travail</h3>
+    {% if job_application.eligibility_diagnosis_by_siae_required %}
         <p>
+            {% include "eligibility/includes/new_diagnosis_button.html" %}
+        </p>
+    {% else %}
+        <p>
+            <a href="{% url 'apply:accept' job_application_id=job_application.id %}"
+                class="btn btn-outline-success btn-block">
+                Je l'embauche
+                {% include "includes/icon.html" with icon="arrow-right" %}
+            </a>
+        </p>
+    {% endif %}
+
+{% endif %}
+
+{# Job application accepted: details -------------------------------------------------------------------- #}
+
+{% if job_application.state.is_accepted %}
+    <hr>
+
+    <h3 class="h2 font-weight-normal text-muted">Détails du contrat de travail</h3>
+    <p>
         <ul>
             <li>Début : {{ job_application.hiring_start_at|date:"d F Y" }}</li>
             <li>Fin : {{ job_application.hiring_end_at|date:"d F Y" }}</li>
         </ul>
+    </p>
+
+    {% if job_application.can_update_hiring_start %}
+        <p>
+            <a href="{% url 'apply:edit_contract_start_date' job_application_id=job_application.pk %}"
+                class="btn btn-outline-primary btn-block">
+                Modifier la période du contrat de travail
+            </a>
         </p>
-
-        {% if job_application.can_update_hiring_start %}
-            <p>
-                <a href="{% url 'apply:edit_contract_start_date' job_application_id=job_application.pk %}"
-                   class="btn btn-outline-primary btn-block">
-                    Modifier la période du contrat de travail
-                </a>
-            </p>
-        {% endif %}
-
-        {# Job application cancellation -------------------------------------------------------------------------- #}
-        {% if job_application.can_be_cancelled %}
-            <hr>
-
-            <h3 class="h2 font-weight-normal text-muted">Rétractation</h3>
-
-            {% if job_application.to_siae.is_subject_to_eligibility_rules %}
-                <p>
-                    Si vous annulez cette embauche, vous ne pourrez pas prétendre à l'aide au poste pour les jours éventuellement travaillés.
-                </p>
-                <p>
-                    {{ job_application.job_seeker.get_full_name|title }} restera éligible à l'IAE et pourra de nouveau vous envoyer une candidature dans le futur.
-                </p>
-                <p>
-                    Si une fiche salarié a été saisie pour cette embauche, elle sera annulée.
-                </p>
-            {% endif %}
-            <p>
-                <a href="{% url 'apply:cancel' job_application_id=job_application.id %}" class="text-decoration-none">
-                    <button class="btn btn-danger btn-block">Annuler l'embauche</button>
-                </a>
-            </p>
-        {% endif %}
-
-
     {% endif %}
 
-    {# Job application archival -------------------------------------------------------------------- #}
+    {# Job application cancellation -------------------------------------------------------------------------- #}
+    {% if job_application.can_be_cancelled %}
+        <hr>
 
-    {% if job_application.can_be_archived %}
-        {% include "apply/includes/archive_button.html" with job_application=job_application %}
+        <h3 class="h2 font-weight-normal text-muted">Rétractation</h3>
+
+        {% if job_application.to_siae.is_subject_to_eligibility_rules %}
+            <p>
+                Si vous annulez cette embauche, vous ne pourrez pas prétendre à l'aide au poste pour les jours éventuellement travaillés.
+            </p>
+            <p>
+                {{ job_application.job_seeker.get_full_name|title }} restera éligible à l'IAE et pourra de nouveau vous envoyer une candidature dans le futur.
+            </p>
+            <p>
+                Si une fiche salarié a été saisie pour cette embauche, elle sera annulée.
+            </p>
+        {% endif %}
+        <p>
+            <a href="{% url 'apply:cancel' job_application_id=job_application.id %}" class="text-decoration-none">
+                <button class="btn btn-danger btn-block">Annuler l'embauche</button>
+            </a>
+        </p>
     {% endif %}
+
+
+{% endif %}
+
+{# Job application archival -------------------------------------------------------------------- #}
+
+{% if job_application.can_be_archived %}
+    {% include "apply/includes/archive_button.html" with job_application=job_application %}
+{% endif %}

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -5,9 +5,9 @@
 
 {% block content %}
     {% if export_for == "siae" %}
-    <h1 class="h1-hero-c1">Export des candidatures reçues chez {{ siae.display_name }}</h1>
+        <h1 class="h1-hero-c1">Export des candidatures reçues chez {{ siae.display_name }}</h1>
     {% else %}
-    <h1 class="h1-hero-c1">Export des candidatures</h1>
+        <h1 class="h1-hero-c1">Export des candidatures</h1>
     {% endif %}
 
     {% if not job_applications_by_month %}
@@ -30,33 +30,33 @@
                 </thead>
                 <tbody>
                     {% for month in job_applications_by_month %}
-                    <tr>
-                        <td>{{ month.month|date:"F Y"|capfirst }}</td>
-                        <td>{{ month.c }}</td>
-                        <td>
-                        {% if export_for == "siae" %}
-                            <a
-                                class="matomo-event text-decoration-none"
-                                data-matomo-category="candidatures"
-                                data-matomo-action="exports"
-                                data-matomo-option="export-siae"
-                                title="Télécharger cet export SIAE"
-                                href="{% url 'apply:list_for_siae_exports_download' month_identifier=month.month|date:"Y-m" %}">
-                                {% include "includes/icon.html" with icon="download" %} Télécharger
-                            </a>
-                        {% else %}
-                            <a
-                                class="matomo-event text-decoration-none"
-                                data-matomo-category="candidatures"
-                                data-matomo-action="exports"
-                                data-matomo-option="export-prescripteur"
-                                title="Télécharger cet export prescriteur"
-                                href="{% url 'apply:list_for_prescriber_exports_download' month_identifier=month.month|date:"Y-m" %}">
-                                {% include "includes/icon.html" with icon="download" %} Télécharger
-                            </a>
-                        {% endif %}
-                        </td>
-                    </tr>
+                        <tr>
+                            <td>{{ month.month|date:"F Y"|capfirst }}</td>
+                            <td>{{ month.c }}</td>
+                            <td>
+                                {% if export_for == "siae" %}
+                                    <a
+                                        class="matomo-event text-decoration-none"
+                                        data-matomo-category="candidatures"
+                                        data-matomo-action="exports"
+                                        data-matomo-option="export-siae"
+                                        title="Télécharger cet export SIAE"
+                                        href="{% url 'apply:list_for_siae_exports_download' month_identifier=month.month|date:"Y-m" %}">
+                                        {% include "includes/icon.html" with icon="download" %} Télécharger
+                                    </a>
+                                {% else %}
+                                    <a
+                                        class="matomo-event text-decoration-none"
+                                        data-matomo-category="candidatures"
+                                        data-matomo-action="exports"
+                                        data-matomo-option="export-prescripteur"
+                                        title="Télécharger cet export prescriteur"
+                                        href="{% url 'apply:list_for_prescriber_exports_download' month_identifier=month.month|date:"Y-m" %}">
+                                        {% include "includes/icon.html" with icon="download" %} Télécharger
+                                    </a>
+                                {% endif %}
+                            </td>
+                        </tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -66,7 +66,7 @@
             {% endif %}
 
             <a class="btn btn-outline-secondary btn-block"
-               href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Annuler</a>
+                href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Annuler</a>
         {% endbuttons %}
     </form>
 

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -41,14 +41,14 @@
                             <a
                                 href="{% url 'approvals:suspend' approval_id=job_application.approval.id %}?back_url={{ request.get_full_path|urlencode }}"
                                 class="btn btn btn-link">
-                                    Suspendre
+                                Suspendre
                             </a>
                         {% endif %}
                         {% if approval_can_be_prolonged_by_siae %}
                             <a
                                 href="{% url 'approvals:declare_prolongation' approval_id=job_application.approval.id %}?back_url={{ request.get_full_path|urlencode }}"
                                 class="btn btn btn-link">
-                                    Prolonger
+                                Prolonger
                             </a>
                         {% endif %}
                         {% if job_application.can_download_approval_as_pdf %}
@@ -58,7 +58,7 @@
                                 data-matomo-category="agrement"
                                 data-matomo-action="telechargement-pdf"
                                 data-matomo-option="details-candidature">
-                                    Télécharger le PASS IAE
+                                Télécharger le PASS IAE
                             </a>
                         {% endif %}
                     {% endif %}

--- a/itou/templates/apply/process_eligibility.html
+++ b/itou/templates/apply/process_eligibility.html
@@ -25,32 +25,32 @@
                 <li>
                     trois critères de niveau 2 (seulement deux critères de niveau 2 pour les ETTI et AI)
                 </li>
-        </li>
-    </ol>
+            </li>
+        </ol>
 
-    <p>
-        Si le candidat ne remplit pas les conditions administratives, <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite/derogation-criteres" target="_blank" rel="noreferrer noopener">orientez-le vers un prescripteur habilité</a>.
-    </p>
-
-    <div class="alert alert-warning">
-        <i>Dans le cadre de l'expérimentation actuelle, nous vous informons que la liste des critères d'éligibilité à l'IAE est susceptible d'évoluer à la marge.</i>
-    </div>
-
-    <hr>
-
-    <h2 class="h1">Critères d'éligibilité</h2>
-
-    {% url 'apply:details_for_siae' job_application_id=job_application.id as cancel_url %}
-    {% include "eligibility/includes/form.html" with cancel_url=cancel_url %}
-
-    <div class="alert alert-emploi">
         <p>
-            Si le candidat n'est pas éligible à l'insertion par l'activité économique, vous pouvez décliner sa candidature :
+            Si le candidat ne remplit pas les conditions administratives, <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite/derogation-criteres" target="_blank" rel="noreferrer noopener">orientez-le vers un prescripteur habilité</a>.
         </p>
-        <a href="{% url 'apply:refuse' job_application_id=job_application.id %}" class="btn btn-outline-danger btn-block">
-            Décliner la candidature
-            {% include "includes/icon.html" with icon="arrow-right" %}
-        </a>
-    </div>
+
+        <div class="alert alert-warning">
+            <i>Dans le cadre de l'expérimentation actuelle, nous vous informons que la liste des critères d'éligibilité à l'IAE est susceptible d'évoluer à la marge.</i>
+        </div>
+
+        <hr>
+
+        <h2 class="h1">Critères d'éligibilité</h2>
+
+        {% url 'apply:details_for_siae' job_application_id=job_application.id as cancel_url %}
+        {% include "eligibility/includes/form.html" with cancel_url=cancel_url %}
+
+        <div class="alert alert-emploi">
+            <p>
+                Si le candidat n'est pas éligible à l'insertion par l'activité économique, vous pouvez décliner sa candidature :
+            </p>
+            <a href="{% url 'apply:refuse' job_application_id=job_application.id %}" class="btn btn-outline-danger btn-block">
+                Décliner la candidature
+                {% include "includes/icon.html" with icon="arrow-right" %}
+            </a>
+        </div>
 
 {% endblock %}

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -48,7 +48,7 @@
         // Clicking on the "other" radio button displays a hidden field.
         $('#js-field-answer-to-prescriber').css("display", "none");
         $('.js-refusal-reasons input')
-          .on('change', function () {
+            .on('change', function () {
             $('#js-field-answer-to-prescriber').hide("slide");
             $('#js-refusal-reason-poorly').hide("up", function(){
                 $(this).remove();
@@ -61,6 +61,6 @@
                     $(this).parent().after('<p id="js-refusal-reason-poorly"><i>En cas de besoin, n\'hésitez pas à contacter le prescripteur pour avoir plus d\'informations</i></p>');
                     break;
             }
-          });
+        });
     </script>
 {% endblock %}

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -20,7 +20,7 @@
 
         {% if form.errors %}
             <div class="alert alert-info">
-                Vous possédez un numéro de sécurité sociale temporaire ? 
+                Vous possédez un numéro de sécurité sociale temporaire ?
                 <button
                     type="submit" name="skip" value="1"
                     class="btn btn-link p-0 matomo-event"
@@ -29,7 +29,7 @@
                     data-matomo-option="candidature">
                     Cliquez ici pour accéder à l'étape suivante.
                 </button>
-                </div>
+            </div>
         {% endif %}
 
         {% buttons %}

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -30,11 +30,11 @@
             {% bootstrap_form_errors form type="all" %}
 
             {% bootstrap_field form.reason %}
-    
+
             {% bootstrap_field form.end_at %}
-    
+
             {% bootstrap_field form.reason_explanation %}
-    
+
             <div id="js-field-email">
                 {% bootstrap_field form.email %}
 
@@ -91,11 +91,11 @@
                         <span class="badge badge-success">{{ form.instance.end_at|date:"d/m/Y" }}</span>
                     </p>
                     {% if form.instance.validated_by.email %}
-                    <p class="card-text">
-                        Un e-mail sera envoyé au prescripteur habilité ayant autorisé la prolongation :
-                        <b>{{ form.instance.validated_by.get_full_name|title }}</b>
-                        ({{ form.instance.validated_by.email }})
-                    </p>
+                        <p class="card-text">
+                            Un e-mail sera envoyé au prescripteur habilité ayant autorisé la prolongation :
+                            <b>{{ form.instance.validated_by.get_full_name|title }}</b>
+                            ({{ form.instance.validated_by.email }})
+                        </p>
                     {% endif %}
                 </div>
             </div>
@@ -133,7 +133,7 @@
             var reasons_max_durations = {{ form.reasons_max_duration_labels|js }};
             var reasons_not_need_prescriber_opinion = {{ form.reasons_not_need_prescriber_opinion|js }};
             $('#js-field-email').css("display", "none");
-            
+
             function ajust_form_according_reason() {
                 const value = $('input[name="reason"]:checked').val();
                 if (reasons_not_need_prescriber_opinion.includes(value)) {

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -103,10 +103,10 @@
                             <br>
                             <small>{{ p.get_reason_display }}</small>
                             {% if p.validated_by %}
-                            <br>
-                            <small>
-                                Autorisation par <i>{{ p.validated_by.get_full_name|title }}</i> ({{ p.validated_by.email }})
-                            </small>
+                                <br>
+                                <small>
+                                    Autorisation par <i>{{ p.validated_by.get_full_name|title }}</i> ({{ p.validated_by.email }})
+                                </small>
                             {% endif %}
                         </li>
                     {% endfor %}

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -40,10 +40,10 @@
                 <p>
                     Mais avant, nous avons besoin de connaître l'adresse e-mail de votre salarié(e).
                 </p>
-                    <a class="btn btn-outline-primary" href="{{ back_url }}">Annuler</a>
-                    <a class="btn btn-primary" href="{% url 'approvals:pe_approval_search_user' approval.pk %}">
-                        Continuer
-                    </a>
+                <a class="btn btn-outline-primary" href="{{ back_url }}">Annuler</a>
+                <a class="btn btn-primary" href="{% url 'approvals:pe_approval_search_user' approval.pk %}">
+                    Continuer
+                </a>
             {% endif %}
         {% endif %}
 

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -32,7 +32,7 @@
             {% bootstrap_field form.start_at %}
             <div id="collapse_end_at" class="collapse{% if not form.set_default_end_date.value %} show{% endif %}">
                 {% bootstrap_field form.end_at %}
-            </div> 
+            </div>
             <div role="button" data-toggle="collapse" data-target="#collapse_end_at" aria-controls="#collapse_end_at">
                 {% bootstrap_field form.set_default_end_date %}
             </div>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -95,8 +95,8 @@
     {# Message d'information temporaire pour les fiches salarié / annexes financières #}
     {% if can_show_employee_records %}
         <div class="alert alert-info">
-          <p>La fin de validité des annexes financières de 2021 n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.</p> 
-          <p>Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
+            <p>La fin de validité des annexes financières de 2021 n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.</p>
+            <p>Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
         </div>
     {% endif %}
 
@@ -127,7 +127,7 @@
         {% if user.is_job_seeker and user.get_full_name %} - <span class="text-muted">{{ user.get_full_name }}</span>{% endif %}
         {% if current_siae %} - <span class="text-muted">{{ current_siae.display_name }}</span>{% endif %}
         {% if current_prescriber_organization %} -
-        <span class="text-muted">{{ current_prescriber_organization.display_name }}</span>
+            <span class="text-muted">{{ current_prescriber_organization.display_name }}</span>
             {% if current_prescriber_organization.is_authorized %}
                 {% include "includes/icon.html" with icon="award" class="h1 align-middle" size=30 %}
             {% endif %}
@@ -194,9 +194,9 @@
                                     {% if user.has_valid_diagnosis %}
                                         <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
                                     {% else %}
-                                    <small>
-                                        {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}
-                                    </small>
+                                        <small>
+                                            {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}
+                                        </small>
                                     {% endif %}
                                 </p>
                             {% endif %}
@@ -220,9 +220,9 @@
                                 {% if user_is_prescriber_org_admin or card_url %}
                                     {% include "includes/icon.html" with icon="bookmark" %}
                                     {% if user_is_prescriber_org_admin %}
-                                    <a href="{% url 'prescribers_views:edit_organization' %}">
-                                        Modifier les informations
-                                    </a>
+                                        <a href="{% url 'prescribers_views:edit_organization' %}">
+                                            Modifier les informations
+                                        </a>
                                         {% if card_url %} / {% endif %}
                                     {% endif %}
                                     {% if card_url %}
@@ -316,7 +316,7 @@
                         {% include "includes/icon.html" with icon="briefcase" %}
                         <a class="title-with-badge" href="{% url 'siaes_views:configure_jobs' %}">Gérer les métiers et recrutements
                             <span class="badge badge-info" data-toggle="tooltip" data-placement="right"
-                            title="À partir de maintenant, vous allez pouvoir informer les prescripteurs et les candidats des métiers qui recrutent en ce moment, avec la fonctionnalité «recrutement en cours»">Nouveau</span>
+                                title="À partir de maintenant, vous allez pouvoir informer les prescripteurs et les candidats des métiers qui recrutent en ce moment, avec la fonctionnalité «recrutement en cours»">Nouveau</span>
                         </a>
                     </p>
 
@@ -384,7 +384,7 @@
                             <a
                                 href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1"
                                 target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
-                                    Liste des critères d'éligibilité
+                                Liste des critères d'éligibilité
                             </a>
                         </p>
                     {% endif %}

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -4,26 +4,26 @@
 {% block title %}Informations personnelles de {{ job_application.job_seeker.get_full_name|title }}{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1 class="h1-hero-c1">Informations personnelles de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
+    <h1 class="h1-hero-c1">Informations personnelles de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
 
-<div class="alert alert-warning">
-  <b>Vous allez modifier des informations sensibles</b> concernant ce candidat ou cette candidate.<br>
-  Tout changement entraînera une modification définitive dans notre base de données. <b>Les informations
-  supprimées seront perdues.</b>
-</div>
+    <div class="alert alert-warning">
+        <b>Vous allez modifier des informations sensibles</b> concernant ce candidat ou cette candidate.<br>
+        Tout changement entraînera une modification définitive dans notre base de données. <b>Les informations
+            supprimées seront perdues.</b>
+    </div>
 
-<form method="post" action="" class="js-prevent-multiple-submit">
+    <form method="post" action="" class="js-prevent-multiple-submit">
 
-    {% csrf_token %}
+        {% csrf_token %}
 
-    {% bootstrap_form form alert_error_type="all" %}
+        {% bootstrap_form form alert_error_type="all" %}
 
-    {% buttons %}
-        <a class="btn btn-outline-primary" href="{{ prev_url }}">Annuler</a>
-        <button type="submit" class="btn btn-primary">Mettre à jour</button>
-    {% endbuttons %}
+        {% buttons %}
+            <a class="btn btn-outline-primary" href="{{ prev_url }}">Annuler</a>
+            <button type="submit" class="btn btn-primary">Mettre à jour</button>
+        {% endbuttons %}
 
-</form>
+    </form>
 {% endblock %}
 
 {% block script %}

--- a/itou/templates/dashboard/edit_user_email.html
+++ b/itou/templates/dashboard/edit_user_email.html
@@ -4,19 +4,19 @@
 {% block title %}Modifier votre profil{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1 class="h1-hero-c1">Modifier votre adresse e-mail</h1>
+    <h1 class="h1-hero-c1">Modifier votre adresse e-mail</h1>
 
-<div class="alert alert-warning">
-    Ce changement entraînera une <b>déconnexion</b>.<br>
-    Veuillez alors vous reconnecter avec votre nouvelle adresse e-mail.
-</div>
+    <div class="alert alert-warning">
+        Ce changement entraînera une <b>déconnexion</b>.<br>
+        Veuillez alors vous reconnecter avec votre nouvelle adresse e-mail.
+    </div>
 
-<form method="post" action="" class="js-prevent-multiple-submit">
-    {% csrf_token %}
+    <form method="post" action="" class="js-prevent-multiple-submit">
+        {% csrf_token %}
 
-    {% bootstrap_form form alert_error_type="all" %}
+        {% bootstrap_form form alert_error_type="all" %}
 
-    <button type="submit" class="btn btn-primary">Enregistrer</button>
-</form>
+        <button type="submit" class="btn btn-primary">Enregistrer</button>
+    </form>
 
 {% endblock %}

--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -4,31 +4,31 @@
 {% block title %}Modifier votre profil{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1 class="h1-hero-c1">Modifier votre profil</h1>
+    <h1 class="h1-hero-c1">Modifier votre profil</h1>
 
-{% if extra_data %}
+    {% if extra_data %}
 
-<div class="alert alert-info">
+        <div class="alert alert-info">
 
-    Certains champs de ce formulaire sont pré-remplis avec des éléments en provenance de votre compte Pôle emploi
-    (récupérés lors de votre connexion du {{extra_data.created_at|date:"d F Y"}}).
+            Certains champs de ce formulaire sont pré-remplis avec des éléments en provenance de votre compte Pôle emploi
+            (récupérés lors de votre connexion du {{extra_data.created_at|date:"d F Y"}}).
 
-</div>
+        </div>
 
-{% endif %}
+    {% endif %}
 
-<form method="post" action="" class="js-prevent-multiple-submit">
+    <form method="post" action="" class="js-prevent-multiple-submit">
 
-    {% csrf_token %}
+        {% csrf_token %}
 
-    {% bootstrap_form form alert_error_type="all" %}
+        {% bootstrap_form form alert_error_type="all" %}
 
-    {% buttons %}
-        <a class="btn btn-outline-primary" href="{{ prev_url }}">Annuler</a>
-        <button type="submit" class="btn btn-primary">Enregistrer</button>
-    {% endbuttons %}
+        {% buttons %}
+            <a class="btn btn-outline-primary" href="{{ prev_url }}">Annuler</a>
+            <button type="submit" class="btn btn-primary">Enregistrer</button>
+        {% endbuttons %}
 
-</form>
+    </form>
 
 {% endblock %}
 

--- a/itou/templates/dashboard/edit_user_preferences.html
+++ b/itou/templates/dashboard/edit_user_preferences.html
@@ -4,13 +4,13 @@
 {% block title %}Préférences personnelles{{ block.super }}{% endblock %}
 
 {% block content %}
-<h1 class="h1-hero-c1">Préférences personnelles</h1>
-<h2 class="h1"><span class="text-muted">{{ current_siae.display_name }}</span></h2>
+    <h1 class="h1-hero-c1">Préférences personnelles</h1>
+    <h2 class="h1"><span class="text-muted">{{ current_siae.display_name }}</span></h2>
 
-<div class="card-deck mt-3">
-    <div class="card">
-        <h3 class="h2 card-header font-weight-bold h3">Notifications e-mail</h3>
-        <div class="card-body">
+    <div class="card-deck mt-3">
+        <div class="card">
+            <h3 class="h2 card-header font-weight-bold h3">Notifications e-mail</h3>
+            <div class="card-body">
                 <h4 class="font-weight-bold h4">Nouvelles candidatures</h4>
                 <form method="post" action="" class="js-prevent-multiple-submit">
                     {% csrf_token %}
@@ -24,7 +24,7 @@
                     {% endbuttons %}
 
                 </form>
+            </div>
         </div>
     </div>
-</div>
 {% endblock %}

--- a/itou/templates/eligibility/includes/criteria_input.html
+++ b/itou/templates/eligibility/includes/criteria_input.html
@@ -17,25 +17,25 @@
             {# to provide them when they don't have to. #}
             {% if request.user.is_siae_staff %}
                 {% with objects_dict|get_dict_item:field.name as criteria %}
-                     {% if criteria.written_proof %}
-                         <small class="form-text text-muted">
-                             <strong>Pièce justificative :</strong>
-                             <i>{{ criteria.written_proof }}</i>
-                         </small>
-                     {% endif %}
-                     {% if criteria.written_proof_validity %}
-                         <small class="form-text text-muted">
+                    {% if criteria.written_proof %}
+                        <small class="form-text text-muted">
+                            <strong>Pièce justificative :</strong>
+                            <i>{{ criteria.written_proof }}</i>
+                        </small>
+                    {% endif %}
+                    {% if criteria.written_proof_validity %}
+                        <small class="form-text text-muted">
                             <strong>Durée de validité du justificatif :</strong>
-                             <i>{{ criteria.written_proof_validity }}</i>
-                         </small>
-                     {% endif %}
-                     {% if criteria.written_proof_url %}
-                         <small class="form-text text-muted">
-                             <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" title="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
-                                 {{ criteria.written_proof_url }}
-                             </a>
-                         </small>
-                     {% endif %}
+                            <i>{{ criteria.written_proof_validity }}</i>
+                        </small>
+                    {% endif %}
+                    {% if criteria.written_proof_url %}
+                        <small class="form-text text-muted">
+                            <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" title="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
+                                {{ criteria.written_proof_url }}
+                            </a>
+                        </small>
+                    {% endif %}
                 {% endwith %}
             {% endif %}
 

--- a/itou/templates/employee_record/create.html
+++ b/itou/templates/employee_record/create.html
@@ -8,47 +8,47 @@
 
 {% block content %}
 
-<div class="content-small">
+    <div class="content-small">
 
-    <h1 class="h1-hero-c1">Fiches salarié ASP</h1>
-    <h2 class="h1 text-muted">{{ job_application.job_seeker.get_full_name|title }}</h2>
+        <h1 class="h1-hero-c1">Fiches salarié ASP</h1>
+        <h2 class="h1 text-muted">{{ job_application.job_seeker.get_full_name|title }}</h2>
 
-    <div class="card bg-gray-400 p-3 mb-3">
-        <div class="card-body p-1">
-            <div class="row">
-                <div class="col-sm-9 pt-3">
-                    <div>Début du contrat : <b>{{ job_application.hiring_start_at|default_if_none:"Non renseigné" }}</b></div>
-                    <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default_if_none:"Non renseigné" }}</b></div>
-                    <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
-                </div>
-                <div class="col-sm-3 text-right">
-                    <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"></img>
+        <div class="card bg-gray-400 p-3 mb-3">
+            <div class="card-body p-1">
+                <div class="row">
+                    <div class="col-sm-9 pt-3">
+                        <div>Début du contrat : <b>{{ job_application.hiring_start_at|default_if_none:"Non renseigné" }}</b></div>
+                        <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default_if_none:"Non renseigné" }}</b></div>
+                        <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
+                    </div>
+                    <div class="col-sm-3 text-right">
+                        <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"></img>
+                    </div>
                 </div>
             </div>
         </div>
+
+        <ul class="list-unstyled multi-steps my-5">
+            {% for pstep, label in steps %}
+                <li {% if pstep == step %}class="is-active"{% endif %}>
+                    {{ label }}
+                </li>
+            {% endfor %}
+        </ul>
+
+        {% if step == 1 %}
+            {% include "employee_record/includes/create_step_1.html" %}
+        {% elif step == 2 %}
+            {% include "employee_record/includes/create_step_2.html" %}
+        {% elif step == 3 %}
+            {% include "employee_record/includes/create_step_3.html" %}
+        {% elif step == 4 %}
+            {% include "employee_record/includes/create_step_4.html" %}
+        {% elif step == 5 %}
+            {% include "employee_record/includes/create_step_5.html" %}
+        {% endif %}
+
     </div>
-
-    <ul class="list-unstyled multi-steps my-5">
-        {% for pstep, label in steps %}
-        <li {% if pstep == step %}class="is-active"{% endif %}>
-            {{ label }}
-        </li>
-        {% endfor %}
-    </ul>
-
-    {% if step == 1 %}
-        {% include "employee_record/includes/create_step_1.html" %}
-    {% elif step == 2 %}
-        {% include "employee_record/includes/create_step_2.html" %}
-    {% elif step == 3 %}
-        {% include "employee_record/includes/create_step_3.html" %}
-    {% elif step == 4 %}
-        {% include "employee_record/includes/create_step_4.html" %}
-    {% elif step == 5 %}
-        {% include "employee_record/includes/create_step_5.html" %}
-    {% endif %}
-
-</div>
 
 {% endblock %}
 

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -10,13 +10,13 @@
     {% endif %}
     <p>{{ job_seeker.post_code}} {{ job_seeker.city}}</p>
 
-    <h5 class="h4"><b>Adresse 
+    <h5 class="h4"><b>Adresse
         {% if address_updated_by_user %}
             modifiée manuellement
         {% else %}
             vérifiée automatiquement
         {% endif %}
-    :</b></h5>
+        :</b></h5>
     {% if profile.hexa_address_filled %}
         <div class="row">
             <div class="col-md-3">Numéro</div>
@@ -53,14 +53,14 @@
         </ul>
         <p>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</p>
     {% else %}
-            <p><b>L'adresse du salarié n'a pu être vérifiée automatiquement.</b></p>
-            <p>Ceci peut-être du à:
+        <p><b>L'adresse du salarié n'a pu être vérifiée automatiquement.</b></p>
+        <p>Ceci peut-être du à:
             <ul>
                 <li>une erreur temporaire de géolocalisation,</li>
                 <li>une adresse introuvable (code postal ou voie erronée).
-            </ul>
-        <p>
-        <p>Merci de bien vouloir ressaisir l'adresse du salarié dans le formulaire ci-dessous.</p>
+                </ul>
+                <p>
+                    <p>Merci de bien vouloir ressaisir l'adresse du salarié dans le formulaire ci-dessous.</p>
     {% endif %}
 </div>
 
@@ -98,17 +98,17 @@
                 {% bootstrap_field form.insee_commune_code %}
             </div>
 
-        <div class="mt-4">
-            {% buttons %}
-                <button type="submit" class="btn btn-primary">Modifier l'adresse du salarié</button>
-            {% endbuttons %}
+            <div class="mt-4">
+                {% buttons %}
+                    <button type="submit" class="btn btn-primary">Modifier l'adresse du salarié</button>
+                {% endbuttons %}
+            </div>
         </div>
-    </div>
-</form>
+    </form>
 
-<div class="mb-3">
-    <a class="btn btn btn-outline-secondary" href="{% url "employee_record_views:create" job_application.id %}">Précédent</a>
-    {% if profile.hexa_address_filled %}
-        <a class="btn btn btn-outline-primary" href="{% url "employee_record_views:create_step_3" job_application.id %}">Continuer</a>
-    {% endif %}
-</div>
+    <div class="mb-3">
+        <a class="btn btn btn-outline-secondary" href="{% url "employee_record_views:create" job_application.id %}">Précédent</a>
+        {% if profile.hexa_address_filled %}
+            <a class="btn btn btn-outline-primary" href="{% url "employee_record_views:create_step_3" job_application.id %}">Continuer</a>
+        {% endif %}
+    </div>

--- a/itou/templates/employee_record/includes/create_step_3.html
+++ b/itou/templates/employee_record/includes/create_step_3.html
@@ -4,14 +4,14 @@
 <h4 class="h3">Situation du salarié</h4>
 
 <form method="post" action="{% url "employee_record_views:create_step_3" job_application.id %}" class="js-prevent-multiple-submit">
-        
+
     {% bootstrap_form_errors form type="all" %}
 
     {% csrf_token %}
 
     {% bootstrap_field form.education_level %}
-    
-    {% if not is_registered_to_pole_emploi %} 
+
+    {% if not is_registered_to_pole_emploi %}
         <div role="button" data-toggle="collapse" data-target="#collapse_pole_emploi" aria-controls="#collapse_pole_emploi">
             {% bootstrap_field form.pole_emploi %}
         </div>
@@ -58,11 +58,11 @@
     <div id="collapse_ass_allocation" class="ml-1 pl-4 border-left border-primary collapse{% if form.ass_allocation.value %} show{% endif %}">
         {% bootstrap_field form.ass_allocation_since %}
     </div>
-    
+
     <div role="button" data-toggle="collapse" data-target="#collapse_aah_allocation" aria-controls="#collapse_aah_allocation">
         {% bootstrap_field form.aah_allocation %}
     </div>
-    
+
     <div id="collapse_aah_allocation" class="ml-1 pl-4 border-left border-primary collapse{% if form.aah_allocation.value %} show{% endif %}">
         {% bootstrap_field form.aah_allocation_since %}
     </div>

--- a/itou/templates/employee_record/includes/create_step_4.html
+++ b/itou/templates/employee_record/includes/create_step_4.html
@@ -4,11 +4,11 @@
 <h4 class="h3">Annexe financière</h4>
 
 <div class="alert alert-info">
-  Le choix d'une annexe financière est <b>optionnel</b>, et dans tous les cas, l'information n'est pas transmise à l'ASP.
+    Le choix d'une annexe financière est <b>optionnel</b>, et dans tous les cas, l'information n'est pas transmise à l'ASP.
 </div>
 
 <form method="post" action="{% url "employee_record_views:create_step_4" job_application.id %}" class="js-prevent-multiple-submit">
-        
+
     {% csrf_token %}
 
     {% bootstrap_form form alert_error_type="all" %}

--- a/itou/templates/employee_record/includes/create_step_5.html
+++ b/itou/templates/employee_record/includes/create_step_5.html
@@ -25,14 +25,14 @@
         {% endbuttons %}
     </form>
 
-    {% else %}
-        <div class="alert alert-success">
-            <p><b>La création de cette fiche salariée est terminée.</b></p>
-            <p>Vous pouvez suivre l'avancement de son traitement par l'ASP via la liste récapitulative accessible depuis le tableau de bord.</p>
-        </div>
-        <div class="mb-3">
-            <a href="{% url "employee_record_views:list" %}?status=NEW" class="btn btn-primary">
-                Retour à la liste des fiches salarié
-            </a>
-        </div>
-    {% endif %}
+{% else %}
+    <div class="alert alert-success">
+        <p><b>La création de cette fiche salariée est terminée.</b></p>
+        <p>Vous pouvez suivre l'avancement de son traitement par l'ASP via la liste récapitulative accessible depuis le tableau de bord.</p>
+    </div>
+    <div class="mb-3">
+        <a href="{% url "employee_record_views:list" %}?status=NEW" class="btn btn-primary">
+            Retour à la liste des fiches salarié
+        </a>
+    </div>
+{% endif %}

--- a/itou/templates/employee_record/includes/employee_record_summary.html
+++ b/itou/templates/employee_record/includes/employee_record_summary.html
@@ -5,7 +5,7 @@
 
         <div class="py-2">
             <div>
-                {{ employee.get_title_display }} {{ employee.get_full_name }} 
+                {{ employee.get_title_display }} {{ employee.get_full_name }}
             </div>
             <div>
                 Né(e) le : {{ employee.birthdate }}
@@ -16,7 +16,7 @@
                 {% endif %}
             </div>
             <div>
-                Pays de naissance : {{ employee.birth_country }} 
+                Pays de naissance : {{ employee.birth_country }}
             </div>
         </div>
 
@@ -39,16 +39,16 @@
 
             {% if profile.resourceless %}
                 <div>Le salarié ne dispose d'aucune ressource</div>
-            {% endif %} 
+            {% endif %}
 
             {% if profile.unemployed_since %}
-            <div>Salarié sans emploi depuis {{ profile.get_unemployed_since_display|lower }}</div>
-            {% endif %} 
+                <div>Salarié sans emploi depuis {{ profile.get_unemployed_since_display|lower }}</div>
+            {% endif %}
 
             {% if profile.oeth_employee %}
                 <div>Employé OETH</div>
             {% endif %}
-            
+
             {% if profile.rqth_employee %}
                 <div>Employé RQTH</div>
             {% endif %}
@@ -58,7 +58,7 @@
                     {{ profile.get_has_rsa_allocation_display }} (depuis {{ profile.get_rsa_allocation_since_display|lower }})
                 </div>
             {% endif %}
-            
+
             {% if profile.ass_allocation_since %}
                 <div>
                     Bénéficiaire de l'ASS depuis (depuis {{ profile.get_ass_allocation_since_display|lower }})
@@ -75,11 +75,11 @@
 
         <h5 class="h4">Annexe financière </h5>
 
-        <div>    
+        <div>
             {% if employee_record.financial_annex %}
-              {{ employee_record.financial_annex.number }} ({{ employee_record.financial_annex.get_state_display|lower }})
+                {{ employee_record.financial_annex.number }} ({{ employee_record.financial_annex.get_state_display|lower }})
             {% else %}
-              Aucune annexe financière n'a été selectionnée.
+                Aucune annexe financière n'a été selectionnée.
             {% endif %}
         </div>
 

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -34,7 +34,7 @@
                 <p><b>Informations sur l'erreur de traitement :</b></p>
                 <p>Erreur {{ employee_record.asp_processing_code }} : <small>{{ employee_record.asp_processing_label }}</small></p>
                 <p>Référence fichier ASP : <small>{{ employee_record.asp_batch_file }} (ligne {{ employee_record.asp_batch_line_number }})</small></p>
-              </div>
+            </div>
         {% endif %}
 
         {# Actions #}

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -9,113 +9,113 @@
 {% block script %}
     {{ block.super }}
     <script>
-    $("#status-filter-form-group :input").change(function() {
-        $("#status-filter-form").submit();
-    });
+        $("#status-filter-form-group :input").change(function() {
+            $("#status-filter-form").submit();
+        });
     </script>
 {% endblock %}
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Fiches salarié ASP - <span class="text-muted">{{ current_siae.display_name }}</span></h1>
+    <h1 class="h1-hero-c1">Fiches salarié ASP - <span class="text-muted">{{ current_siae.display_name }}</span></h1>
 
-<div class="mt-3">
-    <form method="get" class="form" id="status-filter-form">
-        <div class="row">
-            <div class="col-sm-3">
-                <div class="card-deck">
-                    <div class="card">
-                        <div class="card-header">
-                            <b>Filtrer les fiches</b>
-                        </div>
-                        <div class="card-body">
-                            <p class="text-muted"><b>Par statut</b></p>
-                            <div class="container form-group m-0" id="status-filter-form-group">
-                            {% for status, badge in form.status|zip:badges %}
-                                {% if badge.0 != 0 %}
-                                    <div class="row">
-                                        <div class="col-10 p-0">
-                                            {{ status }}
-                                        </div>
-                                        <div class="col-2 p-0 text-right ">
-                                            <small>
-                                                <span class="badge badge-{{ badge.1 }}">{{ badge.0 }}</span>
-                                            </small>
-                                        </div>
-                                    </div>
-                                {% endif %}
-                            {% endfor %}
+    <div class="mt-3">
+        <form method="get" class="form" id="status-filter-form">
+            <div class="row">
+                <div class="col-sm-3">
+                    <div class="card-deck">
+                        <div class="card">
+                            <div class="card-header">
+                                <b>Filtrer les fiches</b>
+                            </div>
+                            <div class="card-body">
+                                <p class="text-muted"><b>Par statut</b></p>
+                                <div class="container form-group m-0" id="status-filter-form-group">
+                                    {% for status, badge in form.status|zip:badges %}
+                                        {% if badge.0 != 0 %}
+                                            <div class="row">
+                                                <div class="col-10 p-0">
+                                                    {{ status }}
+                                                </div>
+                                                <div class="col-2 p-0 text-right ">
+                                                    <small>
+                                                        <span class="badge badge-{{ badge.1 }}">{{ badge.0 }}</span>
+                                                    </small>
+                                                </div>
+                                            </div>
+                                        {% endif %}
+                                    {% endfor %}
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-    </form>
+            </form>
 
-    <div class="col-sm-9">
-        <div class="container rounded bg-gray-400 p-3 mb-3">
-            <div class="row">
-                <div class="col-sm-10">
-                    <h5>Nous transférons vos fiches salarié à l'ASP afin de vous faire gagner du temps</h5>
-                    <p class="mt-3">
-                    Une fois envoyées et validées, vous retrouverez directement vos données sur l'extranet de l'ASP.
-                    </p>
-                    <ul>
-                        <li>Ne sont présentes dans cette liste que les candidatures acceptées (embauches) à partir du <b>{{ feature_availability_date|date }}</b>.</li>
-                        <li>Vous devez avoir une annexe financière valide dans l'extranet de l'ASP pour pouvoir déclarer une fiche salarié dans les emplois.</li>
-                    </ul>
+            <div class="col-sm-9">
+                <div class="container rounded bg-gray-400 p-3 mb-3">
+                    <div class="row">
+                        <div class="col-sm-10">
+                            <h5>Nous transférons vos fiches salarié à l'ASP afin de vous faire gagner du temps</h5>
+                            <p class="mt-3">
+                                Une fois envoyées et validées, vous retrouverez directement vos données sur l'extranet de l'ASP.
+                            </p>
+                            <ul>
+                                <li>Ne sont présentes dans cette liste que les candidatures acceptées (embauches) à partir du <b>{{ feature_availability_date|date }}</b>.</li>
+                                <li>Vous devez avoir une annexe financière valide dans l'extranet de l'ASP pour pouvoir déclarer une fiche salarié dans les emplois.</li>
+                            </ul>
+                        </div>
+                        <div class="col-sm-2 text-right">
+                            <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP" class="img-fluid"></img>
+                        </div>
+                    </div>
                 </div>
-                <div class="col-sm-2 text-right">
-                    <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP" class="img-fluid"></img>
+
+                {# Messages #}
+                <div class="alert alert-info mb-4">
+                    {% if form.status.value == "NEW" %}
+                        Vous trouverez ici les candidatures validées à partir desquelles vous devez créér de nouvelles fiches salarié.
+                    {% elif form.status.value == "READY" %}
+                        <p>Vous trouverez ici les fiches salarié complétées et en attente d'envoi à l'ASP.</p>
+                        <p>À ce stade, seule la visualisation des informations de la fiche est possible.</p>
+                    {% elif form.status.value == "SENT" %}
+                        <p>Vous trouverez ici les fiches salarié complétées et envoyées à l'ASP.</p>
+                        <p>À ce stade, et en attendant un retour de l'ASP, seule la visualisation des informations de la fiche est possible.</p>
+                    {% elif form.status.value == "REJECTED" %}
+                        <p>Vous trouverez ici les fiches salarié envoyées à l'ASP et retournées avec une erreur.</p>
+                        <p>Vous pouvez modifier les fiches en erreur et les envoyer à nouveau.</p>
+                    {% elif form.status.value == "PROCESSED" %}
+                        <p>Vous trouverez ici les fiches salarié envoyées et validées par l'ASP.</p>
+                        <p>Aucune action ultérieure n'est possible à ce stade, mais vous pouvez consulter le détail de la fiche salarié.</p>
+                    {% endif%}
                 </div>
+
+                {# "Real" employee records objects #}
+                <div class="employee-records-list">
+                    {% if employee_records_list %}
+                        {% for employee_record in navigation_pages %}
+                            {% with item=employee_record.job_application %}
+                                {% include "employee_record/includes/list_item.html" %}
+                            {% endwith %}
+                        {% endfor %}
+                        {# New employee records i.e. job applications #}
+                    {% else %}
+                        {% for item in navigation_pages %}
+                            {% include "employee_record/includes/list_item.html" %}
+                        {% endfor %}
+                    {% endif %}
+                </div>
+
+                {% if not navigation_pages %}
+                    <div class="text-muted text-center">
+                        {% include "includes/icon.html" with icon="slash" %}
+                        <span>Aucune fiche salarié avec le statut selectionné ...</span>
+                    </div>
+                {% endif %}
+
+                {% include "includes/pagination.html" with page=navigation_pages %}
+
             </div>
         </div>
-
-        {# Messages #}
-        <div class="alert alert-info mb-4">
-            {% if form.status.value == "NEW" %}
-                Vous trouverez ici les candidatures validées à partir desquelles vous devez créér de nouvelles fiches salarié.
-            {% elif form.status.value == "READY" %}
-                <p>Vous trouverez ici les fiches salarié complétées et en attente d'envoi à l'ASP.</p>
-                <p>À ce stade, seule la visualisation des informations de la fiche est possible.</p>
-            {% elif form.status.value == "SENT" %}
-                <p>Vous trouverez ici les fiches salarié complétées et envoyées à l'ASP.</p>
-                <p>À ce stade, et en attendant un retour de l'ASP, seule la visualisation des informations de la fiche est possible.</p>
-            {% elif form.status.value == "REJECTED" %}
-                <p>Vous trouverez ici les fiches salarié envoyées à l'ASP et retournées avec une erreur.</p>
-                <p>Vous pouvez modifier les fiches en erreur et les envoyer à nouveau.</p>
-            {% elif form.status.value == "PROCESSED" %}
-                <p>Vous trouverez ici les fiches salarié envoyées et validées par l'ASP.</p>
-                <p>Aucune action ultérieure n'est possible à ce stade, mais vous pouvez consulter le détail de la fiche salarié.</p>
-            {% endif%}
-        </div>
-
-        {# "Real" employee records objects #}
-        <div class="employee-records-list">
-            {% if employee_records_list %}
-                {% for employee_record in navigation_pages %}
-                    {% with item=employee_record.job_application %}
-                        {% include "employee_record/includes/list_item.html" %}
-                    {% endwith %}
-                {% endfor %}
-            {# New employee records i.e. job applications #}
-            {% else %}
-                {% for item in navigation_pages %}
-                    {% include "employee_record/includes/list_item.html" %}
-                {% endfor %}
-            {% endif %}
-        </div>
-
-        {% if not navigation_pages %}
-            <div class="text-muted text-center">
-                {% include "includes/icon.html" with icon="slash" %}
-                <span>Aucune fiche salarié avec le statut selectionné ...</span>
-            </div>
-        {% endif %}
-
-        {% include "includes/pagination.html" with page=navigation_pages %}
-
-    </div>
-</div>
 
 {% endblock %}

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -7,35 +7,35 @@
 
 {% block content %}
 
-<div class="content-small mb-3">
-    <h1 class="h1-hero-c1">Détail fiche salarié ASP</h1>
-    <h2 class="h1 text-muted">{{ employee_record.job_seeker.get_full_name|title }}</h2>
+    <div class="content-small mb-3">
+        <h1 class="h1-hero-c1">Détail fiche salarié ASP</h1>
+        <h2 class="h1 text-muted">{{ employee_record.job_seeker.get_full_name|title }}</h2>
 
-    <div class="card bg-gray-400 p-3 mb-3">
-        <div class="card-body p-1">
-            <div class="row">
-                <div class="col-sm-9 pt-3">
-                    {% with job_application=employee_record.job_application %}
-                        <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
-                        <div>Fin du contrat : <b>{{ job_application.hiring_end_at }}</b></div>
-                        <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
-                    {% endwith %}
-                <div>
-                    <b>{{ employee_record.get_status_display }}</b> le {{ employee_record.updated_at }}
-                </div>
-                </div>
-                <div class="col-sm-3 text-right">
-                    <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"></img>
+        <div class="card bg-gray-400 p-3 mb-3">
+            <div class="card-body p-1">
+                <div class="row">
+                    <div class="col-sm-9 pt-3">
+                        {% with job_application=employee_record.job_application %}
+                            <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
+                            <div>Fin du contrat : <b>{{ job_application.hiring_end_at }}</b></div>
+                            <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
+                        {% endwith %}
+                        <div>
+                            <b>{{ employee_record.get_status_display }}</b> le {{ employee_record.updated_at }}
+                        </div>
+                    </div>
+                    <div class="col-sm-3 text-right">
+                        <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"></img>
+                    </div>
                 </div>
             </div>
         </div>
+
+        {% include "employee_record/includes/employee_record_summary.html" %}
+
+        <a href="{% url "employee_record_views:list" %}?status={{ status }}" class="btn btn-primary">Retour à la liste</a>
+
     </div>
-
-    {% include "employee_record/includes/employee_record_summary.html" %}
-
-    <a href="{% url "employee_record_views:list" %}?status={{ status }}" class="btn btn-primary">Retour à la liste</a>
-
-</div>
 
 
 {% endblock %}

--- a/itou/templates/home/home.html
+++ b/itou/templates/home/home.html
@@ -31,7 +31,7 @@
                         <div class="card-body">
                             <h5 class="h4 card-title font-weight-light">
                                 Discutez entre professionnels sur La communauté de l'inclusion
-                           </h5>
+                            </h5>
                         </div>
                         <div class="card-footer">
                             <a class="btn btn-primary stretched-link" href="{{ ITOU_COMMUNITY_URL }}">

--- a/itou/templates/includes/deactivate_member.html
+++ b/itou/templates/includes/deactivate_member.html
@@ -2,7 +2,7 @@
     <h1 class="h1-hero-c1">Retrait d'un collaborateur</h1>
     <div class="mt-4 alert alert-warning">
         Vous allez retirer <b>{{ target_member.get_full_name }}</b>
-         de votre organisation <b>({{ structure.display_name }})</b>.
+        de votre organisation <b>({{ structure.display_name }})</b>.
     </div>
 
     <ul>

--- a/itou/templates/includes/members.html
+++ b/itou/templates/includes/members.html
@@ -9,52 +9,52 @@
                 <th scope="col">Email</th>
                 <th scope="col">Date d'inscription</th>
                 {% if user in active_admin_members %}
-                <th scope="col">Action</th>
+                    <th scope="col">Action</th>
                 {% endif %}
             </tr>
         </thead>
         <tbody>
             {% for member in members %}
-            <tr>
-                <th scope="row">{{ forloop.counter }}</th>
-                <td>
-                    {{ member.user.get_full_name }}
-                    {% if member.user in active_admin_members %}
-                        <small>
-                            <span class="badge badge-info" data-toggle="tooltip" title="Administrateur de la structure">
-                                admin
-                            </span>
-                        </small>
+                <tr>
+                    <th scope="row">{{ forloop.counter }}</th>
+                    <td>
+                        {{ member.user.get_full_name }}
+                        {% if member.user in active_admin_members %}
+                            <small>
+                                <span class="badge badge-info" data-toggle="tooltip" title="Administrateur de la structure">
+                                    admin
+                                </span>
+                            </small>
+                        {% endif %}
+                    </td>
+                    <td><a href="mailto:{{ member.user.email }}">{{ member.user.email }}</a></td>
+                    <td>{{ member.joined_at|date:"d F Y à H:i" }}</td>
+                    {% if user in active_admin_members %}
+                        <td>
+                            <div>
+                                {% if member.user != user %}
+                                    <a href="{% url base_url|add:":deactivate_member" member.user.pk %}" role="button">
+                                        Retirer de la structure
+                                    </a>
+                                    <br>
+                                    {% if not member.user in active_admin_members %}
+                                        <a href="{% url base_url|add:":update_admin_role" "add" member.user.pk %}" role="button">
+                                            Ajouter en tant qu'administrateur
+                                        </a>
+                                    {% else %}
+                                        <a href="{% url base_url|add:":update_admin_role" "remove" member.user.pk %}" role="button">
+                                            Retirer les droits d'administrateur
+                                        </a>
+                                    {% endif %}
+                                {% else %}
+                                    <div class="text-center">
+                                        {% include "includes/icon.html" with icon="slash" %}
+                                    </div>
+                                {% endif %}
+                            </div>
+                        </td>
                     {% endif %}
-                </td>
-                <td><a href="mailto:{{ member.user.email }}">{{ member.user.email }}</a></td>
-                <td>{{ member.joined_at|date:"d F Y à H:i" }}</td>
-                {% if user in active_admin_members %}
-                <td>
-                    <div>
-                        {% if member.user != user %}
-                        <a href="{% url base_url|add:":deactivate_member" member.user.pk %}" role="button">
-                            Retirer de la structure
-                        </a>
-                        <br>
-                        {% if not member.user in active_admin_members %}
-                        <a href="{% url base_url|add:":update_admin_role" "add" member.user.pk %}" role="button">
-                            Ajouter en tant qu'administrateur
-                        </a>
-                        {% else %}
-                        <a href="{% url base_url|add:":update_admin_role" "remove" member.user.pk %}" role="button">
-                            Retirer les droits d'administrateur
-                        </a>
-                        {% endif %}
-                        {% else %}
-                        <div class="text-center">
-                            {% include "includes/icon.html" with icon="slash" %}
-                        </div>
-                        {% endif %}
-                    </div>
-                </td>
-                {% endif %}
-            </tr>
+                </tr>
             {% endfor %}
         </tbody>
     </table>

--- a/itou/templates/includes/pagination.html
+++ b/itou/templates/includes/pagination.html
@@ -14,7 +14,7 @@
                 {% if page.number == 1 %}
                     <li class="page-item disabled">
                         <a class="page-link" aria-disabled="true" tabindex="-1" href="{% url_add_query url page=1 %}">Premier</a>
-                    </li>                    
+                    </li>
                 {% else %}
                     <li class="page-item">
                         <a class="page-link" href="{% url_add_query url page=1 %}">Premier</a>
@@ -26,7 +26,7 @@
                     {% if page.number == i %}
                         <li class="page-item active">
                             <a class="page-link" aria-label="Page {{ i }}" aria-current="page" href="{% url_add_query url page=i %}">{{ i }}</a>
-                        </li>                        
+                        </li>
                     {% else %}
                         <li class="page-item">
                             <a class="page-link" aria-label="Page {{ i }}" href="{% url_add_query url page=i %}">{{ i }}</a>

--- a/itou/templates/includes/test_accounts.html
+++ b/itou/templates/includes/test_accounts.html
@@ -4,121 +4,121 @@
 
 {% if SHOW_TEST_ACCOUNTS_BANNER %}
 
-<!-- Before you change the z-index, check if the BETA banner and a carousel are not overlaying. -->
-<div class="sticky-top shadow bg-danger text-white text-center layout" style="z-index:2;">
-    <div class="layout-content py-0">
-        <div class="d-flex align-items-center text-center p-1">
-            <h4 class="h3 font-weight-bold flex-grow-1 mb-0 text-white h1">{{ ITOU_ENVIRONMENT }}</h4>
-            {% if not user.is_authenticated %}
-                <div>
-                    <button class="btn btn-sm btn-light border" data-toggle="modal" data-target="#testAccountsModal">
-                        Voir les comptes de démonstration
+    <!-- Before you change the z-index, check if the BETA banner and a carousel are not overlaying. -->
+    <div class="sticky-top shadow bg-danger text-white text-center layout" style="z-index:2;">
+        <div class="layout-content py-0">
+            <div class="d-flex align-items-center text-center p-1">
+                <h4 class="h3 font-weight-bold flex-grow-1 mb-0 text-white h1">{{ ITOU_ENVIRONMENT }}</h4>
+                {% if not user.is_authenticated %}
+                    <div>
+                        <button class="btn btn-sm btn-light border" data-toggle="modal" data-target="#testAccountsModal">
+                            Voir les comptes de démonstration
+                        </button>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="testAccountsModal" tabindex=-1 role="dialog" aria-modal="true" aria-labelledby="testAccountsModalTitle">
+        <div class="modal-dialog modal-xl" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3 class="modal-title" id="testAccountsModalTitle">Comptes de démonstration</h3>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
+                        <i class="ri-close-line"></i>
                     </button>
                 </div>
-            {% endif %}
-        </div>
-    </div>
-</div>
+                <div class="modal-body">
 
-<div class="modal fade" id="testAccountsModal" tabindex=-1 role="dialog" aria-modal="true" aria-labelledby="testAccountsModalTitle">
-    <div class="modal-dialog modal-xl" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title" id="testAccountsModalTitle">Comptes de démonstration</h3>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
-                    <i class="ri-close-line"></i>
-                </button>                
-            </div>
-            <div class="modal-body">
+                    <p class="alert alert-danger">
+                        L'environnement de démonstration des <b>emplois de l'inclusion</b> est limité à des fins de formation.<br>
+                        Les données, documents et e-mails envoyés depuis cet environnement n'ont <b>aucune valeur</b>.
+                        Ils sont susceptibles d'être <b>détruits à intervalle régulier</b>.
+                    </p>
 
-                <p class="alert alert-danger">
-                    L'environnement de démonstration des <b>emplois de l'inclusion</b> est limité à des fins de formation.<br>
-                    Les données, documents et e-mails envoyés depuis cet environnement n'ont <b>aucune valeur</b>.
-                    Ils sont susceptibles d'être <b>détruits à intervalle régulier</b>.
-                </p>
+                    <div class="pt-2 pb-5">
+                        <h4 class="h3 text-center pb-3">Employeurs</h4>
+                        <div class="card-deck">
+                            {% employers_accounts_tag as employers_accounts %}
+                            {% for account in employers_accounts %}
+                                <div class="card">
+                                    <div class="card-body mb-auto py-0">
+                                        <img src="{% static '/img/test_accounts/' %}{{ account.image }}" class="card-img-top p-2" style="min-height:11rem;" alt="">
+                                        <h5 class="h5 card-title font-weight-bold text-center">{{ account.title }}</h5>
+                                    </div>
+                                    <div class="p-3 text-center">
+                                        <p class="card-text">{{ account.description }}</p>
+                                        <p class="m-auto card-text">{% include "includes/icon.html" with icon="map" title=title class="mr-1"%}{{ account.location }}</p>
+                                    </div>
+                                    <div class="card-footer text-center">
+                                        <a href="#" class="postLogin btn btn-link" data-email="{{ account.email }}" data-type="siae_staff">
+                                            Utiliser ce compte
+                                        </a>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
 
-                <div class="pt-2 pb-5">
-                    <h4 class="h3 text-center pb-3">Employeurs</h4>
-                    <div class="card-deck">
-                        {% employers_accounts_tag as employers_accounts %}
-                        {% for account in employers_accounts %}
-                            <div class="card">
-                                <div class="card-body mb-auto py-0">
+                    <div class="pb-5">
+                        <h4 class="h3 text-center pb-3">Prescripteurs</h4>
+                        <div class="card-deck">
+                            {% prescribers_accounts_tag as prescribers_accounts %}
+                            {% for account in prescribers_accounts %}
+                                <div class="card">
                                     <img src="{% static '/img/test_accounts/' %}{{ account.image }}" class="card-img-top p-2" style="min-height:11rem;" alt="">
-                                    <h5 class="h5 card-title font-weight-bold text-center">{{ account.title }}</h5>
+                                    <div class="card-body">
+                                        <h5 class="h5 card-title h6 font-weight-bold text-center">{{ account.title|safe }}</h5>
+                                        <p class="card-text">{{ account.description }}</p>
+                                    </div>
+                                    <div class="card-footer text-center">
+                                        <a href="#" class="postLogin btn btn-link" data-email="{{ account.email }}" data-type="prescriber">
+                                            Utiliser ce compte
+                                        </a>
+                                    </div>
                                 </div>
-                                <div class="p-3 text-center">
-                                    <p class="card-text">{{ account.description }}</p>
-                                    <p class="m-auto card-text">{% include "includes/icon.html" with icon="map" title=title class="mr-1"%}{{ account.location }}</p>
-                                </div>
-                                <div class="card-footer text-center">
-                                    <a href="#" class="postLogin btn btn-link" data-email="{{ account.email }}" data-type="siae_staff">
-                                        Utiliser ce compte
-                                    </a>
-                                </div>
-                            </div>
-                        {% endfor %}
+                            {% endfor %}
+                        </div>
                     </div>
+
+                    <div class="pb-5">
+                        <h4 class="h3 text-center pb-3">Candidat</h4>
+                        <div class="card-deck w-sm-33 m-auto">
+                            {% job_seekers_accounts_tag as job_seekers_accounts %}
+                            {% for account in job_seekers_accounts %}
+                                <div class="card">
+                                    <img src="{% static '/img/test_accounts/' %}{{ account.image }}" class="card-img-top p-2" style="min-height:10rem;" alt="">
+                                    <div class="card-body">
+                                        <h5 class="h5 card-title font-weight-bold text-center mb-0">{{ account.title }}</h5>
+                                        <p class="card-text">{{ account.description }}</p>
+                                    </div>
+                                    <div class="card-footer text-center">
+                                        <a href="#" class="postLogin btn btn-link" data-email="{{ account.email }}" data-type="job_seeker">
+                                            Utiliser ce compte
+                                        </a>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-sm btn-primary" data-dismiss="modal">Fermer</button>
                 </div>
 
-                <div class="pb-5">
-                    <h4 class="h3 text-center pb-3">Prescripteurs</h4>
-                    <div class="card-deck">
-                        {% prescribers_accounts_tag as prescribers_accounts %}
-                        {% for account in prescribers_accounts %}
-                            <div class="card">
-                                <img src="{% static '/img/test_accounts/' %}{{ account.image }}" class="card-img-top p-2" style="min-height:11rem;" alt="">
-                                <div class="card-body">
-                                    <h5 class="h5 card-title h6 font-weight-bold text-center">{{ account.title|safe }}</h5>
-                                    <p class="card-text">{{ account.description }}</p>
-                                </div>
-                                <div class="card-footer text-center">
-                                    <a href="#" class="postLogin btn btn-link" data-email="{{ account.email }}" data-type="prescriber">
-                                        Utiliser ce compte
-                                    </a>
-                                </div>
-                            </div>
-                        {% endfor %}
-                    </div>
+                <div class="d-none">
+                    <form id="testAccountsForm" method="post" action="{% url 'account_login' %}">
+                        {% csrf_token %}
+                        <input type="email" name="login">
+                        <input type="password" name="password">
+                        <input type="hidden" name="account_type">
+                    </form>
                 </div>
-
-                <div class="pb-5">
-                    <h4 class="h3 text-center pb-3">Candidat</h4>
-                    <div class="card-deck w-sm-33 m-auto">
-                        {% job_seekers_accounts_tag as job_seekers_accounts %}
-                        {% for account in job_seekers_accounts %}
-                            <div class="card">
-                                <img src="{% static '/img/test_accounts/' %}{{ account.image }}" class="card-img-top p-2" style="min-height:10rem;" alt="">
-                                <div class="card-body">
-                                    <h5 class="h5 card-title font-weight-bold text-center mb-0">{{ account.title }}</h5>
-                                    <p class="card-text">{{ account.description }}</p>
-                                </div>
-                                <div class="card-footer text-center">
-                                    <a href="#" class="postLogin btn btn-link" data-email="{{ account.email }}" data-type="job_seeker">
-                                        Utiliser ce compte
-                                    </a>
-                                </div>
-                            </div>
-                        {% endfor %}
-                    </div>
-                </div>
-
             </div>
-            <div class="modal-footer">
-                <button class="btn btn-sm btn-primary" data-dismiss="modal">Fermer</button>
-            </div>
-
-            <div class="d-none">
-                <form id="testAccountsForm" method="post" action="{% url 'account_login' %}">
-                    {% csrf_token %}
-                    <input type="email" name="login">
-                    <input type="password" name="password">
-                    <input type="hidden" name="account_type">
-                </form>
-            </div>            
         </div>
     </div>
-</div>
 
 
 {% endif %}

--- a/itou/templates/institutions/deactivate_member.html
+++ b/itou/templates/institutions/deactivate_member.html
@@ -4,6 +4,6 @@
 
 {% block content %}
     {% with base_url="institutions_views" %}
-        {% include "includes/deactivate_member.html" %}    
+        {% include "includes/deactivate_member.html" %}
     {% endwith %}
 {% endblock %}

--- a/itou/templates/institutions/members.html
+++ b/itou/templates/institutions/members.html
@@ -4,26 +4,26 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Collaborateurs</h1>
+    <h1 class="h1-hero-c1">Collaborateurs</h1>
 
-<h2 class="h1 text-muted">
-    {{ institution.display_name }}
-</h2>
+    <h2 class="h1 text-muted">
+        {{ institution.display_name }}
+    </h2>
 
-<div class="alert alert-info">
-    Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
-</div>
+    <div class="alert alert-info">
+        Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+    </div>
 
-{% with active_admin_members=institution.active_admin_members base_url="institutions_views" %}
-    {% include "includes/members.html" %}
-{% endwith %}
+    {% with active_admin_members=institution.active_admin_members base_url="institutions_views" %}
+        {% include "includes/members.html" %}
+    {% endwith %}
 
-<a href="{% url 'invitations_views:invite_labor_inspector' %}" class="align-self-center">
-    <span class="btn btn-primary mb-1 w-100 w-sm-auto mt-2">Inviter des collaborateurs</span>
-</a>
+    <a href="{% url 'invitations_views:invite_labor_inspector' %}" class="align-self-center">
+        <span class="btn btn-primary mb-1 w-100 w-sm-auto mt-2">Inviter des collaborateurs</span>
+    </a>
 
-{% if pending_invitations %}
-    {% include "invitations_views/includes/pending_invitations.html" %}
-{% endif %}
+    {% if pending_invitations %}
+        {% include "invitations_views/includes/pending_invitations.html" %}
+    {% endif %}
 
 {% endblock %}

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -40,25 +40,25 @@
         <h1 class="h1-hero-c1 mt-5">Invitations en attente</h1>
         <div class="table-responsive">
             <table class="table table-striped">
-              <caption>Liste des invitations en attente</caption>
-              <thead>
-                <tr>
-                  <th scope="col">Prénom</th>
-                  <th scope="col">Nom</th>
-                  <th scope="col">E-mail</th>
-                  <th scope="col">Envoyée le</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for invitation in pending_invitations %}
+                <caption>Liste des invitations en attente</caption>
+                <thead>
                     <tr>
-                      <td>{{ invitation.first_name }}</td>
-                      <td>{{ invitation.last_name }}</td>
-                      <td>{{ invitation.email }}</td>
-                      <td>{{ invitation.sent_at|date }}</td>
+                        <th scope="col">Prénom</th>
+                        <th scope="col">Nom</th>
+                        <th scope="col">E-mail</th>
+                        <th scope="col">Envoyée le</th>
                     </tr>
-                {% endfor %}
-              </tbody>
+                </thead>
+                <tbody>
+                    {% for invitation in pending_invitations %}
+                        <tr>
+                            <td>{{ invitation.first_name }}</td>
+                            <td>{{ invitation.last_name }}</td>
+                            <td>{{ invitation.email }}</td>
+                            <td>{{ invitation.sent_at|date }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
             </table>
         </div>
     {% endif %}

--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -14,34 +14,34 @@
                 </tr>
             </thead>
             <tbody>
-            {% for invitation in pending_invitations %}
-                <tr>
-                    <th scope="row">{{ forloop.counter }}</th>
-                    <td>{{ invitation.first_name }} {{ invitation.last_name }}</td>
-                    <td><a href="mailto:{{ invitation.email }}">{{ invitation.email }}</a></td>
-                    <td>{{ invitation.sent_at|date:"d F Y à H:i" }}</td>
-                    <td>
-                        <p>
-                            <a data-toggle="collapse" href="#share-invitation-link-{{ forloop.counter }}" role="button" aria-expanded="false">
-                                Afficher le lien
-                            </a>
-                        </p>
-                        <div class="collapse form-group" id="share-invitation-link-{{ forloop.counter }}">
+                {% for invitation in pending_invitations %}
+                    <tr>
+                        <th scope="row">{{ forloop.counter }}</th>
+                        <td>{{ invitation.first_name }} {{ invitation.last_name }}</td>
+                        <td><a href="mailto:{{ invitation.email }}">{{ invitation.email }}</a></td>
+                        <td>{{ invitation.sent_at|date:"d F Y à H:i" }}</td>
+                        <td>
                             <p>
-                                Copiez-collez le lien ci-dessous :
+                                <a data-toggle="collapse" href="#share-invitation-link-{{ forloop.counter }}" role="button" aria-expanded="false">
+                                    Afficher le lien
+                                </a>
                             </p>
-                            {# Poor man's copy and paste with onClick #}
-                            <input type="text" class="form-control" readonly="readonly" value="{{ invitation.acceptance_link }}" onClick="this.select()">
-                        </div>
-                    </td>
-                </tr>
-            {% endfor %}
+                            <div class="collapse form-group" id="share-invitation-link-{{ forloop.counter }}">
+                                <p>
+                                    Copiez-collez le lien ci-dessous :
+                                </p>
+                                {# Poor man's copy and paste with onClick #}
+                                <input type="text" class="form-control" readonly="readonly" value="{{ invitation.acceptance_link }}" onClick="this.select()">
+                            </div>
+                        </td>
+                    </tr>
+                {% endfor %}
             </tbody>
         </table>
     </div>
     <div class="alert alert-warning">
         Chaque collaborateur invité reçoit son propre lien d'invitation, ce lien est valable 15 jours
-        (lorsque le lien expire, l'invitation n'est plus affichée ci-dessus). 
+        (lorsque le lien expire, l'invitation n'est plus affichée ci-dessus).
         Ce lien d'invitation est transmis automatiquement par e-mail.
         En cas de besoin, vous pouvez également le copier depuis la colonne « Lien d'invitation ».
     </div>

--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -2,119 +2,119 @@
 {% load theme_inclusion %}
 
 <section class="s-prefooter s-prefooter--emploi">
-  <div class="s-prefooter__container container">
-    <div class="s-prefooter__row row">
-      <div class="s-prefooter__col col-12 col-sm-auto d-flex align-items-center">
-        <div class="s-prefooter__logo">
-          <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" alt="Les emplois de l'inclusion">
+    <div class="s-prefooter__container container">
+        <div class="s-prefooter__row row">
+            <div class="s-prefooter__col col-12 col-sm-auto d-flex align-items-center">
+                <div class="s-prefooter__logo">
+                    <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" alt="Les emplois de l'inclusion">
+                </div>
+            </div>
+            <div class="s-prefooter__col col-12 col-sm d-flex align-items-center justify-content-start justify-content-sm-end justify-content-lg-start">
+                <p class="mb-0">Le site de la plateforme <br class="d-none d-xl-inline">de l'inclusion dédiée <br class="d-none d-xl-inline">aux emplois</p>
+            </div>
+            <div class="s-prefooter__col col-12 col-lg-6 d-flex align-items-center">
+                <ul class="s-prefooter__gridlist">
+                    <li>
+                        <a href="{% url 'stats:stats_public' %}">Statistiques, lexiques et indicateurs</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'releases:list' %}">Journal des modifications</a>
+                    </li>
+                    <li>
+                        <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique" rel="noopener" target="_blank" title="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">
+                            Qui peut bénéficier des contrats d'IAE ?
+                        </a>
+                        <i class="ri-external-link-line ml-1 font-weight-bold"></i>
+                    </li>
+                    <li>
+                        <a href="{{ ITOU_COMMUNITY_URL }}/c/retours-sur-le-site/2" rel="noopener" target="_blank" title="Questions à la communauté (ouverture dans un nouvel onglet)">
+                            Questions à la communauté
+                        </a>
+                        <i class="ri-external-link-line ml-1 font-weight-bold"></i>
+                    </li>
+                    <li>
+                        <a href="https://stats.uptimerobot.com/JYJ6XHq6xY" rel="noopener" target="_blank" title="Disponibilité (ouverture dans un nouvel onglet)">
+                            Disponibilité
+                        </a>
+                        <i class="ri-external-link-line ml-1 font-weight-bold"></i>
+                    </li>
+                </ul>
+            </div>
         </div>
-      </div>
-      <div class="s-prefooter__col col-12 col-sm d-flex align-items-center justify-content-start justify-content-sm-end justify-content-lg-start">
-        <p class="mb-0">Le site de la plateforme <br class="d-none d-xl-inline">de l'inclusion dédiée <br class="d-none d-xl-inline">aux emplois</p>
-      </div>
-      <div class="s-prefooter__col col-12 col-lg-6 d-flex align-items-center">
-        <ul class="s-prefooter__gridlist">
-          <li>
-              <a href="{% url 'stats:stats_public' %}">Statistiques, lexiques et indicateurs</a>
-          </li>
-          <li>
-              <a href="{% url 'releases:list' %}">Journal des modifications</a>
-          </li>
-          <li>
-              <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique" rel="noopener" target="_blank" title="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">
-                  Qui peut bénéficier des contrats d'IAE ?
-              </a>
-              <i class="ri-external-link-line ml-1 font-weight-bold"></i>
-          </li>
-          <li>
-              <a href="{{ ITOU_COMMUNITY_URL }}/c/retours-sur-le-site/2" rel="noopener" target="_blank" title="Questions à la communauté (ouverture dans un nouvel onglet)">
-                  Questions à la communauté
-              </a>
-              <i class="ri-external-link-line ml-1 font-weight-bold"></i>
-          </li>
-          <li>
-              <a href="https://stats.uptimerobot.com/JYJ6XHq6xY" rel="noopener" target="_blank" title="Disponibilité (ouverture dans un nouvel onglet)">
-                  Disponibilité
-              </a>
-              <i class="ri-external-link-line ml-1 font-weight-bold"></i>
-          </li>
-        </ul>
-      </div>
     </div>
-  </div>
 </section>
 <footer class="s-footer" role="contentinfo" id="footer">
-  <section class="s-footer-help">
-    <div class="s-footer-help__container container">
-      <div class="s-footer-help__row row">
-        <div class="s-footer-help__col col-12 col-lg">
-            <ul>
-                <li><a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" title="Besoin d'aide ? (ouverture dans un nouvel onglet)">Besoin d'aide ?</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
-                <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSebmbvb4RGJOKy-ou5zR2eHWwFOiUlSJtCv_avrpp97HI4RGQ/viewform?ts=5da5a580" rel="noopener" target="_blank" title="Inscription Newsletter (ouverture dans un nouvel onglet)">Inscription Newsletter</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
-              </ul>
+    <section class="s-footer-help">
+        <div class="s-footer-help__container container">
+            <div class="s-footer-help__row row">
+                <div class="s-footer-help__col col-12 col-lg">
+                    <ul>
+                        <li><a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" title="Besoin d'aide ? (ouverture dans un nouvel onglet)">Besoin d'aide ?</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
+                        <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSebmbvb4RGJOKy-ou5zR2eHWwFOiUlSJtCv_avrpp97HI4RGQ/viewform?ts=5da5a580" rel="noopener" target="_blank" title="Inscription Newsletter (ouverture dans un nouvel onglet)">Inscription Newsletter</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
+                    </ul>
+                </div>
+                <div class="s-footer-help__col col-12 col-lg-auto">
+                    <ul>
+                        <li><span>Nous suivre</span></li>
+                        <li><a href="https://twitter.com/inclusion_gouv" rel="noopener" target="_blank"  title="Rejoignez-nous sur Twitter (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-twitter.svg' %}" height="25" alt="Rejoignez-nous sur Twitter"></a></li>
+                        <li><a href="https://www.linkedin.com/company/inclusion-gouv/" rel="noopener" target="_blank"  title="Rejoignez-nous sur Linkedin (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-linkedin.svg' %}" height="25" alt="Rejoignez-nous sur Linkedin"></a></li>
+                        <li><a href="https://www.facebook.com/inclusion.gouv/" rel="noopener" target="_blank"  title="Rejoignez-nous sur Facebook (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-facebook.svg' %}" height="25" alt="Rejoignez-nous sur Facebook"></a></li>
+                        <li><a href="https://www.instagram.com/inclusion_gouv/" rel="noopener" target="_blank"  title="Rejoignez-nous sur Instagram (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-instagram.svg' %}" height="25" alt="Rejoignez-nous sur Instagram"></a></li>
+                        <li><a href="https://www.youtube.com/channel/UC06_yIYfzAiDOMTemH9q3OQ" rel="noopener" target="_blank"  title="Rejoignez-nous sur Youtube (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-youtube.svg' %}" height="25" alt="Rejoignez-nous sur Youtube"></a></li>
+                    </ul>
+                </div>
+            </div>
         </div>
-        <div class="s-footer-help__col col-12 col-lg-auto">
-          <ul>
-            <li><span>Nous suivre</span></li>
-            <li><a href="https://twitter.com/inclusion_gouv" rel="noopener" target="_blank"  title="Rejoignez-nous sur Twitter (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-twitter.svg' %}" height="25" alt="Rejoignez-nous sur Twitter"></a></li>
-            <li><a href="https://www.linkedin.com/company/inclusion-gouv/" rel="noopener" target="_blank"  title="Rejoignez-nous sur Linkedin (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-linkedin.svg' %}" height="25" alt="Rejoignez-nous sur Linkedin"></a></li>
-            <li><a href="https://www.facebook.com/inclusion.gouv/" rel="noopener" target="_blank"  title="Rejoignez-nous sur Facebook (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-facebook.svg' %}" height="25" alt="Rejoignez-nous sur Facebook"></a></li>
-            <li><a href="https://www.instagram.com/inclusion_gouv/" rel="noopener" target="_blank"  title="Rejoignez-nous sur Instagram (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-instagram.svg' %}" height="25" alt="Rejoignez-nous sur Instagram"></a></li>
-            <li><a href="https://www.youtube.com/channel/UC06_yIYfzAiDOMTemH9q3OQ" rel="noopener" target="_blank"  title="Rejoignez-nous sur Youtube (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-youtube.svg' %}" height="25" alt="Rejoignez-nous sur Youtube"></a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </section>
+    </section>
 
-  <section class="s-footer-nav">
-    <div class="s-footer-nav__container container">
-      <div class="s-footer-nav__row row">
-        <div class="s-footer-nav__col col-5 col-lg-2 d-flex align-items-center">
-          <div class="s-footer-nav__logo">
-            <img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française" class="img-fluid">
-          </div>
+    <section class="s-footer-nav">
+        <div class="s-footer-nav__container container">
+            <div class="s-footer-nav__row row">
+                <div class="s-footer-nav__col col-5 col-lg-2 d-flex align-items-center">
+                    <div class="s-footer-nav__logo">
+                        <img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française" class="img-fluid">
+                    </div>
+                </div>
+                <div class="s-footer-nav__col col-7 col-lg-4 d-flex align-items-center justify-content-end justify-content-lg-start">
+                    <div class="d-inline-block text-center">
+                        <span class="d-block">
+                            <a href="https://inclusion.beta.gouv.fr/" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet" >
+                                <img src="{% static_theme_images 'logo-plateforme-inclusion.svg' %}" height="60" alt="Plateforme de l'inclusion">
+                            </a>
+                        </span>
+                        <span class="d-block mt-2">
+                            <a href="https://beta.gouv.fr/" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet" >
+                                <img src="{% static_theme_images 'logo-accelere-betagouv.svg' %}" alt="Accéléré par Beta.gouv.fr">
+                            </a>
+                        </span>
+                    </div>
+                </div>
+                <div class="s-footer-nav__col col-12 col-lg-6 d-flex align-items-center">
+                    <div>
+                        <p class="mb-3">Notre mantra issu du Pacte Ambition IAE : permettre à chacun de trouver sa place. Libérons notre potentiel d'inclusion pour créer 100 000 emplois de plus.</p>
+                        <ul>
+                            <li><a href="https://emplois.inclusion.beta.gouv.fr" rel="noopener" target="_blank">Les emplois</a></li>
+                            <li><a href="https://communaute.inclusion.beta.gouv.fr" rel="noopener" target="_blank">La communauté</a></li>
+                            <li><a href="{{ ITOU_PILOTAGE_URL }}" rel="noopener" target="_blank">Le pilotage</a></li>
+                            <li><a href="https://lemarche.inclusion.beta.gouv.fr" rel="noopener" target="_blank">Le marché</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="s-footer-nav__col col-7 col-lg-4 d-flex align-items-center justify-content-end justify-content-lg-start">
-          <div class="d-inline-block text-center">
-            <span class="d-block">
-              <a href="https://inclusion.beta.gouv.fr/" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet" >
-                <img src="{% static_theme_images 'logo-plateforme-inclusion.svg' %}" height="60" alt="Plateforme de l'inclusion">
-              </a>
-            </span>
-            <span class="d-block mt-2">
-              <a href="https://beta.gouv.fr/" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet" >
-                <img src="{% static_theme_images 'logo-accelere-betagouv.svg' %}" alt="Accéléré par Beta.gouv.fr">
-              </a>
-            </span>
-          </div>
-        </div>
-        <div class="s-footer-nav__col col-12 col-lg-6 d-flex align-items-center">
-          <div>
-            <p class="mb-3">Notre mantra issu du Pacte Ambition IAE : permettre à chacun de trouver sa place. Libérons notre potentiel d'inclusion pour créer 100 000 emplois de plus.</p>
-            <ul>
-                <li><a href="https://emplois.inclusion.beta.gouv.fr" rel="noopener" target="_blank">Les emplois</a></li>
-                <li><a href="https://communaute.inclusion.beta.gouv.fr" rel="noopener" target="_blank">La communauté</a></li>
-                <li><a href="{{ ITOU_PILOTAGE_URL }}" rel="noopener" target="_blank">Le pilotage</a></li>
-                <li><a href="https://lemarche.inclusion.beta.gouv.fr" rel="noopener" target="_blank">Le marché</a></li>
-              </ul>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
+    </section>
 
-  <section class="s-footer-legal">
-    <div class="s-footer-legal__container container">
-      <div class="s-footer-legal__row row">
-        <div class="s-footer-legal__col col-12 col-lg">
-            <ul>
-                <li><a href="{{ ITOU_DOC_URL }}/mentions/" rel="noopener" target="_blank">Mentions légales</a></li>
-                <li><a href="{% url 'accessibility' %}" rel="noopener">Accessibilité : non conforme</a></li>
-              </ul>
+    <section class="s-footer-legal">
+        <div class="s-footer-legal__container container">
+            <div class="s-footer-legal__row row">
+                <div class="s-footer-legal__col col-12 col-lg">
+                    <ul>
+                        <li><a href="{{ ITOU_DOC_URL }}/mentions/" rel="noopener" target="_blank">Mentions légales</a></li>
+                        <li><a href="{% url 'accessibility' %}" rel="noopener">Accessibilité : non conforme</a></li>
+                    </ul>
+                </div>
+                <div class="s-footer-legal__col col-12 col-lg text-lg-right"><span>© République Française 2021</span></div>
+            </div>
         </div>
-        <div class="s-footer-legal__col col-12 col-lg text-lg-right"><span>© République Française 2021</span></div>
-      </div>
-    </div>
-  </section>
+    </section>
 </footer>

--- a/itou/templates/layout/_header.html
+++ b/itou/templates/layout/_header.html
@@ -2,81 +2,81 @@
 {% load theme_inclusion %}
 
 <header class="s-header s-header--emploi sticky-top" role="banner" id="header">
-  <section class="s-header__container container">
-    <div class="s-header__row row">
-      <div class="s-header__col s-header__col--logo col-auto d-flex align-items-center pr-0 pr-md-3">
-        <a href="/" class="s-header__logo-ministere"><img src="{% static_theme_images 'logo-ministere-emploi.svg' %}" alt="Ministère de l'emploi"></a>
-      </div>
-      <div class="s-header__col s-header__col--logo col-auto d-flex align-items-center px-0 px-md-3">
-        <a href="/"><img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" alt="Les emplois de l'inclusion"></a>
-      </div>
-      <div class="s-header__col s-header__col--nav col d-none d-xl-inline-flex d-xl-flex align-items-center justify-content-end">
-        <nav role="navigation" id="nav-primary" role="navigation" aria-label="Navigation principale">
-          <ul>
-            {% include 'layout/_nav_btn_items.html' %}
-          </ul>
-        </nav>
-      </div>
-      <div class="s-header__col s-header__col--burger col d-flex align-items-center justify-content-end d-xl-none" data-toggle="burger">
-        <span id="burger"><img src="{% static_theme_images "picto-burger.svg" %}" alt="Menu"></span>
-        <span id="close"><img src="{% static_theme_images "picto-close.svg" %}" alt="Fermer"></span>
-      </div>
-      <div id="burgerNav">
-        <nav role="navigation">
-          <ul>
-            <li>
-              <a href="/" class="{% if request.path == '/' %}is-active{% endif %}" rel="noopener">
-                <span>Accueil</span>
-              </a>
-            </li>
-            {% include 'layout/_nav_btn_items.html' %}
-          </ul>
-        </nav>
-      </div>
-    </div>
-  </section>
+    <section class="s-header__container container">
+        <div class="s-header__row row">
+            <div class="s-header__col s-header__col--logo col-auto d-flex align-items-center pr-0 pr-md-3">
+                <a href="/" class="s-header__logo-ministere"><img src="{% static_theme_images 'logo-ministere-emploi.svg' %}" alt="Ministère de l'emploi"></a>
+            </div>
+            <div class="s-header__col s-header__col--logo col-auto d-flex align-items-center px-0 px-md-3">
+                <a href="/"><img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" alt="Les emplois de l'inclusion"></a>
+            </div>
+            <div class="s-header__col s-header__col--nav col d-none d-xl-inline-flex d-xl-flex align-items-center justify-content-end">
+                <nav role="navigation" id="nav-primary" role="navigation" aria-label="Navigation principale">
+                    <ul>
+                        {% include 'layout/_nav_btn_items.html' %}
+                    </ul>
+                </nav>
+            </div>
+            <div class="s-header__col s-header__col--burger col d-flex align-items-center justify-content-end d-xl-none" data-toggle="burger">
+                <span id="burger"><img src="{% static_theme_images "picto-burger.svg" %}" alt="Menu"></span>
+                <span id="close"><img src="{% static_theme_images "picto-close.svg" %}" alt="Fermer"></span>
+            </div>
+            <div id="burgerNav">
+                <nav role="navigation">
+                    <ul>
+                        <li>
+                            <a href="/" class="{% if request.path == '/' %}is-active{% endif %}" rel="noopener">
+                                <span>Accueil</span>
+                            </a>
+                        </li>
+                        {% include 'layout/_nav_btn_items.html' %}
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </section>
 </header>
 <section class="s-postheader">
     <div class="container s-postheader__container">
-      <div class="row">
-        <div class="col-12 s-postheader__col s-postheader__col--nav d-flex align-items-center">
-          <nav role="navigation">
-            <ul>
-                {% if user.is_authenticated %}
-                <li>
-                    <a class="{% if request.path == '/dashboard/' %}font-weight-bold{% endif %}" href="{% url 'dashboard:index' %}">
-                        <span>Tableau de bord</span>
-                        <i class="ri-arrow-right-line ri-lg"></i>
-                    </a>
-                </li>
-                {% endif %}
-                <li>
-                    <a class="{% if request.path == '/' or '/search/employers' in request.path %}font-weight-bold{% endif %}" href="/">
-                        <span>Rechercher des employeurs</span>
-                        <i class="ri-arrow-right-line ri-lg"></i>
-                    </a>
-                </li>                
-                <li>
-                    <a class="{% if '/search/prescribers' in request.path %}font-weight-bold{% endif %}" href="{% url 'search:prescribers_home' %}">
-                        <span>Rechercher des prescripteurs</span>
-                        <i class="ri-arrow-right-line ri-lg"></i>
-                    </a>
-                </li>
-                <li>
-                    <a href="{{ ITOU_COMMUNITY_URL }}" rel="noopener" target="_blank" aria-label="Accéder à La communauté de l'inclusion (nouvel onglet)">
-                        <span>Communauté</span>
-                        <i class="ri-arrow-right-up-line ri-lg"></i>
-                    </a>
-                </li>                  
-                <li>
-                    <a href="{{ ITOU_DOC_URL }}/" rel="noopener" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)">
-                        <span>Documentation</span>
-                        <i class="ri-arrow-right-up-line ri-lg"></i>
-                    </a>
-                </li>                  
-            </ul>
-          </nav>
+        <div class="row">
+            <div class="col-12 s-postheader__col s-postheader__col--nav d-flex align-items-center">
+                <nav role="navigation">
+                    <ul>
+                        {% if user.is_authenticated %}
+                            <li>
+                                <a class="{% if request.path == '/dashboard/' %}font-weight-bold{% endif %}" href="{% url 'dashboard:index' %}">
+                                    <span>Tableau de bord</span>
+                                    <i class="ri-arrow-right-line ri-lg"></i>
+                                </a>
+                            </li>
+                        {% endif %}
+                        <li>
+                            <a class="{% if request.path == '/' or '/search/employers' in request.path %}font-weight-bold{% endif %}" href="/">
+                                <span>Rechercher des employeurs</span>
+                                <i class="ri-arrow-right-line ri-lg"></i>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="{% if '/search/prescribers' in request.path %}font-weight-bold{% endif %}" href="{% url 'search:prescribers_home' %}">
+                                <span>Rechercher des prescripteurs</span>
+                                <i class="ri-arrow-right-line ri-lg"></i>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="{{ ITOU_COMMUNITY_URL }}" rel="noopener" target="_blank" aria-label="Accéder à La communauté de l'inclusion (nouvel onglet)">
+                                <span>Communauté</span>
+                                <i class="ri-arrow-right-up-line ri-lg"></i>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="{{ ITOU_DOC_URL }}/" rel="noopener" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)">
+                                <span>Documentation</span>
+                                <i class="ri-arrow-right-up-line ri-lg"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
         </div>
-      </div>
     </div>
-  </section>
+</section>

--- a/itou/templates/layout/_nav_btn_items.html
+++ b/itou/templates/layout/_nav_btn_items.html
@@ -38,11 +38,11 @@
 
             {% if not user.is_peamu %}
                 {% if not request|user_is_france_connected %}
-                <a class="dropdown-item text-primary" href="{% url 'account_change_password' %}">
-                    Modifier mon mot de passe
-                </a>
+                    <a class="dropdown-item text-primary" href="{% url 'account_change_password' %}">
+                        Modifier mon mot de passe
+                    </a>
                 {% endif %}
-                
+
                 <a class="dropdown-item text-primary" href="{% url 'dashboard:edit_user_email' %}">
                     Modifier mon adresse e-mail
                 </a>

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -3,218 +3,218 @@
 {% load bootstrap4 %}
 <!DOCTYPE HTML>
 <html lang="fr">
-<head>
-    <meta charset="utf-8">
-    <title>{% block title %} - Les emplois de l'inclusion{% endblock %}</title>
-    {% block meta_description %}<meta name="description" content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs solidaires (structures de l'insertion par l'activité économique et du secteur adapté)">{% endblock %}
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <head>
+        <meta charset="utf-8">
+        <title>{% block title %} - Les emplois de l'inclusion{% endblock %}</title>
+        {% block meta_description %}<meta name="description" content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs solidaires (structures de l'insertion par l'activité économique et du secteur adapté)">{% endblock %}
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    {# https://metatags.io #}
-    <meta name="title" content="Les emplois de l'inclusion">
-    {# https://metatags.io Open Graph / Facebook #}
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}">
-    <meta property="og:title" content="Les emplois de l'inclusion">
-    <meta property="og:description" content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs solidaires (structures de l'insertion par l'activité économique et du secteur adapté)">
-    <meta property="og:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
-    {# https://metatags.io Twitter #}
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}/">
-    <meta property="twitter:title" content="Les emplois de l'inclusion">
-    <meta property="twitter:description" content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs solidaires (structures de l'insertion par l'activité économique et du secteur adapté)">
-    <meta property="twitter:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
+        {# https://metatags.io #}
+        <meta name="title" content="Les emplois de l'inclusion">
+        {# https://metatags.io Open Graph / Facebook #}
+        <meta property="og:type" content="website">
+        <meta property="og:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}">
+        <meta property="og:title" content="Les emplois de l'inclusion">
+        <meta property="og:description" content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs solidaires (structures de l'insertion par l'activité économique et du secteur adapté)">
+        <meta property="og:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
+        {# https://metatags.io Twitter #}
+        <meta property="twitter:card" content="summary_large_image">
+        <meta property="twitter:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}/">
+        <meta property="twitter:title" content="Les emplois de l'inclusion">
+        <meta property="twitter:description" content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs solidaires (structures de l'insertion par l'activité économique et du secteur adapté)">
+        <meta property="twitter:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
 
-    {# Use this to get the value of the CSRF token in JavaScript. #}
-    <meta name="csrf-token" content="{{ csrf_token }}">
-    <link rel="shortcut icon" href="{% static_theme_images "favico.ico" %}" type="image/ico">
-    {% import_static_CSS_theme_inclusion %}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery-ui_1.12@1.12.0/jquery-ui.min.css" integrity="sha256-NRYg+xSNb5bHzrFEddJ0wL3YDp6YNt2dGNI+T5rOb2c=" crossorigin="anonymous" type="text/css">
-    <link rel="stylesheet" href="{% static "css/itou.css" %}" type="text/css">
-    {% block extra_head %}{% endblock %}
-</head>
-<body>
-    <nav role="navigation" aria-label="Accès rapide" tabindex="1" class="sr-only">
-        <ul>
-            <li><a href="#nav-primary">Aller au menu principal</a></li>
-            <li><a href="#main">Aller au contenu principal</a></li>
-        </ul>
-    </nav>
+        {# Use this to get the value of the CSRF token in JavaScript. #}
+        <meta name="csrf-token" content="{{ csrf_token }}">
+        <link rel="shortcut icon" href="{% static_theme_images "favico.ico" %}" type="image/ico">
+        {% import_static_CSS_theme_inclusion %}
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery-ui_1.12@1.12.0/jquery-ui.min.css" integrity="sha256-NRYg+xSNb5bHzrFEddJ0wL3YDp6YNt2dGNI+T5rOb2c=" crossorigin="anonymous" type="text/css">
+        <link rel="stylesheet" href="{% static "css/itou.css" %}" type="text/css">
+        {% block extra_head %}{% endblock %}
+    </head>
+    <body>
+        <nav role="navigation" aria-label="Accès rapide" tabindex="1" class="sr-only">
+            <ul>
+                <li><a href="#nav-primary">Aller au menu principal</a></li>
+                <li><a href="#main">Aller au contenu principal</a></li>
+            </ul>
+        </nav>
 
-    {% include "includes/test_accounts.html" %}
-    {% include "layout/_header.html" %}
+        {% include "includes/test_accounts.html" %}
+        {% include "layout/_header.html" %}
 
-    <main id="main" role="main" class="s-main bg-gray-400">
+        <main id="main" role="main" class="s-main bg-gray-400">
 
-        <div class="container container-messages">
-            {% block messages %}
+            <div class="container container-messages">
+                {% block messages %}
 
-                {% bootstrap_messages %}
+                    {% bootstrap_messages %}
 
-                {# Display an alert for old browsers #}
-                <div class="alert alert-secondary alert-old-browser" role="status">
-                    La version de votre navigateur n'est plus supportée. Veuillez utiliser une version plus récente pour améliorer votre expérience sur notre site.
-                </div>
+                    {# Display an alert for old browsers #}
+                    <div class="alert alert-secondary alert-old-browser" role="status">
+                        La version de votre navigateur n'est plus supportée. Veuillez utiliser une version plus récente pour améliorer votre expérience sur notre site.
+                    </div>
 
-            {% endblock %}
+                {% endblock %}
+            </div>
+
+            {% block content_full_viewport %}{% endblock %}
+
+        </main>
+
+        {% include "layout/_footer.html" %}
+
+        <div class="sr-only">
+            <a href="#header">Retour au début de la page</a>
         </div>
 
-        {% block content_full_viewport %}{% endblock %}
+        {% import_static_JS_theme_inclusion %}
+        <script src="https://cdn.jsdelivr.net/npm/jquery-ui_1.12@1.12.0/jquery-ui.min.js" integrity="sha256-eGE6blurk5sHj+rmkfsGYeKyZx3M4bG+ZlFyA7Kns7E=" crossorigin="anonymous"></script>
+        <script>
 
-    </main>
+            // Tarteaucitron's language is set according to the browser configuration
+            // but a lot of users don't know how to change it.
+            // This can be forced only by using a global `var` statement.
+            // https://github.com/AmauriC/tarteaucitron.js/blob/98b02b0bdda670bd953752d85443c3fd77dde724/tarteaucitron.js#L5
+            var tarteaucitronForceLanguage = "fr";
 
-    {% include "layout/_footer.html" %}
+            tarteaucitron.init({
+                "hashtag": "#tarteaucitron", /* Open the panel with this hashtag */
+                "cookieName": "tarteaucitron", /* Cookie name */
+                "orientation": "top", /* Banner position (top - bottom) */
+                "groupServices": false, /* Group services by category */
+                "showAlertSmall": false, /* Show the small banner on bottom right */
+                "cookieslist": false, /* Show the cookie list */
+                "closePopup": false, /* Show a close X on the banner */
+                "showIcon": true, /* Show cookie icon to manage cookies */
+                //"iconSrc": "", /* Optionnal: URL or base64 encoded image */
+                "iconPosition": "BottomLeft", /* BottomRight, BottomLeft, TopRight and TopLeft */
+                "adblocker": false, /* Show a Warning if an adblocker is detected */
+                "DenyAllCta" : true, /* Show the deny all button */
+                "AcceptAllCta" : true, /* Show the accept all button when highPrivacy on */
+                "highPrivacy": true, /* HIGHLY RECOMMANDED Disable auto consent */
+                "handleBrowserDNTRequest": false, /* If Do Not Track == 1, disallow all */
+                "removeCredit": true, /* Remove credit link */
+                "moreInfoLink": true, /* Show more info link */
+                "useExternalCss": true, /* If false, the tarteaucitron.css file will be loaded */
+                "useExternalJs": false, /* If false, the tarteaucitron.js file will be loaded */
+                //"cookieDomain": ".my-multisite-domaine.fr", /* Shared cookie for multisite */
+                "readmoreLink": "{{ ITOU_DOC_URL }}/mentions/protection-des-donnees", /* Change the default readmore link */
+                "mandatory": true, /* Show a message about mandatory cookies */
+            });
 
-    <div class="sr-only">
-        <a href="#header">Retour au début de la page</a>
-    </div>
+            // Hotjar.
+            (tarteaucitron.job = tarteaucitron.job || []).push('hotjar');
+            {% if ITOU_ENVIRONMENT == "PROD" %}tarteaucitron.user.hotjarId = 2360441;{% endif %}
+            {% if ITOU_ENVIRONMENT == "DEMO" %}tarteaucitron.user.hotjarId = 1861487;{% endif %}
+            tarteaucitron.user.HotjarSv = 6;
 
-    {% import_static_JS_theme_inclusion %}
-    <script src="https://cdn.jsdelivr.net/npm/jquery-ui_1.12@1.12.0/jquery-ui.min.js" integrity="sha256-eGE6blurk5sHj+rmkfsGYeKyZx3M4bG+ZlFyA7Kns7E=" crossorigin="anonymous"></script>
-    <script>
+            // Matomo :
+            tarteaucitron.user.matomoId = 117;
+            tarteaucitron.user.matomoHost = "https://stats.data.gouv.fr/";
+            (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
 
-        // Tarteaucitron's language is set according to the browser configuration
-        // but a lot of users don't know how to change it.
-        // This can be forced only by using a global `var` statement.
-        // https://github.com/AmauriC/tarteaucitron.js/blob/98b02b0bdda670bd953752d85443c3fd77dde724/tarteaucitron.js#L5
-        var tarteaucitronForceLanguage = "fr";
-
-        tarteaucitron.init({
-            "hashtag": "#tarteaucitron", /* Open the panel with this hashtag */
-            "cookieName": "tarteaucitron", /* Cookie name */
-            "orientation": "top", /* Banner position (top - bottom) */
-            "groupServices": false, /* Group services by category */
-            "showAlertSmall": false, /* Show the small banner on bottom right */
-            "cookieslist": false, /* Show the cookie list */
-            "closePopup": false, /* Show a close X on the banner */
-            "showIcon": true, /* Show cookie icon to manage cookies */
-            //"iconSrc": "", /* Optionnal: URL or base64 encoded image */
-            "iconPosition": "BottomLeft", /* BottomRight, BottomLeft, TopRight and TopLeft */
-            "adblocker": false, /* Show a Warning if an adblocker is detected */
-            "DenyAllCta" : true, /* Show the deny all button */
-            "AcceptAllCta" : true, /* Show the accept all button when highPrivacy on */
-            "highPrivacy": true, /* HIGHLY RECOMMANDED Disable auto consent */
-            "handleBrowserDNTRequest": false, /* If Do Not Track == 1, disallow all */
-            "removeCredit": true, /* Remove credit link */
-            "moreInfoLink": true, /* Show more info link */
-            "useExternalCss": true, /* If false, the tarteaucitron.css file will be loaded */
-            "useExternalJs": false, /* If false, the tarteaucitron.js file will be loaded */
-            //"cookieDomain": ".my-multisite-domaine.fr", /* Shared cookie for multisite */
-            "readmoreLink": "{{ ITOU_DOC_URL }}/mentions/protection-des-donnees", /* Change the default readmore link */
-            "mandatory": true, /* Show a message about mandatory cookies */
-        });
-
-        // Hotjar.
-        (tarteaucitron.job = tarteaucitron.job || []).push('hotjar');
-        {% if ITOU_ENVIRONMENT == "PROD" %}tarteaucitron.user.hotjarId = 2360441;{% endif %}
-        {% if ITOU_ENVIRONMENT == "DEMO" %}tarteaucitron.user.hotjarId = 1861487;{% endif %}
-        tarteaucitron.user.HotjarSv = 6;
-
-        // Matomo :
-        tarteaucitron.user.matomoId = 117;
-        tarteaucitron.user.matomoHost = "https://stats.data.gouv.fr/";
-        (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
-
-        // livestorm
-        const tablet_width = 750;
-        tarteaucitron.services.livestorm = {
-            "key": "livestorm",
-            "type": "video",
-            "name": "Livestorm",
-            "uri": "https://livestorm.co/fr/politique-confidentialite",
-            "needConsent": true,
-            "cookies": [],
-            "js": function () {
-                "use strict";
-                tarteaucitron.fallback(['js-tac-livestorm'], function (x) {
-                    var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'livestorm iframe'),
+            // livestorm
+            const tablet_width = 750;
+            tarteaucitron.services.livestorm = {
+                "key": "livestorm",
+                "type": "video",
+                "name": "Livestorm",
+                "uri": "https://livestorm.co/fr/politique-confidentialite",
+                "needConsent": true,
+                "cookies": [],
+                "js": function () {
+                    "use strict";
+                    tarteaucitron.fallback(['js-tac-livestorm'], function (x) {
+                        var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'livestorm iframe'),
                         width = x.getAttribute("width"),
                         height = x.getAttribute("height"),
                         url = x.getAttribute("data-url");
 
-                    // Poor attempt to make the Livestorm iframe responsive.
-                    if (document.body.clientWidth > tablet_width) {
-                        height = "365px";
-                    }
-                    return '<iframe title="' + frame_title + '" src="' + url + '" width="' + width + '" height="' + height + '" frameborder="0" scrolling="no" allowtransparency allowfullscreen></iframe>';
-                });
-            },
-            "fallback": function () {
-                "use strict";
-                var id = 'livestorm';
-                tarteaucitron.fallback(['js-tac-livestorm'], function (elem) {
-                    elem.style.width = elem.getAttribute('width');
-                    if (document.body.clientWidth > tablet_width) {
-                        elem.style.height = "310px";
-                    } else {
-                        elem.style.height = elem.getAttribute('height');
-                    }
-                    return tarteaucitron.engage(id);
-                });
-            }
-        };
-        (tarteaucitron.job = tarteaucitron.job || []).push('livestorm');
+                        // Poor attempt to make the Livestorm iframe responsive.
+                        if (document.body.clientWidth > tablet_width) {
+                            height = "365px";
+                        }
+                        return '<iframe title="' + frame_title + '" src="' + url + '" width="' + width + '" height="' + height + '" frameborder="0" scrolling="no" allowtransparency allowfullscreen></iframe>';
+                    });
+                },
+                "fallback": function () {
+                    "use strict";
+                    var id = 'livestorm';
+                    tarteaucitron.fallback(['js-tac-livestorm'], function (elem) {
+                        elem.style.width = elem.getAttribute('width');
+                        if (document.body.clientWidth > tablet_width) {
+                            elem.style.height = "310px";
+                        } else {
+                            elem.style.height = elem.getAttribute('height');
+                        }
+                        return tarteaucitron.engage(id);
+                    });
+                }
+            };
+            (tarteaucitron.job = tarteaucitron.job || []).push('livestorm');
 
-    </script>
-
-    {% block script %}
-        <script src="{% static "js/logout.js" %}"></script>
-        <script src="{% static "js/city_autocomplete_field.js" %}"></script>
-        <script src="{% static "js/commune_autocomplete_field.js" %}"></script>
-        <script src="{% static "js/configure_jobs.js" %}"></script>
-        <script src="{% static "js/prevent_multiple_submit.js" %}"></script>
-        <script src="{% static 'js/utils.js'%}"></script>
-        {% if SHOW_TEST_ACCOUNTS_BANNER %}
-        <script src="{% static 'js/test_accounts.js'%}"></script>
-        {% endif %}
-    {% endblock %}
-
-    {% if ITOU_FQDN in ALLOWED_HOSTS %}
-        {# Matomo/Piwik open source web analytics #}
-        <script>
-            var _paq = window._paq || [];
-            /* Custom variables: https://matomo.org/docs/custom-variables/ */
-            /* Fields are, in order: index, name, value, scope. */
-            {% for key, value in  matomo_custom_variables.items %}
-              _paq.push(['setCustomVariable', {{ forloop.counter }}, '{{ key }}', '{{ value }}', 'page']);
-            {% endfor %}
-            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-            _paq.push(['trackPageView']);
-            _paq.push(['enableLinkTracking']);
-            (function() {
-              var u = "//stats.data.gouv.fr/";
-              _paq.push(['setTrackerUrl', u + 'piwik.php']);
-              _paq.push(['setSiteId', '117']);
-              var d = document,
-                g = d.createElement('script'),
-                s = d.getElementsByTagName('script')[0];
-              g.type = 'text/javascript';
-              g.async = true;
-              g.defer = true;
-              g.src = u + 'piwik.js';
-              s.parentNode.insertBefore(g, s);
-            })();
         </script>
-        <script src="{% static "js/matomo.js" %}"></script>
-    {% endif %}
 
-    {# Display "Je donne mon avis" only on HP. #}
-    {# The rationale behind it: "Je donne mon avis" is imposed by DINUM but is redundant with Hotjar. #}
-    {# Hotjar is way more powerful. Compromise: display "Je donne mon avis" only on HP. #}
-    {% if request.path == "/" %}
-        <div class="fixed-sm-bottom text-center text-sm-right p-3 pr-sm-2 pb-sm-2">
-            <a href="https://voxusagers.numerique.gouv.fr/Demarches/2436?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=ca117c905602fb63fda68b31ee0f5bdd" target="_blank">
-              <img src="{% static 'img/je-donne-mon-avis.svg' %}" alt="Je donne mon avis sur cette démarche" style="width: 150px;">
-            </a>
-        </div>
-    {% else %}
-        {# Sticky FAQ link is not displayed on HP and on small devices #}
-        <div class="rounded-pill bg-white shadow fixed-sm-bottom d-none d-sm-inline-block m-4 py-2 px-3 text-center text-md-right">
-            <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" class="text-decoration-none" title="Besoin d'aide ? (ouverture dans un nouvel onglet)">
-                Besoin d'aide ?
-                {% include "includes/icon.html" with icon="external-link" %}
-            </a>
-        </div>
-    {% endif %}
+        {% block script %}
+            <script src="{% static "js/logout.js" %}"></script>
+            <script src="{% static "js/city_autocomplete_field.js" %}"></script>
+            <script src="{% static "js/commune_autocomplete_field.js" %}"></script>
+            <script src="{% static "js/configure_jobs.js" %}"></script>
+            <script src="{% static "js/prevent_multiple_submit.js" %}"></script>
+            <script src="{% static 'js/utils.js'%}"></script>
+            {% if SHOW_TEST_ACCOUNTS_BANNER %}
+                <script src="{% static 'js/test_accounts.js'%}"></script>
+            {% endif %}
+        {% endblock %}
 
-</body>
+        {% if ITOU_FQDN in ALLOWED_HOSTS %}
+            {# Matomo/Piwik open source web analytics #}
+            <script>
+                var _paq = window._paq || [];
+                /* Custom variables: https://matomo.org/docs/custom-variables/ */
+                /* Fields are, in order: index, name, value, scope. */
+                {% for key, value in  matomo_custom_variables.items %}
+                    _paq.push(['setCustomVariable', {{ forloop.counter }}, '{{ key }}', '{{ value }}', 'page']);
+                {% endfor %}
+                /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+                _paq.push(['trackPageView']);
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u = "//stats.data.gouv.fr/";
+                    _paq.push(['setTrackerUrl', u + 'piwik.php']);
+                    _paq.push(['setSiteId', '117']);
+                    var d = document,
+                    g = d.createElement('script'),
+                    s = d.getElementsByTagName('script')[0];
+                    g.type = 'text/javascript';
+                    g.async = true;
+                    g.defer = true;
+                    g.src = u + 'piwik.js';
+                    s.parentNode.insertBefore(g, s);
+                })();
+            </script>
+            <script src="{% static "js/matomo.js" %}"></script>
+        {% endif %}
+
+        {# Display "Je donne mon avis" only on HP. #}
+        {# The rationale behind it: "Je donne mon avis" is imposed by DINUM but is redundant with Hotjar. #}
+        {# Hotjar is way more powerful. Compromise: display "Je donne mon avis" only on HP. #}
+        {% if request.path == "/" %}
+            <div class="fixed-sm-bottom text-center text-sm-right p-3 pr-sm-2 pb-sm-2">
+                <a href="https://voxusagers.numerique.gouv.fr/Demarches/2436?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=ca117c905602fb63fda68b31ee0f5bdd" target="_blank">
+                    <img src="{% static 'img/je-donne-mon-avis.svg' %}" alt="Je donne mon avis sur cette démarche" style="width: 150px;">
+                </a>
+            </div>
+        {% else %}
+            {# Sticky FAQ link is not displayed on HP and on small devices #}
+            <div class="rounded-pill bg-white shadow fixed-sm-bottom d-none d-sm-inline-block m-4 py-2 px-3 text-center text-md-right">
+                <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" class="text-decoration-none" title="Besoin d'aide ? (ouverture dans un nouvel onglet)">
+                    Besoin d'aide ?
+                    {% include "includes/icon.html" with icon="external-link" %}
+                </a>
+            </div>
+        {% endif %}
+
+    </body>
 </html>

--- a/itou/templates/layout/base_pdf.html
+++ b/itou/templates/layout/base_pdf.html
@@ -1,28 +1,28 @@
 {% load static %}
 <!DOCTYPE HTML>
 <html>
-<html lang="fr">
-<head>
-    <meta charset="utf-8">
-    <title>{% block title %} - Les emplois de l'inclusion{% endblock %}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    {% block meta_description %}{% endblock %}
-    <link rel="stylesheet" href="{{ base_url }}{% static 'vendor/bootstrap-4.3.1/bootstrap.min.css' %}" type="text/css">
-    <link rel="stylesheet" href="{{ base_url }}{% static 'css/itou.css' %}" type="text/css">
-    <style type="text/css">
-        /* Don't display the BETA banner on pdf files. */
-        body:after {
-            content: "";
-            background: transparent;
-            color: transparent;
-        }
-        html {
-            background: transparent !important;
-        }
-    </style>
-    {% block extra_head %}{% endblock %}
-</head>
-<body>
-  {% block content %}{% endblock %}
-</body>
-</html>
+    <html lang="fr">
+        <head>
+            <meta charset="utf-8">
+            <title>{% block title %} - Les emplois de l'inclusion{% endblock %}</title>
+            <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+            {% block meta_description %}{% endblock %}
+            <link rel="stylesheet" href="{{ base_url }}{% static 'vendor/bootstrap-4.3.1/bootstrap.min.css' %}" type="text/css">
+            <link rel="stylesheet" href="{{ base_url }}{% static 'css/itou.css' %}" type="text/css">
+            <style type="text/css">
+                /* Don't display the BETA banner on pdf files. */
+                body:after {
+                    content: "";
+                    background: transparent;
+                    color: transparent;
+                }
+                html {
+                    background: transparent !important;
+                }
+            </style>
+            {% block extra_head %}{% endblock %}
+        </head>
+        <body>
+            {% block content %}{% endblock %}
+        </body>
+    </html>

--- a/itou/templates/layout/content_small.html
+++ b/itou/templates/layout/content_small.html
@@ -1,12 +1,12 @@
 {% extends "layout/base.html" %}
 {% block content_full_viewport %}
-<section class="bg-gray-400">
-    <div class="container">
-        <div class="row justify-content-md-center">
-            <div class="col-md-{% block nb_columns %}8{% endblock %}">
-                {% block content %}{% endblock %}
+    <section class="bg-gray-400">
+        <div class="container">
+            <div class="row justify-content-md-center">
+                <div class="col-md-{% block nb_columns %}8{% endblock %}">
+                    {% block content %}{% endblock %}
+                </div>
             </div>
         </div>
-    </div>
-</section>
+    </section>
 {% endblock %}

--- a/itou/templates/prescribers/deactivate_member.html
+++ b/itou/templates/prescribers/deactivate_member.html
@@ -4,6 +4,6 @@
 
 {% block content %}
     {% with base_url="prescribers_views" %}
-        {% include "includes/deactivate_member.html" %}    
+        {% include "includes/deactivate_member.html" %}
     {% endwith %}
 {% endblock %}

--- a/itou/templates/prescribers/edit_organization.html
+++ b/itou/templates/prescribers/edit_organization.html
@@ -5,27 +5,27 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Modifier votre organisation</h1>
+    <h1 class="h1-hero-c1">Modifier votre organisation</h1>
 
-<h2 class="h1 text-muted">
-    {{ organization.display_name }}
-</h2>
+    <h2 class="h1 text-muted">
+        {{ organization.display_name }}
+    </h2>
 
-<div class="alert alert-info">
-    Les coordonnées de contact de votre organisation sont visibles par tous les utilisateurs connectés.
-</div>
+    <div class="alert alert-info">
+        Les coordonnées de contact de votre organisation sont visibles par tous les utilisateurs connectés.
+    </div>
 
-<form method="post" action="" class="js-prevent-multiple-submit">
+    <form method="post" action="" class="js-prevent-multiple-submit">
 
-    {% csrf_token %}
+        {% csrf_token %}
 
-    {% bootstrap_form form alert_error_type="all" %}
+        {% bootstrap_form form alert_error_type="all" %}
 
-    {% buttons %}
-        <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
-        <button type="submit" class="btn btn-primary">Enregistrer</button>
-    {% endbuttons %}
+        {% buttons %}
+            <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
+            <button type="submit" class="btn btn-primary">Enregistrer</button>
+        {% endbuttons %}
 
-</form>
+    </form>
 
 {% endblock %}

--- a/itou/templates/prescribers/list_accredited_organizations.html
+++ b/itou/templates/prescribers/list_accredited_organizations.html
@@ -9,7 +9,7 @@
     </h1>
 
     <h2 class="h1">
-         <span class="text-muted">{{ prescriber_org.display_name }}</span>
+        <span class="text-muted">{{ prescriber_org.display_name }}</span>
     </h2>
 
     <div class="alert alert-info">
@@ -34,9 +34,9 @@
 
                     <p>
                         <b>{{ org.display_name }}</b>
-                         -
-                         <span class="text-muted">{{ org.city }}</span>
-                         <br>
+                        -
+                        <span class="text-muted">{{ org.city }}</span>
+                        <br>
                         <a
                             data-toggle="collapse"
                             href="#collapse_membership_{{ org.pk }}"

--- a/itou/templates/prescribers/members.html
+++ b/itou/templates/prescribers/members.html
@@ -4,26 +4,26 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Collaborateurs</h1>
+    <h1 class="h1-hero-c1">Collaborateurs</h1>
 
-<h2 class="h1 text-muted">
-    {{ organization.display_name }}
-</h2>
+    <h2 class="h1 text-muted">
+        {{ organization.display_name }}
+    </h2>
 
-<div class="alert alert-info">
-    Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
-</div>
+    <div class="alert alert-info">
+        Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+    </div>
 
-{% with active_admin_members=organization.active_admin_members base_url="prescribers_views" %}
-    {% include "includes/members.html" %}
-{% endwith %}
+    {% with active_admin_members=organization.active_admin_members base_url="prescribers_views" %}
+        {% include "includes/members.html" %}
+    {% endwith %}
 
-<a href="{% url 'invitations_views:invite_prescriber_with_org' %}" class="align-self-center">
-    <span class="btn btn-primary mb-1 w-100 w-sm-auto mt-2">Inviter des collaborateurs</span>
-</a>
+    <a href="{% url 'invitations_views:invite_prescriber_with_org' %}" class="align-self-center">
+        <span class="btn btn-primary mb-1 w-100 w-sm-auto mt-2">Inviter des collaborateurs</span>
+    </a>
 
-{% if pending_invitations %}
-    {% include "invitations_views/includes/pending_invitations.html" %}
-{% endif %}
+    {% if pending_invitations %}
+        {% include "invitations_views/includes/pending_invitations.html" %}
+    {% endif %}
 
 {% endblock %}

--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -10,15 +10,15 @@
 {% block script %}
     {{ block.super }}
     <script>
-    $("#search-filter-form :input").change(function() {
-        $("#search-form").submit();
-    });
-    // If the Filtres button is present, the associated card shoud be collapsed on display.
-    if ($("#js-search-filter-button").is(":visible")) {
-        // The button should be always visible now (on windows resize)
-        $("#js-search-filter-button").removeClass("d-md-none");
-        $('#search-filter-form').collapse();
-    }
+        $("#search-filter-form :input").change(function() {
+            $("#search-form").submit();
+        });
+        // If the Filtres button is present, the associated card shoud be collapsed on display.
+        if ($("#js-search-filter-button").is(":visible")) {
+            // The button should be always visible now (on windows resize)
+            $("#js-search-filter-button").removeClass("d-md-none");
+            $('#search-filter-form').collapse();
+        }
     </script>
 {% endblock %}
 

--- a/itou/templates/siaes/create_siae.html
+++ b/itou/templates/siaes/create_siae.html
@@ -5,45 +5,45 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Créer/rejoindre une nouvelle structure</h1>
+    <h1 class="h1-hero-c1">Créer/rejoindre une nouvelle structure</h1>
 
-<form method="post" action="" class="js-prevent-multiple-submit">
+    <form method="post" action="" class="js-prevent-multiple-submit">
 
-    <div class="alert alert-info">
-        <p>Vous souhaitez rejoindre une structure :</p>
-        <ul>
-            <li>ayant déjà un ou plusieurs membres, <b>demandez à l’un de ces membres de vous inviter depuis son tableau de bord</b></li>
-            <li>connue dans l'extranet IAE 2.0 de l'ASP mais n’ayant pas encore de membre : <a href="{% url 'signup:siae_select' %}">utilisez ce formulaire</a></li>
-        </ul>
-        <p>Dans les autres cas, complétez le formulaire ci-dessous.</p>
-    </div>
-
-    {% csrf_token %}
-
-    {% if form.non_field_errors %}
-        <div class="alert alert-danger alert-dismissible alert-link" role="alert">
-            {% for error in form.non_field_errors %}
-                {{ error | safe }}{% if not forloop.last %}<br>{% endif %}
-            {% endfor %}
-            <button type="button" class="close" data-dismiss="alert" aria-label="Fermer">
-                <i class="ri-close-line"></i>
-            </button>               
+        <div class="alert alert-info">
+            <p>Vous souhaitez rejoindre une structure :</p>
+            <ul>
+                <li>ayant déjà un ou plusieurs membres, <b>demandez à l’un de ces membres de vous inviter depuis son tableau de bord</b></li>
+                <li>connue dans l'extranet IAE 2.0 de l'ASP mais n’ayant pas encore de membre : <a href="{% url 'signup:siae_select' %}">utilisez ce formulaire</a></li>
+            </ul>
+            <p>Dans les autres cas, complétez le formulaire ci-dessous.</p>
         </div>
-    {% endif %}
 
-    {% for field in form %}
-        {% bootstrap_field field %}
-    {% endfor %}
+        {% csrf_token %}
+
+        {% if form.non_field_errors %}
+            <div class="alert alert-danger alert-dismissible alert-link" role="alert">
+                {% for error in form.non_field_errors %}
+                    {{ error | safe }}{% if not forloop.last %}<br>{% endif %}
+                {% endfor %}
+                <button type="button" class="close" data-dismiss="alert" aria-label="Fermer">
+                    <i class="ri-close-line"></i>
+                </button>
+            </div>
+        {% endif %}
+
+        {% for field in form %}
+            {% bootstrap_field field %}
+        {% endfor %}
 
 
-    <p>
-        En cliquant sur le bouton "Enregistrer", vous acceptez que vos informations et coordonnées ci-dessus soient rendues publiques.
-    </p>
-    {% buttons %}
-        <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
-        <button type="submit" class="btn btn-primary">Enregistrer</button>
-    {% endbuttons %}
+        <p>
+            En cliquant sur le bouton "Enregistrer", vous acceptez que vos informations et coordonnées ci-dessus soient rendues publiques.
+        </p>
+        {% buttons %}
+            <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
+            <button type="submit" class="btn btn-primary">Enregistrer</button>
+        {% endbuttons %}
 
-</form>
+    </form>
 
 {% endblock %}

--- a/itou/templates/siaes/deactivate_member.html
+++ b/itou/templates/siaes/deactivate_member.html
@@ -4,6 +4,6 @@
 
 {% block content %}
     {% with base_url="siaes_views" %}
-        {% include "includes/deactivate_member.html" %}    
+        {% include "includes/deactivate_member.html" %}
     {% endwith %}
 {% endblock %}

--- a/itou/templates/siaes/edit_siae.html
+++ b/itou/templates/siaes/edit_siae.html
@@ -5,38 +5,38 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Modifier les coordonnées de votre structure</h1>
+    <h1 class="h1-hero-c1">Modifier les coordonnées de votre structure</h1>
 
-<h2 class="h1 text-muted">
-    {{ siae.display_name }}
-</h2>
-<p class="text-muted">
-    {% if siae.siret %}
-        SIRET : {{ siae.siret }}
-    {% endif %}
-</p>
-
-<form method="post" action="" class="js-prevent-multiple-submit">
-
-    <div class="alert alert-emploi">
-        <i>Laisser les champs vides pour ne rien afficher.</i>
-    </div>
-
-    {% csrf_token %}
-    {% bootstrap_form_errors form type="all" %}
-    {% bootstrap_label "Nom à afficher" label_title="a" label_for=form.brand.id  %}
-    {% bootstrap_field form.brand show_label=False %}
-
-    {% bootstrap_form form exclude="brand" %}
-
-    <p>
-        En cliquant sur le bouton "Enregistrer", vous acceptez que vos informations et coordonnées ci-dessus soient rendues publiques.
+    <h2 class="h1 text-muted">
+        {{ siae.display_name }}
+    </h2>
+    <p class="text-muted">
+        {% if siae.siret %}
+            SIRET : {{ siae.siret }}
+        {% endif %}
     </p>
-    {% buttons %}
-        <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
-        <button type="submit" class="btn btn-primary">Enregistrer</button>
-    {% endbuttons %}
 
-</form>
+    <form method="post" action="" class="js-prevent-multiple-submit">
+
+        <div class="alert alert-emploi">
+            <i>Laisser les champs vides pour ne rien afficher.</i>
+        </div>
+
+        {% csrf_token %}
+        {% bootstrap_form_errors form type="all" %}
+        {% bootstrap_label "Nom à afficher" label_title="a" label_for=form.brand.id  %}
+        {% bootstrap_field form.brand show_label=False %}
+
+        {% bootstrap_form form exclude="brand" %}
+
+        <p>
+            En cliquant sur le bouton "Enregistrer", vous acceptez que vos informations et coordonnées ci-dessus soient rendues publiques.
+        </p>
+        {% buttons %}
+            <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
+            <button type="submit" class="btn btn-primary">Enregistrer</button>
+        {% endbuttons %}
+
+    </form>
 
 {% endblock %}

--- a/itou/templates/siaes/includes/_alert_configure_job.html
+++ b/itou/templates/siaes/includes/_alert_configure_job.html
@@ -7,6 +7,6 @@
         </ul>
         <button type="button" class="close" data-dismiss="alert" aria-label="Fermer">
             <i class="ri-close-line"></i>
-        </button>           
+        </button>
     </div>
 {% endif %}

--- a/itou/templates/siaes/includes/_configure_jobs_list.html
+++ b/itou/templates/siaes/includes/_configure_jobs_list.html
@@ -11,60 +11,60 @@
     </thead>
     <tbody class="js-jobs-tbody">
         {% for job in job_descriptions %}
-        {# Important: keep the JavaScript template in sync if you edit the row markup. #}
-        <tr>
-            <td class="font-weight-bold">{{ job.appellation.rome.code }}</td>
-            <td class="text-left">
-                <p class="job-appellation-name">
-                    <i>{{ job.appellation.name }}</i>
-                </p>
-                <input type="hidden" name="code-update" value="{{ job.appellation.code }}">
-                <div class="form-group">
-                    <label for="custom-name-{{ job.appellation.code }}">
-                        <small>Nom personnalisé</small>
-                    </label>
-                    <input
-                        type="text"
-                        class="form-control form-control-sm"
-                        id="custom-name-{{ job.appellation.code }}"
-                        name="custom-name-{{ job.appellation.code }}"
-                        value="{{ job.custom_name }}">
-                    <small class="form-text text-muted">
-                        Si ce champ est renseigné, il sera utilisé à la place du nom ci-dessus.
-                    </small>
-                </div>
-                <div class="form-group">
-                    <label for="description-{{ job.appellation.code }}">
-                        <small>Description</small>
-                    </label>
-                    <textarea
-                        class="form-control form-control-sm"
-                        id="description-{{ job.appellation.code }}"
-                        name="description-{{ job.appellation.code }}"
-                        rows="3">{{ job.description }}</textarea>
-                    <small class="form-text text-muted">
-                        Renseignez ici le détail des missions, les compétences/habilitations nécessaires, les conditions de travail, les éventuelles adaptations ou restrictions du poste.
-                    </small>
-                </div>
-            </td>
-            <td class="text-center align-middle" scope="row">
-                <div class="custom-control custom-switch is-rtl">
-                    <input name="is_active-{{ job.appellation.code }}"
-                        type="checkbox" class="custom-control-input"
-                        id="is_active-{{ job.appellation.code }}"
-                        {% if job.is_active %}checked{% endif %}>
-                    <label class="custom-control-label font-weight-bold"
-                        for="is_active-{{ job.appellation.code }}">Ouvrir au recrutement</label>
-                </div>
-            </td>
-            <td class="align-middle">
-                <a href="#" role="button" class="js-job-delete">
-                    {% include "includes/icon.html" with icon="trash-2" %}
-                </a>
-                {# will be enable with JavaScript if user click to delete it #}
-                <input type="hidden" name="code-delete"  value="{{ job.appellation.code }}" disabled>
-            </td>
-        </tr>
+            {# Important: keep the JavaScript template in sync if you edit the row markup. #}
+            <tr>
+                <td class="font-weight-bold">{{ job.appellation.rome.code }}</td>
+                <td class="text-left">
+                    <p class="job-appellation-name">
+                        <i>{{ job.appellation.name }}</i>
+                    </p>
+                    <input type="hidden" name="code-update" value="{{ job.appellation.code }}">
+                    <div class="form-group">
+                        <label for="custom-name-{{ job.appellation.code }}">
+                            <small>Nom personnalisé</small>
+                        </label>
+                        <input
+                            type="text"
+                            class="form-control form-control-sm"
+                            id="custom-name-{{ job.appellation.code }}"
+                            name="custom-name-{{ job.appellation.code }}"
+                            value="{{ job.custom_name }}">
+                        <small class="form-text text-muted">
+                            Si ce champ est renseigné, il sera utilisé à la place du nom ci-dessus.
+                        </small>
+                    </div>
+                    <div class="form-group">
+                        <label for="description-{{ job.appellation.code }}">
+                            <small>Description</small>
+                        </label>
+                        <textarea
+                            class="form-control form-control-sm"
+                            id="description-{{ job.appellation.code }}"
+                            name="description-{{ job.appellation.code }}"
+                            rows="3">{{ job.description }}</textarea>
+                        <small class="form-text text-muted">
+                            Renseignez ici le détail des missions, les compétences/habilitations nécessaires, les conditions de travail, les éventuelles adaptations ou restrictions du poste.
+                        </small>
+                    </div>
+                </td>
+                <td class="text-center align-middle" scope="row">
+                    <div class="custom-control custom-switch is-rtl">
+                        <input name="is_active-{{ job.appellation.code }}"
+                            type="checkbox" class="custom-control-input"
+                            id="is_active-{{ job.appellation.code }}"
+                            {% if job.is_active %}checked{% endif %}>
+                        <label class="custom-control-label font-weight-bold"
+                            for="is_active-{{ job.appellation.code }}">Ouvrir au recrutement</label>
+                    </div>
+                </td>
+                <td class="align-middle">
+                    <a href="#" role="button" class="js-job-delete">
+                        {% include "includes/icon.html" with icon="trash-2" %}
+                    </a>
+                    {# will be enable with JavaScript if user click to delete it #}
+                    <input type="hidden" name="code-delete"  value="{{ job.appellation.code }}" disabled>
+                </td>
+            </tr>
         {% endfor %}
     </tbody>
 </table>

--- a/itou/templates/siaes/includes/_list_siae_actives_jobs.html
+++ b/itou/templates/siaes/includes/_list_siae_actives_jobs.html
@@ -10,8 +10,8 @@
         {% if job.is_popular %}
             <small>
                 <span class="ml-3">
-                        {% include "includes/icon.html" with icon="layers" size=15 class="mr-1 text-danger" %}
-                        Plus de {{ job.POPULAR_THRESHOLD }} candidatures reçues
+                    {% include "includes/icon.html" with icon="layers" size=15 class="mr-1 text-danger" %}
+                    Plus de {{ job.POPULAR_THRESHOLD }} candidatures reçues
                 </span>
             </small>
         {% endif %}
@@ -19,14 +19,14 @@
     {% endif %}
     {# Collapsing block start (more than 5 jobs descriptions) #}
     {% if forloop.counter == 5 and not forloop.last %}
-      <div class="pt-2">
-        <button class="btn collapsed collapse-caret p-0" data-toggle="collapse" data-target="#collapse_{{ forloop.parentloop.counter0 }}" type="button" aria-expanded="false" aria-controls="collapse_{{ forloop.parentloop.counter0 }}">
-          <h6 class="h5">Voir tous les recrutements en cours ({{ forloop.revcounter0 }} de plus)</h6>
-        </button>
-      </div>
-      <div class="collapse" id="collapse_{{forloop.parentloop.counter0}}">
+        <div class="pt-2">
+            <button class="btn collapsed collapse-caret p-0" data-toggle="collapse" data-target="#collapse_{{ forloop.parentloop.counter0 }}" type="button" aria-expanded="false" aria-controls="collapse_{{ forloop.parentloop.counter0 }}">
+                <h6 class="h5">Voir tous les recrutements en cours ({{ forloop.revcounter0 }} de plus)</h6>
+            </button>
+        </div>
+        <div class="collapse" id="collapse_{{forloop.parentloop.counter0}}">
     {% elif forloop.last and forloop.counter > 5 %}
-      {# Collapsing block end #}
-      </div>
+        {# Collapsing block end #}
+        </div>
     {% endif %}
 {% endfor %}

--- a/itou/templates/siaes/job_description_card.html
+++ b/itou/templates/siaes/job_description_card.html
@@ -74,9 +74,9 @@
         <div class="pt-4">
             <h2 class="h1">Consulter le(s) recrutement(s) en cours dans cette structure</h2>
             {% for other_job in others_active_jobs %}
-                    <a href="{{ other_job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}" class="matomo-event btn btn-outline-primary mb-2" data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-metiers">
-                        {{ other_job.display_name }}
-                    </a>
+                <a href="{{ other_job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}" class="matomo-event btn btn-outline-primary mb-2" data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-metiers">
+                    {{ other_job.display_name }}
+                </a>
                 <br >
             {% endfor %}
         </div>

--- a/itou/templates/siaes/select_financial_annex.html
+++ b/itou/templates/siaes/select_financial_annex.html
@@ -5,23 +5,23 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Sélectionner une annexe financière</h1>
-<h2 class="h1 text-muted">{{ current_siae.display_name }}</h2>
+    <h1 class="h1-hero-c1">Sélectionner une annexe financière</h1>
+    <h2 class="h1 text-muted">{{ current_siae.display_name }}</h2>
 
-<form method="post" action="" role="form" class="js-prevent-multiple-submit">
+    <form method="post" action="" role="form" class="js-prevent-multiple-submit">
 
-    {% csrf_token %}
+        {% csrf_token %}
 
-    {% bootstrap_form_errors select_form type="all" %}
+        {% bootstrap_form_errors select_form type="all" %}
 
-    {% bootstrap_field select_form.financial_annexes %}
+        {% bootstrap_field select_form.financial_annexes %}
 
-    {% buttons %}
-        <button type="submit" class="btn btn-primary">Continuer</button>
-    {% endbuttons %}
+        {% buttons %}
+            <button type="submit" class="btn btn-primary">Continuer</button>
+        {% endbuttons %}
 
-</form>
+    </form>
 
-Si votre annexe financière correspond à un SIREN différent de {{ current_siae.siren }} ou à un type de structure différent de {{ current_siae.kind }}, ou bien si elle n'apparait pas dans la liste ci-dessus, contactez nous via la rubrique votre structure sur <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
+    Si votre annexe financière correspond à un SIREN différent de {{ current_siae.siren }} ou à un type de structure différent de {{ current_siae.kind }}, ou bien si elle n'apparait pas dans la liste ci-dessus, contactez nous via la rubrique votre structure sur <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
 
 {% endblock %}

--- a/itou/templates/siaes/show_financial_annexes.html
+++ b/itou/templates/siaes/show_financial_annexes.html
@@ -30,52 +30,52 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Mes annexes financières</h1>
-<h2 class="h1 text-muted">{{ siae.display_name }}</h2>
+    <h1 class="h1-hero-c1">Mes annexes financières</h1>
+    <h2 class="h1 text-muted">{{ siae.display_name }}</h2>
 
-<div class="table-responsive">
-    <table class="table table-striped table-bordered">
-        <caption>Liste des annexes financières</caption>
-        <thead>
-            <tr>
-                <th scope="col">Numéro d'annexe financière</th>
-                <th scope="col">Date de début d'effet</th>
-                <th scope="col">Date de fin d'effet</th>
-                <th scope="col">Validité à ce jour</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% if financial_annexes %}
-                {% for financial_annex in financial_annexes %}
-                    <tr>
-                        <td>{{ financial_annex.number_with_spaces }}</td>
-                        <td>{{ financial_annex.start_at|date:"d/m/Y" }}</td>
-                        <td>{{ financial_annex.end_at|date:"d/m/Y" }}</td>
-                        {% if financial_annex.is_active %}
-                            <td><span class="badge badge-success">Valide</span></td>
-                        {% else %}
-                            <td><span class="badge badge-secondary">Inactive</span></td>
-                        {% endif %}
-                    </tr>
-                {% endfor %}
-            {% else %}
+    <div class="table-responsive">
+        <table class="table table-striped table-bordered">
+            <caption>Liste des annexes financières</caption>
+            <thead>
                 <tr>
-                    <td>
-                        Aucune annexe financière associée à cette structure.
-                    </td>
-                    <td></td>
-                    <td></td>
-                    <td></td>
+                    <th scope="col">Numéro d'annexe financière</th>
+                    <th scope="col">Date de début d'effet</th>
+                    <th scope="col">Date de fin d'effet</th>
+                    <th scope="col">Validité à ce jour</th>
                 </tr>
-            {% endif %}
-        </tbody>
-    </table>
-</div>
+            </thead>
+            <tbody>
+                {% if financial_annexes %}
+                    {% for financial_annex in financial_annexes %}
+                        <tr>
+                            <td>{{ financial_annex.number_with_spaces }}</td>
+                            <td>{{ financial_annex.start_at|date:"d/m/Y" }}</td>
+                            <td>{{ financial_annex.end_at|date:"d/m/Y" }}</td>
+                            {% if financial_annex.is_active %}
+                                <td><span class="badge badge-success">Valide</span></td>
+                            {% else %}
+                                <td><span class="badge badge-secondary">Inactive</span></td>
+                            {% endif %}
+                        </tr>
+                    {% endfor %}
+                {% else %}
+                    <tr>
+                        <td>
+                            Aucune annexe financière associée à cette structure.
+                        </td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                    </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
 
-{% if can_select_af %}
-    <a href="{% url 'siaes_views:select_financial_annex' %}" class="align-self-center">
-        <span class="btn btn-primary mb-1 w-100 w-sm-auto mt-2">Sélectionner une autre annexe financière</span>
-    </a>
-{% endif %}
+    {% if can_select_af %}
+        <a href="{% url 'siaes_views:select_financial_annex' %}" class="align-self-center">
+            <span class="btn btn-primary mb-1 w-100 w-sm-auto mt-2">Sélectionner une autre annexe financière</span>
+        </a>
+    {% endif %}
 
 {% endblock %}

--- a/itou/templates/signup/includes/no_email_link.html
+++ b/itou/templates/signup/includes/no_email_link.html
@@ -23,7 +23,7 @@
                 </h3>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
                     <i class="ri-close-line"></i>
-                </button>                
+                </button>
             </div>
             <div class="modal-body">
                 <div class="container">
@@ -51,7 +51,7 @@
                     target="_blank">
                     Créer une adresse e-mail {% include "includes/icon.html" with icon="external-link" %}
                 </a>
-            </div>            
+            </div>
         </div>
     </div>
 </div>

--- a/itou/templates/signup/job_seeker_nir.html
+++ b/itou/templates/signup/job_seeker_nir.html
@@ -21,7 +21,7 @@
 
             {% if form.errors %}
                 <div class="alert alert-info">
-                    Vous possédez un numéro de sécurité sociale temporaire ? 
+                    Vous possédez un numéro de sécurité sociale temporaire ?
                     <button
                         type="submit" name="skip" value="1"
                         class="btn btn-link p-0 matomo-event"

--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -11,7 +11,7 @@
         </h1>
 
         <b class="mb-4">Inscrivez-vous avec un service tiers</b>
-            {% if show_france_connect %}
+        {% if show_france_connect %}
             <div>
                 {% include "signup/includes/france_connect_button.html" %}
             </div>
@@ -20,13 +20,13 @@
                     <b>Ou</b>
                 </p>
             </div>
-            {% endif %}
+        {% endif %}
 
-            <div class="row mt-3">
-                <div class="col-sm">
-                    <p class="text-center">{% include "signup/includes/peamu_button.html" %}</p>
-                </div>
+        <div class="row mt-3">
+            <div class="col-sm">
+                <p class="text-center">{% include "signup/includes/peamu_button.html" %}</p>
             </div>
+        </div>
         <div class="mt-4 mb-3">
             <b>Ou utilisez votre adresse e-mail</b>
         </div>
@@ -67,7 +67,7 @@
             <p>Vous avez déjà un compte ?</p>
             <p>
                 <a class="btn btn-outline-primary" href="{% url 'account_login' %}">
-                Connexion
+                    Connexion
                 </a>
             </p>
         </div>

--- a/itou/templates/signup/prescriber_check_already_exists.html
+++ b/itou/templates/signup/prescriber_check_already_exists.html
@@ -32,9 +32,9 @@
 
     {# Display link only before the search otherwise an organization is put in session and no longer allows creation without an organization  #}
     {% if not prescriber_orgs_with_members_same_siret and not prescriber_orgs_with_members_same_siren %}
-    <p class="mt-3">
-        <a href="{% url 'signup:prescriber_user' %}">Je ne fais partie d'aucune organisation</a>
-    </p>
+        <p class="mt-3">
+            <a href="{% url 'signup:prescriber_user' %}">Je ne fais partie d'aucune organisation</a>
+        </p>
     {% endif %}
 
     {% if prescriber_orgs_with_members_same_siret %}
@@ -50,12 +50,12 @@
     {% if prescriber_orgs_with_members_same_siren %}
         <div class="mt-5">
             {% if not prescriber_orgs_with_members_same_siret %}
-            <h3 class="h2">Organisation(s) inscrite(s) avec ce SIREN sur le département</h3>
-            <p>Par mesure de sécurité, vous devez obtenir une invitation pour rejoindre une organisation déjà inscrite.</p>
+                <h3 class="h2">Organisation(s) inscrite(s) avec ce SIREN sur le département</h3>
+                <p>Par mesure de sécurité, vous devez obtenir une invitation pour rejoindre une organisation déjà inscrite.</p>
             {% else %}
-            <h3 class="h2">Autre(s) organisation(s) inscrite(s) avec ce SIREN sur le département</h3>
+                <h3 class="h2">Autre(s) organisation(s) inscrite(s) avec ce SIREN sur le département</h3>
             {% endif %}
-            
+
             {% for prescriber_org in prescriber_orgs_with_members_same_siren %}
                 {% include "signup/includes/prescriber_card.html" %}
             {% endfor %}
@@ -63,29 +63,29 @@
     {% endif %}
 
     {% if prescriber_orgs_with_members_same_siret or prescriber_orgs_with_members_same_siren %}
-    <div class="mt-5">
-        <h3 class="h2">Ajouter mon organisation</h3>
+        <div class="mt-5">
+            <h3 class="h2">Ajouter mon organisation</h3>
 
-        {% if prescriber_orgs_with_members_same_siret %}
-        <div class="alert alert-warning pb-0" role="status">
-            <p>
-                <small>
-                    Attention une ou plusieurs organisations existent déjà avec ce SIRET.<br>
-                    Si vous ne trouvez pas votre organisation dans la liste ci-dessus ou si
-                    vous souhaitez créer un compte avec ce SIRET pour un autre type
-                    d'organisation, vous avez la possibilité de l'inscrire.
-                </small>
-            </p>
+            {% if prescriber_orgs_with_members_same_siret %}
+                <div class="alert alert-warning pb-0" role="status">
+                    <p>
+                        <small>
+                            Attention une ou plusieurs organisations existent déjà avec ce SIRET.<br>
+                            Si vous ne trouvez pas votre organisation dans la liste ci-dessus ou si
+                            vous souhaitez créer un compte avec ce SIRET pour un autre type
+                            d'organisation, vous avez la possibilité de l'inscrire.
+                        </small>
+                    </p>
+                </div>
+            {% else %}
+                <p>
+                    <small>
+                        Si vous ne trouvez pas votre organisation dans la liste ci-dessus, vous avez la possibilité de l'inscrire.
+                    </small>
+                </p>
+            {% endif %}
+            <a class="btn btn btn-outline-secondary mt-3" href="{{ prev_url }}">Retour</a>
+            <a href="{% url 'signup:prescriber_choose_org' %}" class="btn btn-primary mt-3">Inscrire mon organisation</a>
         </div>
-        {% else %}
-        <p>
-            <small>
-                Si vous ne trouvez pas votre organisation dans la liste ci-dessus, vous avez la possibilité de l'inscrire.
-            </small>
-        </p>
-        {% endif %}
-        <a class="btn btn btn-outline-secondary mt-3" href="{{ prev_url }}">Retour</a>
-        <a href="{% url 'signup:prescriber_choose_org' %}" class="btn btn-primary mt-3">Inscrire mon organisation</a>
-    </div>
     {% endif %}
 {% endblock %}

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -6,149 +6,149 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">
-    Inscription
-    <small class="text-muted">Employeur solidaire</small>
-</h1>
+    <h1 class="h1-hero-c1">
+        Inscription
+        <small class="text-muted">Employeur solidaire</small>
+    </h1>
 
-<form method="get" action="" role="form">
+    <form method="get" action="" role="form">
 
-    {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
+        {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
 
-    {% bootstrap_form siren_form alert_error_type="all" %}
+        {% bootstrap_form siren_form alert_error_type="all" %}
 
-    {% buttons %}
-        <button type="submit" class="btn btn-primary">Rechercher</button>
-    {% endbuttons %}
+        {% buttons %}
+            <button type="submit" class="btn btn-primary">Rechercher</button>
+        {% endbuttons %}
 
-</form>
-
-
-{% if siren_form.cleaned_data and not siaes_without_members and not siaes_with_members %}
-    <div class="alert alert-emploi mt-5" role="status">
-        Aucun résultat pour <b>{{ siren_form.cleaned_data.siren }}</b>.
-    </div>
-
-    <div class="alert alert-danger mt-2" role="status">
-        <p>
-            <b>Si votre conventionnement est récent</b>, nous vous invitons à renouveler votre inscription dans une semaine.
-        </p>
-        <p>
-            <b>Si votre conventionnement a plus d’un mois</b>, prenez contact avec votre DIRECCTE en lui demandant de nous envoyer la confirmation de votre conventionnement via <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>.
-            <br>
-            La DIRECCTE doit nous indiquer si le conventionnement de votre structure est en cours en précisant le numéro de SIRET, le type de structure, l’adresse postale et l’adresse e-mail du correspondant technique ASP.<br>
-        </p>
-        <p>
-            <b>Si vous tentez d'inscrire une Entreprise Adaptée ou un GEIQ</b>, merci d'utiliser <a href="{{ TYPEFORM_URL }}/to/RYfNLR79" target="_blank" rel="noopener" title="Merci d'utiliser ce formulaire (ouverture dans un nouvel onglet)">ce formulaire</a>.
-        </p>
-    </div>
-{% endif %}
+    </form>
 
 
-{% if siaes_without_members and siae_select_form %}
-    <div class="mt-5">
-
-        <h3 class="h2">Entreprises disponibles</h3>
-
-        <div class="alert alert-emploi" role="status">
-            <i>Les données sont fournies par l'extranet IAE 2.0 de l'ASP.</i>
+    {% if siren_form.cleaned_data and not siaes_without_members and not siaes_with_members %}
+        <div class="alert alert-emploi mt-5" role="status">
+            Aucun résultat pour <b>{{ siren_form.cleaned_data.siren }}</b>.
         </div>
 
-        <form method="post" action="" class="js-prevent-multiple-submit">
+        <div class="alert alert-danger mt-2" role="status">
+            <p>
+                <b>Si votre conventionnement est récent</b>, nous vous invitons à renouveler votre inscription dans une semaine.
+            </p>
+            <p>
+                <b>Si votre conventionnement a plus d’un mois</b>, prenez contact avec votre DIRECCTE en lui demandant de nous envoyer la confirmation de votre conventionnement via <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>.
+                <br>
+                La DIRECCTE doit nous indiquer si le conventionnement de votre structure est en cours en précisant le numéro de SIRET, le type de structure, l’adresse postale et l’adresse e-mail du correspondant technique ASP.<br>
+            </p>
+            <p>
+                <b>Si vous tentez d'inscrire une Entreprise Adaptée ou un GEIQ</b>, merci d'utiliser <a href="{{ TYPEFORM_URL }}/to/RYfNLR79" target="_blank" rel="noopener" title="Merci d'utiliser ce formulaire (ouverture dans un nouvel onglet)">ce formulaire</a>.
+            </p>
+        </div>
+    {% endif %}
 
-            {% csrf_token %}
 
-            {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
+    {% if siaes_without_members and siae_select_form %}
+        <div class="mt-5">
 
-            {% comment %}
+            <h3 class="h2">Entreprises disponibles</h3>
+
+            <div class="alert alert-emploi" role="status">
+                <i>Les données sont fournies par l'extranet IAE 2.0 de l'ASP.</i>
+            </div>
+
+            <form method="post" action="" class="js-prevent-multiple-submit">
+
+                {% csrf_token %}
+
+                {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
+
+                {% comment %}
             A ModelChoiceField's iterator only returns a tuple with (value, label).
             This means that using e.g. {% bootstrap_field form.siaes %} would only display
             a radio input and a label.
             The best solution I've yet found to display more info to the user than just a
             label is to manually render the inputs.
             {% endcomment %}
+                <ul>
+                    {% for siae in siaes_without_members %}
+                        <li>
+                            <p>
+                                <label for="id_{{ siae_select_form.siaes.html_name }}_{{ forloop.counter0 }}" class="align-top">
+                                    <input
+                                        type="radio"
+                                        name="{{ siae_select_form.siaes.html_name }}"
+                                        value="{{ siae.pk }}"
+                                        id="id_{{ siae_select_form.siaes.html_name }}_{{ forloop.counter0 }}"
+                                        required>
+                                    <b>{{ siae.siren }} {{ siae.siret_nic }}</b> - {{ siae.kind }}
+                                    <br>
+                                    {{ siae.display_name }}
+                                    <br>
+                                    {{ siae.address_line_1 }},
+                                    {% if siae.address_line_2 %}{{ siae.address_line_2 }},{% endif %}
+                                    {{ siae.post_code }} {{ siae.city }}
+                                </label>
+                            </p>
+                        </li>
+                    {% endfor %}
+                </ul>
+
+                <div class="alert alert-warning pb-0">
+                    <p>
+                        Pour sécuriser l'inscription, un e-mail de confirmation sera envoyé au correspondant technique référencé dans l'extranet IAE 2.0 de l'ASP. Il permettra de poursuivre la procédure.
+                    </p>
+                    {% buttons %}
+                        <button type="submit" class="btn btn-primary">Continuer l'inscription</button>
+                    {% endbuttons %}
+                </div>
+
+            </form>
+
+        </div>
+    {% endif %}
+
+
+    {% if siaes_with_members %}
+        <div class="mt-5">
+
+            <h3 class="h2">Entreprises déjà inscrites</h3>
+
+            <div class="alert alert-emploi" role="status">
+                <i>Par sécurité vous devez obtenir une invitation pour rejoindre ces structures.</i>
+            </div>
+
             <ul>
-                {% for siae in siaes_without_members %}
+                {% for siae in siaes_with_members %}
                     <li>
                         <p>
-                            <label for="id_{{ siae_select_form.siaes.html_name }}_{{ forloop.counter0 }}" class="align-top">
-                                <input
-                                    type="radio"
-                                    name="{{ siae_select_form.siaes.html_name }}"
-                                    value="{{ siae.pk }}"
-                                    id="id_{{ siae_select_form.siaes.html_name }}_{{ forloop.counter0 }}"
-                                    required>
-                                <b>{{ siae.siren }} {{ siae.siret_nic }}</b> - {{ siae.kind }}
-                                <br>
-                                {{ siae.display_name }}
-                                <br>
-                                {{ siae.address_line_1 }},
-                                {% if siae.address_line_2 %}{{ siae.address_line_2 }},{% endif %}
-                                {{ siae.post_code }} {{ siae.city }}
-                            </label>
+                            <b>{{ siae.siren }} {{ siae.siret_nic }}</b> - {{ siae.kind }}
+                            <br>
+                            {{ siae.display_name }}
+                            <br>
+                            {{ siae.address_line_1 }},
+                            {% if siae.address_line_2 %}{{ siae.address_line_2 }},{% endif %}
+                            {{ siae.post_code }} {{ siae.city }}
+                            <br>
+                            {% if siae.active_admin_members %}
+                                {% with siae.active_admin_members.first as admin %}
+                                    {# For security, display only the first char of the last name. #}
+                                    <i>Pour obtenir une invitation, contactez {{ admin.first_name|title }} {{ admin.last_name|slice:1 }}.</i>
+                                {% endwith %}
+                            {% endif %}
                         </p>
                     </li>
                 {% endfor %}
             </ul>
 
-            <div class="alert alert-warning pb-0">
-                <p>
-                    Pour sécuriser l'inscription, un e-mail de confirmation sera envoyé au correspondant technique référencé dans l'extranet IAE 2.0 de l'ASP. Il permettra de poursuivre la procédure.
-                </p>
-                {% buttons %}
-                    <button type="submit" class="btn btn-primary">Continuer l'inscription</button>
-                {% endbuttons %}
-            </div>
-
-        </form>
-
-    </div>
-{% endif %}
-
-
-{% if siaes_with_members %}
-    <div class="mt-5">
-
-        <h3 class="h2">Entreprises déjà inscrites</h3>
-
-        <div class="alert alert-emploi" role="status">
-            <i>Par sécurité vous devez obtenir une invitation pour rejoindre ces structures.</i>
         </div>
-
-        <ul>
-            {% for siae in siaes_with_members %}
-                <li>
-                    <p>
-                        <b>{{ siae.siren }} {{ siae.siret_nic }}</b> - {{ siae.kind }}
-                        <br>
-                        {{ siae.display_name }}
-                        <br>
-                        {{ siae.address_line_1 }},
-                        {% if siae.address_line_2 %}{{ siae.address_line_2 }},{% endif %}
-                        {{ siae.post_code }} {{ siae.city }}
-                        <br>
-                        {% if siae.active_admin_members %}
-                            {% with siae.active_admin_members.first as admin %}
-                                {# For security, display only the first char of the last name. #}
-                                <i>Pour obtenir une invitation, contactez {{ admin.first_name|title }} {{ admin.last_name|slice:1 }}.</i>
-                            {% endwith %}
-                        {% endif %}
-                    </p>
-                </li>
-            {% endfor %}
-        </ul>
-
-    </div>
-{% endif %}
+    {% endif %}
 
 
-{% if siaes_without_members or siaes_with_members %}
-    <div class="mt-5">
-        <p>
-            En cas de problème contactez-nous : <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
-        </p>
-    </div>
-{% endif %}
+    {% if siaes_without_members or siaes_with_members %}
+        <div class="mt-5">
+            <p>
+                En cas de problème contactez-nous : <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
+            </p>
+        </div>
+    {% endif %}
 
 
 {% endblock %}

--- a/itou/templates/signup/siae_signup.html
+++ b/itou/templates/signup/siae_signup.html
@@ -5,40 +5,40 @@
 
 
 {% block content %}
-<h1 class="h1-hero-c1">
-    Inscription
-    <small class="text-muted">Employeur solidaire</small>
-</h1>
+    <h1 class="h1-hero-c1">
+        Inscription
+        <small class="text-muted">Employeur solidaire</small>
+    </h1>
 
-<form method="post" action="" role="form" class="js-prevent-multiple-submit">
+    <form method="post" action="" role="form" class="js-prevent-multiple-submit">
 
-    {% csrf_token %}
+        {% csrf_token %}
 
-    {% bootstrap_form_errors form type="all" %}
+        {% bootstrap_form_errors form type="all" %}
 
-    {% if redirect_field_value %}
-        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
-    {% endif %}
+        {% if redirect_field_value %}
+            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
+        {% endif %}
 
-    {% bootstrap_field form.encoded_siae_id %}
-    {% bootstrap_field form.token %}
+        {% bootstrap_field form.encoded_siae_id %}
+        {% bootstrap_field form.token %}
 
-    {% bootstrap_field form.kind %}
-    {% bootstrap_field form.siret %}
-    {% bootstrap_field form.siae_name %}
-    {% bootstrap_field form.first_name %}
-    {% bootstrap_field form.last_name %}
-    {% bootstrap_field form.email %}
-    {% bootstrap_field form.password1 %}
-    {% bootstrap_field form.password2 %}
+        {% bootstrap_field form.kind %}
+        {% bootstrap_field form.siret %}
+        {% bootstrap_field form.siae_name %}
+        {% bootstrap_field form.first_name %}
+        {% bootstrap_field form.last_name %}
+        {% bootstrap_field form.email %}
+        {% bootstrap_field form.password1 %}
+        {% bootstrap_field form.password2 %}
 
-    {% include "signup/includes/submit_rgpd.html" %}
+        {% include "signup/includes/submit_rgpd.html" %}
 
-</form>
+    </form>
 
-<hr>
+    <hr>
 
-<p>
-    <a href="{% url 'account_login' %}">Vous avez déjà un compte ?</a>
-</p>
+    <p>
+        <a href="{% url 'account_login' %}">Vous avez déjà un compte ?</a>
+    </p>
 {% endblock %}

--- a/itou/templates/socialaccount/authentication_error.html
+++ b/itou/templates/socialaccount/authentication_error.html
@@ -12,14 +12,14 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Erreur inattendue à la connexion</h1>
+    <h1 class="h1-hero-c1">Erreur inattendue à la connexion</h1>
 
-<p>Une erreur inattendue s'est produite. Essayez à nouveau de vous connecter.</p>
+    <p>Une erreur inattendue s'est produite. Essayez à nouveau de vous connecter.</p>
 
-<p>Code de l'erreur : {{ auth_error.code }}</p>
+    <p>Code de l'erreur : {{ auth_error.code }}</p>
 
-<p>Nature de l'erreur : {{ auth_error.exception }}</p>
+    <p>Nature de l'erreur : {{ auth_error.exception }}</p>
 
-<p>Détails : {{ auth_error }}</p>
+    <p>Détails : {{ auth_error }}</p>
 
 {% endblock %}

--- a/itou/templates/socialaccount/login_cancelled.html
+++ b/itou/templates/socialaccount/login_cancelled.html
@@ -6,22 +6,22 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Connexion annulée</h1>
+    <h1 class="h1-hero-c1">Connexion annulée</h1>
 
-<p>
-    Vous avez annulé votre tentative de connexion.
-</p>
-<p>
-    <a href="{% url 'account_login' %}?account_type=job_seeker">
-        <button class="btn btn-secondary">
-            Retour
-        </button>
-    </a>
-    <a href="{% url 'peamu_login' %}">
-        <button class="btn btn-primary">
-            Se connecter à nouveau avec son compte Pôle emploi
-        </button>
-    </a>
-</p>
+    <p>
+        Vous avez annulé votre tentative de connexion.
+    </p>
+    <p>
+        <a href="{% url 'account_login' %}?account_type=job_seeker">
+            <button class="btn btn-secondary">
+                Retour
+            </button>
+        </a>
+        <a href="{% url 'peamu_login' %}">
+            <button class="btn btn-primary">
+                Se connecter à nouveau avec son compte Pôle emploi
+            </button>
+        </a>
+    </p>
 
 {% endblock %}

--- a/itou/templates/socialaccount/signup.html
+++ b/itou/templates/socialaccount/signup.html
@@ -18,19 +18,19 @@
 
 {% block content %}
 
-<h1 class="h1-hero-c1">Votre compte Pôle emploi doit être validé</h1>
+    <h1 class="h1-hero-c1">Votre compte Pôle emploi doit être validé</h1>
 
-<p>
-    Vous devez valider votre compte Pôle emploi pour vous connecter.
-</p>
-<p>
-    Cliquez sur le lien « <i>Je confirme mon adresse électronique</i> » dans le courriel
-    « <i>Confirmation de votre adresse électronique</i> » que Pôle emploi vous a envoyé.
-</p>
-<p>
-    <a href="{% url 'account_login' %}?account_type=job_seeker">
-        <span class="btn btn-secondary">Retour</span>
-    </a>
-</p>
+    <p>
+        Vous devez valider votre compte Pôle emploi pour vous connecter.
+    </p>
+    <p>
+        Cliquez sur le lien « <i>Je confirme mon adresse électronique</i> » dans le courriel
+        « <i>Confirmation de votre adresse électronique</i> » que Pôle emploi vous a envoyé.
+    </p>
+    <p>
+        <a href="{% url 'account_login' %}?account_type=job_seeker">
+            <span class="btn btn-secondary">Retour</span>
+        </a>
+    </p>
 
 {% endblock %}

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -29,10 +29,10 @@
 
         <h4 class="h5">Comment obtenir le nombre (ou la répartition) exacte correspondant à un élément de réponse ?</h4>
         <p>En survolant la couleur attribuée à cet élément de réponse sur le graphique, vous trouverez le nombre (ou la part) de cet élément dans une infobulle.</p>
-    
+
         <h4 class="h5">Comment obtenir la définition d'un chiffre ou d'un indicateur/graphique ?</h4>
         <p>En cliquant dessus, notre dictionnaire des indicateurs s’ouvrira (directement au niveau de celui demandé).</p>
-    
+
         <h4 class="h5">Vous n’êtes pas sûr(e) de comprendre les termes/sigles utilisés ?</h4>
         <p>
             L'ensemble des termes/sigles utilisés ici est défini dans le
@@ -40,14 +40,14 @@
                 glossaire de l’inclusion
             </a>.
         </p>
-    
+
         <h4 class="h5">Est-il possible de sélectionner seulement certaines données pour générer ces indicateurs/graphiques ?</h4>
         <p>
             Oui, vous pouvez sélectionner les données que vous souhaitez en utilisant les filtres en haut de l’écran, voici un exemple :
             <br>
             <img class="mt-5 img-fluid" src="{% static 'img/stats/metabase-department-filter.png' %}">
         </p>
-    
+
         <h4 class="h5">Comment télécharger les données d'un indicateur/graphique ?</h4>
         <p>
             En cliquant sur cette icône qui apparaît en haut à droite d’un graphique au survol de la souris :

--- a/itou/templates/stats/stats_pilotage.html
+++ b/itou/templates/stats/stats_pilotage.html
@@ -1,49 +1,49 @@
 
 <!DOCTYPE html>
 <html lang="fr">
-​
-  <head>
-    <meta name="robots" content="noindex, nofollow">
+    ​
+    <head>
+        <meta name="robots" content="noindex, nofollow">
 
-    <style>
-      html,
-      body,
-      iframe {
-        margin: 0;
-        padding: 0;
-        font-size: 0;
-        line-height: 0;
-      }
-​
-      html,
-      body {
-        width: 100%;
-      }
-​
-      iframe {
-        width: 100%;
-        height: 100%;
-      }
-    </style>
-  </head>
-​
-  <body>
-    {% block content %}
-        <script>
-            window.iFrameResizer = {
-                targetOrigin: "{{ ITOU_PILOTAGE_URL }}"
+        <style>
+            html,
+            body,
+            iframe {
+                margin: 0;
+                padding: 0;
+                font-size: 0;
+                line-height: 0;
             }
-        </script>
-        <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.2/js/iframeResizer.contentWindow.min.js"></script>
-        {% comment %} we took the scripts from {{stats_base_url}} to always use the same version{% endcomment %}
-        <script src="{{ stats_base_url }}/app/iframeResizer.js"></script>
-        <iframe
-            src="{{ iframeurl }}"
-            width="100%"
-            onload="iFrameResize({}, this)"
-            frameborder="0">
-        </iframe>
-    {% endblock %}
-  </body>
-​
+            ​
+            html,
+            body {
+                width: 100%;
+            }
+            ​
+            iframe {
+                width: 100%;
+                height: 100%;
+            }
+        </style>
+    </head>
+    ​
+    <body>
+        {% block content %}
+            <script>
+                window.iFrameResizer = {
+                    targetOrigin: "{{ ITOU_PILOTAGE_URL }}"
+                }
+            </script>
+            <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.2/js/iframeResizer.contentWindow.min.js"></script>
+            {% comment %} we took the scripts from {{stats_base_url}} to always use the same version{% endcomment %}
+            <script src="{{ stats_base_url }}/app/iframeResizer.js"></script>
+            <iframe
+                src="{{ iframeurl }}"
+                width="100%"
+                onload="iFrameResize({}, this)"
+                frameborder="0">
+            </iframe>
+        {% endblock %}
+    </body>
+    ​
 </html>

--- a/itou/templates/storage/s3_upload_form.html
+++ b/itou/templates/storage/s3_upload_form.html
@@ -6,26 +6,26 @@
             <div class="small">Taille maximale : {{ s3_upload_config.max_file_size }} Mo</div>
             <div class="small">Type de fichier : PDF</div>
         </a>
-        </div>
     </div>
+</div>
 
 
-    <p class="small mt-0">
-        {% include "includes/icon.html" with icon="help-circle" size="16" class="mr-1" %}
-        Ce fichier n'est pas un PDF ?
-        <a
-            href="https://doc.inclusion.beta.gouv.fr/mon-mode-demploi-prescripteur/postuler-pour-un-candidat#ajouter-un-cv-a-la-candidature"
-            target="_blank"
-            rel="noopener"
-            class="matomo-event"
-            matomo-category="ajout-fichier-candidature"
-            matomo-action="clic"
-            matomo-option="clic-sur-lien-aide-pdf"
-            title="Découvrez comment le convertir (ouverture dans un nouvel onglet)"
-            >
-            Découvrez comment le convertir.
-        </a>
-    </p>
+<p class="small mt-0">
+    {% include "includes/icon.html" with icon="help-circle" size="16" class="mr-1" %}
+    Ce fichier n'est pas un PDF ?
+    <a
+        href="https://doc.inclusion.beta.gouv.fr/mon-mode-demploi-prescripteur/postuler-pour-un-candidat#ajouter-un-cv-a-la-candidature"
+        target="_blank"
+        rel="noopener"
+        class="matomo-event"
+        matomo-category="ajout-fichier-candidature"
+        matomo-action="clic"
+        matomo-option="clic-sur-lien-aide-pdf"
+        title="Découvrez comment le convertir (ouverture dans un nouvel onglet)"
+    >
+        Découvrez comment le convertir.
+    </a>
+</p>
 </div>
 <noscript>
     <div class="alert alert-danger" role="status">

--- a/itou/templates/utils/widgets/duet_date_picker_widget.html
+++ b/itou/templates/utils/widgets/duet_date_picker_widget.html
@@ -12,4 +12,4 @@
         https://getbootstrap.com/docs/4.6/components/forms/#server-side
     {% endcomment %}
     {% if widget.attrs.class %}class="{{ widget.attrs.class }}"{% endif %}
-    ></duet-date-picker>
+></duet-date-picker>

--- a/itou/templates/welcoming_tour/includes/message.html
+++ b/itou/templates/welcoming_tour/includes/message.html
@@ -2,5 +2,5 @@
     👋 Bienvenue sur les emplois de l'inclusion ! 👉 <a href="{% url 'welcoming_tour:index' %}" class="alert-link">Revoir le message de bienvenue</a>
     <button type="button" class="close" data-dismiss="alert" aria-label="Fermer">
         <i class="ri-close-line"></i>
-    </button>       
+    </button>
 </div>

--- a/itou/templates/welcoming_tour/job_seeker.html
+++ b/itou/templates/welcoming_tour/job_seeker.html
@@ -6,59 +6,59 @@
 
 {% block content %}
 
-<div id="welcoming_tour" class="carousel">
-    <ol class="carousel-indicators">
-        <li data-target="#welcoming_tour" data-slide-to="0" class="active"></li>
-        <li data-target="#welcoming_tour" data-slide-to="1"></li>
-    </ol>
-    <div class="carousel-inner">
-        <div class="carousel-item active">
-            <div class="d-block w-100">
-                <h1 class="h1-hero-c1 text-center">Bienvenue sur les emplois de l'inclusion !</h1>
+    <div id="welcoming_tour" class="carousel">
+        <ol class="carousel-indicators">
+            <li data-target="#welcoming_tour" data-slide-to="0" class="active"></li>
+            <li data-target="#welcoming_tour" data-slide-to="1"></li>
+        </ol>
+        <div class="carousel-inner">
+            <div class="carousel-item active">
+                <div class="d-block w-100">
+                    <h1 class="h1-hero-c1 text-center">Bienvenue sur les emplois de l'inclusion !</h1>
 
-                <img src="{% static 'img/welcoming_tour/candidat_1.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
+                    <img src="{% static 'img/welcoming_tour/candidat_1.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
 
-                <p class="w-sm-50 m-auto lead text-center pb-5">
-                    Les emplois de l'inclusion m’aident dans ma recherche d’emploi en insertion.<br>
-                    Je trouve les offres proches de chez moi, et je contacte directement les employeurs. C’est plus facile et rapide !
-                </p>
-                <p class="pt-3 text-center">
-                    <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="next">
-                      <span type="button" class="btn btn-primary">Suivant</span>
-                    </a>
-                </p>
+                    <p class="w-sm-50 m-auto lead text-center pb-5">
+                        Les emplois de l'inclusion m’aident dans ma recherche d’emploi en insertion.<br>
+                        Je trouve les offres proches de chez moi, et je contacte directement les employeurs. C’est plus facile et rapide !
+                    </p>
+                    <p class="pt-3 text-center">
+                        <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="next">
+                            <span type="button" class="btn btn-primary">Suivant</span>
+                        </a>
+                    </p>
+                </div>
             </div>
-        </div>
-        <div class="carousel-item">
-            <div class="d-block w-100">
-                <h1 class="text-center">Je suis informé de l’avancement de mes candidatures !</h1>
+            <div class="carousel-item">
+                <div class="d-block w-100">
+                    <h1 class="text-center">Je suis informé de l’avancement de mes candidatures !</h1>
 
-                <img src="{% static 'img/welcoming_tour/candidat_2.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
+                    <img src="{% static 'img/welcoming_tour/candidat_2.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
 
-                <p class="w-sm-50 m-auto lead text-center">
-                    Une fois inscrit, je trouve les offres d’insertion proches de moi, et j’envoie mes candidatures aux employeurs.<br>
-                    Les emplois de l'inclusion m’informent par mail quand ma candidature est acceptée.
-                </p>
-                <p class="w-sm-50 m-auto lead text-center pt-2 pb-5">
-                    Maintenant, à moi de jouer !<br>
-                    J’ai toutes les chances dans mes recherches.
-                </p>
-                <p class="pt-3 text-center">
-                    <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="prev" >
-                      <span type="button" class="btn btn-secondary">Précédent</span>
-                    </a>
-                    <a class="text-decoration-none" href="{% url 'dashboard:index' %}" role="button" data-slide="next" >
-                      <span type="button" class="btn btn-primary">Terminer</span>
-                    </a>
-                </p>
+                    <p class="w-sm-50 m-auto lead text-center">
+                        Une fois inscrit, je trouve les offres d’insertion proches de moi, et j’envoie mes candidatures aux employeurs.<br>
+                        Les emplois de l'inclusion m’informent par mail quand ma candidature est acceptée.
+                    </p>
+                    <p class="w-sm-50 m-auto lead text-center pt-2 pb-5">
+                        Maintenant, à moi de jouer !<br>
+                        J’ai toutes les chances dans mes recherches.
+                    </p>
+                    <p class="pt-3 text-center">
+                        <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="prev" >
+                            <span type="button" class="btn btn-secondary">Précédent</span>
+                        </a>
+                        <a class="text-decoration-none" href="{% url 'dashboard:index' %}" role="button" data-slide="next" >
+                            <span type="button" class="btn btn-primary">Terminer</span>
+                        </a>
+                    </p>
+                </div>
             </div>
         </div>
     </div>
-</div>
-<p class="text-center pt-5 mb-0">
-    <a href="{% url 'dashboard:index' %}">
-        <span type="button" class="btn btn-link">Ignorer la présentation</span>
-    </a>
-</p>
+    <p class="text-center pt-5 mb-0">
+        <a href="{% url 'dashboard:index' %}">
+            <span type="button" class="btn btn-link">Ignorer la présentation</span>
+        </a>
+    </p>
 
 {% endblock content %}

--- a/itou/templates/welcoming_tour/prescriber.html
+++ b/itou/templates/welcoming_tour/prescriber.html
@@ -6,79 +6,79 @@
 
 {% block content %}
 
-<div id="welcoming_tour" class="carousel">
-    <ol class="carousel-indicators">
-        <li data-target="#welcoming_tour" data-slide-to="0" class="active"></li>
-        <li data-target="#welcoming_tour" data-slide-to="1"></li>
-        <li data-target="#welcoming_tour" data-slide-to="2"></li>
-    </ol>
-    <div class="carousel-inner">
-        <div class="carousel-item active">
-            <div class="d-block w-100">
-                <h1 class="h1-hero-c1 text-center">Bienvenue sur les emplois de l'inclusion !</h1>
+    <div id="welcoming_tour" class="carousel">
+        <ol class="carousel-indicators">
+            <li data-target="#welcoming_tour" data-slide-to="0" class="active"></li>
+            <li data-target="#welcoming_tour" data-slide-to="1"></li>
+            <li data-target="#welcoming_tour" data-slide-to="2"></li>
+        </ol>
+        <div class="carousel-inner">
+            <div class="carousel-item active">
+                <div class="d-block w-100">
+                    <h1 class="h1-hero-c1 text-center">Bienvenue sur les emplois de l'inclusion !</h1>
 
-                <img src="{% static 'img/welcoming_tour/prescripteur_1.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
+                    <img src="{% static 'img/welcoming_tour/prescripteur_1.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
 
-                <p class="w-sm-50 m-auto lead text-center pb-5">
-                    Découvrez un outil qui accélère la mise en relation des candidats à l’insertion auprès des employeurs solidaires et simplifie la mission des acteurs de l’IAE.
-                </p>
-                <p class="pt-3 text-center">
-                    <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="next">
-                      <span type="button" class="btn btn-primary">Suivant</span>
-                    </a>
-                </p>
+                    <p class="w-sm-50 m-auto lead text-center pb-5">
+                        Découvrez un outil qui accélère la mise en relation des candidats à l’insertion auprès des employeurs solidaires et simplifie la mission des acteurs de l’IAE.
+                    </p>
+                    <p class="pt-3 text-center">
+                        <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="next">
+                            <span type="button" class="btn btn-primary">Suivant</span>
+                        </a>
+                    </p>
+                </div>
             </div>
-        </div>
-        <div class="carousel-item">
-            <div class="d-block w-100">
-                <h1 class="h1-hero-c1 text-center">Identifiez toutes les offres d’emploi de l’inclusion localement !</h1>
+            <div class="carousel-item">
+                <div class="d-block w-100">
+                    <h1 class="h1-hero-c1 text-center">Identifiez toutes les offres d’emploi de l’inclusion localement !</h1>
 
-                <img src="{% static 'img/welcoming_tour/prescripteur_2.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
+                    <img src="{% static 'img/welcoming_tour/prescripteur_2.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
 
-                <p class="w-sm-50 m-auto lead text-center pb-5">
-                    Optimisez les chances de vos candidats et renforcez le pilotage de leur parcours en insertion.<br>
-                    Profitez d’un outil mutualisé d’accompagnement de l’IAE : mise en relation simplifiée, partage entre acteurs, simplification des procédures d’agrément, réduction des délais de recrutement.
-                </p>
-                <p class="pt-3 text-center">
-                    <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="prev">
-                      <span type="button" class="btn btn-secondary">Précédent</span>
-                    </a>
-                    <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="next">
-                      <span type="button" class="btn btn-primary">Suivant</span>
-                    </a>
-                </p>
+                    <p class="w-sm-50 m-auto lead text-center pb-5">
+                        Optimisez les chances de vos candidats et renforcez le pilotage de leur parcours en insertion.<br>
+                        Profitez d’un outil mutualisé d’accompagnement de l’IAE : mise en relation simplifiée, partage entre acteurs, simplification des procédures d’agrément, réduction des délais de recrutement.
+                    </p>
+                    <p class="pt-3 text-center">
+                        <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="prev">
+                            <span type="button" class="btn btn-secondary">Précédent</span>
+                        </a>
+                        <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="next">
+                            <span type="button" class="btn btn-primary">Suivant</span>
+                        </a>
+                    </p>
+                </div>
             </div>
-        </div>
-        <div class="carousel-item">
-            <div class="d-block w-100">
-                <h1 class="text-center">Suivez toutes vos candidatures en ligne</h1>
+            <div class="carousel-item">
+                <div class="d-block w-100">
+                    <h1 class="text-center">Suivez toutes vos candidatures en ligne</h1>
 
-                <img src="{% static 'img/welcoming_tour/prescripteur_3.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
+                    <img src="{% static 'img/welcoming_tour/prescripteur_3.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
 
-                <p class="w-sm-50 m-auto lead text-center">
-                   Prescripteur ou orienteur... affilié ou pas à une organisation... habilitée ou non, vous pouvez tous vous inscrire !<br>
-                   Postulez pour un candidat à l’insertion en quelques clics, suivez l’avancement de ses candidatures en temps réel, échangez avec les collaborateurs de votre organisation ou rejoignez la communauté active.
-                </p>
-                <p class="w-sm-50 m-auto lead text-center pt-2 pb-5">
-                    À vous de jouer maintenant !<br>
-                    Bonne découverte et bon accompagnement.
-                </p>
-                <p class="pt-3 text-center">
-                    <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="prev">
-                      <span type="button" class="btn btn-secondary">Précédent</span>
-                    </a>
-                    <a class="text-decoration-none" href="{% url 'dashboard:index' %}" role="button" data-slide="next">
-                      <span type="button" class="btn btn-primary">Terminer</span>
-                    </a>
-                </p>
+                    <p class="w-sm-50 m-auto lead text-center">
+                        Prescripteur ou orienteur... affilié ou pas à une organisation... habilitée ou non, vous pouvez tous vous inscrire !<br>
+                        Postulez pour un candidat à l’insertion en quelques clics, suivez l’avancement de ses candidatures en temps réel, échangez avec les collaborateurs de votre organisation ou rejoignez la communauté active.
+                    </p>
+                    <p class="w-sm-50 m-auto lead text-center pt-2 pb-5">
+                        À vous de jouer maintenant !<br>
+                        Bonne découverte et bon accompagnement.
+                    </p>
+                    <p class="pt-3 text-center">
+                        <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="prev">
+                            <span type="button" class="btn btn-secondary">Précédent</span>
+                        </a>
+                        <a class="text-decoration-none" href="{% url 'dashboard:index' %}" role="button" data-slide="next">
+                            <span type="button" class="btn btn-primary">Terminer</span>
+                        </a>
+                    </p>
+                </div>
             </div>
         </div>
     </div>
-</div>
-<p class="text-center pt-5 mb-0">
-    <a href="{% url 'dashboard:index' %}">
-        <span type="button" class="btn btn-link">Ignorer la présentation</span>
-    </a>
-</p>
+    <p class="text-center pt-5 mb-0">
+        <a href="{% url 'dashboard:index' %}">
+            <span type="button" class="btn btn-link">Ignorer la présentation</span>
+        </a>
+    </p>
 
 {% endblock content %}

--- a/itou/templates/welcoming_tour/siae_staff.html
+++ b/itou/templates/welcoming_tour/siae_staff.html
@@ -6,79 +6,79 @@
 
 {% block content %}
 
-<div id="welcoming_tour" class="carousel">
-    <ol class="carousel-indicators">
-        <li data-target="#welcoming_tour" data-slide-to="0" class="active"></li>
-        <li data-target="#welcoming_tour" data-slide-to="1"></li>
-        <li data-target="#welcoming_tour" data-slide-to="2"></li>
-    </ol>
-    <div class="carousel-inner">
-        <div class="carousel-item active">
-            <div class="d-block w-100">
-                <h1 class="h1-hero-c1 text-center">Bienvenue sur les emplois de l'inclusion !</h1>
+    <div id="welcoming_tour" class="carousel">
+        <ol class="carousel-indicators">
+            <li data-target="#welcoming_tour" data-slide-to="0" class="active"></li>
+            <li data-target="#welcoming_tour" data-slide-to="1"></li>
+            <li data-target="#welcoming_tour" data-slide-to="2"></li>
+        </ol>
+        <div class="carousel-inner">
+            <div class="carousel-item active">
+                <div class="d-block w-100">
+                    <h1 class="h1-hero-c1 text-center">Bienvenue sur les emplois de l'inclusion !</h1>
 
-                <img src="{% static 'img/welcoming_tour/employeur_1.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
+                    <img src="{% static 'img/welcoming_tour/employeur_1.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
 
-                <p class="w-sm-50 m-auto lead text-center pb-5">
-                    Découvrez l’outil qui simplifie la mise en relation des candidats à l’insertion avec les employeurs solidaires et facilite tous vos recrutements.
-                </p>
-                <p class="pt-3 text-center">
-                    <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="next">
-                      <span type="button" class="btn btn-primary">Suivant</span>
-                    </a>
-                </p>
+                    <p class="w-sm-50 m-auto lead text-center pb-5">
+                        Découvrez l’outil qui simplifie la mise en relation des candidats à l’insertion avec les employeurs solidaires et facilite tous vos recrutements.
+                    </p>
+                    <p class="pt-3 text-center">
+                        <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="next">
+                            <span type="button" class="btn btn-primary">Suivant</span>
+                        </a>
+                    </p>
+                </div>
             </div>
-        </div>
-        <div class="carousel-item">
-            <div class="d-block w-100">
-                <h1 class="h1-hero-c1 text-center">Publiez vos offres, augmentez votre visibilité</h1>
+            <div class="carousel-item">
+                <div class="d-block w-100">
+                    <h1 class="h1-hero-c1 text-center">Publiez vos offres, augmentez votre visibilité</h1>
 
-                <img src="{% static 'img/welcoming_tour/employeur_2.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
+                    <img src="{% static 'img/welcoming_tour/employeur_2.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
 
-                <p class="w-sm-50 m-auto lead text-center pb-5">
-                    Grâce aux emplois de l'inclusion, disposez d’une plus large diffusion de vos offres auprès des candidats à l’insertion de votre région.<br>
-                    Gagnez en visibilité pour vous faire connaître des prescripteurs locaux.
-                </p>
-                <p class="pt-3 text-center">
-                    <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="prev">
-                      <span type="button" class="btn btn-secondary">Précédent</span>
-                    </a>
-                    <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="next">
-                      <span type="button" class="btn btn-primary">Suivant</span>
-                    </a>
-                </p>
+                    <p class="w-sm-50 m-auto lead text-center pb-5">
+                        Grâce aux emplois de l'inclusion, disposez d’une plus large diffusion de vos offres auprès des candidats à l’insertion de votre région.<br>
+                        Gagnez en visibilité pour vous faire connaître des prescripteurs locaux.
+                    </p>
+                    <p class="pt-3 text-center">
+                        <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="prev">
+                            <span type="button" class="btn btn-secondary">Précédent</span>
+                        </a>
+                        <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="next">
+                            <span type="button" class="btn btn-primary">Suivant</span>
+                        </a>
+                    </p>
+                </div>
             </div>
-        </div>
-        <div class="carousel-item">
-            <div class="d-block w-100">
-                <h1 class="h1-hero-c1 text-center">Gérez toutes vos candidatures en ligne !</h1>
+            <div class="carousel-item">
+                <div class="d-block w-100">
+                    <h1 class="h1-hero-c1 text-center">Gérez toutes vos candidatures en ligne !</h1>
 
-                <img src="{% static 'img/welcoming_tour/employeur_3.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
+                    <img src="{% static 'img/welcoming_tour/employeur_3.svg' %}" class="d-block mx-auto my-4 w-sm-25" alt="">
 
-                <p class="w-sm-50 m-auto lead text-center">
-                    Renseignez votre profil SIAE, valorisez votre activité, configurez vos fiches de postes... et voilà !<br>
-                    Vous pouvez recruter en toute autonomie, que ce soit en candidature spontanée ou via un orienteur et un prescripteur, et même recevoir votre agrément IAE en ligne (PASS IAE) !
-                </p>
-                <p class="w-sm-50 m-auto lead text-center pb-5 pt-2">
-                    À vous de jouer maintenant !<br>
-                    Bonne découverte et bons recrutements.
-                </p>
-                <p class="pt-3 text-center">
-                    <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="prev">
-                      <span type="button" class="btn btn-secondary">Précédent</span>
-                    </a>
-                    <a class="text-decoration-none" href="{% url 'dashboard:index' %}" role="button" data-slide="next">
-                      <span type="button" class="btn btn-primary">Terminer</span>
-                    </a>
-                </p>
+                    <p class="w-sm-50 m-auto lead text-center">
+                        Renseignez votre profil SIAE, valorisez votre activité, configurez vos fiches de postes... et voilà !<br>
+                        Vous pouvez recruter en toute autonomie, que ce soit en candidature spontanée ou via un orienteur et un prescripteur, et même recevoir votre agrément IAE en ligne (PASS IAE) !
+                    </p>
+                    <p class="w-sm-50 m-auto lead text-center pb-5 pt-2">
+                        À vous de jouer maintenant !<br>
+                        Bonne découverte et bons recrutements.
+                    </p>
+                    <p class="pt-3 text-center">
+                        <a class="text-decoration-none" href="#welcoming_tour" role="button" data-slide="prev">
+                            <span type="button" class="btn btn-secondary">Précédent</span>
+                        </a>
+                        <a class="text-decoration-none" href="{% url 'dashboard:index' %}" role="button" data-slide="next">
+                            <span type="button" class="btn btn-primary">Terminer</span>
+                        </a>
+                    </p>
+                </div>
             </div>
         </div>
     </div>
-</div>
-<p class="text-center pt-5 mb-0">
-    <a href="{% url 'dashboard:index' %}">
-        <span type="button" class="btn btn-link">Ignorer la présentation</span>
-    </a>
-</p>
+    <p class="text-center pt-5 mb-0">
+        <a href="{% url 'dashboard:index' %}">
+            <span type="button" class="btn btn-link">Ignorer la présentation</span>
+        </a>
+    </p>
 
 {% endblock content %}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,6 +23,7 @@ pylint==2.12.2  # https://github.com/PyCQA/pylint
 pylint-django==2.4.3  # https://github.com/PyCQA/pylint-django
 pre-commit==2.16.0  # https://github.com/pre-commit/pre-commit
 coverage==6.2  # https://github.com/nedbat/coveragepy
+djhtml==1.5.0  # https://github.com/rtts/djhtml
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
### Quoi ?

Ajouter `djhtml` en tant qu'outil de formatage de nos templates.

### Pourquoi ?
Cela permet dans la meme veine que pour `black` et `isort` de ne plus se poser de questions quant au formatage des templates HTML Django du projet.

### Comment ?
En installant `djhtml` et:
- en proposant des nouvelles commandes `make` à la fois pour vérifier et corriger l'environnement
- en ajoutant une vérification des templates dans la CI

Un commit assez gros est ajouté qui reformate dès aujourd'hui les templates existantes qui ne seraient pas confiormes.