### PR TITLE
Rendre le champ 'date de fin de contrat' optionnel

### DIFF
--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -517,21 +517,7 @@ class JobApplicationNotificationsTest(TestCase):
     def test_accept_for_proxy_without_hiring_end_at(self, *args, **kwargs):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(hiring_end_at=None)
         email = job_application.email_accept_for_proxy
-        # To.
-        self.assertIn(job_application.sender.email, email.to)
-        self.assertEqual(len(email.to), 1)
-        self.assertEqual(len(email.bcc), 0)
-        # Subject.
-        self.assertIn("Candidature acceptée et votre avis sur les emplois de l'inclusion", email.subject)
-        # Body.
-        self.assertIn(title(job_application.job_seeker.get_full_name()), email.body)
-        self.assertIn(title(job_application.sender.get_full_name()), email.body)
-        self.assertIn(job_application.to_siae.display_name, email.body)
-        self.assertIn(job_application.answer, email.body)
-        self.assertIn("Date de début du contrat", email.body)
-        self.assertIn(job_application.hiring_start_at.strftime("%d/%m/%Y"), email.body)
         self.assertIn("Date de fin du contrat : Non renseigné", email.body)
-        self.assertIn(job_application.sender_prescriber_organization.accept_survey_url, email.body)
 
     def test_accept_trigger_manual_approval(self, *args, **kwargs):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(
@@ -564,24 +550,7 @@ class JobApplicationNotificationsTest(TestCase):
         )
         accepted_by = job_application.to_siae.members.first()
         email = job_application.email_manual_approval_delivery_required_notification(accepted_by)
-        # To.
-        self.assertIn(settings.ITOU_EMAIL_CONTACT, email.to)
-        self.assertEqual(len(email.to), 1)
-        # Body.
-        self.assertIn(job_application.job_seeker.first_name, email.body)
-        self.assertIn(job_application.job_seeker.last_name, email.body)
-        self.assertIn(job_application.job_seeker.email, email.body)
-        self.assertIn(job_application.job_seeker.birthdate.strftime("%d/%m/%Y"), email.body)
-        self.assertIn(job_application.to_siae.siret, email.body)
-        self.assertIn(job_application.to_siae.kind, email.body)
-        self.assertIn(job_application.to_siae.get_kind_display(), email.body)
-        self.assertIn(job_application.to_siae.get_department_display(), email.body)
-        self.assertIn(job_application.to_siae.display_name, email.body)
-        self.assertIn(job_application.hiring_start_at.strftime("%d/%m/%Y"), email.body)
         self.assertIn("Date de fin du contrat : Non renseigné", email.body)
-        self.assertIn(accepted_by.get_full_name(), email.body)
-        self.assertIn(accepted_by.email, email.body)
-        self.assertIn(reverse("admin:approvals_approval_manually_add_approval", args=[job_application.pk]), email.body)
 
     def test_refuse(self, *args, **kwargs):
 
@@ -656,27 +625,7 @@ class JobApplicationNotificationsTest(TestCase):
         )
         accepted_by = job_application.to_siae.members.first()
         email = job_application.email_deliver_approval(accepted_by)
-        # To.
-        self.assertIn(accepted_by.email, email.to)
-        self.assertEqual(len(email.to), 1)
-        # Body.
-        self.assertIn(approval.user.get_full_name(), email.subject)
-        self.assertIn(approval.number_with_spaces, email.body)
-        self.assertIn(approval.start_at.strftime("%d/%m/%Y"), email.body)
-        self.assertIn(approval.end_at.strftime("%d/%m/%Y"), email.body)
-        self.assertIn(approval.user.last_name, email.body)
-        self.assertIn(approval.user.first_name, email.body)
-        self.assertIn(approval.user.birthdate.strftime("%d/%m/%Y"), email.body)
-        self.assertIn(job_application.hiring_start_at.strftime("%d/%m/%Y"), email.body)
         self.assertIn("Se terminant le : Non renseigné", email.body)
-        self.assertIn(job_application.to_siae.display_name, email.body)
-        self.assertIn(job_application.to_siae.get_kind_display(), email.body)
-        self.assertIn(job_application.to_siae.address_line_1, email.body)
-        self.assertIn(job_application.to_siae.address_line_2, email.body)
-        self.assertIn(job_application.to_siae.post_code, email.body)
-        self.assertIn(job_application.to_siae.city, email.body)
-        self.assertIn(settings.ITOU_ASSISTANCE_URL, email.body)
-        self.assertIn(job_application.to_siae.accept_survey_url, email.body)
 
     def test_manually_deliver_approval(self, *args, **kwargs):
         staff_member = UserFactory(is_staff=True)

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -514,6 +514,25 @@ class JobApplicationNotificationsTest(TestCase):
         self.assertIn(job_application.hiring_end_at.strftime("%d/%m/%Y"), email.body)
         self.assertIn(job_application.sender_prescriber_organization.accept_survey_url, email.body)
 
+    def test_accept_for_proxy_without_hiring_end_at(self, *args, **kwargs):
+        job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(hiring_end_at=None)
+        email = job_application.email_accept_for_proxy
+        # To.
+        self.assertIn(job_application.sender.email, email.to)
+        self.assertEqual(len(email.to), 1)
+        self.assertEqual(len(email.bcc), 0)
+        # Subject.
+        self.assertIn("Candidature acceptée et votre avis sur les emplois de l'inclusion", email.subject)
+        # Body.
+        self.assertIn(title(job_application.job_seeker.get_full_name()), email.body)
+        self.assertIn(title(job_application.sender.get_full_name()), email.body)
+        self.assertIn(job_application.to_siae.display_name, email.body)
+        self.assertIn(job_application.answer, email.body)
+        self.assertIn("Date de début du contrat", email.body)
+        self.assertIn(job_application.hiring_start_at.strftime("%d/%m/%Y"), email.body)
+        self.assertIn("Date de fin du contrat : Non renseigné", email.body)
+        self.assertIn(job_application.sender_prescriber_organization.accept_survey_url, email.body)
+
     def test_accept_trigger_manual_approval(self, *args, **kwargs):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(
             state=JobApplicationWorkflow.STATE_ACCEPTED, hiring_start_at=datetime.date.today()
@@ -535,6 +554,31 @@ class JobApplicationNotificationsTest(TestCase):
         self.assertIn(job_application.to_siae.display_name, email.body)
         self.assertIn(job_application.hiring_start_at.strftime("%d/%m/%Y"), email.body)
         self.assertIn(job_application.hiring_end_at.strftime("%d/%m/%Y"), email.body)
+        self.assertIn(accepted_by.get_full_name(), email.body)
+        self.assertIn(accepted_by.email, email.body)
+        self.assertIn(reverse("admin:approvals_approval_manually_add_approval", args=[job_application.pk]), email.body)
+
+    def test_accept_trigger_manual_approval_without_hiring_end_at(self, *args, **kwargs):
+        job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(
+            state=JobApplicationWorkflow.STATE_ACCEPTED, hiring_start_at=datetime.date.today(), hiring_end_at=None
+        )
+        accepted_by = job_application.to_siae.members.first()
+        email = job_application.email_manual_approval_delivery_required_notification(accepted_by)
+        # To.
+        self.assertIn(settings.ITOU_EMAIL_CONTACT, email.to)
+        self.assertEqual(len(email.to), 1)
+        # Body.
+        self.assertIn(job_application.job_seeker.first_name, email.body)
+        self.assertIn(job_application.job_seeker.last_name, email.body)
+        self.assertIn(job_application.job_seeker.email, email.body)
+        self.assertIn(job_application.job_seeker.birthdate.strftime("%d/%m/%Y"), email.body)
+        self.assertIn(job_application.to_siae.siret, email.body)
+        self.assertIn(job_application.to_siae.kind, email.body)
+        self.assertIn(job_application.to_siae.get_kind_display(), email.body)
+        self.assertIn(job_application.to_siae.get_department_display(), email.body)
+        self.assertIn(job_application.to_siae.display_name, email.body)
+        self.assertIn(job_application.hiring_start_at.strftime("%d/%m/%Y"), email.body)
+        self.assertIn("Date de fin du contrat : Non renseigné", email.body)
         self.assertIn(accepted_by.get_full_name(), email.body)
         self.assertIn(accepted_by.email, email.body)
         self.assertIn(reverse("admin:approvals_approval_manually_add_approval", args=[job_application.pk]), email.body)
@@ -595,6 +639,36 @@ class JobApplicationNotificationsTest(TestCase):
         self.assertIn(approval.user.birthdate.strftime("%d/%m/%Y"), email.body)
         self.assertIn(job_application.hiring_start_at.strftime("%d/%m/%Y"), email.body)
         self.assertIn(job_application.hiring_end_at.strftime("%d/%m/%Y"), email.body)
+        self.assertIn(job_application.to_siae.display_name, email.body)
+        self.assertIn(job_application.to_siae.get_kind_display(), email.body)
+        self.assertIn(job_application.to_siae.address_line_1, email.body)
+        self.assertIn(job_application.to_siae.address_line_2, email.body)
+        self.assertIn(job_application.to_siae.post_code, email.body)
+        self.assertIn(job_application.to_siae.city, email.body)
+        self.assertIn(settings.ITOU_ASSISTANCE_URL, email.body)
+        self.assertIn(job_application.to_siae.accept_survey_url, email.body)
+
+    def test_email_deliver_approval_without_hiring_end_at(self, *args, **kwargs):
+        job_seeker = JobSeekerFactory()
+        approval = ApprovalFactory(user=job_seeker)
+        job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(
+            job_seeker=job_seeker, state=JobApplicationWorkflow.STATE_ACCEPTED, approval=approval, hiring_end_at=None
+        )
+        accepted_by = job_application.to_siae.members.first()
+        email = job_application.email_deliver_approval(accepted_by)
+        # To.
+        self.assertIn(accepted_by.email, email.to)
+        self.assertEqual(len(email.to), 1)
+        # Body.
+        self.assertIn(approval.user.get_full_name(), email.subject)
+        self.assertIn(approval.number_with_spaces, email.body)
+        self.assertIn(approval.start_at.strftime("%d/%m/%Y"), email.body)
+        self.assertIn(approval.end_at.strftime("%d/%m/%Y"), email.body)
+        self.assertIn(approval.user.last_name, email.body)
+        self.assertIn(approval.user.first_name, email.body)
+        self.assertIn(approval.user.birthdate.strftime("%d/%m/%Y"), email.body)
+        self.assertIn(job_application.hiring_start_at.strftime("%d/%m/%Y"), email.body)
+        self.assertIn("Se terminant le : Non renseigné", email.body)
         self.assertIn(job_application.to_siae.display_name, email.body)
         self.assertIn(job_application.to_siae.get_kind_display(), email.body)
         self.assertIn(job_application.to_siae.address_line_1, email.body)

--- a/itou/templates/apply/email/accept_for_proxy_body.txt
+++ b/itou/templates/apply/email/accept_for_proxy_body.txt
@@ -4,7 +4,7 @@
 Nous sommes ravis de vous annoncer que la candidature de {{ job_application.job_seeker.get_full_name|title }}, adressée par {{ job_application.sender.get_full_name|title }}, a été acceptée par {{ job_application.to_siae.display_name }}.
 
 - Date de début du contrat : {{ job_application.hiring_start_at|date:"d/m/Y" }}
-- Date de fin du contrat : {{ job_application.hiring_end_at|date:"d/m/Y" }}
+- Date de fin du contrat : {{ job_application.hiring_end_at|date:"d/m/Y"|default:"Non renseigné" }}
 
 Ces dates sont uniquement pour information.
 

--- a/itou/templates/apply/includes/state_transition_siae.html
+++ b/itou/templates/apply/includes/state_transition_siae.html
@@ -147,7 +147,7 @@
     <p>
         <ul>
             <li>Début : {{ job_application.hiring_start_at|date:"d F Y" }}</li>
-            <li>Fin : {{ job_application.hiring_end_at|date:"d F Y" }}</li>
+            <li>Fin : {{ job_application.hiring_end_at|date:"d F Y"|default:"Non renseigné" }}</li>
         </ul>
     </p>
 

--- a/itou/templates/approvals/email/deliver_body.txt
+++ b/itou/templates/approvals/email/deliver_body.txt
@@ -13,7 +13,7 @@ Date de naissance : {{ job_application.approval.user.birthdate|date:"d/m/Y" }}
 
 Pour un contrat d'insertion :
 Débutant le : {{ job_application.hiring_start_at|date:"d/m/Y" }}
-Se terminant le : {{ job_application.hiring_end_at|date:"d/m/Y" }}
+Se terminant le : {{ job_application.hiring_end_at|date:"d/m/Y"|default:"Non renseigné" }}
 
 Au sein de la structure :
 {{ job_application.to_siae.display_name }}

--- a/itou/templates/approvals/email/manual_delivery_required_notification_body.txt
+++ b/itou/templates/approvals/email/manual_delivery_required_notification_body.txt
@@ -18,7 +18,7 @@ Informations pour l'obtention d'un PASS IAE suite à l'embauche de votre candida
 - Type : {{ job_application.to_siae.kind }} ({{ job_application.to_siae.get_kind_display }})
 - Département : {{ job_application.to_siae.get_department_display }}
 - Date de début du contrat : {{ job_application.hiring_start_at|date:"d/m/Y" }}
-- Date de fin du contrat : {{ job_application.hiring_end_at|date:"d/m/Y" }}{% if accepted_by %}
+- Date de fin du contrat : {{ job_application.hiring_end_at|date:"d/m/Y"|default:"Non renseigné" }}{% if accepted_by %}
 - Accepté par : {{ accepted_by.get_full_name }} - {{ accepted_by.email }}{% endif %}
 
 Délivrer un PASS IAE dans l'admin :

--- a/itou/templates/approvals/email/manual_delivery_required_notification_body.txt
+++ b/itou/templates/approvals/email/manual_delivery_required_notification_body.txt
@@ -18,7 +18,7 @@ Informations pour l'obtention d'un PASS IAE suite à l'embauche de votre candida
 - Type : {{ job_application.to_siae.kind }} ({{ job_application.to_siae.get_kind_display }})
 - Département : {{ job_application.to_siae.get_department_display }}
 - Date de début du contrat : {{ job_application.hiring_start_at|date:"d/m/Y" }}
-- Date de fin du contrat : {{ job_application.hiring_end_at|date:"d/m/Y"|default:"Non renseigné" }}{% if accepted_by %}
+- Date de fin du contrat : {{ job_application.hiring_end_at|date:"d/m/Y"|default:"Non renseigné" }}{% if accepted_by %}
 - Accepté par : {{ accepted_by.get_full_name }} - {{ accepted_by.email }}{% endif %}
 
 Délivrer un PASS IAE dans l'admin :

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -17,7 +17,7 @@
                     <div class="col-sm-9 pt-3">
                         {% with job_application=employee_record.job_application %}
                             <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
-                            <div>Fin du contrat : <b>{{ job_application.hiring_end_at }}</b></div>
+                            <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default_if_none:"Non renseigné" }}</b></div>
                             <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
                         {% endwith %}
                         <div>

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -7,35 +7,35 @@
 
 {% block content %}
 
-    <div class="content-small mb-3">
-        <h1 class="h1-hero-c1">Détail fiche salarié ASP</h1>
-        <h2 class="h1 text-muted">{{ employee_record.job_seeker.get_full_name|title }}</h2>
+<div class="content-small mb-3">
+    <h1 class="h1-hero-c1">Détail fiche salarié ASP</h1>
+    <h2 class="h1 text-muted">{{ employee_record.job_seeker.get_full_name|title }}</h2>
 
-        <div class="card bg-gray-400 p-3 mb-3">
-            <div class="card-body p-1">
-                <div class="row">
-                    <div class="col-sm-9 pt-3">
-                        {% with job_application=employee_record.job_application %}
-                            <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
-                            <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default_if_none:"Non renseigné" }}</b></div>
-                            <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
-                        {% endwith %}
-                        <div>
-                            <b>{{ employee_record.get_status_display }}</b> le {{ employee_record.updated_at }}
-                        </div>
+    <div class="card bg-gray-400 p-3 mb-3">
+        <div class="card-body p-1">
+            <div class="row">
+                <div class="col-sm-9 pt-3">
+                    {% with job_application=employee_record.job_application %}
+                    <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
+                    <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default:"Non renseigné" }}</b></div>
+                    <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
+                    {% endwith %}
+                    <div>
+                        <b>{{ employee_record.get_status_display }}</b> le {{ employee_record.updated_at }}
                     </div>
-                    <div class="col-sm-3 text-right">
-                        <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"></img>
-                    </div>
+                </div>
+                <div class="col-sm-3 text-right">
+                    <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"></img>
                 </div>
             </div>
         </div>
-
-        {% include "employee_record/includes/employee_record_summary.html" %}
-
-        <a href="{% url "employee_record_views:list" %}?status={{ status }}" class="btn btn-primary">Retour à la liste</a>
-
     </div>
+
+    {% include "employee_record/includes/employee_record_summary.html" %}
+
+    <a href="{% url "employee_record_views:list" %}?status={{ status }}" class="btn btn-primary">Retour à la liste</a>
+
+</div>
 
 
 {% endblock %}

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -7,35 +7,35 @@
 
 {% block content %}
 
-<div class="content-small mb-3">
-    <h1 class="h1-hero-c1">Détail fiche salarié ASP</h1>
-    <h2 class="h1 text-muted">{{ employee_record.job_seeker.get_full_name|title }}</h2>
+    <div class="content-small mb-3">
+        <h1 class="h1-hero-c1">Détail fiche salarié ASP</h1>
+        <h2 class="h1 text-muted">{{ employee_record.job_seeker.get_full_name|title }}</h2>
 
-    <div class="card bg-gray-400 p-3 mb-3">
-        <div class="card-body p-1">
-            <div class="row">
-                <div class="col-sm-9 pt-3">
-                    {% with job_application=employee_record.job_application %}
-                    <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
-                    <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default:"Non renseigné" }}</b></div>
-                    <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
-                    {% endwith %}
-                    <div>
-                        <b>{{ employee_record.get_status_display }}</b> le {{ employee_record.updated_at }}
+        <div class="card bg-gray-400 p-3 mb-3">
+            <div class="card-body p-1">
+                <div class="row">
+                    <div class="col-sm-9 pt-3">
+                        {% with job_application=employee_record.job_application %}
+                            <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
+                            <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default:"Non renseigné" }}</b></div>
+                            <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
+                        {% endwith %}
+                        <div>
+                            <b>{{ employee_record.get_status_display }}</b> le {{ employee_record.updated_at }}
+                        </div>
                     </div>
-                </div>
-                <div class="col-sm-3 text-right">
-                    <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"></img>
+                    <div class="col-sm-3 text-right">
+                        <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"></img>
+                    </div>
                 </div>
             </div>
         </div>
+
+        {% include "employee_record/includes/employee_record_summary.html" %}
+
+        <a href="{% url "employee_record_views:list" %}?status={{ status }}" class="btn btn-primary">Retour à la liste</a>
+
     </div>
-
-    {% include "employee_record/includes/employee_record_summary.html" %}
-
-    <a href="{% url "employee_record_views:list" %}?status={{ status }}" class="btn btn-primary">Retour à la liste</a>
-
-</div>
 
 
 {% endblock %}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -265,8 +265,7 @@ class AcceptForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["hiring_without_approval"].widget = forms.HiddenInput()
-        for field in ["hiring_start_at"]:
-            self.fields[field].required = True
+        self.fields["hiring_start_at"].required = True
         for field in ["hiring_start_at", "hiring_end_at"]:
             self.fields[field].widget = DuetDatePickerWidget()
         # Job applications can be accepted twice if they have been cancelled.
@@ -331,8 +330,7 @@ class EditHiringDateForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        for field in ["hiring_start_at"]:
-            self.fields[field].required = True
+        self.fields["hiring_start_at"].required = True
         for field in ["hiring_start_at", "hiring_end_at"]:
             self.fields[field].widget = DuetDatePickerWidget()
 

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -265,8 +265,9 @@ class AcceptForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["hiring_without_approval"].widget = forms.HiddenInput()
-        for field in ["hiring_start_at", "hiring_end_at"]:
+        for field in ["hiring_start_at"]:
             self.fields[field].required = True
+        for field in ["hiring_start_at", "hiring_end_at"]:
             self.fields[field].widget = DuetDatePickerWidget()
         # Job applications can be accepted twice if they have been cancelled.
         # They also can be accepted after a refusal.
@@ -283,14 +284,14 @@ class AcceptForm(forms.ModelForm):
             # "parcours IAE" and the payment of the "aide au poste".
             "hiring_start_at": (
                 "Au format JJ/MM/AAAA, par exemple  %(date)s. Il n'est pas possible d'antidater un contrat. "
-                "La date est modifiable jusqu'à la veille de la date saisie. En cas de premier PASS IAE pour "
+                "La date est modifiable jusqu'à la veille de la date saisie. En cas de premier PASS IAE pour "
                 "la personne, cette date déclenche le début de son parcours."
             )
             % {"date": datetime.date.today().strftime("%d/%m/%Y")},
             "hiring_end_at": (
                 "Au format JJ/MM/AAAA, par exemple  %(date)s. "
                 "Elle sert uniquement à des fins d'informations et est sans conséquence sur les déclarations "
-                "à faire dans l'extranet 2.0 de l'ASP."
+                "à faire dans l'extranet 2.0 de l'ASP. <b>Ne pas compléter cette date dans le cadre d’un CDI Inclusion</b>"
             )
             % {
                 "date": (datetime.date.today() + relativedelta(years=Approval.DEFAULT_APPROVAL_YEARS)).strftime(
@@ -317,7 +318,7 @@ class AcceptForm(forms.ModelForm):
         hiring_start_at = self.cleaned_data["hiring_start_at"]
         hiring_end_at = self.cleaned_data["hiring_end_at"]
 
-        if hiring_end_at < hiring_start_at:
+        if hiring_end_at and hiring_end_at < hiring_start_at:
             raise forms.ValidationError(JobApplication.ERROR_END_IS_BEFORE_START)
 
         return cleaned_data
@@ -330,8 +331,9 @@ class EditHiringDateForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        for field in ["hiring_start_at", "hiring_end_at"]:
+        for field in ["hiring_start_at"]:
             self.fields[field].required = True
+        for field in ["hiring_start_at", "hiring_end_at"]:
             self.fields[field].widget = DuetDatePickerWidget()
 
     class Meta:
@@ -346,7 +348,7 @@ class EditHiringDateForm(forms.ModelForm):
             ),
             "hiring_end_at": (
                 "Cette date sert uniquement à des fins d'informations et est sans conséquence"
-                " sur les déclarations à faire dans l'extranet 2.0 de l'ASP."
+                " sur les déclarations à faire dans l'extranet 2.0 de l'ASP. <b>Ne pas compléter cette date dans le cadre d’un CDI Inclusion</b>"
             ),
         }
 
@@ -370,7 +372,7 @@ class EditHiringDateForm(forms.ModelForm):
         hiring_start_at = self.cleaned_data["hiring_start_at"]
         hiring_end_at = self.cleaned_data["hiring_end_at"]
 
-        if hiring_end_at < hiring_start_at:
+        if hiring_end_at and hiring_end_at < hiring_start_at:
             raise forms.ValidationError(JobApplication.ERROR_END_IS_BEFORE_START)
 
         # Check if hiring date is before end of a possible "old" approval

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -290,7 +290,8 @@ class AcceptForm(forms.ModelForm):
             "hiring_end_at": (
                 "Au format JJ/MM/AAAA, par exemple  %(date)s. "
                 "Elle sert uniquement à des fins d'informations et est sans conséquence sur les déclarations "
-                "à faire dans l'extranet 2.0 de l'ASP. <b>Ne pas compléter cette date dans le cadre d’un CDI Inclusion</b>"
+                "à faire dans l'extranet 2.0 de l'ASP. "
+                "<b>Ne pas compléter cette date dans le cadre d’un CDI Inclusion</b>"
             )
             % {
                 "date": (datetime.date.today() + relativedelta(years=Approval.DEFAULT_APPROVAL_YEARS)).strftime(
@@ -346,7 +347,8 @@ class EditHiringDateForm(forms.ModelForm):
             ),
             "hiring_end_at": (
                 "Cette date sert uniquement à des fins d'informations et est sans conséquence"
-                " sur les déclarations à faire dans l'extranet 2.0 de l'ASP. <b>Ne pas compléter cette date dans le cadre d’un CDI Inclusion</b>"
+                " sur les déclarations à faire dans l'extranet 2.0 de l'ASP. "
+                "<b>Ne pas compléter cette date dans le cadre d’un CDI Inclusion</b>"
             ),
         }
 

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -228,6 +228,11 @@ class ProcessViewsTest(TestCase):
             self.assertEqual(job_application.hiring_end_at, hiring_end_at)
             self.assertTrue(job_application.state.is_accepted)
 
+            # test how hiring_end_date is displayed
+            response = self.client.get(next_url)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, f"Fin : {hiring_end_at.strftime('%d')}")
+
         ##############
         # Exceptions #
         ##############
@@ -280,6 +285,62 @@ class ProcessViewsTest(TestCase):
         self.assertFormError(response, "form_user_address", "address_line_1", "Ce champ est obligatoire.")
         self.assertFormError(response, "form_user_address", "city", "Ce champ est obligatoire.")
         self.assertFormError(response, "form_user_address", "post_code", "Ce champ est obligatoire.")
+
+    def test_accept_without_hiring_end_at(self, *args, **kwargs):
+        """Test the `accept` transition."""
+        create_test_cities(["54", "57"], num_per_department=2)
+        city = City.objects.first()
+        today = timezone.localdate()
+
+        job_seeker = JobSeekerWithAddressFactory(city=city.name)
+        address = {
+            "address_line_1": job_seeker.address_line_1,
+            "post_code": job_seeker.post_code,
+            "city": city.name,
+            "city_slug": city.slug,
+        }
+        siae = SiaeWithMembershipFactory()
+        siae_user = siae.members.first()
+
+        for state in JobApplicationWorkflow.CAN_BE_ACCEPTED_STATES:
+            job_application = JobApplicationSentByJobSeekerFactory(state=state, job_seeker=job_seeker, to_siae=siae)
+            self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+
+            url = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+
+            job_application = JobApplicationSentByJobSeekerFactory(state=state, job_seeker=job_seeker, to_siae=siae)
+            self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+
+            url = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+
+            hiring_start_at = today
+            hiring_end_at = None
+            post_data = {
+                # Data for `JobSeekerPoleEmploiStatusForm`.
+                "pole_emploi_id": job_application.job_seeker.pole_emploi_id,
+                # Data for `AcceptForm`.
+                "hiring_start_at": hiring_start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
+                "answer": "",
+                **address,
+            }
+            response = self.client.post(url, data=post_data)
+            next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
+            self.assertRedirects(response, next_url)
+
+            job_application = JobApplication.objects.get(pk=job_application.pk)
+            self.assertEqual(job_application.hiring_start_at, hiring_start_at)
+            self.assertEqual(job_application.hiring_end_at, hiring_end_at)
+            self.assertTrue(job_application.state.is_accepted)
+
+            # test how hiring_end_date is displayed
+            response = self.client.get(next_url)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, "Fin : Non renseigné")
+
 
     def test_accept_with_active_suspension(self, *args, **kwargs):
         """Test the `accept` transition with active suspension for active user"""

--- a/itou/www/employee_record_views/tests/test_create.py
+++ b/itou/www/employee_record_views/tests/test_create.py
@@ -148,6 +148,26 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_hiring_end_at_date_in_header(self):
+
+        hiring_end_at = self.job_application.hiring_end_at
+
+        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f"Fin du contrat : <b>{hiring_end_at.strftime('%d')}")
+
+    def test_no_hiring_end_at_in_header(self):
+        self.job_application.hiring_end_at = None
+        self.job_application.save()
+
+        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Fin du contrat : <b>Non renseigné")
+
     def test_title(self):
         # Job seeker / employee must have a title
 

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -68,7 +68,7 @@ class ListEmployeeRecordsTest(TestCase):
 
     def test_employee_records_with_hiring_end_at(self):
         """
-        Check if "hiring_end_at" of job_application is displayed
+        Check "hiring_end_at" display
         """
         self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
         hiring_end_at = self.job_application.hiring_end_at
@@ -80,7 +80,7 @@ class ListEmployeeRecordsTest(TestCase):
 
     def test_employee_records_without_hiring_end_at(self):
         """
-        Check if "hiring_end_at" of job_application is replaced by "non renseigné"
+        Check "hiring_end_at" display when None
         """
         self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
         self.job_application.hiring_end_at = None

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -65,3 +65,28 @@ class ListEmployeeRecordsTest(TestCase):
         for status in [EmployeeRecord.Status.SENT, EmployeeRecord.Status.REJECTED, EmployeeRecord.Status.PROCESSED]:
             response = self.client.get(self.url + f"?status={status.value}")
             self.assertNotContains(response, job_seeker_name)
+
+    def test_employee_records_with_hiring_end_at(self):
+        """
+        Check if "hiring_end_at" of job_application is displayed
+        """
+        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        hiring_end_at = self.job_application.hiring_end_at
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f"Fin de contrat : <b>{hiring_end_at.strftime('%d')}")
+
+    def test_employee_records_without_hiring_end_at(self):
+        """
+        Check if "hiring_end_at" of job_application is replaced by "non renseigné"
+        """
+        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.job_application.hiring_end_at = None
+        self.job_application.save()
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Fin de contrat : <b>Non renseigné")

--- a/itou/www/employee_record_views/tests/test_summary.py
+++ b/itou/www/employee_record_views/tests/test_summary.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from itou.employee_record.factories import EmployeeRecordWithProfileFactory
+from itou.job_applications.factories import JobApplicationWithCompleteJobSeekerProfileFactory
+from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
+from itou.users.factories import DEFAULT_PASSWORD
+
+
+class SummaryEmployeeRecordsTest(TestCase):
+    def setUp(self):
+        # User must be super user for UI first part (tmp)
+        self.siae = SiaeWithMembershipAndJobsFactory(
+            name="Wanna Corp.", membership__user__first_name="Billy", membership__user__is_superuser=True
+        )
+        self.user = self.siae.members.get(first_name="Billy")
+        self.job_application = JobApplicationWithCompleteJobSeekerProfileFactory(to_siae=self.siae)
+        self.employee_record = EmployeeRecordWithProfileFactory(job_application=self.job_application)
+        self.url = reverse("employee_record_views:summary", args=(self.employee_record.id,))
+
+    def test_access_granted(self):
+        # Must have access
+        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_hiring_end_at_date_in_header(self):
+        hiring_end_at = self.job_application.hiring_end_at
+        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f"Fin du contrat : <b>{hiring_end_at.strftime('%d')}")
+
+    def test_no_hiring_end_at_in_header(self):
+        self.job_application.hiring_end_at = None
+        self.job_application.save()
+        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Fin du contrat : <b>Non renseigné")


### PR DESCRIPTION
### Quoi ?

Mise en place du CDI inclusion pour les SIAE au 01/01/22

### Pourquoi ?

Lorsqu'un employeur déclare une embauche pour un CDI inclusion il ne sait pas quelle date de fin renseigner car le système lui demande de renseigner une date de fin prévisionnelle.

### Comment ?

- Ajouter un texte "ne pas compléter la date de fin dans le cadre d’un CDI Inclusion" dans les formulaires de saisie des dates de contrat, 
- Rendre le champ “date de fin” optionnel,
- Adapter les affichages de la date de fin du contrat dans le front office et dans les emails envoyés : date de fin de contrat ou "non renseigné".

Pas d'impact dans l'admin.