### PR TITLE
Correctif pour permettre de nouveau l'envoi de candidature

### DIFF
--- a/itou/common_apps/resume/forms.py
+++ b/itou/common_apps/resume/forms.py
@@ -16,7 +16,7 @@ class ResumeFormMixin(forms.Form):
     def clean_resume_link(self):
         resume_link = self.cleaned_data["resume_link"]
         # ensure the CV has been uploaded via our S3 platform and is not a link to a 3rd party website
-        if settings.S3_STORAGE_ENDPOINT_DOMAIN not in resume_link:
+        if resume_link and settings.S3_STORAGE_ENDPOINT_DOMAIN not in resume_link:
             self.add_error(
                 "resume_link", forms.ValidationError("Le CV proposé ne provient pas d'une source de confiance.")
             )

--- a/itou/templates/apply/submit_step_application.html
+++ b/itou/templates/apply/submit_step_application.html
@@ -16,6 +16,8 @@
 
         {% csrf_token %}
 
+        {% bootstrap_form_errors form alert_error_type="all" %}
+
         {% if siae.jobs.exists %}
             {% bootstrap_field form.selected_jobs %}
         {% endif %}


### PR DESCRIPTION
### Quoi ?

Correction pour rétablir l'envoi des candidatures.

### Pourquoi ?

La PR #1133 a modifié la fonctionnalité d'ajout de CV et cassé l'envoi des candidatures. En effet, il a rendu obligatoire l'ajout d'un CV sans le vouloir.
Cela est passé inaperçu car le gabarit n'affiche pas les erreurs. C'est aussi corrigé dans cette PR.

### Comment ?

Rétablissement du CV optionnel et ajout des erreurs dans le gabarit.

### Captures d'écran

![image](https://user-images.githubusercontent.com/6150920/155358423-fc48bbc4-a81c-4e64-809a-1c059dfc1f7b.png)
