### PR TITLE
HOTFIX : niveau de log de certaines erreurs lors du transfert de fiches salarié

### DIFF
--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -175,12 +175,12 @@ class Command(BaseCommand):
             employee_record = EmployeeRecord.objects.find_by_batch(batch_filename, line_number).first()
 
             if not employee_record:
-                self.logger.error(
+                self.logger.warning(
                     "Could not get existing employee record data: BATCH_FILE=%s, LINE_NUMBER=%s",
                     batch_filename,
                     line_number,
                 )
-                record_errors += 1
+                # Do not count as an error
                 continue
 
             # Employee record succesfully processed by ASP :


### PR DESCRIPTION
### Quoi ?

Sentry se prends une marée de log d'erreurs en provenance des transferts de fiches salarié.

### Pourquoi ?

Si des fiches sont effacées manuellement avant un retour de l'ASP, le traitement du fichier retour renvoie des erreurs (sans crasher) et n'efface pas le fichier (ça boucle et à chaque passage : bingo).

### Comment ?

- ce cas particulier n'est plus loggé comme une erreur mais comme un `warning`
- le fichier peut être effacé sans impact majeur

## Divers

Pas de revue