### PR TITLE
Boost

### DIFF
--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -284,6 +284,11 @@ def mise_a_jour_pass_iae(job_application, pass_approved_code, encrypted_identifi
             return True
         except Exception:
             raise PoleEmploiMiseAJourPassIAEException(r.status_code, r.content)
+    except httpx.ConnectTimeout:  # noqa
+        # We need to deal with this special case because
+        # ConnectTimeout do not carry a response
+        HTTP_CODE_REQUEST_TIMEOUT = 408
+        raise PoleEmploiMiseAJourPassIAEException(HTTP_CODE_REQUEST_TIMEOUT)
     except httpx.HTTPError as e:
         raise PoleEmploiMiseAJourPassIAEException(e.response.status_code)
 

--- a/itou/utils/templatetags/format_filters.py
+++ b/itou/utils/templatetags/format_filters.py
@@ -45,7 +45,12 @@ def format_siret(siret):
 @register.filter
 @stringfilter
 def format_nir(nir):
-    nir = nir.replace(" ", "")
+    nir_without_spaces = nir.replace(" ", "")
     nir_regex = r"^([12])([0-9]{2})([0-9]{2})(2[AB]|[0-9]{2})([0-9]{3})([0-9]{3})([0-9]{2})$"
-    match = re.match(nir_regex, nir)
-    return " ".join(match.groups())
+    match = re.match(nir_regex, nir_without_spaces)
+    if match is not None:
+        return " ".join(match.groups())
+    else:
+        # Some NIRs do not match the pattern (they can be NTT/NIA) so we can’t format them
+        # When this happen, we should not crash but return the initial value
+        return nir

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -463,6 +463,8 @@ class UtilsTemplateFiltersTestCase(TestCase):
     def test_format_nir(self):
         self.assertEqual(format_filters.format_nir("141068078200557"), "1 41 06 80 782 005 57")
         self.assertEqual(format_filters.format_nir(" 1 41 06 80 782 005 57"), "1 41 06 80 782 005 57")
+        self.assertEqual(format_filters.format_nir(""), "")
+        self.assertEqual(format_filters.format_nir("12345678910"), "12345678910")
 
 
 class UtilsEmailsTestCase(TestCase):

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -844,6 +844,22 @@ class PoleEmploiTest(TestCase):
 
     @mock.patch(
         "httpx.post",
+        raises=httpx.ConnectTimeout,
+    )
+    def test_mise_a_jour_pass_iae_timeout(self, mock_post):
+        """
+        If the API answers with a non-S001 codeSortie (this is something in the json output)
+        mise_a_jour_pass_iae will return false
+        """
+        job_application = JobApplicationWithApprovalFactory()
+        with self.assertRaises(PoleEmploiMiseAJourPassIAEException):
+            mise_a_jour_pass_iae(
+                job_application, POLE_EMPLOI_PASS_APPROVED, "some_valid_encrypted_identifier", "some_valid_token"
+            )
+            mock_post.assert_called()
+
+    @mock.patch(
+        "httpx.post",
         return_value=httpx.Response(401, json=""),
     )
     def test_mise_a_jour_pass_iae_invalid_token(self, mock_post):


### PR DESCRIPTION
### Quoi ?

 - `by_insee_code_and_period` ne doit pas crasher lorsque le code_insee est vide
 - `MiseAJourPassIAE` ne doit pas crasher lors des timeout, mais logger une exception
 - `format_nir` ne doit pas crasher si le nir fournit ne match pas la regex

### Pourquoi ?

Pour calmer sentry qui s’affole, et avant tout pour fournir une meilleur expérience à nos utilisateurs.