### PR TITLE
Correction des erreurs a11y sur les éléments obligatoires

### DIFF
--- a/itou/templates/account/account_inactive.html
+++ b/itou/templates/account/account_inactive.html
@@ -8,7 +8,9 @@
     <h1 class="h1-hero-c1">Compte inactif</h1>
 
     <div class="alert alert-warning" role="status">
-        Ce compte est inactif.
+        <p class="mb-0">
+            Ce compte est inactif.
+        </p>
     </div>
 
 {% endblock %}

--- a/itou/templates/account/email_confirm.html
+++ b/itou/templates/account/email_confirm.html
@@ -35,9 +35,12 @@
         {% url 'account_email' as email_url %}
 
         <div class="alert alert-danger" role="status">
-            Ce lien de confirmation d'adresse e-mail a expiré ou n'est pas valide.
-            <br>
-            Veuillez lancer <a href="{{ email_url }}">une nouvelle demande de confirmation</a>.
+            <p>
+                Ce lien de confirmation d'adresse e-mail a expiré ou n'est pas valide.
+            </p>
+            <p class="mb-0">
+                Veuillez lancer <a href="{{ email_url }}">une nouvelle demande de confirmation</a>.
+            </p>
         </div>
 
     {% endif %}

--- a/itou/templates/account/password_change.html
+++ b/itou/templates/account/password_change.html
@@ -10,9 +10,12 @@
     <h1 class="h1-hero-c1">Modifier votre mot de passe</h1>
     {% if request|user_is_france_connected %}
         <div class="alert alert-info" role="status">
-            {{ password_change_message }}
-            <br>
-            Si vous venez d’utiliser FranceConnect pour créer votre compte, vous ne connaissez pas votre votre mot de passe. Merci d’utiliser la fonctionnalité « <a href="{% url 'account_reset_password' %}">Mot de passe oublié</a> » pour le réinitialiser.
+            <p>
+                {{ password_change_message }}
+            </p>
+            <p class="mb-0">
+                Si vous venez d’utiliser FranceConnect pour créer votre compte, vous ne connaissez pas votre votre mot de passe. Merci d’utiliser la fonctionnalité « <a href="{% url 'account_reset_password' %}">Mot de passe oublié</a> » pour le réinitialiser.
+            </p>
         </div>
     {% endif %}
     <form method="post" action="{% url 'account_change_password' %}" class="js-prevent-multiple-submit">

--- a/itou/templates/apply/includes/eligibility_diagnosis.html
+++ b/itou/templates/apply/includes/eligibility_diagnosis.html
@@ -116,8 +116,9 @@
         <hr>
         <h3 class="h2 font-weight-normal text-muted">Éligibilité IAE</h3>
         <div class="alert alert-warning" role="status">
-            Le diagnostic d'éligibilité IAE de ce candidat a expiré le {{ expired_eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }},
-            vous devez valider les critères d'éligibilité.
+            <p class="mb-0">
+                Le diagnostic d'éligibilité IAE de ce candidat a expiré le {{ expired_eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}, vous devez valider les critères d'éligibilité.
+            </p>
         </div>
     {% endif %}
 

--- a/itou/templates/apply/includes/list_card_header.html
+++ b/itou/templates/apply/includes/list_card_header.html
@@ -1,31 +1,32 @@
 <div class="card-header">
+    <p>
+        <b>{{ job_application.job_seeker.get_full_name }}</b>
 
-    <b>{{ job_application.job_seeker.get_full_name }}</b>
+        <small>chez</small>
 
-    <small>chez</small>
+        <b>
+            <a href="{{ job_application.to_siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                {{ job_application.to_siae.display_name }}
+            </a>
+        </b>
 
-    <b>
-        <a href="{{ job_application.to_siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
-            {{ job_application.to_siae.display_name }}
-        </a>
-    </b>
+        {% if job_application.to_siae.grace_period_has_expired %}
+            <span class="badge badge-danger">
+                Structure déconventionnée depuis le
+                {{ job_application.to_siae.grace_period_end_date|date:"d F Y" }}
+            </span>
+        {% endif %}
+    </p>
 
-    {% if job_application.to_siae.grace_period_has_expired %}
-        <span class="badge badge-danger">
-            Structure déconventionnée depuis le
-            {{ job_application.to_siae.grace_period_end_date|date:"d F Y" }}
-        </span>
-    {% endif %}
+    <p>
+        <small class="text-muted">{{ job_application.created_at|date:"d F Y à H:i" }}</small>
 
-    <br>
-
-    <small class="text-muted">{{ job_application.created_at|date:"d F Y à H:i" }}</small>
-
-    {% if job_application.is_pending_for_too_long and not request.user_is_job_seeker %}
-        <br>
-        <small class="text-danger font-weight-bold">
-            En attente de réponse depuis plus de {{ job_application.WEEKS_BEFORE_CONSIDERED_OLD }} semaines.
-        </small>
-    {% endif %}
+        {% if job_application.is_pending_for_too_long and not request.user_is_job_seeker %}
+            <br>
+            <small class="text-danger font-weight-bold">
+                En attente de réponse depuis plus de {{ job_application.WEEKS_BEFORE_CONSIDERED_OLD }} semaines.
+            </small>
+        {% endif %}
+    </p>
 
 </div>

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -13,8 +13,12 @@
 
     {% if siae.is_subject_to_eligibility_rules %}
         <div class="alert alert-emploi mt-3">
-            Toute demande de PASS IAE doit être effectuée <b>au plus tard le jour de l'embauche</b>.<br>
-            Les demandes rétroactives ne sont pas autorisées.
+            <p>
+                Toute demande de PASS IAE doit être effectuée <b>au plus tard le jour de l'embauche</b>.
+            </p>
+            <p class="mb-0">
+                Les demandes rétroactives ne sont pas autorisées.
+            </p>
         </div>
     {% endif %}
 

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -6,7 +6,9 @@
     {{ block.super }}
 
     <div class="alert alert-info">
-        Confirmez votre choix en renseignant quelques informations supplémentaires.
+        <p class="mb-0">
+            Confirmez votre choix en renseignant quelques informations supplémentaires.
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit mt-5">
@@ -20,7 +22,9 @@
         {% if form_pe_status %}
             {% if not job_application.approval_not_needed %}
                 <div class="alert alert-warning" role="status">
-                    Pour obtenir un PASS IAE dans les meilleurs délais, assurez-vous de l'exactitude de la date de naissance et du statut Pôle emploi du candidat.
+                    <p class="mb-0">
+                        Pour obtenir un PASS IAE dans les meilleurs délais, assurez-vous de l'exactitude de la date de naissance et du statut Pôle emploi du candidat.
+                    </p>
                 </div>
             {% endif %}
             {% bootstrap_form form_pe_status alert_error_type="all" %}

--- a/itou/templates/apply/process_cancel.html
+++ b/itou/templates/apply/process_cancel.html
@@ -6,7 +6,9 @@
     {{ block.super }}
 
     <div class="alert alert-warning" role="status">
-        Confirmez votre choix.
+        <p class="mb-0">
+            Confirmez votre choix.
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/templates/apply/process_eligibility.html
+++ b/itou/templates/apply/process_eligibility.html
@@ -33,7 +33,9 @@
         </p>
 
         <div class="alert alert-warning">
-            <i>Dans le cadre de l'expérimentation actuelle, nous vous informons que la liste des critères d'éligibilité à l'IAE est susceptible d'évoluer à la marge.</i>
+            <p class="mb-0">
+                <i>Dans le cadre de l'expérimentation actuelle, nous vous informons que la liste des critères d'éligibilité à l'IAE est susceptible d'évoluer à la marge.</i>
+            </p>
         </div>
 
         <hr>

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -6,7 +6,9 @@
     {{ block.super }}
 
     <div class="alert alert-warning" role="status">
-        Confirmez votre choix.
+        <p class="mb-0">
+            Confirmez votre choix.
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/templates/apply/submit_step_check_prev_applications.html
+++ b/itou/templates/apply/submit_step_check_prev_applications.html
@@ -9,11 +9,11 @@
 
         {% with prev_application.created_at|date:"d F Y à H:i" as prev_created_at %}
             {% if request.user == job_seeker %}
-                <p>
+                <p class="mb-0">
                     Vous avez déjà postulé chez cet employeur le <b>{{ prev_created_at }}</b>
                 </p>
             {% else %}
-                <p>
+                <p class="mb-0">
                     Le candidat a déjà postulé chez cet employeur le <b>{{ prev_created_at }}</b>
                 </p>
             {% endif %}

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -7,8 +7,12 @@
     {{ block.super }}
 
     <div class="alert alert-info">
-        Aucun utilisateur n'est incrit avec ce numéro de sécurité sociale.
-        Merci de renseigner l'adresse e-mail de votre candidat.
+        <p class="mb-0">
+            Aucun utilisateur n'est incrit avec ce numéro de sécurité sociale.
+        </p>
+        <p class="mb-0">
+            Merci de renseigner l'adresse e-mail de votre candidat.
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/templates/apply/submit_step_job_seeker_check_info.html
+++ b/itou/templates/apply/submit_step_job_seeker_check_info.html
@@ -6,7 +6,9 @@
     {{ block.super }}
 
     <div class="alert alert-warning" role="status">
-        La date de naissance et les informations Pôle emploi sont obligatoires pour continuer.
+        <p class="mb-0">
+            La date de naissance et les informations Pôle emploi sont obligatoires pour continuer.
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/templates/apply/submit_step_job_seeker_create.html
+++ b/itou/templates/apply/submit_step_job_seeker_create.html
@@ -7,7 +7,9 @@
     {{ block.super }}
 
     <div class="alert alert-warning" role="status">
-        Cet email n'existe pas dans notre base de données. Vous devez créer un compte pour votre candidat en utilisant le formulaire ci-dessous afin de pouvoir continuer.
+        <p class="mb-0">
+            Cet email n'existe pas dans notre base de données. Vous devez créer un compte pour votre candidat en utilisant le formulaire ci-dessous afin de pouvoir continuer.
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/templates/approvals/pe_approval_search.html
+++ b/itou/templates/approvals/pe_approval_search.html
@@ -6,16 +6,16 @@
 {% block content %}
     <h1 class="h1-hero-c1">Prolonger ou suspendre un agrément émis par Pôle emploi</h1>
 
-    <div class="alert alert-info pb-0">
-        <p>
+    <div class="alert alert-info">
+        <p class="mb-0">
             Cette fonction est destinée à prolonger ou suspendre un agrément émis par Pôle emploi pour un salarié déjà présent dans vos effectifs (donc déjà déclaré dans l’ASP)
         </p>
     </div>
 
     {% if number %}
 
-        <div class="alert alert-danger pb-0" role="status">
-            <p>
+        <div class="alert alert-danger" role="status">
+            <p class="mb-0">
                 Nous n'avons pas trouvé d'agrément en cours de validité avec le numéro <strong>{{ number }}</strong>.
             </p>
         </div>

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -8,8 +8,8 @@
 
     {% if approval.is_valid %}
         {% if approval.originates_from_itou %}
-            <div class="alert alert-danger pb-0" role="status">
-                <p>Le numéro <strong>{{ approval.number|slice:12 }}</strong> correspond à un PASS IAE.</p>
+            <div class="alert alert-danger" role="status">
+                <p class="mb-0">Le numéro <strong>{{ approval.number|slice:12 }}</strong> correspond à un PASS IAE.</p>
             </div>
             <p>
                 Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">réaliser une auto-prescription</a>. Il sera automatiquement importé dans votre compte.
@@ -23,8 +23,8 @@
                     A redirection is made upstream if the current SIAE can prolong or suspend it.
                     It means another SIAE is using it right now.
                 {% endcomment %}
-                <div class="alert alert-danger pb-0" role="status">
-                    <p>L'agrément <strong>{{ approval.number|slice:12 }}</strong> a déjà été converti en PASS IAE.</p>
+                <div class="alert alert-danger" role="status">
+                    <p class="mb-0">L'agrément <strong>{{ approval.number|slice:12 }}</strong> a déjà été converti en PASS IAE.</p>
                 </div>
                 <p>
                     Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">réaliser une auto-prescription</a>.
@@ -48,9 +48,8 @@
         {% endif %}
 
     {% else %}
-        <div class="alert alert-danger pb-0" role="status">
-            <p>L'agrément <strong>{{ approval.number|slice:12 }}</strong> est expiré depuis le {{ approval.end_at|date:"d/m/Y" }}. Vous ne pouvez pas le prolonger ou le suspendre.
-            </p>
+        <div class="alert alert-danger" role="status">
+            <p class="mb-0">L'agrément <strong>{{ approval.number|slice:12 }}</strong> est expiré depuis le {{ approval.end_at|date:"d/m/Y" }}. Vous ne pouvez pas le prolonger ou le suspendre.</p>
         </div>
         <p>
             S'il s'agit d'un nouveau contrat, vous pouvez solliciter <a href="{% url 'search:prescribers_home' %}" title="Solliciter un prescripteur habilité">un prescripteur habilité</a> pour qu'il puisse vous orienter le candidat.

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -11,29 +11,33 @@
             <p>Tous les salariés déclarés auprès de l'ASP avant le 1er décembre ont été ajoutés au tableau de bord de la SIAE porteuse de l’annexe financière. Nous travaillons à vous permettre de les transférer dans le tableau de bord d’une structure fille.</p>
             <p>Pour les salariés qui ne seraient plus en poste, il vous est demandé de procéder à une suspension d’un an au motif « contrat de travail terminé ». Dans la mesure où ces salariés sont connus dans l’Extranet IAE 2.0 de l'ASP, ces PASS IAE ne peuvent pas être annulés.</p>
             <p>Pour les salariés entrés en parcours avant le 1er décembre 2021 qui n’auraient pas été déclarés dans l’Extranet avant le 1er décembre 2021, vous devez procéder à une déclaration d’éligibilité sur la plateforme de l’inclusion.</p>
-            <p>Pour toute question liée à un cas individuel, <a href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/#support" rel="noopener" target="_blank" class="is-external" title="Une assistance est disponible ici (ouverture dans un nouvel onglet)">une assistance est disponible ici <i class="ri-external-link-line ri-lg"></i></a>.</p>
+            <p class="mb-0">Pour toute question liée à un cas individuel, <a href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/#support" rel="noopener" target="_blank" title="Une assistance est disponible ici (ouverture dans un nouvel onglet)">une assistance est disponible ici <i class="ri-external-link-line ri-lg"></i></a>.</p>
         </div>
     {% endif %}
 
     {% if current_siae and not current_siae.jobs.exists %}
         <div class="alert alert-warning">
-            Pour optimiser la réception de vos candidatures, pensez à renseigner le descriptif de vos postes et leurs prérequis.
+            <p class="mb-0">
+                Pour optimiser la réception de vos candidatures, pensez à renseigner le descriptif de vos postes et leurs prérequis.
+            </p>
         </div>
     {% endif %}
 
     {# Alerte pour les employeurs en cas d'absence ou de mauvais score de geocoding. #}
     {% if current_siae and not current_siae.has_reliable_coords %}
         <div class="alert alert-warning mb-0" role="status">
-            Nous n'avons pas pu géolocaliser votre établissement.<br>
-            Cela peut affecter sa position dans les résultats de recherche.<br>
-            {% if user_is_siae_admin %}
-                <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">Indiquez une autre adresse</a>
-            {% else %}
-                {% with current_siae.active_admin_members.first as admin %}
-                    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
-                {% endwith %}
-            {% endif %}
-            ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
+            <p class="mb-0">
+                Nous n'avons pas pu géolocaliser votre établissement.<br>
+                Cela peut affecter sa position dans les résultats de recherche.<br>
+                {% if user_is_siae_admin %}
+                    <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">Indiquez une autre adresse</a>
+                {% else %}
+                    {% with current_siae.active_admin_members.first as admin %}
+                        Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
+                    {% endwith %}
+                {% endif %}
+                ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
+            </p>
         </div>
     {% endif %}
 
@@ -41,43 +45,47 @@
     {# Seuls les prescripteurs habilités apparaissent dans le moteur de recherche. #}
     {% if current_prescriber_organization and current_prescriber_organization.is_authorized and not current_prescriber_organization.has_reliable_coords %}
         <div class="alert alert-warning mb-0" role="status">
-            Nous n'avons pas pu géolocaliser votre établissement.<br>
-            Cela peut affecter sa position dans les résultats de recherche.<br>
-            {% if user_is_prescriber_org_admin %}
-                <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a>
-            {% else %}
-                {% with current_prescriber_organization.active_admin_members.first as admin %}
-                    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
-                {% endwith %}
-            {% endif %}
-            ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
+            <p class="mb-0">
+                Nous n'avons pas pu géolocaliser votre établissement.<br>
+                Cela peut affecter sa position dans les résultats de recherche.<br>
+                {% if user_is_prescriber_org_admin %}
+                    <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a>
+                {% else %}
+                    {% with current_prescriber_organization.active_admin_members.first as admin %}
+                        Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
+                    {% endwith %}
+                {% endif %}
+                ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
+            </p>
         </div>
     {% endif %}
 
     {% if current_siae and not current_siae.is_active %}
         <div class="alert alert-warning mb-0" role="status">
-            La DGEFP nous indique que votre structure {% if current_siae.siret %}(inscrite avec le numéro SIRET : {{ current_siae.siret }}) {% endif %}n'est plus conventionnée.<br>
-            Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.<br>
-            À compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
+            <p class="mb-0">
+                La DGEFP nous indique que votre structure {% if current_siae.siret %}(inscrite avec le numéro SIRET : {{ current_siae.siret }}) {% endif %}n'est plus conventionnée.<br>
+                Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.<br>
+                À compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
 
-            {% if user_is_siae_admin %}
-                Veuillez dès que possible régulariser votre situation
-                <a href="{% url 'siaes_views:show_financial_annexes' %}">en sélectionnant une annexe financière valide}</a>.<br>
-            {% else %}
-                {% with current_siae.active_admin_members.first as admin %}
-                    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle régularise la situation de votre structure.
-                {% endwith %}
-            {% endif %}
+                {% if user_is_siae_admin %}
+                    Veuillez dès que possible régulariser votre situation
+                    <a href="{% url 'siaes_views:show_financial_annexes' %}">en sélectionnant une annexe financière valide}</a>.<br>
+                {% else %}
+                    {% with current_siae.active_admin_members.first as admin %}
+                        Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle régularise la situation de votre structure.
+                    {% endwith %}
+                {% endif %}
+            </p>
         </div>
     {% endif %}
 
     {% if current_prescriber_organization and current_prescriber_organization.has_pending_authorization %}
-        <div class="alert alert-warning pb-0" role="status">
-            <p>
+        <div class="alert alert-warning" role="status">
+            <p class="mb-0">
                 Votre habilitation à valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique est en cours de vérification par nos équipes. Vous ne pouvez pas encore réaliser le diagnostic d'éligibilité des candidats.
             </p>
             {% if current_prescriber_organization.has_pending_authorization_proof %}
-                <p>
+                <p class="mb-0">
                     Merci de nous transmettre l'arrêté préfectoral portant mention de cette habilitation :
                     <a href="{{ TYPEFORM_URL }}/to/mk0GyI67#idprescriber={{ current_prescriber_organization.pk }}&iduser={{ user.pk }}&source={{ ITOU_ENVIRONMENT }}" rel="noopener" target="_blank" title="Cliquez ici pour l'envoyer (ouverture dans un nouvel onglet)">
                         cliquez ici pour l'envoyer
@@ -96,7 +104,7 @@
     {% if can_show_employee_records %}
         <div class="alert alert-info">
             <p>La fin de validité des annexes financières de 2021 n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.</p>
-            <p>Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
+            <p class="mb-0">Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
         </div>
     {% endif %}
 

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -7,9 +7,13 @@
     <h1 class="h1-hero-c1">Informations personnelles de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span></h1>
 
     <div class="alert alert-warning">
-        <b>Vous allez modifier des informations sensibles</b> concernant ce candidat ou cette candidate.<br>
-        Tout changement entraînera une modification définitive dans notre base de données. <b>Les informations
-            supprimées seront perdues.</b>
+        <p>
+            <b>Vous allez modifier des informations sensibles</b> concernant ce candidat ou cette candidate.
+        </p>
+        <p class="mb-0">
+            Tout changement entraînera une modification définitive dans notre base de données. <b>Les informations
+                supprimées seront perdues.</b>
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/templates/dashboard/edit_user_email.html
+++ b/itou/templates/dashboard/edit_user_email.html
@@ -7,8 +7,10 @@
     <h1 class="h1-hero-c1">Modifier votre adresse e-mail</h1>
 
     <div class="alert alert-warning">
-        Ce changement entraînera une <b>déconnexion</b>.<br>
-        Veuillez alors vous reconnecter avec votre nouvelle adresse e-mail.
+        <p class="mb-0">
+            Ce changement entraînera une <b>déconnexion</b>.<br>
+            Veuillez alors vous reconnecter avec votre nouvelle adresse e-mail.
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -9,10 +9,9 @@
     {% if extra_data %}
 
         <div class="alert alert-info">
-
-            Certains champs de ce formulaire sont pré-remplis avec des éléments en provenance de votre compte Pôle emploi
-            (récupérés lors de votre connexion du {{extra_data.created_at|date:"d F Y"}}).
-
+            <p class="mb-0">
+                Certains champs de ce formulaire sont pré-remplis avec des éléments en provenance de votre compte Pôle emploi (récupérés lors de votre connexion du {{extra_data.created_at|date:"d F Y"}}).
+            </p>
         </div>
 
     {% endif %}

--- a/itou/templates/eligibility/includes/criteria_input.html
+++ b/itou/templates/eligibility/includes/criteria_input.html
@@ -10,7 +10,7 @@
             {{ field.label }}
 
             {% if field.help_text %}
-                <small class="form-text text-muted">{{ field.help_text }}</small>
+                <p class="small mb-0 form-text text-muted">{{ field.help_text }}</p>
             {% endif %}
 
             {# Show written proof only to SIAE because prescribers feel they have #}
@@ -18,23 +18,23 @@
             {% if request.user.is_siae_staff %}
                 {% with objects_dict|get_dict_item:field.name as criteria %}
                     {% if criteria.written_proof %}
-                        <small class="form-text text-muted">
+                        <p class="small mb-0 form-text text-muted">
                             <strong>Pièce justificative :</strong>
                             <i>{{ criteria.written_proof }}</i>
-                        </small>
+                        </p>
                     {% endif %}
                     {% if criteria.written_proof_validity %}
-                        <small class="form-text text-muted">
+                        <p class="small mb-0 form-text text-muted">
                             <strong>Durée de validité du justificatif :</strong>
                             <i>{{ criteria.written_proof_validity }}</i>
-                        </small>
+                        </p>
                     {% endif %}
                     {% if criteria.written_proof_url %}
-                        <small class="form-text text-muted">
+                        <p class="small mb-0 form-text text-muted">
                             <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" title="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
                                 {{ criteria.written_proof_url }}
                             </a>
-                        </small>
+                        </p>
                     {% endif %}
                 {% endwith %}
             {% endif %}

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -54,13 +54,12 @@
         <p>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</p>
     {% else %}
         <p><b>L'adresse du salarié n'a pu être vérifiée automatiquement.</b></p>
-        <p>Ceci peut-être du à:
-            <ul>
-                <li>une erreur temporaire de géolocalisation,</li>
-                <li>une adresse introuvable (code postal ou voie erronée).
-                </ul>
-                <p>
-                    <p>Merci de bien vouloir ressaisir l'adresse du salarié dans le formulaire ci-dessous.</p>
+        <p class="mb-0">Ceci peut-être du à:</p>
+        <ul>
+            <li>une erreur temporaire de géolocalisation,</li>
+            <li>une adresse introuvable (code postal ou voie erronée).</li>
+        </ul>
+        <p>Merci de bien vouloir ressaisir l'adresse du salarié dans le formulaire ci-dessous.</p>
     {% endif %}
 </div>
 

--- a/itou/templates/employee_record/includes/create_step_4.html
+++ b/itou/templates/employee_record/includes/create_step_4.html
@@ -4,7 +4,9 @@
 <h4 class="h3">Annexe financière</h4>
 
 <div class="alert alert-info">
-    Le choix d'une annexe financière est <b>optionnel</b>, et dans tous les cas, l'information n'est pas transmise à l'ASP.
+    <p class="mb-0">
+        Le choix d'une annexe financière est <b>optionnel</b>, et dans tous les cas, l'information n'est pas transmise à l'ASP.
+    </p>
 </div>
 
 <form method="post" action="{% url "employee_record_views:create_step_4" job_application.id %}" class="js-prevent-multiple-submit">

--- a/itou/templates/employee_record/includes/create_step_5.html
+++ b/itou/templates/employee_record/includes/create_step_5.html
@@ -12,7 +12,7 @@
             Le traitement est effectué à intervalle régulier et vous serez notifié du changement d'état
             de la fiche salarié sur la liste récapitulative accessible depuis le tableau de bord.
         </p>
-        <p>
+        <p class="mb-0">
             Après validation de la fiche salarié, <b>la modification de la date de début du PASS IAE n'est plus possible</b>.
         </p>
     </div>
@@ -28,7 +28,7 @@
 {% else %}
     <div class="alert alert-success">
         <p><b>La création de cette fiche salariée est terminée.</b></p>
-        <p>Vous pouvez suivre l'avancement de son traitement par l'ASP via la liste récapitulative accessible depuis le tableau de bord.</p>
+        <p class="mb-0">Vous pouvez suivre l'avancement de son traitement par l'ASP via la liste récapitulative accessible depuis le tableau de bord.</p>
     </div>
     <div class="mb-3">
         <a href="{% url "employee_record_views:list" %}?status=NEW" class="btn btn-primary">

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -14,7 +14,7 @@
 
             {# Statuses #}
             <div class="col-md-5 text-right">
-                <small>
+                <p class="small mb-0">
                     {% if form.status.value == "SENT" %}
                         <p class="badge badge-warning">Transmise à l'ASP le <b>{{ employee_record.updated_at }}</b></p>
                     {% elif form.status.value == "REJECTED" %}
@@ -24,7 +24,7 @@
                     {% elif form.status.value == "READY" %}
                         <p class="badge badge-secondary">Complétée le <b>{{ employee_record.updated_at }}</b></p>
                     {% endif %}
-                </small>
+                </p>
             </div>
         </div>
 

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -37,10 +37,10 @@
                                                 <div class="col-10 p-0">
                                                     {{ status }}
                                                 </div>
-                                                <div class="col-2 p-0 text-right ">
-                                                    <small>
+                                                <div class="col-2 p-0 text-right">
+                                                    <p class="small mb-0">
                                                         <span class="badge badge-{{ badge.1 }}">{{ badge.0 }}</span>
-                                                    </small>
+                                                    </p>
                                                 </div>
                                             </div>
                                         {% endif %}
@@ -74,19 +74,19 @@
                 {# Messages #}
                 <div class="alert alert-info mb-4">
                     {% if form.status.value == "NEW" %}
-                        Vous trouverez ici les candidatures validées à partir desquelles vous devez créér de nouvelles fiches salarié.
+                        <p class="mb-0">Vous trouverez ici les candidatures validées à partir desquelles vous devez créér de nouvelles fiches salarié.</p>
                     {% elif form.status.value == "READY" %}
-                        <p>Vous trouverez ici les fiches salarié complétées et en attente d'envoi à l'ASP.</p>
-                        <p>À ce stade, seule la visualisation des informations de la fiche est possible.</p>
+                        <p class="mb-0">Vous trouverez ici les fiches salarié complétées et en attente d'envoi à l'ASP.</p>
+                        <p class="mb-0">À ce stade, seule la visualisation des informations de la fiche est possible.</p>
                     {% elif form.status.value == "SENT" %}
-                        <p>Vous trouverez ici les fiches salarié complétées et envoyées à l'ASP.</p>
-                        <p>À ce stade, et en attendant un retour de l'ASP, seule la visualisation des informations de la fiche est possible.</p>
+                        <p class="mb-0">Vous trouverez ici les fiches salarié complétées et envoyées à l'ASP.</p>
+                        <p class="mb-0">À ce stade, et en attendant un retour de l'ASP, seule la visualisation des informations de la fiche est possible.</p>
                     {% elif form.status.value == "REJECTED" %}
-                        <p>Vous trouverez ici les fiches salarié envoyées à l'ASP et retournées avec une erreur.</p>
-                        <p>Vous pouvez modifier les fiches en erreur et les envoyer à nouveau.</p>
+                        <p class="mb-0">Vous trouverez ici les fiches salarié envoyées à l'ASP et retournées avec une erreur.</p>
+                        <p class="mb-0">Vous pouvez modifier les fiches en erreur et les envoyer à nouveau.</p>
                     {% elif form.status.value == "PROCESSED" %}
-                        <p>Vous trouverez ici les fiches salarié envoyées et validées par l'ASP.</p>
-                        <p>Aucune action ultérieure n'est possible à ce stade, mais vous pouvez consulter le détail de la fiche salarié.</p>
+                        <p class="mb-0">Vous trouverez ici les fiches salarié envoyées et validées par l'ASP.</p>
+                        <p class="mb-0">Aucune action ultérieure n'est possible à ce stade, mais vous pouvez consulter le détail de la fiche salarié.</p>
                     {% endif%}
                 </div>
 

--- a/itou/templates/institutions/members.html
+++ b/itou/templates/institutions/members.html
@@ -11,7 +11,9 @@
     </h2>
 
     <div class="alert alert-info">
-        Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+        <p class="mb-0">
+            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+        </p>
     </div>
 
     {% with active_admin_members=institution.active_admin_members base_url="institutions_views" %}

--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -40,9 +40,10 @@
         </table>
     </div>
     <div class="alert alert-warning">
-        Chaque collaborateur invité reçoit son propre lien d'invitation, ce lien est valable 15 jours
-        (lorsque le lien expire, l'invitation n'est plus affichée ci-dessus).
-        Ce lien d'invitation est transmis automatiquement par e-mail.
-        En cas de besoin, vous pouvez également le copier depuis la colonne « Lien d'invitation ».
+        <p class="mb-0">
+            Chaque collaborateur invité reçoit son propre lien d'invitation, ce lien est valable 15 jours (lorsque le lien expire, l'invitation n'est plus affichée ci-dessus). <br>
+            Ce lien d'invitation est transmis automatiquement par e-mail. <br>
+            En cas de besoin, vous pouvez également le copier depuis la colonne « Lien d'invitation ».
+        </p>
     </div>
 {% endif %}

--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -50,7 +50,7 @@
                 <div class="s-footer-help__col col-12 col-lg">
                     <ul>
                         <li><a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" title="Besoin d'aide ? (ouverture dans un nouvel onglet)">Besoin d'aide ?</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
-                        <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSebmbvb4RGJOKy-ou5zR2eHWwFOiUlSJtCv_avrpp97HI4RGQ/viewform?ts=5da5a580" rel="noopener" target="_blank" title="Inscription Newsletter (ouverture dans un nouvel onglet)">Inscription Newsletter</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
+                        <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSebmbvb4RGJOKy-ou5zR2eHWwFOiUlSJtCv_avrpp97HI4RGQ/viewform?ts=5da5a580" rel="noopener" target="_blank" title="Inscription Newsletter (ouverture dans un nouvel onglet)">Inscription <span lang="en">Newsletter</span></a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
                     </ul>
                 </div>
                 <div class="s-footer-help__col col-12 col-lg-auto">

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -52,7 +52,9 @@
 
                     {# Display an alert for old browsers #}
                     <div class="alert alert-secondary alert-old-browser" role="status">
-                        La version de votre navigateur n'est plus supportée. Veuillez utiliser une version plus récente pour améliorer votre expérience sur notre site.
+                        <p class="mb-0">
+                            La version de votre navigateur n'est plus supportée. Veuillez utiliser une version plus récente pour améliorer votre expérience sur notre site.
+                        </p>
                     </div>
 
                 {% endblock %}

--- a/itou/templates/prescribers/edit_organization.html
+++ b/itou/templates/prescribers/edit_organization.html
@@ -12,7 +12,9 @@
     </h2>
 
     <div class="alert alert-info">
-        Les coordonnées de contact de votre organisation sont visibles par tous les utilisateurs connectés.
+        <p class="mb-0">
+            Les coordonnées de contact de votre organisation sont visibles par tous les utilisateurs connectés.
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/templates/prescribers/list_accredited_organizations.html
+++ b/itou/templates/prescribers/list_accredited_organizations.html
@@ -13,7 +13,9 @@
     </h2>
 
     <div class="alert alert-info">
-        Seuls les administrateurs peuvent voir cette liste.
+        <p class="mb-0">
+            Seuls les administrateurs peuvent voir cette liste.
+        </p>
     </div>
 
     <hr>
@@ -21,7 +23,9 @@
     {% if not accredited_orgs %}
 
         <div class="alert alert-emploi" role="status">
-            Aucun résultat.
+            <p class="mb-0">
+                Aucun résultat.
+            </p>
         </div>
 
     {% else %}

--- a/itou/templates/prescribers/members.html
+++ b/itou/templates/prescribers/members.html
@@ -11,7 +11,9 @@
     </h2>
 
     <div class="alert alert-info">
-        Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+        <p class="mb-0">
+            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+        </p>
     </div>
 
     {% with active_admin_members=organization.active_admin_members base_url="prescribers_views" %}

--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -65,10 +65,10 @@
                             <h4 class="h5 card-subtitle mb-2 text-muted">
                                 {{ prescriber_org.address_on_one_line }}
                             </h4>
-                            <small class="card-text">
+                            <p class="small mb-0 card-text">
                                 <span class="badge badge-info">{{ prescriber_org.distance.km|floatformat:"-1" }} km</span>
                                 de votre lieu de recherche
-                            </small>
+                            </p>
                         </div>
                     </div>
                 {% empty %}

--- a/itou/templates/siaes/configure_jobs.html
+++ b/itou/templates/siaes/configure_jobs.html
@@ -53,7 +53,7 @@
 
             <div class="alert alert-emploi">
                 <p class="font-weight-bold">Ouvrir un recrutement</p>
-                <p>A partir de maintenant, vous pouvez informer les prescripteurs et les candidats de vos recrutements en cours.</p>
+                <p class="mb-0">A partir de maintenant, vous pouvez informer les prescripteurs et les candidats de vos recrutements en cours.</p>
             </div>
 
             {% include "siaes/includes/_configure_jobs_list.html" %}

--- a/itou/templates/siaes/create_siae.html
+++ b/itou/templates/siaes/create_siae.html
@@ -15,16 +15,18 @@
                 <li>ayant déjà un ou plusieurs membres, <b>demandez à l’un de ces membres de vous inviter depuis son tableau de bord</b></li>
                 <li>connue dans l'extranet IAE 2.0 de l'ASP mais n’ayant pas encore de membre : <a href="{% url 'signup:siae_select' %}">utilisez ce formulaire</a></li>
             </ul>
-            <p>Dans les autres cas, complétez le formulaire ci-dessous.</p>
+            <p class="mb-0">Dans les autres cas, complétez le formulaire ci-dessous.</p>
         </div>
 
         {% csrf_token %}
 
         {% if form.non_field_errors %}
             <div class="alert alert-danger alert-dismissible alert-link" role="alert">
-                {% for error in form.non_field_errors %}
-                    {{ error | safe }}{% if not forloop.last %}<br>{% endif %}
-                {% endfor %}
+                <p class="mb-0">
+                    {% for error in form.non_field_errors %}
+                        {{ error | safe }}{% if not forloop.last %}<br>{% endif %}
+                    {% endfor %}
+                </p>
                 <button type="button" class="close" data-dismiss="alert" aria-label="Fermer">
                     <i class="ri-close-line"></i>
                 </button>

--- a/itou/templates/siaes/includes/_card_siae.html
+++ b/itou/templates/siaes/includes/_card_siae.html
@@ -17,9 +17,9 @@
             </small>
             <br />
         {% endif %}
-        <small>
+        <p class="small mb-0">
             <span class="badge badge-dark mb-3">{{ siae.distance|floatformat:"-1"|default:"12" }} km</span> de votre lieu de recherche.
-        </small>
+        </p>
         {% if jobs_descriptions %}
             {% include "siaes/includes/_list_siae_jobs.html" with siae=siae jobs_descriptions=jobs_descriptions %}
         {% endif %}

--- a/itou/templates/siaes/includes/_configure_jobs_list.html
+++ b/itou/templates/siaes/includes/_configure_jobs_list.html
@@ -30,9 +30,9 @@
                             id="custom-name-{{ job.appellation.code }}"
                             name="custom-name-{{ job.appellation.code }}"
                             value="{{ job.custom_name }}">
-                        <small class="form-text text-muted">
+                        <p class="small mb-0 form-text text-muted">
                             Si ce champ est renseigné, il sera utilisé à la place du nom ci-dessus.
-                        </small>
+                        </p>
                     </div>
                     <div class="form-group">
                         <label for="description-{{ job.appellation.code }}">
@@ -43,9 +43,9 @@
                             id="description-{{ job.appellation.code }}"
                             name="description-{{ job.appellation.code }}"
                             rows="3">{{ job.description }}</textarea>
-                        <small class="form-text text-muted">
+                        <p class="small mb-0 form-text text-muted">
                             Renseignez ici le détail des missions, les compétences/habilitations nécessaires, les conditions de travail, les éventuelles adaptations ou restrictions du poste.
-                        </small>
+                        </p>
                     </div>
                 </td>
                 <td class="text-center align-middle" scope="row">

--- a/itou/templates/siaes/members.html
+++ b/itou/templates/siaes/members.html
@@ -8,7 +8,9 @@
     <h2 class="h1 text-muted">{{ siae.display_name }}</h2>
 
     <div class="alert alert-info">
-        Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+        <p class="mb-0">
+            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+        </p>
     </div>
 
     {% with active_admin_members=siae.active_admin_members base_url="siaes_views" %}

--- a/itou/templates/siaes/show_financial_annexes.html
+++ b/itou/templates/siaes/show_financial_annexes.html
@@ -6,23 +6,31 @@
     {{ block.super }}
 
     <div class="alert alert-success">
-        Cette interface vous permet de vous assurer que votre structure est associée aux bonnes annexes financières. La gestion de vos annexes financières continue de se faire dans l'extranet 2.0 de l'ASP.
+        <p class="mb-0">
+            Cette interface vous permet de vous assurer que votre structure est associée aux bonnes annexes financières. La gestion de vos annexes financières continue de se faire dans l'extranet 2.0 de l'ASP.
+        </p>
     </div>
 
     {% if current_siae.is_active %}
         <div class="alert alert-success" role="status">
-            Votre structure est active car elle est associée à au moins une annexe financière valide listée ci-dessous ou bien elle a été manuellement activée par notre support. Vous n'avez rien à faire.
+            <p class="mb-0">
+                Votre structure est active car elle est associée à au moins une annexe financière valide listée ci-dessous ou bien elle a été manuellement activée par notre support. Vous n'avez rien à faire.
+            </p>
         </div>
     {% elif current_siae_is_asp %}
         <div class="alert alert-danger" role="status">
-            {# Inactive siaes of ASP source cannot be fixed by user. #}
-            Votre structure est inactive car elle n'est associée à aucune annexe financière valide. Contactez nous via la rubrique votre structure sur
-            <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
+            <p class="mb-0">
+                {# Inactive siaes of ASP source cannot be fixed by user. #}
+                Votre structure est inactive car elle n'est associée à aucune annexe financière valide. Contactez nous via la rubrique votre structure sur
+                <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
+            </p>
         </div>
     {% elif current_siae_is_user_created %}
         <div class="alert alert-danger" role="status">
-            {# Inactive user created siaes can be fixed by the user. #}
-            Votre structure sera prochainement désactivée car elle n'est associée à aucune annexe financière valide. Veuillez dès que possible procéder à la sélection d'une annexe financière valide ci-dessous.
+            <p class="mb-0">
+                {# Inactive user created siaes can be fixed by the user. #}
+                Votre structure sera prochainement désactivée car elle n'est associée à aucune annexe financière valide. Veuillez dès que possible procéder à la sélection d'une annexe financière valide ci-dessous.
+            </p>
         </div>
     {% endif %}
 

--- a/itou/templates/signup/includes/authorization_proof.html
+++ b/itou/templates/signup/includes/authorization_proof.html
@@ -1,4 +1,6 @@
 
 <div class="alert alert-warning" role="status">
-    Afin d'enregistrer votre habilitation à valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique, <b>nous vous demanderons de nous transmettre l'arrêté préfectoral</b> portant mention de cette habilitation.
+    <p class="mb-0">
+        Afin d'enregistrer votre habilitation à valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique, <b>nous vous demanderons de nous transmettre l'arrêté préfectoral</b> portant mention de cette habilitation.
+    </p>
 </div>

--- a/itou/templates/signup/includes/submit_rgpd.html
+++ b/itou/templates/signup/includes/submit_rgpd.html
@@ -1,30 +1,23 @@
 {% load bootstrap4 %}
 
 <div class="alert alert-warning">
-
     <p>
         <small>
             Le Ministère du Travail (DGEFP) et Pôle emploi traitent vos données personnelles. Ce site est ouvert aux acteurs de l'inclusion et permet de simplifier le recrutement des personnes éligibles aux structures de l'Insertion par l'Activité Économique (IAE). Il est une composante du Pacte ambition IAE.
         </small>
     </p>
-
-    <p>
+    <p class="mb-0">
         <small>
-
             Pour plus d'information sur le traitement de vos données personnelles ou pour exercer vos droits, consultez
-
             <a href="{{ ITOU_DOC_URL }}/mentions/protection-des-donnees" rel="noopener" target="_blank" title="Consultez la section Protection des données (ouverture dans une nouvel onglet)">
                 la section Protection des données
                 {% include "includes/icon.html" with icon="external-link" %}
             </a>.
-
             En cliquant sur le bouton "Inscription", vous acceptez
-
             <a href="{{ ITOU_DOC_URL }}/mentions/cgu" rel="noopener" target="_blank" title="Acceptez les conditions générales d'utilisation (ouverture dans une nouvel onglet)">
                 les conditions générales d'utilisation
                 {% include "includes/icon.html" with icon="external-link" %}
             </a>.
-
         </small>
     </p>
 </div>

--- a/itou/templates/signup/prescriber_check_already_exists.html
+++ b/itou/templates/signup/prescriber_check_already_exists.html
@@ -67,18 +67,16 @@
             <h3 class="h2">Ajouter mon organisation</h3>
 
             {% if prescriber_orgs_with_members_same_siret %}
-                <div class="alert alert-warning pb-0" role="status">
-                    <p>
-                        <small>
-                            Attention une ou plusieurs organisations existent déjà avec ce SIRET.<br>
-                            Si vous ne trouvez pas votre organisation dans la liste ci-dessus ou si
-                            vous souhaitez créer un compte avec ce SIRET pour un autre type
-                            d'organisation, vous avez la possibilité de l'inscrire.
-                        </small>
+                <div class="alert alert-warning" role="status">
+                    <p class="small mb-0">
+                        Attention une ou plusieurs organisations existent déjà avec ce SIRET.<br>
+                        Si vous ne trouvez pas votre organisation dans la liste ci-dessus ou si
+                        vous souhaitez créer un compte avec ce SIRET pour un autre type
+                        d'organisation, vous avez la possibilité de l'inscrire.
                     </p>
                 </div>
             {% else %}
-                <p>
+                <p class="mb-0">
                     <small>
                         Si vous ne trouvez pas votre organisation dans la liste ci-dessus, vous avez la possibilité de l'inscrire.
                     </small>

--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -15,7 +15,7 @@
         <p>
             Les organisations habilitées permettent à leurs collaborateurs de valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique. Cette habilitation est officialisée par arrêté préfectoral.
         </p>
-        <p>
+        <p class="mb-0">
             <a href="{{ ITOU_DOC_URL }}/pourquoi-une-plateforme-de-linclusion/qui-sont-les-differents-prescripteurs" rel="noopener" target="_blank" title="En savoir plus sur les différents prescripteurs (ouverture dans un nouvel onglet)">En savoir plus sur les différents prescripteurs {% include "includes/icon.html" with icon="external-link" %}</a>
         </p>
     </div>

--- a/itou/templates/signup/prescriber_choose_org.html
+++ b/itou/templates/signup/prescriber_choose_org.html
@@ -12,7 +12,9 @@
     </h1>
 
     <div class="alert alert-secondary">
-        Votre organisation n'est pas encore inscrite.
+        <p class="mb-0">
+            Votre organisation n'est pas encore inscrite.
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/templates/signup/prescriber_request_invitation.html
+++ b/itou/templates/signup/prescriber_request_invitation.html
@@ -13,7 +13,9 @@
     </h1>
 
     <div class="alert alert-info">
-        Renseignez vos coordonnées afin d'être invité par {{ prescriber.first_name|title }} {{ prescriber.last_name|slice:1 }} de l'organisation « {{ organization.display_name }} ».
+        <p class="mb-0">
+            Renseignez vos coordonnées afin d'être invité par {{ prescriber.first_name|title }} {{ prescriber.last_name|slice:1 }} de l'organisation « {{ organization.display_name }} ».
+        </p>
     </div>
 
     <form method="post" class="js-prevent-multiple-submit">{% csrf_token %}

--- a/itou/templates/signup/prescriber_signup.html
+++ b/itou/templates/signup/prescriber_signup.html
@@ -13,14 +13,14 @@
 
     {% if join_authorized_org and kind_label and not kind_is_other %}
         {# Display kind's full name if known. #}
-        <div class="alert alert-emploi pb-0" role="status">
-            <p class="lead">{{ kind_label }}</p>
+        <div class="alert alert-emploi" role="status">
+            <p class="lead mb-0">{{ kind_label }}</p>
         </div>
     {% endif %}
 
     {% if prescriber_org_data %}
-        <div class="alert alert-emploi pb-0" role="status">
-            <p>
+        <div class="alert alert-emploi" role="status">
+            <p class="mb-0">
                 <b>{{ prescriber_org_data.name }}</b> - {{ prescriber_org_data.siret|format_siret }}<br>
                 {% if prescriber_org_data.address_line_1 %}{{ prescriber_org_data.address_line_1 }}<br>{% endif %}
                 {% if prescriber_org_data.address_line_2 %}{{ prescriber_org_data.address_line_2 }}<br>{% endif %}

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -26,7 +26,9 @@
 
     {% if siren_form.cleaned_data and not siaes_without_members and not siaes_with_members %}
         <div class="alert alert-emploi mt-5" role="status">
-            Aucun résultat pour <b>{{ siren_form.cleaned_data.siren }}</b>.
+            <p class="mb-0">
+                Aucun résultat pour <b>{{ siren_form.cleaned_data.siren }}</b>.
+            </p>
         </div>
 
         <div class="alert alert-danger mt-2" role="status">
@@ -38,7 +40,7 @@
                 <br>
                 La DIRECCTE doit nous indiquer si le conventionnement de votre structure est en cours en précisant le numéro de SIRET, le type de structure, l’adresse postale et l’adresse e-mail du correspondant technique ASP.<br>
             </p>
-            <p>
+            <p class="mb-0">
                 <b>Si vous tentez d'inscrire une Entreprise Adaptée ou un GEIQ</b>, merci d'utiliser <a href="{{ TYPEFORM_URL }}/to/RYfNLR79" target="_blank" rel="noopener" title="Merci d'utiliser ce formulaire (ouverture dans un nouvel onglet)">ce formulaire</a>.
             </p>
         </div>
@@ -51,7 +53,9 @@
             <h3 class="h2">Entreprises disponibles</h3>
 
             <div class="alert alert-emploi" role="status">
-                <i>Les données sont fournies par l'extranet IAE 2.0 de l'ASP.</i>
+                <p class="mb-0">
+                    <i>Les données sont fournies par l'extranet IAE 2.0 de l'ASP.</i>
+                </p>
             </div>
 
             <form method="post" action="" class="js-prevent-multiple-submit">
@@ -112,7 +116,9 @@
             <h3 class="h2">Entreprises déjà inscrites</h3>
 
             <div class="alert alert-emploi" role="status">
-                <i>Par sécurité vous devez obtenir une invitation pour rejoindre ces structures.</i>
+                <p class="mb-0">
+                    <i>Par sécurité vous devez obtenir une invitation pour rejoindre ces structures.</i>
+                </p>
             </div>
 
             <ul>

--- a/itou/templates/storage/s3_upload_form.html
+++ b/itou/templates/storage/s3_upload_form.html
@@ -29,6 +29,8 @@
 </div>
 <noscript>
     <div class="alert alert-danger" role="status">
-        JavaScript n'est pas activé. Il est nécessaire de réactiver JavaScript pour activer la fonctionnalité envoi de CV.
+        <p class="mb-0">
+            JavaScript n'est pas activé. Il est nécessaire de réactiver JavaScript pour activer la fonctionnalité envoi de CV.
+        </p>
     </div>
 </noscript>

--- a/itou/templates/welcoming_tour/includes/message.html
+++ b/itou/templates/welcoming_tour/includes/message.html
@@ -1,6 +1,8 @@
 <div class="alert alert-success alert-dismissible" role="status">
-    👋 Bienvenue sur les emplois de l'inclusion ! 👉 <a href="{% url 'welcoming_tour:index' %}" class="alert-link">Revoir le message de bienvenue</a>
     <button type="button" class="close" data-dismiss="alert" aria-label="Fermer">
         <i class="ri-close-line"></i>
     </button>
+    <p class="mb-0">
+        👋 Bienvenue sur les emplois de l'inclusion ! 👉 <a href="{% url 'welcoming_tour:index' %}" class="alert-link">Revoir le message de bienvenue</a>
+    </p>
 </div>


### PR DESCRIPTION
### Quoi ?

Correction des erreurs a11y sur éléments obligatoires

### Pourquoi ?

Pour mettre en conformité le site avec les règles d'accessibilité et respecter les recommandations de l'audit.

### Comment ?
En précisant le changement de langue quand un mot ou une expression n'est pas en fr
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-8-7

En englobant toujours le texte dans une balise sémantique (souvent un `<p>`)
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-8-9