### PR TITLE
SIAE description: minor changes to the template design

### DIFF
--- a/itou/templates/siaes/card.html
+++ b/itou/templates/siaes/card.html
@@ -15,7 +15,9 @@
                     <h2 class="h2">
                         {{ siae.display_name }}
                     </h2>
-                    <p> {{ siae.address_on_one_line }} </p>
+                    {% if siae.address_on_one_line %}
+                        <p> {{ siae.address_on_one_line }} </p>
+                    {% endif %}
                 </div>
             </div>
 
@@ -54,22 +56,19 @@
                 {% endif %}
             {% endif %}
 
-            <hr>
-
             {% if siae.block_job_applications and siae.count_active_job_descriptions == 0 %}
                 <span class="badge badge-pill badge-warning">Pas de recrutement en cours</span>
             {% endif %}
 
             {% if jobs_descriptions %}
+                <hr>
                 {% include "siaes/includes/_list_siae_jobs.html" with siae=siae jobs_descriptions=jobs_descriptions %}
             {% endif %}
 
-            <hr>
-
             {% if siae.count_active_job_descriptions > 0 and not siae.block_job_applications %}
+                <hr>
                 {% include "siaes/includes/_list_siae_actives_jobs.html" with jobs_descriptions=jobs_descriptions siae=siae %}
             {% endif %}
-
 
             {% if not siae.block_job_applications %}
                 <hr class="mb-3 mb-lg-5">


### PR DESCRIPTION
When we get a VERY distorted SIAE (which should normally never happen)
at least display it somewhat correctly.

### Quoi ?
Corriger l'affochage de la nouvelle fiche structure dans certains cas extrêmes.


### Pourquoi ?
Quand un SIAE n'a aucune information définie, la fiche structure est moche.

### Comment ?
En bougeant les `<hr>` de place et les rendant conditionnels.

Si l'adresse est vide, ne rien afficher.

### Captures d'écran (optionnel)

Avant
![Screenshot from 2022-02-23 11-54-58](https://user-images.githubusercontent.com/88618/155328976-7cb28d5f-a468-42b9-8ecd-d62cd2408212.png)

Après
![Screenshot from 2022-02-23 14-31-03](https://user-images.githubusercontent.com/88618/155329234-3f273984-a74b-4ade-b2ba-58eb460e7186.png)
