### PR TITLE
Correction des erreurs a11y sur le contraste de couleurs, la présentation et consultation de l'information 

### DIFF
--- a/itou/templates/home/home.html
+++ b/itou/templates/home/home.html
@@ -60,7 +60,7 @@
 
     <section class="bg-gray-400 text-center">
         <div class="container">
-            <div class="js-tac-livestorm" data-url="https://app.livestorm.co/itou/upcoming?limit=3" title="Événements des emplois de l'inclusion | Livestorm" width="100%"></div>
+            <div class="js-tac-livestorm w-100" data-url="https://app.livestorm.co/itou/upcoming?limit=3" title="Événements des emplois de l'inclusion | Livestorm"></div>
         </div>
     </section>
 

--- a/itou/templates/layout/_header.html
+++ b/itou/templates/layout/_header.html
@@ -17,7 +17,7 @@
                     </ul>
                 </nav>
             </div>
-            <div class="s-header__col s-header__col--burger col d-flex align-items-center justify-content-end d-xl-none" data-toggle="burger">
+            <div class="s-header__col s-header__col--burger col d-flex align-items-center justify-content-end d-xl-none" data-toggle="burger" aria-controls="burgerNav" tabindex="0">
                 <span id="burger"><img src="{% static_theme_images "picto-burger.svg" %}" alt="Menu"></span>
                 <span id="close"><img src="{% static_theme_images "picto-close.svg" %}" alt="Fermer"></span>
             </div>

--- a/itou/templates/layout/_nav_btn_items.html
+++ b/itou/templates/layout/_nav_btn_items.html
@@ -74,7 +74,7 @@
 
     {% if user.is_siae_staff and user_siaes|length > 1 %}
         <li class="dropdown">
-            <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="switchUserDropdown" aria-expanded="false" data-display="static">
+            <button type="button" class="btn btn-outline-primary w-100 w-sm-auto my-1 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="switchUserDropdown" aria-expanded="false">
                 Changer de structure
             </button>
             <div class="dropdown-menu dropdown-menu-left" id="switchUserDropdown">

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -135,7 +135,7 @@
                         if (document.body.clientWidth > tablet_width) {
                             height = "365px";
                         }
-                        return '<iframe title="' + frame_title + '" src="' + url + '" width="' + width + '" height="' + height + '" frameborder="0" scrolling="no" allowtransparency allowfullscreen></iframe>';
+                        return '<iframe title="' + frame_title + '" src="' + url + '" style="min-height:' + height + ';" allowtransparency allowfullscreen></iframe>';
                     });
                 },
                 "fallback": function () {

--- a/itou/templates/siaes/card.html
+++ b/itou/templates/siaes/card.html
@@ -15,9 +15,9 @@
                     <p class="h2">
                         {{ siae.display_name }}
                     </p>
-                    {% if siae.address_on_one_line %}
-                        <p> {{ siae.address_on_one_line }} </p>
-                    {% endif %}
+                    {# Display non-user-edited name too. #}
+                    {% comment %} {% if siae.brand %}<small class="text-muted">({{ siae.name|title }})</small>{% endif %} {% endcomment %}
+                    <adresse class="card-subtitle fs-lg font-weight-bold text-secondary">{{ siae.address_on_one_line }}</adresse>
                 </div>
             </div>
 


### PR DESCRIPTION
### Quoi ?

Correction de certaines erreurs a11y sur le contraste de couleurs, la présentation de l'information et la consultation. 

### Pourquoi ?

Pour mettre en conformité le site avec les règles d'accessibilité et respecter les recommandations de l'audit.

### Comment ?

En modifiant le contraste et/ou la taille de certains éléments texte.
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-3-1
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-3-2
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-10-4

En supprimant les attributs html de mise en forme 
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-10-1

En ajoutant ou supprimant les attributs aria.
https://www.w3.org/TR/html-aria/
