### PR TITLE
Corrections des nombres de postes pour coller au design

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -381,3 +381,7 @@ Usage:
     z-index: 10;
 }
 
+.job-appellation-nb_open_positions {
+    width:80px;
+    margin:0 auto;
+}

--- a/itou/templates/siaes/includes/_configure_jobs_list.html
+++ b/itou/templates/siaes/includes/_configure_jobs_list.html
@@ -49,19 +49,17 @@
                     </div>
                 </td>
                 <td class="text-center align-middle" scope="row">
-                    <div class="custom-control custom-switch is-rtl">
-                        <input
-                            type="number"
-                            class="form-control form-control-sm"
-                            id="nb_open_positions-{{ job.appellation.code }}"
-                            name="nb_open_positions-{{ job.appellation.code }}"
-                            value="{{ job.nb_open_positions }}"
-                            aria-label="Nombre de postes ouverts pour {{ job.appellation.name }}"
-                            {% if not job.is_active %}
-                                disabled="disabled"
-                            {% endif %}
-                            min="1" step="1" />
-                    </div>
+                    <input
+                        type="number"
+                        class="form-control form-control-sm job-appellation-nb_open_positions"
+                        id="nb_open_positions-{{ job.appellation.code }}"
+                        name="nb_open_positions-{{ job.appellation.code }}"
+                        value="{{ job.nb_open_positions }}"
+                        aria-label="Nombre de postes ouverts pour {{ job.appellation.name }}"
+                        {% if not job.is_active %}
+                            disabled="disabled"
+                        {% endif %}
+                        min="1" step="1" />
                 </td>
                 <td class="text-center align-middle" scope="row">
                     <div class="custom-control custom-switch is-rtl">

--- a/itou/templates/siaes/includes/_configure_jobs_list.html
+++ b/itou/templates/siaes/includes/_configure_jobs_list.html
@@ -50,15 +50,13 @@
                 </td>
                 <td class="text-center align-middle" scope="row">
                     <div class="custom-control custom-switch is-rtl">
-                        <label for="nb_open_positions-{{ job.appellation.code }}">
-                            <small>Nombre de postes ouverts</small>
-                        </label>
                         <input
                             type="number"
                             class="form-control form-control-sm"
                             id="nb_open_positions-{{ job.appellation.code }}"
                             name="nb_open_positions-{{ job.appellation.code }}"
                             value="{{ job.nb_open_positions }}"
+                            aria-label="Nombre de postes ouverts pour {{ job.appellation.name }}"
                             {% if not job.is_active %}
                                 disabled="disabled"
                             {% endif %}

--- a/itou/templates/siaes/includes/_configure_jobs_list.html
+++ b/itou/templates/siaes/includes/_configure_jobs_list.html
@@ -5,7 +5,7 @@
         <tr>
             <th scope="col">ROME</th>
             <th scope="col" class="text-left">Le(s) métiers(s) exercé(s) dans votre structure</th>
-            <th class="w-25" scope="col">Nombre de postes</th>
+            <th class="w-25" scope="col">Nombre de postes ouverts</th>
             <th class="w-25" scope="col">Actions</th>
             <th scope="col">Supprimer</th>
         </tr>


### PR DESCRIPTION
## Quoi
[Retours designs](https://www.notion.so/Indiquer-le-nombre-de-postes-ouverts-sur-chaque-fiche-de-poste-c9ee7545c5124782b16851be888026bb) liés au formulaire de fiches de postes:
- replacement du label par un aria-label
- Largeur + centrage de l’input qui colle à la maquette

## Pourquoi

L’implémentation initiale n’est pas fidèle au design

## Screenshot

![Sélection_240](https://user-images.githubusercontent.com/1223316/156143874-bcb5c52c-6b4c-4049-a90a-e59d7206f5cf.png)

