### PR TITLE
ResumeFormMixin: ensure the resume_link will stay optional

### DIFF
--- a/itou/common_apps/resume/forms.py
+++ b/itou/common_apps/resume/forms.py
@@ -14,7 +14,7 @@ class ResumeFormMixin(forms.Form):
         ]
 
     def clean_resume_link(self):
-        resume_link = self.cleaned_data["resume_link"]
+        resume_link = self.cleaned_data.get("resume_link")
         # ensure the CV has been uploaded via our S3 platform and is not a link to a 3rd party website
         if resume_link and settings.S3_STORAGE_ENDPOINT_DOMAIN not in resume_link:
             self.add_error(

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -910,6 +910,16 @@ class ResumeFormMixinTest(TestCase):
         form = ResumeFormMixin(data={"resume_link": "https://foobar.com/safe.pdf"})
         self.assertTrue(form.is_valid())
 
+    def test_resume_is_optional(self):
+        form = ResumeFormMixin(data={})
+        self.assertTrue(form.is_valid())
+
+        form = ResumeFormMixin(data={"resume_link": None})
+        self.assertTrue(form.is_valid())
+
+        form = ResumeFormMixin(data={"resume_link": ""})
+        self.assertTrue(form.is_valid())
+
 
 class SupportRemarkAdminViewsTest(TestCase):
     def test_add_support_remark_to_suspension(self):


### PR DESCRIPTION
### Quoi ?

Ajouter un test pour ne plus avoir de régression à ce sujet.

### Pourquoi ?

Le comportement de "CV optionnel" n'était pas garanti par un test. Il a donc sauté sans qu'on s'en rende compte, cassant la prod.

### Comment ?

En ajoutant un test.
