### PR TITLE
Remplacement des icones SVG du dashboard pour les icones remixicon

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -3,477 +3,477 @@
 {% block title %}Tableau de bord{{ block.super }}{% endblock %}
 
 {% block messages %}
-{{ block.super }}
+    {{ block.super }}
 
-{# Alerte pour gérer les cas d'exception lors de l'importation des AI. #}
-{% if current_siae and current_siae.kind == current_siae.KIND_AI %}
-<div class="alert alert-warning">
-    <p>Tous les salariés déclarés auprès de l'ASP avant le 1er décembre ont été ajoutés au tableau de bord de la SIAE porteuse de l’annexe financière. Nous travaillons à vous permettre de les transférer dans le tableau de bord d’une structure fille.</p>
-    <p>Pour les salariés qui ne seraient plus en poste, il vous est demandé de procéder à une suspension d’un an au motif « contrat de travail terminé ». Dans la mesure où ces salariés sont connus dans l’Extranet IAE 2.0 de l'ASP, ces PASS IAE ne peuvent pas être annulés.</p>
-    <p>Pour les salariés entrés en parcours avant le 1er décembre 2021 qui n’auraient pas été déclarés dans l’Extranet avant le 1er décembre 2021, vous devez procéder à une déclaration d’éligibilité sur la plateforme de l’inclusion.</p>
-    <p>Pour toute question liée à un cas individuel, <a href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/#support" rel="noopener" target="_blank" class="is-external" title="Une assistance est disponible ici (ouverture dans un nouvel onglet)">une assistance est disponible ici <i class="ri-external-link-line ri-lg"></i></a>.</p>
-</div>
-{% endif %}
-
-{% if current_siae and not current_siae.jobs.exists %}
-<div class="alert alert-warning">
-    Pour optimiser la réception de vos candidatures, pensez à renseigner le descriptif de vos postes et leurs prérequis.
-</div>
-{% endif %}
-
-{# Alerte pour les employeurs en cas d'absence ou de mauvais score de geocoding. #}
-{% if current_siae and not current_siae.has_reliable_coords %}
-<div class="alert alert-warning mb-0" role="status">
-    Nous n'avons pas pu géolocaliser votre établissement.<br>
-    Cela peut affecter sa position dans les résultats de recherche.<br>
-    {% if user_is_siae_admin %}
-    <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">Indiquez une autre adresse</a>
-    {% else %}
-    {% with current_siae.active_admin_members.first as admin %}
-    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
-    {% endwith %}
+    {# Alerte pour gérer les cas d'exception lors de l'importation des AI. #}
+    {% if current_siae and current_siae.kind == current_siae.KIND_AI %}
+        <div class="alert alert-warning">
+            <p>Tous les salariés déclarés auprès de l'ASP avant le 1er décembre ont été ajoutés au tableau de bord de la SIAE porteuse de l’annexe financière. Nous travaillons à vous permettre de les transférer dans le tableau de bord d’une structure fille.</p>
+            <p>Pour les salariés qui ne seraient plus en poste, il vous est demandé de procéder à une suspension d’un an au motif « contrat de travail terminé ». Dans la mesure où ces salariés sont connus dans l’Extranet IAE 2.0 de l'ASP, ces PASS IAE ne peuvent pas être annulés.</p>
+            <p>Pour les salariés entrés en parcours avant le 1er décembre 2021 qui n’auraient pas été déclarés dans l’Extranet avant le 1er décembre 2021, vous devez procéder à une déclaration d’éligibilité sur la plateforme de l’inclusion.</p>
+            <p>Pour toute question liée à un cas individuel, <a href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/#support" rel="noopener" target="_blank" class="is-external" title="Une assistance est disponible ici (ouverture dans un nouvel onglet)">une assistance est disponible ici <i class="ri-external-link-line ri-lg"></i></a>.</p>
+        </div>
     {% endif %}
-    ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
-</div>
-{% endif %}
 
-{# Alerte pour les prescripteurs en cas d'absence ou de mauvais score de geocoding. #}
-{# Seuls les prescripteurs habilités apparaissent dans le moteur de recherche. #}
-{% if current_prescriber_organization and current_prescriber_organization.is_authorized and not current_prescriber_organization.has_reliable_coords %}
-<div class="alert alert-warning mb-0" role="status">
-    Nous n'avons pas pu géolocaliser votre établissement.<br>
-    Cela peut affecter sa position dans les résultats de recherche.<br>
-    {% if user_is_prescriber_org_admin %}
-    <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a>
-    {% else %}
-    {% with current_prescriber_organization.active_admin_members.first as admin %}
-    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
-    {% endwith %}
+    {% if current_siae and not current_siae.jobs.exists %}
+        <div class="alert alert-warning">
+            Pour optimiser la réception de vos candidatures, pensez à renseigner le descriptif de vos postes et leurs prérequis.
+        </div>
     {% endif %}
-    ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
-</div>
-{% endif %}
 
-{% if current_siae and not current_siae.is_active %}
-<div class="alert alert-warning mb-0" role="status">
-    La DGEFP nous indique que votre structure {% if current_siae.siret %}(inscrite avec le numéro SIRET : {{ current_siae.siret }}) {% endif %}n'est plus conventionnée.<br>
-    Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.<br>
-    À compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
-
-    {% if user_is_siae_admin %}
-    Veuillez dès que possible régulariser votre situation
-    <a href="{% url 'siaes_views:show_financial_annexes' %}">en sélectionnant une annexe financière valide}</a>.<br>
-    {% else %}
-    {% with current_siae.active_admin_members.first as admin %}
-    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle régularise la situation de votre structure.
-    {% endwith %}
+    {# Alerte pour les employeurs en cas d'absence ou de mauvais score de geocoding. #}
+    {% if current_siae and not current_siae.has_reliable_coords %}
+        <div class="alert alert-warning mb-0" role="status">
+            Nous n'avons pas pu géolocaliser votre établissement.<br>
+            Cela peut affecter sa position dans les résultats de recherche.<br>
+            {% if user_is_siae_admin %}
+                <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">Indiquez une autre adresse</a>
+            {% else %}
+                {% with current_siae.active_admin_members.first as admin %}
+                    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
+                {% endwith %}
+            {% endif %}
+            ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
+        </div>
     {% endif %}
-</div>
-{% endif %}
 
-{% if current_prescriber_organization and current_prescriber_organization.has_pending_authorization %}
-<div class="alert alert-warning pb-0" role="status">
-    <p>
-        Votre habilitation à valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique est en cours de vérification par nos équipes. Vous ne pouvez pas encore réaliser le diagnostic d'éligibilité des candidats.
-    </p>
-    {% if current_prescriber_organization.has_pending_authorization_proof %}
-    <p>
-        Merci de nous transmettre l'arrêté préfectoral portant mention de cette habilitation :
-        <a href="{{ TYPEFORM_URL }}/to/mk0GyI67#idprescriber={{ current_prescriber_organization.pk }}&iduser={{ user.pk }}&source={{ ITOU_ENVIRONMENT }}" rel="noopener" target="_blank" title="Cliquez ici pour l'envoyer (ouverture dans un nouvel onglet)">
-            cliquez ici pour l'envoyer
-            <i class="ri-external-link-line ri-lg"></i>
-        </a>
-    </p>
+    {# Alerte pour les prescripteurs en cas d'absence ou de mauvais score de geocoding. #}
+    {# Seuls les prescripteurs habilités apparaissent dans le moteur de recherche. #}
+    {% if current_prescriber_organization and current_prescriber_organization.is_authorized and not current_prescriber_organization.has_reliable_coords %}
+        <div class="alert alert-warning mb-0" role="status">
+            Nous n'avons pas pu géolocaliser votre établissement.<br>
+            Cela peut affecter sa position dans les résultats de recherche.<br>
+            {% if user_is_prescriber_org_admin %}
+                <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a>
+            {% else %}
+                {% with current_prescriber_organization.active_admin_members.first as admin %}
+                    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
+                {% endwith %}
+            {% endif %}
+            ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
+        </div>
     {% endif %}
-</div>
-{% endif %}
 
-{% if user.joined_recently %}
-{% include "welcoming_tour/includes/message.html" %}
-{% endif %}
+    {% if current_siae and not current_siae.is_active %}
+        <div class="alert alert-warning mb-0" role="status">
+            La DGEFP nous indique que votre structure {% if current_siae.siret %}(inscrite avec le numéro SIRET : {{ current_siae.siret }}) {% endif %}n'est plus conventionnée.<br>
+            Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.<br>
+            À compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
 
-{# Message d'information temporaire pour les fiches salarié / annexes financières #}
-{% if can_show_employee_records %}
-<div class="alert alert-info">
-    <p>La fin de validité des annexes financières de 2021 n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.</p>
-    <p>Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
-</div>
-{% endif %}
+            {% if user_is_siae_admin %}
+                Veuillez dès que possible régulariser votre situation
+                <a href="{% url 'siaes_views:show_financial_annexes' %}">en sélectionnant une annexe financière valide}</a>.<br>
+            {% else %}
+                {% with current_siae.active_admin_members.first as admin %}
+                    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle régularise la situation de votre structure.
+                {% endwith %}
+            {% endif %}
+        </div>
+    {% endif %}
+
+    {% if current_prescriber_organization and current_prescriber_organization.has_pending_authorization %}
+        <div class="alert alert-warning pb-0" role="status">
+            <p>
+                Votre habilitation à valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique est en cours de vérification par nos équipes. Vous ne pouvez pas encore réaliser le diagnostic d'éligibilité des candidats.
+            </p>
+            {% if current_prescriber_organization.has_pending_authorization_proof %}
+                <p>
+                    Merci de nous transmettre l'arrêté préfectoral portant mention de cette habilitation :
+                    <a href="{{ TYPEFORM_URL }}/to/mk0GyI67#idprescriber={{ current_prescriber_organization.pk }}&iduser={{ user.pk }}&source={{ ITOU_ENVIRONMENT }}" rel="noopener" target="_blank" title="Cliquez ici pour l'envoyer (ouverture dans un nouvel onglet)">
+                        cliquez ici pour l'envoyer
+                        <i class="ri-external-link-line ri-lg"></i>
+                    </a>
+                </p>
+            {% endif %}
+        </div>
+    {% endif %}
+
+    {% if user.joined_recently %}
+        {% include "welcoming_tour/includes/message.html" %}
+    {% endif %}
+
+    {# Message d'information temporaire pour les fiches salarié / annexes financières #}
+    {% if can_show_employee_records %}
+        <div class="alert alert-info">
+            <p>La fin de validité des annexes financières de 2021 n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.</p>
+            <p>Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
+        </div>
+    {% endif %}
 
 {% endblock %}
 
 {% block content %}
 
-{# Mise en avant temporaire du forum pour les prescripteurs. #}
-{% if user.is_prescriber %}
-<div class="card mb-5 bg-gray-400 text-center">
-    <div class="card-body">
-        <p class="h4 mb-3">
-            <span class="badge badge-warning">Nouveau</span>
-            Bénéficiez des bonnes pratiques et actualités de la 1ère communauté des professionnels de l'inclusion !
-        </p>
-        <p class="mb-0">
-            <a href="{{ ITOU_COMMUNITY_URL }}" rel="noopener" target="_blank" class="btn btn-primary" title="Partagez et découvrez les outils qui facilitent votre quotidien (ouverture dans un nouvel onglet)">
-                Partagez et découvrez les outils qui facilitent votre quotidien
-                <i class="ri-external-link-line ri-lg"></i>
-            </a>
-        </p>
-    </div>
-</div>
-{% endif %}
-
-<h1 class="h1">
-    Tableau de bord
-    {% if user.is_job_seeker and user.get_full_name %} - <span class="text-muted">{{ user.get_full_name }}</span>{% endif %}
-    {% if current_siae %} - <span class="text-muted">{{ current_siae.display_name }}</span>{% endif %}
-    {% if current_prescriber_organization %} -
-    <span class="text-muted">{{ current_prescriber_organization.display_name }}</span>
-    {% if current_prescriber_organization.is_authorized %}<i class="ri-award-line ri-2x"></i>
-    {% endif %}
-    {% endif %}
-    {% if current_institution %}
-    - <span class="text-muted">{{ current_institution.display_name }}</span>
-    {% endif %}
-</h1>
-
-{% if current_prescriber_organization and current_prescriber_organization.is_authorized %}
-<p class="text-muted">
-    <span class="badge badge-warning">Prescripteur habilité</span>
-    {% if current_prescriber_organization.code_safir_pole_emploi %}
-    <span class="badge badge-light">
-        Code SAFIR {{ current_prescriber_organization.code_safir_pole_emploi }}
-    </span>
-    {% endif %}
-</p>
-{% endif %}
-
-<div class="card-deck mt-3">
-
-    {% if user.is_staff %}
-    <div class="card">
-        <h5 class="card-header">Admin</h5>
-        <div class="card-body">
-            <p class="card-text">
-                <i class="ri-key-2-line ri-lg"></i>
-                <a href="{% url 'admin:index' %}">
-                    Admin
-                </a>
-            </p>
-        </div>
-    </div>
-    {% endif %}
-
-    {% if user.is_job_seeker %}
-
-    <div class="card">
-        <h5 class="h4 card-header">Candidatures</h5>
-        <div class="card-body">
-            <p class="card-text">
-                <i class="ri-chat-4-line ri-lg"></i>
-                <a href="{% url 'apply:list_for_job_seeker' %}">Vos candidatures</a>
-            </p>
-            <p class="card-text">
-                <i class="ri-briefcase-3-line ri-lg"></i>
-                <a href="/">Rechercher une entreprise</a>
-            </p>
-        </div>
-    </div>
-
-    {% with user.approvals_wrapper as approvals_wrapper %}
-    {% if approvals_wrapper.latest_approval %}
-    <div class="card">
-        <h5 class="h4 card-header">Numéro d'agrément</h5>
-        <div class="card-body">
-            {# Approval status. #}
-            <div class="card-text">
-                {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
-            </div>
-            {% if approvals_wrapper.has_in_waiting_period %}
-            <p class="card-text">
-                {% if user.has_valid_diagnosis %}
-                <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
-                {% else %}
-                <small>
-                    {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}
-                </small>
-                {% endif %}
-            </p>
-            {% endif %}
-        </div>
-    </div>
-    {% endif %}
-    {% endwith %}
-
-    {% endif %}{# end of if user.is_job_seeker #}
-
+    {# Mise en avant temporaire du forum pour les prescripteurs. #}
     {% if user.is_prescriber %}
-
-    {% if current_prescriber_organization %}
-    <div class="card">
-        <h5 class="h4 card-header">
-            Organisation <span class="ml-1 badge badge-secondary">{{ current_prescriber_organization.kind }} - ID {{ current_prescriber_organization.id }}</span>
-        </h5>
-        <div class="card-body">
-            <p class="card-text">
-                {% with card_url=current_prescriber_organization.get_card_url %}
-                {% if user_is_prescriber_org_admin or card_url %}
-                <i class="ri-bookmark-line ri-lg"></i>
-                {% if user_is_prescriber_org_admin %}
-                <a href="{% url 'prescribers_views:edit_organization' %}">
-                    Modifier les informations
-                </a>
-                {% if card_url %} / {% endif %}
-                {% endif %}
-                {% if card_url %}
-                <a href="{{ card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                    Voir la fiche
-                </a>
-                {% endif %}
-                {% endif %}
-                {% endwith %}
-            </p>
-            <p class="card-text">
-                <i class="ri-group-line ri-lg"></i>
-                <a href="{% url 'prescribers_views:members' %}">
-                    Gérer vos collaborateurs
-                </a>
-            </p>
-            {% if current_prescriber_organization.kind == current_prescriber_organization.Kind.DEPT and user_is_prescriber_org_admin %}
-            <p class="card-text">
-                <i class="ri-list-unordered ri-lg"></i>
-                <a href="{% url 'prescribers_views:list_accredited_organizations' %}">
-                    Voir la liste des organisations conventionnées
-                </a>
-                <span class="badge badge-info">Nouveau</span>
-            </p>
-            {% endif %}
-            {% if current_prescriber_organization.is_authorized %}
-            <hr>
-            <p class="card-text">
-                <i class="ri-award-line ri-lg"></i>
-                <span>
-                    {{ current_prescriber_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique#diagnostic_de_reference" target="_blank" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
-                </span>
-            </p>
-            {% endif %}
+        <div class="card mb-5 bg-gray-400 text-center">
+            <div class="card-body">
+                <p class="h4 mb-3">
+                    <span class="badge badge-warning">Nouveau</span>
+                    Bénéficiez des bonnes pratiques et actualités de la 1ère communauté des professionnels de l'inclusion !
+                </p>
+                <p class="mb-0">
+                    <a href="{{ ITOU_COMMUNITY_URL }}" rel="noopener" target="_blank" class="btn btn-primary" title="Partagez et découvrez les outils qui facilitent votre quotidien (ouverture dans un nouvel onglet)">
+                        Partagez et découvrez les outils qui facilitent votre quotidien
+                        <i class="ri-external-link-line ri-lg"></i>
+                    </a>
+                </p>
+            </div>
         </div>
-    </div>
     {% endif %}
 
-    <div class="card">
-        <h5 class="h4 card-header">Candidatures</h5>
-        <div class="card-body">
-            <p class="card-text">
-                <i class="ri-chat-4-line ri-lg"></i>
-                <a href="{% url 'apply:list_for_prescriber' %}">Suivi des candidatures</a>
-            </p>
-            <p class="card-text">
-                <i class="ri-user-follow-line ri-lg"></i>
-                <a href="/">Postuler pour un candidat</a>
-            </p>
-            <p class="card-text">
-                <i class="ri-download-2-line ri-lg"></i>
-                <a href="{% url 'apply:list_for_prescriber_exports' %}">
-                    Export des candidatures
-                </a>
-            </p>
-        </div>
-    </div>
-
-    {% endif %}{# end of if user.is_prescriber #}
-
-    {% if user.is_siae_staff %}
-
-    <div class="card">
-        <h5 class="h4 card-header">
-            Ma structure
-            <span class="ml-1 badge badge-secondary">{{ current_siae.kind }} - ID {{ current_siae.id }}</span>
-        </h5>
-        <div class="card-body">
-            <p class="card-text">
-                <i class="ri-settings-6-line ri-lg"></i>
-                {% if user_is_siae_admin %}
-                <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">
-                    Modifier les informations de l'établissement
-                </a>
-                /
-                {% endif %}
-                <a href="{{ current_siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                    Voir la fiche publique
-                </a>
-            </p>
-            {% if current_siae.is_active %}
-            <p class="card-text">
-                <i class="ri-group-line ri-lg"></i>
-                <a href="{% url 'siaes_views:members' %}">
-                    Gérer des collaborateurs
-                </a>
-            </p>
+    <h1 class="h1">
+        Tableau de bord
+        {% if user.is_job_seeker and user.get_full_name %} - <span class="text-muted">{{ user.get_full_name }}</span>{% endif %}
+        {% if current_siae %} - <span class="text-muted">{{ current_siae.display_name }}</span>{% endif %}
+        {% if current_prescriber_organization %} -
+            <span class="text-muted">{{ current_prescriber_organization.display_name }}</span>
+            {% if current_prescriber_organization.is_authorized %}<i class="ri-award-line ri-2x"></i>
             {% endif %}
+        {% endif %}
+        {% if current_institution %}
+            - <span class="text-muted">{{ current_institution.display_name }}</span>
+        {% endif %}
+    </h1>
 
-            <p class="card-text">
-                <i class="ri-briefcase-3-line ri-lg"></i>
-                <a class="title-with-badge" href="{% url 'siaes_views:configure_jobs' %}">Gérer les métiers et recrutements
-                    <span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="À partir de maintenant, vous allez pouvoir informer les prescripteurs et les candidats des métiers qui recrutent en ce moment, avec la fonctionnalité «recrutement en cours»">Nouveau</span>
-                </a>
-            </p>
-
-            {% if can_show_financial_annexes %}
-            <p class="card-text">
-                <i class="ri-checkbox-circle-line ri-lg"></i>
-                <a href="{% url 'siaes_views:show_financial_annexes' %}">
-                    Mes annexes financières
-                </a>
-                {% if not current_siae.is_active %}
-                <span class="badge badge-danger">
-                    Action requise
+    {% if current_prescriber_organization and current_prescriber_organization.is_authorized %}
+        <p class="text-muted">
+            <span class="badge badge-warning">Prescripteur habilité</span>
+            {% if current_prescriber_organization.code_safir_pole_emploi %}
+                <span class="badge badge-light">
+                    Code SAFIR {{ current_prescriber_organization.code_safir_pole_emploi }}
                 </span>
+            {% endif %}
+        </p>
+    {% endif %}
+
+    <div class="card-deck mt-3">
+
+        {% if user.is_staff %}
+            <div class="card">
+                <h5 class="card-header">Admin</h5>
+                <div class="card-body">
+                    <p class="card-text">
+                        <i class="ri-key-2-line ri-lg"></i>
+                        <a href="{% url 'admin:index' %}">
+                            Admin
+                        </a>
+                    </p>
+                </div>
+            </div>
+        {% endif %}
+
+        {% if user.is_job_seeker %}
+
+            <div class="card">
+                <h5 class="h4 card-header">Candidatures</h5>
+                <div class="card-body">
+                    <p class="card-text">
+                        <i class="ri-chat-4-line ri-lg"></i>
+                        <a href="{% url 'apply:list_for_job_seeker' %}">Vos candidatures</a>
+                    </p>
+                    <p class="card-text">
+                        <i class="ri-briefcase-3-line ri-lg"></i>
+                        <a href="/">Rechercher une entreprise</a>
+                    </p>
+                </div>
+            </div>
+
+            {% with user.approvals_wrapper as approvals_wrapper %}
+                {% if approvals_wrapper.latest_approval %}
+                    <div class="card">
+                        <h5 class="h4 card-header">Numéro d'agrément</h5>
+                        <div class="card-body">
+                            {# Approval status. #}
+                            <div class="card-text">
+                                {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
+                            </div>
+                            {% if approvals_wrapper.has_in_waiting_period %}
+                                <p class="card-text">
+                                    {% if user.has_valid_diagnosis %}
+                                        <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
+                                    {% else %}
+                                        <small>
+                                            {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}
+                                        </small>
+                                    {% endif %}
+                                </p>
+                            {% endif %}
+                        </div>
+                    </div>
                 {% endif %}
-            </p>
-            {% endif %}
-            {% if can_create_siae_antenna %}
-            <p class="card-text">
-                <i class="ri-add-box-line ri-lg"></i>
-                <a href="{% url 'siaes_views:create_siae' %}">Créer/rejoindre une autre structure</a>
-            </p>
-            {% endif %}
-        </div>
-    </div>
+            {% endwith %}
 
-    <div class="card">
-        <h5 class="h4 card-header">Mes candidatures</h5>
-        <div class="card-body">
-            {% for category in job_applications_categories %}
-            {% if category.counter %}
-            <p class="card-text">
-                <i class="{{ category.icon }} ri-lg"></i>
-                <a href="{{ category.url }}">{{ category.name }}</a>
-                <span class="badge {{ category.badge }}">{{ category.counter }}</span>
-            </p>
-            {% endif %}
-            {% endfor %}
+        {% endif %}{# end of if user.is_job_seeker #}
 
-            {% if can_show_employee_records %}
-            <p class="card-text">
-                <i class="ri-file-3-line ri-lg"></i>
-                <a href="{% url 'employee_record_views:list' %}?status=NEW">Gérer mes fiches salarié (ASP)</a>
-            </p>
+        {% if user.is_prescriber %}
+
+            {% if current_prescriber_organization %}
+                <div class="card">
+                    <h5 class="h4 card-header">
+                        Organisation <span class="ml-1 badge badge-secondary">{{ current_prescriber_organization.kind }} - ID {{ current_prescriber_organization.id }}</span>
+                    </h5>
+                    <div class="card-body">
+                        <p class="card-text">
+                            {% with card_url=current_prescriber_organization.get_card_url %}
+                                {% if user_is_prescriber_org_admin or card_url %}
+                                    <i class="ri-bookmark-line ri-lg"></i>
+                                    {% if user_is_prescriber_org_admin %}
+                                        <a href="{% url 'prescribers_views:edit_organization' %}">
+                                            Modifier les informations
+                                        </a>
+                                        {% if card_url %} / {% endif %}
+                                    {% endif %}
+                                    {% if card_url %}
+                                        <a href="{{ card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                                            Voir la fiche
+                                        </a>
+                                    {% endif %}
+                                {% endif %}
+                            {% endwith %}
+                        </p>
+                        <p class="card-text">
+                            <i class="ri-group-line ri-lg"></i>
+                            <a href="{% url 'prescribers_views:members' %}">
+                                Gérer vos collaborateurs
+                            </a>
+                        </p>
+                        {% if current_prescriber_organization.kind == current_prescriber_organization.Kind.DEPT and user_is_prescriber_org_admin %}
+                            <p class="card-text">
+                                <i class="ri-list-unordered ri-lg"></i>
+                                <a href="{% url 'prescribers_views:list_accredited_organizations' %}">
+                                    Voir la liste des organisations conventionnées
+                                </a>
+                                <span class="badge badge-info">Nouveau</span>
+                            </p>
+                        {% endif %}
+                        {% if current_prescriber_organization.is_authorized %}
+                            <hr>
+                            <p class="card-text">
+                                <i class="ri-award-line ri-lg"></i>
+                                <span>
+                                    {{ current_prescriber_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique#diagnostic_de_reference" target="_blank" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
+                                </span>
+                            </p>
+                        {% endif %}
+                    </div>
+                </div>
             {% endif %}
 
-            <p class="card-text">
-                <i class="ri-login-box-line ri-lg"></i>
-                <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">
-                    {% if current_siae.is_subject_to_eligibility_rules %}
-                    Déclarer une embauche
-                    {% else %}
-                    Candidature spontanée
+            <div class="card">
+                <h5 class="h4 card-header">Candidatures</h5>
+                <div class="card-body">
+                    <p class="card-text">
+                        <i class="ri-chat-4-line ri-lg"></i>
+                        <a href="{% url 'apply:list_for_prescriber' %}">Suivi des candidatures</a>
+                    </p>
+                    <p class="card-text">
+                        <i class="ri-user-follow-line ri-lg"></i>
+                        <a href="/">Postuler pour un candidat</a>
+                    </p>
+                    <p class="card-text">
+                        <i class="ri-download-2-line ri-lg"></i>
+                        <a href="{% url 'apply:list_for_prescriber_exports' %}">
+                            Export des candidatures
+                        </a>
+                    </p>
+                </div>
+            </div>
+
+        {% endif %}{# end of if user.is_prescriber #}
+
+        {% if user.is_siae_staff %}
+
+            <div class="card">
+                <h5 class="h4 card-header">
+                    Ma structure
+                    <span class="ml-1 badge badge-secondary">{{ current_siae.kind }} - ID {{ current_siae.id }}</span>
+                </h5>
+                <div class="card-body">
+                    <p class="card-text">
+                        <i class="ri-settings-6-line ri-lg"></i>
+                        {% if user_is_siae_admin %}
+                            <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">
+                                Modifier les informations de l'établissement
+                            </a>
+                            /
+                        {% endif %}
+                        <a href="{{ current_siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                            Voir la fiche publique
+                        </a>
+                    </p>
+                    {% if current_siae.is_active %}
+                        <p class="card-text">
+                            <i class="ri-group-line ri-lg"></i>
+                            <a href="{% url 'siaes_views:members' %}">
+                                Gérer des collaborateurs
+                            </a>
+                        </p>
                     {% endif %}
-                </a>
-            </p>
-            <p class="card-text">
-                <i class="ri-search-line ri-lg"></i>
-                <a href="{% url 'approvals:pe_approval_search' %}">
-                    Prolonger ou suspendre un agrément émis par Pôle emploi
-                </a>
-            </p>
-            {% if current_siae.is_subject_to_eligibility_rules %}
-            <p class="card-text">
-                <i class="ri-book-open-line ri-lg"></i>
-                <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1" target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
-                    Liste des critères d'éligibilité
-                </a>
-            </p>
-            {% endif %}
-            <p class="card-text">
-                <i class="ri-download-2-line ri-lg"></i>
-                <a href="{% url 'apply:list_for_siae_exports' %}">
-                    Export des candidatures
-                </a>
-            </p>
-        </div>
+
+                    <p class="card-text">
+                        <i class="ri-briefcase-3-line ri-lg"></i>
+                        <a class="title-with-badge" href="{% url 'siaes_views:configure_jobs' %}">Gérer les métiers et recrutements
+                            <span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="À partir de maintenant, vous allez pouvoir informer les prescripteurs et les candidats des métiers qui recrutent en ce moment, avec la fonctionnalité «recrutement en cours»">Nouveau</span>
+                        </a>
+                    </p>
+
+                    {% if can_show_financial_annexes %}
+                        <p class="card-text">
+                            <i class="ri-checkbox-circle-line ri-lg"></i>
+                            <a href="{% url 'siaes_views:show_financial_annexes' %}">
+                                Mes annexes financières
+                            </a>
+                            {% if not current_siae.is_active %}
+                                <span class="badge badge-danger">
+                                    Action requise
+                                </span>
+                            {% endif %}
+                        </p>
+                    {% endif %}
+                    {% if can_create_siae_antenna %}
+                        <p class="card-text">
+                            <i class="ri-add-box-line ri-lg"></i>
+                            <a href="{% url 'siaes_views:create_siae' %}">Créer/rejoindre une autre structure</a>
+                        </p>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="card">
+                <h5 class="h4 card-header">Mes candidatures</h5>
+                <div class="card-body">
+                    {% for category in job_applications_categories %}
+                        {% if category.counter %}
+                            <p class="card-text">
+                                <i class="{{ category.icon }} ri-lg"></i>
+                                <a href="{{ category.url }}">{{ category.name }}</a>
+                                <span class="badge {{ category.badge }}">{{ category.counter }}</span>
+                            </p>
+                        {% endif %}
+                    {% endfor %}
+
+                    {% if can_show_employee_records %}
+                        <p class="card-text">
+                            <i class="ri-file-3-line ri-lg"></i>
+                            <a href="{% url 'employee_record_views:list' %}?status=NEW">Gérer mes fiches salarié (ASP)</a>
+                        </p>
+                    {% endif %}
+
+                    <p class="card-text">
+                        <i class="ri-login-box-line ri-lg"></i>
+                        <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">
+                            {% if current_siae.is_subject_to_eligibility_rules %}
+                                Déclarer une embauche
+                            {% else %}
+                                Candidature spontanée
+                            {% endif %}
+                        </a>
+                    </p>
+                    <p class="card-text">
+                        <i class="ri-search-line ri-lg"></i>
+                        <a href="{% url 'approvals:pe_approval_search' %}">
+                            Prolonger ou suspendre un agrément émis par Pôle emploi
+                        </a>
+                    </p>
+                    {% if current_siae.is_subject_to_eligibility_rules %}
+                        <p class="card-text">
+                            <i class="ri-book-open-line ri-lg"></i>
+                            <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1" target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
+                                Liste des critères d'éligibilité
+                            </a>
+                        </p>
+                    {% endif %}
+                    <p class="card-text">
+                        <i class="ri-download-2-line ri-lg"></i>
+                        <a href="{% url 'apply:list_for_siae_exports' %}">
+                            Export des candidatures
+                        </a>
+                    </p>
+                </div>
+            </div>
+
+        {% endif %}{# end of if user.is_siae_staff #}
+
+        {% if user.is_labor_inspector %}
+            <div class="card">
+                <h5 class="h4 card-header">
+                    Organisation <span class="ml-1 badge badge-secondary">{{ current_institution.kind }} - ID {{ current_institution.id }}</span>
+                </h5>
+                <div class="card-body">
+                    <p class="card-text">
+                        <i class="ri-group-line ri-lg"></i>
+                        <a href="{% url 'institutions_views:members' %}">
+                            Gérer vos collaborateurs
+                        </a>
+                    </p>
+                </div>
+            </div>
+        {% endif %} {# end of if user.is_labor_inspector #}
+
+
+        {% if can_view_stats_dashboard_widget %}
+
+            <div class="card">
+                <h5 class="h4 card-header">Statistiques et pilotage</h5>
+                <div class="card-body">
+                    <p class="card-text">
+                        <i class="ri-pulse-line ri-lg"></i>
+                        <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Accéder au Pilotage de l'inclusion (ouverture dans un nouvel onglet)">
+                            Accéder au Pilotage de l'inclusion
+                        </a>
+                    </p>
+                    {% if can_view_stats_siae %}
+                        <p class="card-text">
+                            <i class="ri-pulse-line ri-lg"></i>
+                            <a href="{% url 'stats:stats_siae' %}">Voir les données de ma structure</a>
+                            <span class="badge badge-info">Nouveau</span>
+                        </p>
+                    {% endif %}
+                    {% if can_view_stats_cd %}
+                        <p class="card-text">
+                            <i class="ri-pulse-line ri-lg"></i>
+                            <a href="{% url 'stats:stats_cd' %}">Données IAE</a>
+                        </p>
+                    {% endif %}
+                    {% if can_view_stats_ddets %}
+                        <p class="card-text">
+                            <i class="ri-pulse-line ri-lg"></i>
+                            <a href="{% url 'stats:stats_ddets_iae' %}">Données IAE</a>
+                        </p>
+                        <p class="card-text">
+                            <i class="ri-pulse-line ri-lg"></i>
+                            <a href="{% url 'stats:stats_ddets_diagnosis_control' %}">Voir mes données 2021 du contrôle a posteriori (version bêta)</a>
+                            <span class="badge badge-info">Nouveau</span>
+                        </p>
+                    {% endif %}
+                    {% if can_view_stats_dreets %}
+                        <p class="card-text">
+                            <i class="ri-pulse-line ri-lg"></i>
+                            <a href="{% url 'stats:stats_dreets_iae' %}">Données IAE</a>
+                        </p>
+                    {% endif %}
+                    {% if can_view_stats_dgefp %}
+                        <p class="card-text">
+                            <i class="ri-pulse-line ri-lg"></i>
+                            <a href="{% url 'stats:stats_dgefp_iae' %}">Données IAE</a>
+                        </p>
+                        <p class="card-text">
+                            <i class="ri-pulse-line ri-lg"></i>
+                            <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données 2021 du contrôle a posteriori (version bêta)</a>
+                            <span class="badge badge-info">Nouveau</span>
+                        </p>
+                        <p class="card-text">
+                            <i class="ri-pulse-line ri-lg"></i>
+                            <a href="{% url 'stats:stats_dgefp_af' %}">Annexes financières actives</a>
+                            <span class="badge badge-info">Nouveau</span>
+                        </p>
+                    {% endif %}
+                </div>
+            </div>
+
+        {% endif %}
+
     </div>
-
-    {% endif %}{# end of if user.is_siae_staff #}
-
-    {% if user.is_labor_inspector %}
-    <div class="card">
-        <h5 class="h4 card-header">
-            Organisation <span class="ml-1 badge badge-secondary">{{ current_institution.kind }} - ID {{ current_institution.id }}</span>
-        </h5>
-        <div class="card-body">
-            <p class="card-text">
-                <i class="ri-group-line ri-lg"></i>
-                <a href="{% url 'institutions_views:members' %}">
-                    Gérer vos collaborateurs
-                </a>
-            </p>
-        </div>
-    </div>
-    {% endif %} {# end of if user.is_labor_inspector #}
-
-
-    {% if can_view_stats_dashboard_widget %}
-
-    <div class="card">
-        <h5 class="h4 card-header">Statistiques et pilotage</h5>
-        <div class="card-body">
-            <p class="card-text">
-                <i class="ri-pulse-line ri-lg"></i>
-                <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Accéder au Pilotage de l'inclusion (ouverture dans un nouvel onglet)">
-                    Accéder au Pilotage de l'inclusion
-                </a>
-            </p>
-            {% if can_view_stats_siae %}
-            <p class="card-text">
-                <i class="ri-pulse-line ri-lg"></i>
-                <a href="{% url 'stats:stats_siae' %}">Voir les données de ma structure</a>
-                <span class="badge badge-info">Nouveau</span>
-            </p>
-            {% endif %}
-            {% if can_view_stats_cd %}
-            <p class="card-text">
-                <i class="ri-pulse-line ri-lg"></i>
-                <a href="{% url 'stats:stats_cd' %}">Données IAE</a>
-            </p>
-            {% endif %}
-            {% if can_view_stats_ddets %}
-            <p class="card-text">
-                <i class="ri-pulse-line ri-lg"></i>
-                <a href="{% url 'stats:stats_ddets_iae' %}">Données IAE</a>
-            </p>
-            <p class="card-text">
-                <i class="ri-pulse-line ri-lg"></i>
-                <a href="{% url 'stats:stats_ddets_diagnosis_control' %}">Voir mes données 2021 du contrôle a posteriori (version bêta)</a>
-                <span class="badge badge-info">Nouveau</span>
-            </p>
-            {% endif %}
-            {% if can_view_stats_dreets %}
-            <p class="card-text">
-                <i class="ri-pulse-line ri-lg"></i>
-                <a href="{% url 'stats:stats_dreets_iae' %}">Données IAE</a>
-            </p>
-            {% endif %}
-            {% if can_view_stats_dgefp %}
-            <p class="card-text">
-                <i class="ri-pulse-line ri-lg"></i>
-                <a href="{% url 'stats:stats_dgefp_iae' %}">Données IAE</a>
-            </p>
-            <p class="card-text">
-                <i class="ri-pulse-line ri-lg"></i>
-                <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données 2021 du contrôle a posteriori (version bêta)</a>
-                <span class="badge badge-info">Nouveau</span>
-            </p>
-            <p class="card-text">
-                <i class="ri-pulse-line ri-lg"></i>
-                <a href="{% url 'stats:stats_dgefp_af' %}">Annexes financières actives</a>
-                <span class="badge badge-info">Nouveau</span>
-            </p>
-            {% endif %}
-        </div>
-    </div>
-
-    {% endif %}
-
-</div>
 
 {% endblock %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -3,493 +3,477 @@
 {% block title %}Tableau de bord{{ block.super }}{% endblock %}
 
 {% block messages %}
-    {{ block.super }}
+{{ block.super }}
 
-    {# Alerte pour gérer les cas d'exception lors de l'importation des AI. #}
-    {% if current_siae and current_siae.kind == current_siae.KIND_AI %}
-        <div class="alert alert-warning">
-            <p>Tous les salariés déclarés auprès de l'ASP avant le 1er décembre ont été ajoutés au tableau de bord de la SIAE porteuse de l’annexe financière. Nous travaillons à vous permettre de les transférer dans le tableau de bord d’une structure fille.</p>
-            <p>Pour les salariés qui ne seraient plus en poste, il vous est demandé de procéder à une suspension d’un an au motif « contrat de travail terminé ». Dans la mesure où ces salariés sont connus dans l’Extranet IAE 2.0 de l'ASP, ces PASS IAE ne peuvent pas être annulés.</p>
-            <p>Pour les salariés entrés en parcours avant le 1er décembre 2021 qui n’auraient pas été déclarés dans l’Extranet avant le 1er décembre 2021, vous devez procéder à une déclaration d’éligibilité sur la plateforme de l’inclusion.</p>
-            <p>Pour toute question liée à un cas individuel, <a href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/#support" rel="noopener" target="_blank" class="is-external" title="Une assistance est disponible ici (ouverture dans un nouvel onglet)">une assistance est disponible ici {% include "includes/icon.html" with icon="external-link" %}</a>.</p>
-        </div>
+{# Alerte pour gérer les cas d'exception lors de l'importation des AI. #}
+{% if current_siae and current_siae.kind == current_siae.KIND_AI %}
+<div class="alert alert-warning">
+    <p>Tous les salariés déclarés auprès de l'ASP avant le 1er décembre ont été ajoutés au tableau de bord de la SIAE porteuse de l’annexe financière. Nous travaillons à vous permettre de les transférer dans le tableau de bord d’une structure fille.</p>
+    <p>Pour les salariés qui ne seraient plus en poste, il vous est demandé de procéder à une suspension d’un an au motif « contrat de travail terminé ». Dans la mesure où ces salariés sont connus dans l’Extranet IAE 2.0 de l'ASP, ces PASS IAE ne peuvent pas être annulés.</p>
+    <p>Pour les salariés entrés en parcours avant le 1er décembre 2021 qui n’auraient pas été déclarés dans l’Extranet avant le 1er décembre 2021, vous devez procéder à une déclaration d’éligibilité sur la plateforme de l’inclusion.</p>
+    <p>Pour toute question liée à un cas individuel, <a href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/#support" rel="noopener" target="_blank" class="is-external" title="Une assistance est disponible ici (ouverture dans un nouvel onglet)">une assistance est disponible ici <i class="ri-external-link-line ri-lg"></i></a>.</p>
+</div>
+{% endif %}
+
+{% if current_siae and not current_siae.jobs.exists %}
+<div class="alert alert-warning">
+    Pour optimiser la réception de vos candidatures, pensez à renseigner le descriptif de vos postes et leurs prérequis.
+</div>
+{% endif %}
+
+{# Alerte pour les employeurs en cas d'absence ou de mauvais score de geocoding. #}
+{% if current_siae and not current_siae.has_reliable_coords %}
+<div class="alert alert-warning mb-0" role="status">
+    Nous n'avons pas pu géolocaliser votre établissement.<br>
+    Cela peut affecter sa position dans les résultats de recherche.<br>
+    {% if user_is_siae_admin %}
+    <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">Indiquez une autre adresse</a>
+    {% else %}
+    {% with current_siae.active_admin_members.first as admin %}
+    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
+    {% endwith %}
     {% endif %}
+    ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
+</div>
+{% endif %}
 
-    {% if current_siae and not current_siae.jobs.exists %}
-        <div class="alert alert-warning">
-            Pour optimiser la réception de vos candidatures, pensez à renseigner le descriptif de vos postes et leurs prérequis.
-        </div>
+{# Alerte pour les prescripteurs en cas d'absence ou de mauvais score de geocoding. #}
+{# Seuls les prescripteurs habilités apparaissent dans le moteur de recherche. #}
+{% if current_prescriber_organization and current_prescriber_organization.is_authorized and not current_prescriber_organization.has_reliable_coords %}
+<div class="alert alert-warning mb-0" role="status">
+    Nous n'avons pas pu géolocaliser votre établissement.<br>
+    Cela peut affecter sa position dans les résultats de recherche.<br>
+    {% if user_is_prescriber_org_admin %}
+    <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a>
+    {% else %}
+    {% with current_prescriber_organization.active_admin_members.first as admin %}
+    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
+    {% endwith %}
     {% endif %}
+    ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
+</div>
+{% endif %}
 
-    {# Alerte pour les employeurs en cas d'absence ou de mauvais score de geocoding. #}
-    {% if current_siae and not current_siae.has_reliable_coords %}
-        <div class="alert alert-warning mb-0" role="status">
-            Nous n'avons pas pu géolocaliser votre établissement.<br>
-            Cela peut affecter sa position dans les résultats de recherche.<br>
-            {% if user_is_siae_admin %}
-                <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">Indiquez une autre adresse</a>
-            {% else %}
-                {% with current_siae.active_admin_members.first as admin %}
-                    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
-                {% endwith %}
-            {% endif %}
-            ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
-        </div>
+{% if current_siae and not current_siae.is_active %}
+<div class="alert alert-warning mb-0" role="status">
+    La DGEFP nous indique que votre structure {% if current_siae.siret %}(inscrite avec le numéro SIRET : {{ current_siae.siret }}) {% endif %}n'est plus conventionnée.<br>
+    Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.<br>
+    À compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
+
+    {% if user_is_siae_admin %}
+    Veuillez dès que possible régulariser votre situation
+    <a href="{% url 'siaes_views:show_financial_annexes' %}">en sélectionnant une annexe financière valide}</a>.<br>
+    {% else %}
+    {% with current_siae.active_admin_members.first as admin %}
+    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle régularise la situation de votre structure.
+    {% endwith %}
     {% endif %}
+</div>
+{% endif %}
 
-    {# Alerte pour les prescripteurs en cas d'absence ou de mauvais score de geocoding. #}
-    {# Seuls les prescripteurs habilités apparaissent dans le moteur de recherche. #}
-    {% if current_prescriber_organization and current_prescriber_organization.is_authorized and not current_prescriber_organization.has_reliable_coords %}
-        <div class="alert alert-warning mb-0" role="status">
-            Nous n'avons pas pu géolocaliser votre établissement.<br>
-            Cela peut affecter sa position dans les résultats de recherche.<br>
-            {% if user_is_prescriber_org_admin %}
-                <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a>
-            {% else %}
-                {% with current_prescriber_organization.active_admin_members.first as admin %}
-                    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
-                {% endwith %}
-            {% endif %}
-            ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
-        </div>
+{% if current_prescriber_organization and current_prescriber_organization.has_pending_authorization %}
+<div class="alert alert-warning pb-0" role="status">
+    <p>
+        Votre habilitation à valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique est en cours de vérification par nos équipes. Vous ne pouvez pas encore réaliser le diagnostic d'éligibilité des candidats.
+    </p>
+    {% if current_prescriber_organization.has_pending_authorization_proof %}
+    <p>
+        Merci de nous transmettre l'arrêté préfectoral portant mention de cette habilitation :
+        <a href="{{ TYPEFORM_URL }}/to/mk0GyI67#idprescriber={{ current_prescriber_organization.pk }}&iduser={{ user.pk }}&source={{ ITOU_ENVIRONMENT }}" rel="noopener" target="_blank" title="Cliquez ici pour l'envoyer (ouverture dans un nouvel onglet)">
+            cliquez ici pour l'envoyer
+            <i class="ri-external-link-line ri-lg"></i>
+        </a>
+    </p>
     {% endif %}
+</div>
+{% endif %}
 
-    {% if current_siae and not current_siae.is_active %}
-        <div class="alert alert-warning mb-0" role="status">
-            La DGEFP nous indique que votre structure {% if current_siae.siret %}(inscrite avec le numéro SIRET : {{ current_siae.siret }}) {% endif %}n'est plus conventionnée.<br>
-            Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.<br>
-            À compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
+{% if user.joined_recently %}
+{% include "welcoming_tour/includes/message.html" %}
+{% endif %}
 
-            {% if user_is_siae_admin %}
-                Veuillez dès que possible régulariser votre situation
-                <a href="{% url 'siaes_views:show_financial_annexes' %}">en sélectionnant une annexe financière valide}</a>.<br>
-            {% else %}
-                {% with current_siae.active_admin_members.first as admin %}
-                    Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle régularise la situation de votre structure.
-                {% endwith %}
-            {% endif %}
-        </div>
-    {% endif %}
-
-    {% if current_prescriber_organization and current_prescriber_organization.has_pending_authorization %}
-        <div class="alert alert-warning pb-0" role="status">
-            <p>
-                Votre habilitation à valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique est en cours de vérification par nos équipes. Vous ne pouvez pas encore réaliser le diagnostic d'éligibilité des candidats.
-            </p>
-            {% if current_prescriber_organization.has_pending_authorization_proof %}
-                <p>
-                    Merci de nous transmettre l'arrêté préfectoral portant mention de cette habilitation :
-                    <a href="{{ TYPEFORM_URL }}/to/mk0GyI67#idprescriber={{ current_prescriber_organization.pk }}&iduser={{ user.pk }}&source={{ ITOU_ENVIRONMENT }}" rel="noopener" target="_blank" title="Cliquez ici pour l'envoyer (ouverture dans un nouvel onglet)">
-                        cliquez ici pour l'envoyer
-                        {% include "includes/icon.html" with icon="external-link" %}
-                    </a>
-                </p>
-            {% endif %}
-        </div>
-    {% endif %}
-
-    {% if user.joined_recently %}
-        {% include "welcoming_tour/includes/message.html" %}
-    {% endif %}
-
-    {# Message d'information temporaire pour les fiches salarié / annexes financières #}
-    {% if can_show_employee_records %}
-        <div class="alert alert-info">
-            <p>La fin de validité des annexes financières de 2021 n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.</p>
-            <p>Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
-        </div>
-    {% endif %}
+{# Message d'information temporaire pour les fiches salarié / annexes financières #}
+{% if can_show_employee_records %}
+<div class="alert alert-info">
+    <p>La fin de validité des annexes financières de 2021 n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.</p>
+    <p>Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
+</div>
+{% endif %}
 
 {% endblock %}
 
 {% block content %}
 
-    {# Mise en avant temporaire du forum pour les prescripteurs. #}
-    {% if user.is_prescriber %}
-        <div class="card mb-5 bg-gray-400 text-center">
-            <div class="card-body">
-                <p class="h4 mb-3">
-                    <span class="badge badge-warning">Nouveau</span>
-                    Bénéficiez des bonnes pratiques et actualités de la 1ère communauté des professionnels de l'inclusion !
-                </p>
-                <p class="mb-0">
-                    <a href="{{ ITOU_COMMUNITY_URL }}" rel="noopener" target="_blank" class="btn btn-primary" title="Partagez et découvrez les outils qui facilitent votre quotidien (ouverture dans un nouvel onglet)">
-                        Partagez et découvrez les outils qui facilitent votre quotidien
-                        {% include "includes/icon.html" with icon="external-link" %}
-                    </a>
-                </p>
-            </div>
-        </div>
-    {% endif %}
-
-    <h1 class="h1">
-        Tableau de bord
-        {% if user.is_job_seeker and user.get_full_name %} - <span class="text-muted">{{ user.get_full_name }}</span>{% endif %}
-        {% if current_siae %} - <span class="text-muted">{{ current_siae.display_name }}</span>{% endif %}
-        {% if current_prescriber_organization %} -
-            <span class="text-muted">{{ current_prescriber_organization.display_name }}</span>
-            {% if current_prescriber_organization.is_authorized %}
-                {% include "includes/icon.html" with icon="award" class="h1 align-middle" size=30 %}
-            {% endif %}
-        {% endif %}
-        {% if current_institution %}
-            - <span class="text-muted">{{ current_institution.display_name }}</span>
-        {% endif %}
-    </h1>
-
-    {% if current_prescriber_organization and current_prescriber_organization.is_authorized %}
-        <p class="text-muted">
-            <span class="badge badge-warning">Prescripteur habilité</span>
-            {% if current_prescriber_organization.code_safir_pole_emploi %}
-                <span class="badge badge-light">
-                    Code SAFIR {{ current_prescriber_organization.code_safir_pole_emploi }}
-                </span>
-            {% endif %}
+{# Mise en avant temporaire du forum pour les prescripteurs. #}
+{% if user.is_prescriber %}
+<div class="card mb-5 bg-gray-400 text-center">
+    <div class="card-body">
+        <p class="h4 mb-3">
+            <span class="badge badge-warning">Nouveau</span>
+            Bénéficiez des bonnes pratiques et actualités de la 1ère communauté des professionnels de l'inclusion !
         </p>
+        <p class="mb-0">
+            <a href="{{ ITOU_COMMUNITY_URL }}" rel="noopener" target="_blank" class="btn btn-primary" title="Partagez et découvrez les outils qui facilitent votre quotidien (ouverture dans un nouvel onglet)">
+                Partagez et découvrez les outils qui facilitent votre quotidien
+                <i class="ri-external-link-line ri-lg"></i>
+            </a>
+        </p>
+    </div>
+</div>
+{% endif %}
+
+<h1 class="h1">
+    Tableau de bord
+    {% if user.is_job_seeker and user.get_full_name %} - <span class="text-muted">{{ user.get_full_name }}</span>{% endif %}
+    {% if current_siae %} - <span class="text-muted">{{ current_siae.display_name }}</span>{% endif %}
+    {% if current_prescriber_organization %} -
+    <span class="text-muted">{{ current_prescriber_organization.display_name }}</span>
+    {% if current_prescriber_organization.is_authorized %}<i class="ri-award-line ri-2x"></i>
+    {% endif %}
+    {% endif %}
+    {% if current_institution %}
+    - <span class="text-muted">{{ current_institution.display_name }}</span>
+    {% endif %}
+</h1>
+
+{% if current_prescriber_organization and current_prescriber_organization.is_authorized %}
+<p class="text-muted">
+    <span class="badge badge-warning">Prescripteur habilité</span>
+    {% if current_prescriber_organization.code_safir_pole_emploi %}
+    <span class="badge badge-light">
+        Code SAFIR {{ current_prescriber_organization.code_safir_pole_emploi }}
+    </span>
+    {% endif %}
+</p>
+{% endif %}
+
+<div class="card-deck mt-3">
+
+    {% if user.is_staff %}
+    <div class="card">
+        <h5 class="card-header">Admin</h5>
+        <div class="card-body">
+            <p class="card-text">
+                <i class="ri-key-2-line ri-lg"></i>
+                <a href="{% url 'admin:index' %}">
+                    Admin
+                </a>
+            </p>
+        </div>
+    </div>
     {% endif %}
 
-    <div class="card-deck mt-3">
+    {% if user.is_job_seeker %}
 
-        {% if user.is_staff %}
-            <div class="card">
-                <h5 class="card-header">Admin</h5>
-                <div class="card-body">
-                    <p class="card-text mb-3">
-                        {% include "includes/icon.html" with icon="key" %}
-                        <a href="{% url 'admin:index' %}">
-                            Admin
-                        </a>
-                    </p>
-                </div>
+    <div class="card">
+        <h5 class="h4 card-header">Candidatures</h5>
+        <div class="card-body">
+            <p class="card-text">
+                <i class="ri-chat-4-line ri-lg"></i>
+                <a href="{% url 'apply:list_for_job_seeker' %}">Vos candidatures</a>
+            </p>
+            <p class="card-text">
+                <i class="ri-briefcase-3-line ri-lg"></i>
+                <a href="/">Rechercher une entreprise</a>
+            </p>
+        </div>
+    </div>
+
+    {% with user.approvals_wrapper as approvals_wrapper %}
+    {% if approvals_wrapper.latest_approval %}
+    <div class="card">
+        <h5 class="h4 card-header">Numéro d'agrément</h5>
+        <div class="card-body">
+            {# Approval status. #}
+            <div class="card-text">
+                {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
             </div>
-        {% endif %}
-
-        {% if user.is_job_seeker %}
-
-            <div class="card">
-                <p class="h4 card-header">Candidatures</p>
-                <div class="card-body">
-                    <ul class="list-unstyled">
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="message-square" %}
-                            <a href="{% url 'apply:list_for_job_seeker' %}">Vos candidatures</a>
-                        </li>
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="briefcase" %}
-                            <a href="/">Rechercher une entreprise</a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-
-            {% with user.approvals_wrapper as approvals_wrapper %}
-                {% if approvals_wrapper.latest_approval %}
-                    <div class="card">
-                        <p class="h4 card-header">Numéro d'agrément</p>
-                        <div class="card-body">
-                            <ul class="list-unstyled">
-                                {# Approval status. #}
-                                <li class="card-text mb-3">
-                                    {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
-                                </li>
-                                {% if approvals_wrapper.has_in_waiting_period %}
-                                    <li class="card-text mb-3">
-                                        {% if user.has_valid_diagnosis %}
-                                            <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
-                                        {% else %}
-                                            <small>
-                                                {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}
-                                            </small>
-                                        {% endif %}
-                                    </li>
-                                {% endif %}
-                            </ul>
-                        </div>
-                    </div>
+            {% if approvals_wrapper.has_in_waiting_period %}
+            <p class="card-text">
+                {% if user.has_valid_diagnosis %}
+                <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
+                {% else %}
+                <small>
+                    {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}
+                </small>
                 {% endif %}
-            {% endwith %}
+            </p>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+    {% endwith %}
 
-        {% endif %}{# end of if user.is_job_seeker #}
+    {% endif %}{# end of if user.is_job_seeker #}
 
-        {% if user.is_prescriber %}
+    {% if user.is_prescriber %}
 
-            {% if current_prescriber_organization %}
-                <div class="card">
-                    <p class="h4 card-header">
-                        Organisation <span class="ml-1 badge badge-secondary">{{ current_prescriber_organization.kind }} - ID {{ current_prescriber_organization.id }}</span>
-                    </p>
-                    <div class="card-body">
-                        <ul class="list-unstyled">
-                            <li class="card-text mb-3">
-                                {% with card_url=current_prescriber_organization.get_card_url %}
-                                    {% if user_is_prescriber_org_admin or card_url %}
-                                        {% include "includes/icon.html" with icon="bookmark" %}
-                                        {% if user_is_prescriber_org_admin %}
-                                            <a href="{% url 'prescribers_views:edit_organization' %}">
-                                                Modifier les informations
-                                            </a>
-                                            {% if card_url %} / {% endif %}
-                                        {% endif %}
-                                        {% if card_url %}
-                                            <a href="{{ card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                                                Voir la fiche
-                                            </a>
-                                        {% endif %}
-                                    {% endif %}
-                                {% endwith %}
-                            </li>
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="users" %}
-                                <a href="{% url 'prescribers_views:members' %}">
-                                    Gérer vos collaborateurs
-                                </a>
-                            </li>
-                            {% if current_prescriber_organization.kind == current_prescriber_organization.Kind.DEPT and user_is_prescriber_org_admin %}
-                                <li class="card-text mb-3">
-                                    {% include "includes/icon.html" with icon="list" %}
-                                    <a href="{% url 'prescribers_views:list_accredited_organizations' %}">
-                                        Voir la liste des organisations conventionnées
-                                    </a>
-                                    <span class="badge badge-info">Nouveau</span>
-                                </li>
-                            {% endif %}
-                            {% if current_prescriber_organization.is_authorized %}
-                                <li>
-                                    <hr>
-                                </li>
-                                <li class="card-text mb-3">
-                                    {% include "includes/icon.html" with icon="award" %}
-                                    <span>
-                                        {{ current_prescriber_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique#diagnostic_de_reference" target="_blank" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
-                                    </span>
-                                </li>
-                            {% endif %}
-                        </ul>
-                    </div>
-                </div>
+    {% if current_prescriber_organization %}
+    <div class="card">
+        <h5 class="h4 card-header">
+            Organisation <span class="ml-1 badge badge-secondary">{{ current_prescriber_organization.kind }} - ID {{ current_prescriber_organization.id }}</span>
+        </h5>
+        <div class="card-body">
+            <p class="card-text">
+                {% with card_url=current_prescriber_organization.get_card_url %}
+                {% if user_is_prescriber_org_admin or card_url %}
+                <i class="ri-bookmark-line ri-lg"></i>
+                {% if user_is_prescriber_org_admin %}
+                <a href="{% url 'prescribers_views:edit_organization' %}">
+                    Modifier les informations
+                </a>
+                {% if card_url %} / {% endif %}
+                {% endif %}
+                {% if card_url %}
+                <a href="{{ card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                    Voir la fiche
+                </a>
+                {% endif %}
+                {% endif %}
+                {% endwith %}
+            </p>
+            <p class="card-text">
+                <i class="ri-group-line ri-lg"></i>
+                <a href="{% url 'prescribers_views:members' %}">
+                    Gérer vos collaborateurs
+                </a>
+            </p>
+            {% if current_prescriber_organization.kind == current_prescriber_organization.Kind.DEPT and user_is_prescriber_org_admin %}
+            <p class="card-text">
+                <i class="ri-list-unordered ri-lg"></i>
+                <a href="{% url 'prescribers_views:list_accredited_organizations' %}">
+                    Voir la liste des organisations conventionnées
+                </a>
+                <span class="badge badge-info">Nouveau</span>
+            </p>
+            {% endif %}
+            {% if current_prescriber_organization.is_authorized %}
+            <hr>
+            <p class="card-text">
+                <i class="ri-award-line ri-lg"></i>
+                <span>
+                    {{ current_prescriber_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique#diagnostic_de_reference" target="_blank" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
+                </span>
+            </p>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="card">
+        <h5 class="h4 card-header">Candidatures</h5>
+        <div class="card-body">
+            <p class="card-text">
+                <i class="ri-chat-4-line ri-lg"></i>
+                <a href="{% url 'apply:list_for_prescriber' %}">Suivi des candidatures</a>
+            </p>
+            <p class="card-text">
+                <i class="ri-user-follow-line ri-lg"></i>
+                <a href="/">Postuler pour un candidat</a>
+            </p>
+            <p class="card-text">
+                <i class="ri-download-2-line ri-lg"></i>
+                <a href="{% url 'apply:list_for_prescriber_exports' %}">
+                    Export des candidatures
+                </a>
+            </p>
+        </div>
+    </div>
+
+    {% endif %}{# end of if user.is_prescriber #}
+
+    {% if user.is_siae_staff %}
+
+    <div class="card">
+        <h5 class="h4 card-header">
+            Ma structure
+            <span class="ml-1 badge badge-secondary">{{ current_siae.kind }} - ID {{ current_siae.id }}</span>
+        </h5>
+        <div class="card-body">
+            <p class="card-text">
+                <i class="ri-settings-6-line ri-lg"></i>
+                {% if user_is_siae_admin %}
+                <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">
+                    Modifier les informations de l'établissement
+                </a>
+                /
+                {% endif %}
+                <a href="{{ current_siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                    Voir la fiche publique
+                </a>
+            </p>
+            {% if current_siae.is_active %}
+            <p class="card-text">
+                <i class="ri-group-line ri-lg"></i>
+                <a href="{% url 'siaes_views:members' %}">
+                    Gérer des collaborateurs
+                </a>
+            </p>
             {% endif %}
 
-            <div class="card">
-                <p class="h4 card-header">Candidatures</p>
-                <div class="card-body">
-                    <ul class="list-unstyled">
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="message-square" %}
-                            <a href="{% url 'apply:list_for_prescriber' %}">Suivi des candidatures</a>
-                        </li>
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="user-check" %}
-                            <a href="/">Postuler pour un candidat</a>
-                        </li>
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="download" %}
-                            <a href="{% url 'apply:list_for_prescriber_exports' %}">
-                                Export des candidatures
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
+            <p class="card-text">
+                <i class="ri-briefcase-3-line ri-lg"></i>
+                <a class="title-with-badge" href="{% url 'siaes_views:configure_jobs' %}">Gérer les métiers et recrutements
+                    <span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="À partir de maintenant, vous allez pouvoir informer les prescripteurs et les candidats des métiers qui recrutent en ce moment, avec la fonctionnalité «recrutement en cours»">Nouveau</span>
+                </a>
+            </p>
 
-        {% endif %}{# end of if user.is_prescriber #}
-
-        {% if user.is_siae_staff %}
-
-            <div class="card">
-                <p class="h4 card-header">
-                    Ma structure
-                    <span class="ml-1 badge badge-secondary">{{ current_siae.kind }} - ID {{ current_siae.id }}</span>
-                </p>
-                <div class="card-body">
-                    <ul class="list-unstyled">
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="box" %}
-                            {% if user_is_siae_admin %}
-                                <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">
-                                    Modifier les informations de l'établissement
-                                </a>
-                                /
-                            {% endif %}
-                            <a href="{{ current_siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                                Voir la fiche publique
-                            </a>
-                        </li>
-                        {% if current_siae.is_active %}
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="users" %}
-                                <a href="{% url 'siaes_views:members' %}">
-                                    Gérer des collaborateurs
-                                </a>
-                            </li>
-                        {% endif %}
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="briefcase" %}
-                            <a class="title-with-badge" href="{% url 'siaes_views:configure_jobs' %}">Gérer les métiers et recrutements
-                                <span class="badge badge-info" data-toggle="tooltip" data-placement="right"
-                                    title="À partir de maintenant, vous allez pouvoir informer les prescripteurs et les candidats des métiers qui recrutent en ce moment, avec la fonctionnalité «recrutement en cours»">Nouveau</span>
-                            </a>
-                        </li>
-                        {% if can_show_financial_annexes %}
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="check-circle" %}
-                                <a href="{% url 'siaes_views:show_financial_annexes' %}">
-                                    Mes annexes financières
-                                </a>
-                                {% if not current_siae.is_active %}
-                                    <span class="badge badge-danger">
-                                        Action requise
-                                    </span>
-                                {% endif %}
-                            </li>
-                        {% endif %}
-                        {% if can_create_siae_antenna %}
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="plus-square" %}
-                                <a href="{% url 'siaes_views:create_siae' %}">Créer/rejoindre une autre structure</a>
-                            </li>
-                        {% endif %}
-                    </ul>
-                </div>
-            </div>
-
-            <div class="card">
-                <p class="h4 card-header">Mes candidatures</p>
-                <div class="card-body">
-                    <ul class="list-unstyled">
-                        {% for category in job_applications_categories %}
-                            {% if category.counter %}
-                                <li class="card-text mb-3">
-                                    {% include "includes/icon.html" with icon=category.icon %}
-                                    <a href="{{ category.url }}">{{ category.name }}</a>
-                                    <span class="badge {{ category.badge }}">{{ category.counter }}</span>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-                        {% if can_show_employee_records %}
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="file" %}
-                                <a href="{% url 'employee_record_views:list' %}?status=NEW">Gérer mes fiches salarié (ASP)</a>
-                            </li>
-                        {% endif %}
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="log-in" %}
-                            <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">
-                                {% if current_siae.is_subject_to_eligibility_rules %}
-                                    Déclarer une embauche
-                                {% else %}
-                                    Candidature spontanée
-                                {% endif %}
-                            </a>
-                        </li>
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="search" %}
-                            <a href="{% url 'approvals:pe_approval_search' %}">
-                                Prolonger ou suspendre un agrément émis par Pôle emploi
-                            </a>
-                        </li>
-                        {% if current_siae.is_subject_to_eligibility_rules %}
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="book-open" %}
-                                <a
-                                    href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1"
-                                    target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
-                                    Liste des critères d'éligibilité
-                                </a>
-                            </li>
-                        {% endif %}
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="download" %}
-                            <a href="{% url 'apply:list_for_siae_exports' %}">
-                                Export des candidatures
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-
-        {% endif %}{# end of if user.is_siae_staff #}
-
-        {% if user.is_labor_inspector %}
-            <div class="card">
-                <p class="h4 card-header">
-                    Organisation <span class="ml-1 badge badge-secondary">{{ current_institution.kind }} - ID {{ current_institution.id }}</span>
-                </p>
-                <div class="card-body">
-                    <p class="card-text">
-                        {% include "includes/icon.html" with icon="users" %}
-                        <a href="{% url 'institutions_views:members' %}">
-                            Gérer vos collaborateurs
-                        </a>
-                    </p>
-                </div>
-            </div>
-        {% endif %} {# end of if user.is_labor_inspector #}
-
-
-        {% if can_view_stats_dashboard_widget %}
-
-            <div class="card">
-                <p class="h4 card-header">Statistiques et pilotage</p>
-                <div class="card-body">
-                    <ul class="list-unstyled">
-                        <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="activity" %}
-                            <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Accéder au Pilotage de l'inclusion (ouverture dans un nouvel onglet)">
-                                Accéder au Pilotage de l'inclusion
-                            </a>
-                        </li>
-                        {% if can_view_stats_siae %}
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="activity" %}
-                                <a href="{% url 'stats:stats_siae' %}">Voir les données de ma structure</a>
-                                <span class="badge badge-info">Nouveau</span>
-                            </li>
-                        {% endif %}
-                        {% if can_view_stats_cd %}
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="activity" %}
-                                <a href="{% url 'stats:stats_cd' %}">Données IAE</a>
-                            </li>
-                        {% endif %}
-                        {% if can_view_stats_ddets %}
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="activity" %}
-                                <a href="{% url 'stats:stats_ddets_iae' %}">Données IAE</a>
-                            </li>
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="activity" %}
-                                <a href="{% url 'stats:stats_ddets_diagnosis_control' %}">Voir mes données 2021 du contrôle a posteriori (version bêta)</a>
-                                <span class="badge badge-info">Nouveau</span>
-                            </li>
-                        {% endif %}
-                        {% if can_view_stats_dreets %}
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="activity" %}
-                                <a href="{% url 'stats:stats_dreets_iae' %}">Données IAE</a>
-                            </li>
-                        {% endif %}
-                        {% if can_view_stats_dgefp %}
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="activity" %}
-                                <a href="{% url 'stats:stats_dgefp_iae' %}">Données IAE</a>
-                            </li>
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="activity" %}
-                                <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données 2021 du contrôle a posteriori (version bêta)</a>
-                                <span class="badge badge-info">Nouveau</span>
-                            </li>
-                            <li class="card-text mb-3">
-                                {% include "includes/icon.html" with icon="activity" %}
-                                <a href="{% url 'stats:stats_dgefp_af' %}">Annexes financières actives</a>
-                                <span class="badge badge-info">Nouveau</span>
-                            </li>
-                        {% endif %}
-                    </ul>
-                </div>
-            </div>
-
-        {% endif %}
-
+            {% if can_show_financial_annexes %}
+            <p class="card-text">
+                <i class="ri-checkbox-circle-line ri-lg"></i>
+                <a href="{% url 'siaes_views:show_financial_annexes' %}">
+                    Mes annexes financières
+                </a>
+                {% if not current_siae.is_active %}
+                <span class="badge badge-danger">
+                    Action requise
+                </span>
+                {% endif %}
+            </p>
+            {% endif %}
+            {% if can_create_siae_antenna %}
+            <p class="card-text">
+                <i class="ri-add-box-line ri-lg"></i>
+                <a href="{% url 'siaes_views:create_siae' %}">Créer/rejoindre une autre structure</a>
+            </p>
+            {% endif %}
+        </div>
     </div>
+
+    <div class="card">
+        <h5 class="h4 card-header">Mes candidatures</h5>
+        <div class="card-body">
+            {% for category in job_applications_categories %}
+            {% if category.counter %}
+            <p class="card-text">
+                <i class="{{ category.icon }} ri-lg"></i>
+                <a href="{{ category.url }}">{{ category.name }}</a>
+                <span class="badge {{ category.badge }}">{{ category.counter }}</span>
+            </p>
+            {% endif %}
+            {% endfor %}
+
+            {% if can_show_employee_records %}
+            <p class="card-text">
+                <i class="ri-file-3-line ri-lg"></i>
+                <a href="{% url 'employee_record_views:list' %}?status=NEW">Gérer mes fiches salarié (ASP)</a>
+            </p>
+            {% endif %}
+
+            <p class="card-text">
+                <i class="ri-login-box-line ri-lg"></i>
+                <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">
+                    {% if current_siae.is_subject_to_eligibility_rules %}
+                    Déclarer une embauche
+                    {% else %}
+                    Candidature spontanée
+                    {% endif %}
+                </a>
+            </p>
+            <p class="card-text">
+                <i class="ri-search-line ri-lg"></i>
+                <a href="{% url 'approvals:pe_approval_search' %}">
+                    Prolonger ou suspendre un agrément émis par Pôle emploi
+                </a>
+            </p>
+            {% if current_siae.is_subject_to_eligibility_rules %}
+            <p class="card-text">
+                <i class="ri-book-open-line ri-lg"></i>
+                <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1" target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
+                    Liste des critères d'éligibilité
+                </a>
+            </p>
+            {% endif %}
+            <p class="card-text">
+                <i class="ri-download-2-line ri-lg"></i>
+                <a href="{% url 'apply:list_for_siae_exports' %}">
+                    Export des candidatures
+                </a>
+            </p>
+        </div>
+    </div>
+
+    {% endif %}{# end of if user.is_siae_staff #}
+
+    {% if user.is_labor_inspector %}
+    <div class="card">
+        <h5 class="h4 card-header">
+            Organisation <span class="ml-1 badge badge-secondary">{{ current_institution.kind }} - ID {{ current_institution.id }}</span>
+        </h5>
+        <div class="card-body">
+            <p class="card-text">
+                <i class="ri-group-line ri-lg"></i>
+                <a href="{% url 'institutions_views:members' %}">
+                    Gérer vos collaborateurs
+                </a>
+            </p>
+        </div>
+    </div>
+    {% endif %} {# end of if user.is_labor_inspector #}
+
+
+    {% if can_view_stats_dashboard_widget %}
+
+    <div class="card">
+        <h5 class="h4 card-header">Statistiques et pilotage</h5>
+        <div class="card-body">
+            <p class="card-text">
+                <i class="ri-pulse-line ri-lg"></i>
+                <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Accéder au Pilotage de l'inclusion (ouverture dans un nouvel onglet)">
+                    Accéder au Pilotage de l'inclusion
+                </a>
+            </p>
+            {% if can_view_stats_siae %}
+            <p class="card-text">
+                <i class="ri-pulse-line ri-lg"></i>
+                <a href="{% url 'stats:stats_siae' %}">Voir les données de ma structure</a>
+                <span class="badge badge-info">Nouveau</span>
+            </p>
+            {% endif %}
+            {% if can_view_stats_cd %}
+            <p class="card-text">
+                <i class="ri-pulse-line ri-lg"></i>
+                <a href="{% url 'stats:stats_cd' %}">Données IAE</a>
+            </p>
+            {% endif %}
+            {% if can_view_stats_ddets %}
+            <p class="card-text">
+                <i class="ri-pulse-line ri-lg"></i>
+                <a href="{% url 'stats:stats_ddets_iae' %}">Données IAE</a>
+            </p>
+            <p class="card-text">
+                <i class="ri-pulse-line ri-lg"></i>
+                <a href="{% url 'stats:stats_ddets_diagnosis_control' %}">Voir mes données 2021 du contrôle a posteriori (version bêta)</a>
+                <span class="badge badge-info">Nouveau</span>
+            </p>
+            {% endif %}
+            {% if can_view_stats_dreets %}
+            <p class="card-text">
+                <i class="ri-pulse-line ri-lg"></i>
+                <a href="{% url 'stats:stats_dreets_iae' %}">Données IAE</a>
+            </p>
+            {% endif %}
+            {% if can_view_stats_dgefp %}
+            <p class="card-text">
+                <i class="ri-pulse-line ri-lg"></i>
+                <a href="{% url 'stats:stats_dgefp_iae' %}">Données IAE</a>
+            </p>
+            <p class="card-text">
+                <i class="ri-pulse-line ri-lg"></i>
+                <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données 2021 du contrôle a posteriori (version bêta)</a>
+                <span class="badge badge-info">Nouveau</span>
+            </p>
+            <p class="card-text">
+                <i class="ri-pulse-line ri-lg"></i>
+                <a href="{% url 'stats:stats_dgefp_af' %}">Annexes financières actives</a>
+                <span class="badge badge-info">Nouveau</span>
+            </p>
+            {% endif %}
+        </div>
+    </div>
+
+    {% endif %}
+
+</div>
 
 {% endblock %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -153,7 +153,7 @@
             <div class="card">
                 <h5 class="card-header">Admin</h5>
                 <div class="card-body">
-                    <p class="card-text">
+                    <p class="card-text mb-3">
                         <i class="ri-key-2-line ri-lg"></i>
                         <a href="{% url 'admin:index' %}">
                             Admin
@@ -166,39 +166,43 @@
         {% if user.is_job_seeker %}
 
             <div class="card">
-                <h5 class="h4 card-header">Candidatures</h5>
+                <p class="h4 card-header">Candidatures</p>
                 <div class="card-body">
-                    <p class="card-text">
-                        <i class="ri-chat-4-line ri-lg"></i>
-                        <a href="{% url 'apply:list_for_job_seeker' %}">Vos candidatures</a>
-                    </p>
-                    <p class="card-text">
-                        <i class="ri-briefcase-3-line ri-lg"></i>
-                        <a href="/">Rechercher une entreprise</a>
-                    </p>
+                    <ul class="list-unstyled">
+                        <li class="card-text mb-3">
+                            <i class="ri-chat-4-line ri-lg"></i>
+                            <a href="{% url 'apply:list_for_job_seeker' %}">Vos candidatures</a>
+                        </li>
+                        <li class="card-text mb-3">
+                            <i class="ri-briefcase-3-line ri-lg"></i>
+                            <a href="/">Rechercher une entreprise</a>
+                        </li>
+                    </ul>
                 </div>
             </div>
 
             {% with user.approvals_wrapper as approvals_wrapper %}
                 {% if approvals_wrapper.latest_approval %}
                     <div class="card">
-                        <h5 class="h4 card-header">Numéro d'agrément</h5>
+                        <p class="h4 card-header">Numéro d'agrément</p>
                         <div class="card-body">
-                            {# Approval status. #}
-                            <div class="card-text">
-                                {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
-                            </div>
-                            {% if approvals_wrapper.has_in_waiting_period %}
-                                <p class="card-text">
-                                    {% if user.has_valid_diagnosis %}
-                                        <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
-                                    {% else %}
-                                        <small>
-                                            {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}
-                                        </small>
-                                    {% endif %}
-                                </p>
-                            {% endif %}
+                            <ul class="list-unstyled">
+                                {# Approval status. #}
+                                <li class="card-text mb-3">
+                                    {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
+                                </li>
+                                {% if approvals_wrapper.has_in_waiting_period %}
+                                    <li class="card-text mb-3">
+                                        {% if user.has_valid_diagnosis %}
+                                            <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
+                                        {% else %}
+                                            <small>
+                                                {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}
+                                            </small>
+                                        {% endif %}
+                                    </li>
+                                {% endif %}
+                            </ul>
                         </div>
                     </div>
                 {% endif %}
@@ -210,73 +214,79 @@
 
             {% if current_prescriber_organization %}
                 <div class="card">
-                    <h5 class="h4 card-header">
+                    <p class="h4 card-header">
                         Organisation <span class="ml-1 badge badge-secondary">{{ current_prescriber_organization.kind }} - ID {{ current_prescriber_organization.id }}</span>
-                    </h5>
+                    </p>
                     <div class="card-body">
-                        <p class="card-text">
-                            {% with card_url=current_prescriber_organization.get_card_url %}
-                                {% if user_is_prescriber_org_admin or card_url %}
-                                    <i class="ri-bookmark-line ri-lg"></i>
-                                    {% if user_is_prescriber_org_admin %}
-                                        <a href="{% url 'prescribers_views:edit_organization' %}">
-                                            Modifier les informations
-                                        </a>
-                                        {% if card_url %} / {% endif %}
+                        <ul class="list-unstyled">
+                            <li class="card-text mb-3">
+                                {% with card_url=current_prescriber_organization.get_card_url %}
+                                    {% if user_is_prescriber_org_admin or card_url %}
+                                        <i class="ri-bookmark-line ri-lg"></i>
+                                        {% if user_is_prescriber_org_admin %}
+                                            <a href="{% url 'prescribers_views:edit_organization' %}">
+                                                Modifier les informations
+                                            </a>
+                                            {% if card_url %} / {% endif %}
+                                        {% endif %}
+                                        {% if card_url %}
+                                            <a href="{{ card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                                                Voir la fiche
+                                            </a>
+                                        {% endif %}
                                     {% endif %}
-                                    {% if card_url %}
-                                        <a href="{{ card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                                            Voir la fiche
-                                        </a>
-                                    {% endif %}
-                                {% endif %}
-                            {% endwith %}
-                        </p>
-                        <p class="card-text">
-                            <i class="ri-group-line ri-lg"></i>
-                            <a href="{% url 'prescribers_views:members' %}">
-                                Gérer vos collaborateurs
-                            </a>
-                        </p>
-                        {% if current_prescriber_organization.kind == current_prescriber_organization.Kind.DEPT and user_is_prescriber_org_admin %}
-                            <p class="card-text">
-                                <i class="ri-list-unordered ri-lg"></i>
-                                <a href="{% url 'prescribers_views:list_accredited_organizations' %}">
-                                    Voir la liste des organisations conventionnées
+                                {% endwith %}
+                            </li>
+                            <li class="card-text mb-3">
+                                <i class="ri-group-line ri-lg"></i>
+                                <a href="{% url 'prescribers_views:members' %}">
+                                    Gérer vos collaborateurs
                                 </a>
-                                <span class="badge badge-info">Nouveau</span>
-                            </p>
-                        {% endif %}
-                        {% if current_prescriber_organization.is_authorized %}
-                            <hr>
-                            <p class="card-text">
-                                <i class="ri-award-line ri-lg"></i>
-                                <span>
-                                    {{ current_prescriber_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique#diagnostic_de_reference" target="_blank" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
-                                </span>
-                            </p>
-                        {% endif %}
+                            </li>
+                            {% if current_prescriber_organization.kind == current_prescriber_organization.Kind.DEPT and user_is_prescriber_org_admin %}
+                                <li class="card-text mb-3">
+                                    <i class="ri-list-unordered ri-lg"></i>
+                                    <a href="{% url 'prescribers_views:list_accredited_organizations' %}">
+                                        Voir la liste des organisations conventionnées
+                                    </a>
+                                    <span class="badge badge-info">Nouveau</span>
+                                </li>
+                            {% endif %}
+                            {% if current_prescriber_organization.is_authorized %}
+                                <li>
+                                    <hr>
+                                </li>
+                                <li class="card-text mb-3">
+                                    <i class="ri-award-line ri-lg"></i>
+                                    <span>
+                                        {{ current_prescriber_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique#diagnostic_de_reference" target="_blank" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
+                                    </span>
+                                </li>
+                            {% endif %}
+                        </ul>
                     </div>
                 </div>
             {% endif %}
 
             <div class="card">
-                <h5 class="h4 card-header">Candidatures</h5>
+                <p class="h4 card-header">Candidatures</p>
                 <div class="card-body">
-                    <p class="card-text">
-                        <i class="ri-chat-4-line ri-lg"></i>
-                        <a href="{% url 'apply:list_for_prescriber' %}">Suivi des candidatures</a>
-                    </p>
-                    <p class="card-text">
-                        <i class="ri-user-follow-line ri-lg"></i>
-                        <a href="/">Postuler pour un candidat</a>
-                    </p>
-                    <p class="card-text">
-                        <i class="ri-download-2-line ri-lg"></i>
-                        <a href="{% url 'apply:list_for_prescriber_exports' %}">
-                            Export des candidatures
-                        </a>
-                    </p>
+                    <ul class="list-unstyled">
+                        <li class="card-text mb-3">
+                            <i class="ri-chat-4-line ri-lg"></i>
+                            <a href="{% url 'apply:list_for_prescriber' %}">Suivi des candidatures</a>
+                        </li>
+                        <li class="card-text mb-3">
+                            <i class="ri-user-follow-line ri-lg"></i>
+                            <a href="/">Postuler pour un candidat</a>
+                        </li>
+                        <li class="card-text mb-3">
+                            <i class="ri-download-2-line ri-lg"></i>
+                            <a href="{% url 'apply:list_for_prescriber_exports' %}">
+                                Export des candidatures
+                            </a>
+                        </li>
+                    </ul>
                 </div>
             </div>
 
@@ -285,111 +295,111 @@
         {% if user.is_siae_staff %}
 
             <div class="card">
-                <h5 class="h4 card-header">
+                <p class="h4 card-header">
                     Ma structure
                     <span class="ml-1 badge badge-secondary">{{ current_siae.kind }} - ID {{ current_siae.id }}</span>
-                </h5>
+                </p>
                 <div class="card-body">
-                    <p class="card-text">
-                        <i class="ri-settings-6-line ri-lg"></i>
-                        {% if user_is_siae_admin %}
-                            <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">
-                                Modifier les informations de l'établissement
-                            </a>
-                            /
-                        {% endif %}
-                        <a href="{{ current_siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                            Voir la fiche publique
-                        </a>
-                    </p>
-                    {% if current_siae.is_active %}
-                        <p class="card-text">
-                            <i class="ri-group-line ri-lg"></i>
-                            <a href="{% url 'siaes_views:members' %}">
-                                Gérer des collaborateurs
-                            </a>
-                        </p>
-                    {% endif %}
-
-                    <p class="card-text">
-                        <i class="ri-briefcase-3-line ri-lg"></i>
-                        <a class="title-with-badge" href="{% url 'siaes_views:configure_jobs' %}">Gérer les métiers et recrutements
-                            <span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="À partir de maintenant, vous allez pouvoir informer les prescripteurs et les candidats des métiers qui recrutent en ce moment, avec la fonctionnalité «recrutement en cours»">Nouveau</span>
-                        </a>
-                    </p>
-
-                    {% if can_show_financial_annexes %}
-                        <p class="card-text">
-                            <i class="ri-checkbox-circle-line ri-lg"></i>
-                            <a href="{% url 'siaes_views:show_financial_annexes' %}">
-                                Mes annexes financières
-                            </a>
-                            {% if not current_siae.is_active %}
-                                <span class="badge badge-danger">
-                                    Action requise
-                                </span>
+                    <ul class="list-unstyled">
+                        <li class="card-text mb-3">
+                            <i class="ri-settings-line ri-lg mr-1"></i>
+                            {% if user_is_siae_admin %}
+                                <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">
+                                    Modifier les informations de l'établissement
+                                </a>
+                                /
                             {% endif %}
-                        </p>
-                    {% endif %}
-                    {% if can_create_siae_antenna %}
-                        <p class="card-text">
-                            <i class="ri-add-box-line ri-lg"></i>
-                            <a href="{% url 'siaes_views:create_siae' %}">Créer/rejoindre une autre structure</a>
-                        </p>
-                    {% endif %}
+                            <a href="{{ current_siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
+                                Voir la fiche publique
+                            </a>
+                        </li>
+                        {% if current_siae.is_active %}
+                            <li class="card-text mb-3">
+                                <i class="ri-group-line ri-lg mr-1"></i>
+                                <a href="{% url 'siaes_views:members' %}">
+                                    Gérer des collaborateurs
+                                </a>
+                            </li>
+                        {% endif %}
+                        <li class="card-text mb-3">
+                            {% include "includes/icon.html" with icon="briefcase" %}
+                            <a class="title-with-badge" href="{% url 'siaes_views:configure_jobs' %}">Gérer les métiers et recrutements
+                                <span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="À partir de maintenant, vous allez pouvoir informer les prescripteurs et les candidats des métiers qui recrutent en ce moment, avec la fonctionnalité «recrutement en cours»">Nouveau</span>
+                            </a>
+                        </li>
+                        {% if can_show_financial_annexes %}
+                            <li class="card-text mb-3">
+                                <i class="ri-checkbox-circle-line ri-lg mr-1"></i>
+                                <a href="{% url 'siaes_views:show_financial_annexes' %}">
+                                    Mes annexes financières
+                                </a>
+                                {% if not current_siae.is_active %}
+                                    <span class="badge badge-danger">
+                                        Action requise
+                                    </span>
+                                {% endif %}
+                            </li>
+                        {% endif %}
+                        {% if can_create_siae_antenna %}
+                            <li class="card-text mb-3">
+                                <i class="ri-add-box-line ri-lg mr-1"></i>
+                                <a href="{% url 'siaes_views:create_siae' %}">Créer/rejoindre une autre structure</a>
+                            </li>
+                        {% endif %}
+                    </ul>
                 </div>
             </div>
 
             <div class="card">
-                <h5 class="h4 card-header">Mes candidatures</h5>
+                <p class="h4 card-header">Mes candidatures</p>
                 <div class="card-body">
-                    {% for category in job_applications_categories %}
-                        {% if category.counter %}
-                            <p class="card-text">
-                                <i class="{{ category.icon }} ri-lg"></i>
-                                <a href="{{ category.url }}">{{ category.name }}</a>
-                                <span class="badge {{ category.badge }}">{{ category.counter }}</span>
-                            </p>
-                        {% endif %}
-                    {% endfor %}
-
-                    {% if can_show_employee_records %}
-                        <p class="card-text">
-                            <i class="ri-file-3-line ri-lg"></i>
-                            <a href="{% url 'employee_record_views:list' %}?status=NEW">Gérer mes fiches salarié (ASP)</a>
-                        </p>
-                    {% endif %}
-
-                    <p class="card-text">
-                        <i class="ri-login-box-line ri-lg"></i>
-                        <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">
-                            {% if current_siae.is_subject_to_eligibility_rules %}
-                                Déclarer une embauche
-                            {% else %}
-                                Candidature spontanée
+                    <ul class="list-unstyled">
+                        {% for category in job_applications_categories %}
+                            {% if category.counter %}
+                                <li class="card-text mb-3">
+                                    <i class="{{ category.icon }} ri-lg mr-1"></i>
+                                    <a href="{{ category.url }}">{{ category.name }}</a>
+                                    <span class="badge {{ category.badge }}">{{ category.counter }}</span>
+                                </li>
                             {% endif %}
-                        </a>
-                    </p>
-                    <p class="card-text">
-                        <i class="ri-search-line ri-lg"></i>
-                        <a href="{% url 'approvals:pe_approval_search' %}">
-                            Prolonger ou suspendre un agrément émis par Pôle emploi
-                        </a>
-                    </p>
-                    {% if current_siae.is_subject_to_eligibility_rules %}
-                        <p class="card-text">
-                            <i class="ri-book-open-line ri-lg"></i>
-                            <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1" target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
-                                Liste des critères d'éligibilité
+                        {% endfor %}
+                        {% if can_show_employee_records %}
+                            <li class="card-text mb-3">
+                                <i class="ri-file-3-line ri-lg mr-1"></i>
+                                <a href="{% url 'employee_record_views:list' %}?status=NEW">Gérer mes fiches salarié (ASP)</a>
+                            </li>
+                        {% endif %}
+                        <li class="card-text mb-3">
+                            <i class="ri-login-box-line ri-lg mr-1"></i>
+                            <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">
+                                {% if current_siae.is_subject_to_eligibility_rules %}
+                                    Déclarer une embauche
+                                {% else %}
+                                    Candidature spontanée
+                                {% endif %}
                             </a>
-                        </p>
-                    {% endif %}
-                    <p class="card-text">
-                        <i class="ri-download-2-line ri-lg"></i>
-                        <a href="{% url 'apply:list_for_siae_exports' %}">
-                            Export des candidatures
-                        </a>
-                    </p>
+                        </li>
+                        <li class="card-text mb-3">
+                            <i class="ri-search-line ri-lg mr-1"></i>
+                            <a href="{% url 'approvals:pe_approval_search' %}">
+                                Prolonger ou suspendre un agrément émis par Pôle emploi
+                            </a>
+                        </li>
+                        {% if current_siae.is_subject_to_eligibility_rules %}
+                            <li class="card-text mb-3">
+                                <i class="ri-book-open-line ri-lg mr-1"></i>
+                                <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1" target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
+                                    Liste des critères d'éligibilité
+                                </a>
+                            </li>
+                        {% endif %}
+                        <li class="card-text mb-3">
+                            <i class="ri-download-2-line ri-lg mr-1"></i>
+                            <a href="{% url 'apply:list_for_siae_exports' %}">
+                                Export des candidatures
+                            </a>
+                        </li>
+                    </ul>
                 </div>
             </div>
 
@@ -397,12 +407,12 @@
 
         {% if user.is_labor_inspector %}
             <div class="card">
-                <h5 class="h4 card-header">
+                <p class="h4 card-header">
                     Organisation <span class="ml-1 badge badge-secondary">{{ current_institution.kind }} - ID {{ current_institution.id }}</span>
-                </h5>
+                </p>
                 <div class="card-body">
                     <p class="card-text">
-                        <i class="ri-group-line ri-lg"></i>
+                        <i class="ri-group-line ri-lg mr-1"></i>
                         <a href="{% url 'institutions_views:members' %}">
                             Gérer vos collaborateurs
                         </a>
@@ -415,65 +425,66 @@
         {% if can_view_stats_dashboard_widget %}
 
             <div class="card">
-                <h5 class="h4 card-header">Statistiques et pilotage</h5>
+                <p class="h4 card-header">Statistiques et pilotage</p>
                 <div class="card-body">
-                    <p class="card-text">
-                        <i class="ri-pulse-line ri-lg"></i>
-                        <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Accéder au Pilotage de l'inclusion (ouverture dans un nouvel onglet)">
-                            Accéder au Pilotage de l'inclusion
-                        </a>
-                    </p>
-                    {% if can_view_stats_siae %}
-                        <p class="card-text">
-                            <i class="ri-pulse-line ri-lg"></i>
-                            <a href="{% url 'stats:stats_siae' %}">Voir les données de ma structure</a>
-                            <span class="badge badge-info">Nouveau</span>
-                        </p>
-                    {% endif %}
-                    {% if can_view_stats_cd %}
-                        <p class="card-text">
-                            <i class="ri-pulse-line ri-lg"></i>
-                            <a href="{% url 'stats:stats_cd' %}">Données IAE</a>
-                        </p>
-                    {% endif %}
-                    {% if can_view_stats_ddets %}
-                        <p class="card-text">
-                            <i class="ri-pulse-line ri-lg"></i>
-                            <a href="{% url 'stats:stats_ddets_iae' %}">Données IAE</a>
-                        </p>
-                        <p class="card-text">
-                            <i class="ri-pulse-line ri-lg"></i>
-                            <a href="{% url 'stats:stats_ddets_diagnosis_control' %}">Voir mes données 2021 du contrôle a posteriori (version bêta)</a>
-                            <span class="badge badge-info">Nouveau</span>
-                        </p>
-                    {% endif %}
-                    {% if can_view_stats_dreets %}
-                        <p class="card-text">
-                            <i class="ri-pulse-line ri-lg"></i>
-                            <a href="{% url 'stats:stats_dreets_iae' %}">Données IAE</a>
-                        </p>
-                    {% endif %}
-                    {% if can_view_stats_dgefp %}
-                        <p class="card-text">
-                            <i class="ri-pulse-line ri-lg"></i>
-                            <a href="{% url 'stats:stats_dgefp_iae' %}">Données IAE</a>
-                        </p>
-                        <p class="card-text">
-                            <i class="ri-pulse-line ri-lg"></i>
-                            <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données 2021 du contrôle a posteriori (version bêta)</a>
-                            <span class="badge badge-info">Nouveau</span>
-                        </p>
-                        <p class="card-text">
-                            <i class="ri-pulse-line ri-lg"></i>
-                            <a href="{% url 'stats:stats_dgefp_af' %}">Annexes financières actives</a>
-                            <span class="badge badge-info">Nouveau</span>
-                        </p>
-                    {% endif %}
+                    <ul class="list-unstyled">
+                        <li class="card-text mb-3">
+                            <i class="ri-pulse-line ri-lg mr-1"></i>
+                            <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Accéder au Pilotage de l'inclusion (ouverture dans un nouvel onglet)">
+                                Accéder au Pilotage de l'inclusion
+                            </a>
+                        </li>
+                        {% if can_view_stats_siae %}
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_siae' %}">Voir les données de ma structure</a>
+                                <span class="badge badge-info">Nouveau</span>
+                            </li>
+                        {% endif %}
+                        {% if can_view_stats_cd %}
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_cd' %}">Données IAE</a>
+                            </li>
+                        {% endif %}
+                        {% if can_view_stats_ddets %}
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_ddets_iae' %}">Données IAE</a>
+                            </li>
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_ddets_diagnosis_control' %}">Voir mes données 2021 du contrôle a posteriori (version bêta)</a>
+                                <span class="badge badge-info">Nouveau</span>
+                            </li>
+                        {% endif %}
+                        {% if can_view_stats_dreets %}
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_dreets_iae' %}">Données IAE</a>
+                            </li>
+                        {% endif %}
+                        {% if can_view_stats_dgefp %}
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_dgefp_iae' %}">Données IAE</a>
+                            </li>
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données 2021 du contrôle a posteriori (version bêta)</a>
+                                <span class="badge badge-info">Nouveau</span>
+                            </li>
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_dgefp_af' %}">Annexes financières actives</a>
+                                <span class="badge badge-info">Nouveau</span>
+                            </li>
+                        {% endif %}
+                    </ul>
                 </div>
             </div>
 
         {% endif %}
-
     </div>
 
 {% endblock %}

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -40,13 +40,13 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
             {
                 "name": "Candidatures à traiter",
                 "states": [JobApplicationWorkflow.STATE_NEW, JobApplicationWorkflow.STATE_PROCESSING],
-                "icon": "user-plus",
+                "icon": "ri-user-add-line",
                 "badge": "badge-danger",
             },
             {
                 "name": "Candidatures acceptées ou mises en liste d'attente",
                 "states": [JobApplicationWorkflow.STATE_ACCEPTED, JobApplicationWorkflow.STATE_POSTPONED],
-                "icon": "user-check",
+                "icon": "ri-user-follow-line",
                 "badge": "badge-secondary",
             },
             {
@@ -56,7 +56,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                     JobApplicationWorkflow.STATE_CANCELLED,
                     JobApplicationWorkflow.STATE_OBSOLETE,
                 ],
-                "icon": "user-x",
+                "icon": "ri-user-follow-line",
                 "badge": "badge-secondary",
             },
         ]


### PR DESCRIPTION
### **Quoi ?**

La référence pour les icônes est désormais [remixicon.com](http://remixicon.com/)

### **Pourquoi ?**

De nouveaux liens sont ajoutés dans le dashboard pour les DDETS et les SIAE pour le projet “Evaluation à postériori”.

### **Comment ?**

Mettre à jour les icônes existants dans la page dashboard pour ne pas faire cohabiter 2 façons de gérer les icônes dans une même page, avant d’ajouter les nouveaux liens.