### PR TITLE
Ajout de djhtml à la configuration de pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,4 +13,9 @@ repos:
     hooks:
       - id: flake8
         language_version: python3
+  - repo: https://github.com/rtts/djhtml
+    rev: v1.5.0
+    hooks:
+      - id: djhtml
+        language_version: python3
 


### PR DESCRIPTION
### Quoi ?

Modification de la configuration de pre-commit.

### Pourquoi ?

Au lieu de casser la CI et de s'énerver, lançons djhtml en local à chaque commit grâce à `pre-commit`.

Pour refléter ces changements, lancez en local la commande suivante :
```
(venv) cms@cms $ git add .pre-commit-config.yaml 
```