### PR TITLE
Analyse des candidatures reçues sur les fiches de poste

### DIFF
--- a/itou/metabase/management/commands/sql/016_candidatures_recues_par_fiche_de_poste.sql
+++ b/itou/metabase/management/commands/sql/016_candidatures_recues_par_fiche_de_poste.sql
@@ -1,0 +1,44 @@
+/* 
+ 
+L'objectif est d'analyser les candidatures qui sont reliées à une fiche de poste dans le but de détécter celles qui ont
+des difficultés à recruter.
+
+*/
+
+select 
+    c.date_candidature,
+    c.date_embauche,
+    c.délai_de_réponse,
+    (current_date - c.date_candidature) as anciennete_candidature,
+    (current_date - fdp.date_création) as delai_mise_en_ligne,
+    c.délai_prise_en_compte,
+    c.département_structure,
+    c.id_anonymisé as id_candidature_anonymisé,
+    c.id_candidat_anonymisé ,
+    c.id_structure,
+    c.motif_de_refus,
+    c.nom_département_structure,
+    c.nom_org_prescripteur,
+    c.nom_structure,
+    c.origine as origine_candidature,
+    c.origine_détaillée as origine_détaillée_candidature,
+    c.région_structure,
+    c.safir_org_prescripteur,
+    c.type_structure,
+    c.état as état_candidature,
+    fdp.recrutement_ouvert as recrutement_ouvert_fdp,
+    fdp.code_rome as code_rome_fpd,
+    fdp.date_création as date_création_fdp,
+    fdp.date_mise_à_jour_metabase,
+    fdp.id as id_fdp,
+    fdp.nom_rome as nom_rome_fdp,
+    fdp.id_employeur,
+    fdp.siret_employeur
+from 
+    candidatures c 
+inner join 
+    fiches_de_poste_par_candidature fdppc 
+    on c.id_anonymisé = fdppc.id_anonymisé_candidature 
+inner join 
+    fiches_de_poste fdp 
+    on fdp.id = fdppc.id_fiche_de_poste


### PR DESCRIPTION
### Quoi ?

Table Metabase avec pour chaque fiche de poste les candidatures qui lui sont associées

### Pourquoi ?

- Analyser les fiches de poste qui ont des difficultés à recruter 
- Mettre en place un plan d'action adapté : contacter les structures d'insertion qui ont des fiches de poste en tension de recrutement par exemple
