### PR TITLE
hiring_start_at is optional so it can be none

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -605,7 +605,8 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         Check if EmployeeRecord does not exist and can be created for this JobApplication.
         """
         is_application_valid = (
-            self.hiring_start_at >= settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE.date()
+            self.hiring_start_at is not None
+            and self.hiring_start_at >= settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE.date()
             and not self.hiring_without_approval
             and self.state == JobApplicationWorkflow.STATE_ACCEPTED
             and self.approval.is_valid()

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -223,6 +223,10 @@ class JobApplicationModelTest(TestCase):
         job_application = JobApplicationWithApprovalFactory()
         to_siae = job_application.to_siae
 
+        # test application with missing hiring_start_at (it’s an optional)
+        job_application.hiring_start_at = None
+        self.assertFalse(job_application.is_waiting_for_employee_record_creation)
+
         # test application before EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE
         day_in_the_past = settings.EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE.date() - relativedelta(months=2)
         job_application.hiring_start_at = day_in_the_past


### PR DESCRIPTION
### Quoi ?

Bug sur la gestion de la date de début `hiring_start_at` qui est optionnelle et peut être nulle.

https://sentry.io/organizations/itou/issues/3037587654/?project=6164438&query=is%3Aunresolved

### Comment ?

Gestion du cas nul