### PR TITLE
setup navigation logic + tests

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -59,6 +59,7 @@ urlpatterns = [
     path("apply/", include("itou.www.apply.urls")),
     path("approvals/", include("itou.www.approvals_views.urls")),
     path("autocomplete/", include("itou.www.autocomplete.urls")),
+    path("controls/", include("itou.www.controls.urls")),
     path("dashboard/", include("itou.www.dashboard.urls")),
     path("employee_record/", include("itou.www.employee_record_views.urls")),
     path("institutions/", include("itou.www.institutions_views.urls")),

--- a/itou/templates/controls/review_self_approvals.html
+++ b/itou/templates/controls/review_self_approvals.html
@@ -1,0 +1,7 @@
+{% extends "layout/content.html" %}
+
+{% block title %}Contrôle des pièces justificatives{{ block.super }}{% endblock %}
+
+{% block content %}
+    Contrôle des pièces justificatives par {{ institution.name }}
+{% endblock %}

--- a/itou/templates/controls/self_approvals.html
+++ b/itou/templates/controls/self_approvals.html
@@ -1,0 +1,8 @@
+{% extends "layout/content.html" %}
+
+{% block title %}Auto-prescription à justifier{{ block.super }}{% endblock %}
+
+{% block content %}
+    Auto-prescription {{ job_application.approval.number}} à justifier pour {{ siae.name }}
+    <a href="{% url "controls:self_approvals_list" %}" class="btn btn-primary">Retour à la liste</a>
+{% endblock %}

--- a/itou/templates/controls/self_approvals_list.html
+++ b/itou/templates/controls/self_approvals_list.html
@@ -1,0 +1,16 @@
+{% extends "layout/content.html" %}
+
+{% block title %}Liste des auto-prescriptions à justifier{{ block.super }}{% endblock %}
+
+{% block content %}
+    Liste des auto-prescriptions à justifier pour {{ siae.name }}
+    {% for approval_id in approval_list %}
+        <div><a href="{% url "controls:self_approvals" approval_id %}">{{approval_id}}</a></div>
+
+    {% endfor %}
+
+    navigation_pages
+    <a class="btn btn-outline-primary" href="{{ back_url }}">
+        Retour
+    </a>
+{% endblock %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -315,8 +315,7 @@
                     <p class="card-text">
                         {% include "includes/icon.html" with icon="briefcase" %}
                         <a class="title-with-badge" href="{% url 'siaes_views:configure_jobs' %}">Gérer les métiers et recrutements
-                            <span class="badge badge-info" data-toggle="tooltip" data-placement="right"
-                                title="À partir de maintenant, vous allez pouvoir informer les prescripteurs et les candidats des métiers qui recrutent en ce moment, avec la fonctionnalité «recrutement en cours»">Nouveau</span>
+                            <span class="badge badge-info" data-toggle="tooltip" data-placement="right" title="À partir de maintenant, vous allez pouvoir informer les prescripteurs et les candidats des métiers qui recrutent en ce moment, avec la fonctionnalité «recrutement en cours»">Nouveau</span>
                         </a>
                     </p>
 
@@ -381,9 +380,7 @@
                     {% if current_siae.is_subject_to_eligibility_rules %}
                         <p class="card-text">
                             {% include "includes/icon.html" with icon="book-open" %}
-                            <a
-                                href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1"
-                                target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
+                            <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1" target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
                                 Liste des critères d'éligibilité
                             </a>
                         </p>
@@ -393,6 +390,15 @@
                         <a href="{% url 'apply:list_for_siae_exports' %}">
                             Export des candidatures
                         </a>
+                    </p>
+                </div>
+            </div>
+            <div class="card">
+                <h5 class="h4 card-header">Contrôle à postériori <span class="badge badge-info">Nouveau</span></h5>
+                <div class="card-body">
+                    <p class="card-text">
+                        <i class="ri-file-copy-2-line ri-lg"></i>
+                        <a href="{% url 'controls:self_approvals_list' %}">Justifier mes auto-prescriptions</a>
                     </p>
                 </div>
             </div>
@@ -445,11 +451,6 @@
                             {% include "includes/icon.html" with icon="activity" %}
                             <a href="{% url 'stats:stats_ddets_iae' %}">Données IAE</a>
                         </p>
-                        <p class="card-text">
-                            {% include "includes/icon.html" with icon="activity" %}
-                            <a href="{% url 'stats:stats_ddets_diagnosis_control' %}">Voir mes données 2021 du contrôle a posteriori (version bêta)</a>
-                            <span class="badge badge-info">Nouveau</span>
-                        </p>
                     {% endif %}
                     {% if can_view_stats_dreets %}
                         <p class="card-text">
@@ -475,6 +476,22 @@
                     {% endif %}
                 </div>
             </div>
+
+            {% if can_view_stats_ddets %}
+                <div class="card">
+                    <h5 class="h4 card-header">Contrôle à postériori <span class="badge badge-info">Nouveau</span></h5>
+                    <div class="card-body">
+                        <p class="card-text">
+                            <i class="ri-pulse-line ri-lg"></i>
+                            <a href="{% url 'stats:stats_ddets_diagnosis_control' %}">Sélectionner l'échantilonnage</a>
+                        </p>
+                        <p class="card-text">
+                            <i class="ri-file-copy-2-line ri-lg"></i>
+                            <a href="{% url 'controls:review_self_approvals' %}">Contrôler les pièces justificatives</a>
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
 
         {% endif %}
 

--- a/itou/www/controls/tests.py
+++ b/itou/www/controls/tests.py
@@ -1,0 +1,112 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from itou.approvals.models import Approval
+from itou.institutions.factories import InstitutionWithMembershipFactory
+from itou.institutions.models import Institution
+from itou.job_applications.factories import JobApplicationWithApprovalFactory
+from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.models import Siae
+from itou.users.factories import DEFAULT_PASSWORD, UserFactory
+from itou.www.stats.views import _STATS_HTML_TEMPLATE
+
+
+class InstitutionNavigationTest(TestCase):
+    def test_access_to_stat_page(self):
+        institution = InstitutionWithMembershipFactory(kind=Institution.Kind.DDETS, department="14")
+        user = institution.members.first()
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        url = reverse("stats:stats_ddets_diagnosis_control")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, _STATS_HTML_TEMPLATE)
+        self.assertContains(response, "Adapter le ratio de mon département")
+        self.assertContains(response, "Valider le paramètre de contrôle national")
+
+    def test_cannot_access_to_stat_page_for_other_users(self):
+        user = UserFactory()
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        url = reverse("stats:stats_ddets_diagnosis_control")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_access_to_review_page(self):
+        institution = InstitutionWithMembershipFactory(kind=Institution.Kind.DDETS, department="14")
+        user = institution.members.first()
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        url = reverse("controls:review_self_approvals")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "controls/review_self_approvals.html")
+        self.assertEqual(response.context["institution"], institution)
+
+    def test_cannot_access_to_review_page_for_other_users(self):
+        user = UserFactory()
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        url = reverse("controls:review_self_approvals")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_backlink_on_self_approval_list(self):
+        self.assertTrue(False)
+
+    def test_backlink_on_self_approval_detail(self):
+        self.assertTrue(False)
+
+
+class SiaeNavigationTest(TestCase):
+    def test_access_to_self_approval_list(self):
+        siae = SiaeWithMembershipFactory()
+        user = siae.members.last()
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        url = reverse("controls:self_approvals_list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "controls/self_approvals_list.html")
+        self.assertEqual(response.context["siae"], siae)
+        # backlink
+        self.assertContains(response, reverse("dashboard:index"))
+
+    def test_cannot_access_to_self_approval_list_for_not_siae_members(self):
+        user = UserFactory()
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        url = reverse("controls:self_approvals_list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_access_self_approval_detail_for_siae_members(self):
+        siae = SiaeWithMembershipFactory()
+        job_application = JobApplicationWithApprovalFactory(to_siae=siae)
+        user = siae.members.first()
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        url = reverse("controls:self_approvals", args=(job_application.approval_id,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "controls/self_approvals.html")
+        self.assertEqual(response.context["siae"], siae)
+        self.assertEqual(response.context["job_application"], job_application)
+        # backlink
+        self.assertContains(response, reverse("controls:self_approvals_list"))
+
+    def test_cannot_access_self_approval_detail_for_members_of_an_other_siae(self):
+        siae1 = SiaeWithMembershipFactory()
+        user = siae1.members.first()
+
+        siae2 = SiaeWithMembershipFactory()
+        job_application2 = JobApplicationWithApprovalFactory(to_siae=siae2)
+
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        url = reverse("controls:self_approvals", args=(job_application2.approval_id,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_cannot_access_self_approval_detail_for_not_siae_members(self):
+        user = UserFactory()
+
+        siae2 = SiaeWithMembershipFactory()
+        job_application2 = JobApplicationWithApprovalFactory(to_siae=siae2)
+
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        url = reverse("controls:self_approvals", args=(job_application2.approval_id,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)

--- a/itou/www/controls/urls.py
+++ b/itou/www/controls/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from itou.www.controls import views
+
+
+# https://docs.djangoproject.com/en/dev/topics/http/urls/#url-namespaces-and-included-urlconfs
+app_name = "controls"
+
+urlpatterns = [
+    path("review_self_approvals", views.review_self_approvals, name="review_self_approvals"),
+    path("self_approvals_list", views.self_approvals_list, name="self_approvals_list"),
+    path("self_approvals/<int:approval_id>", views.self_approvals, name="self_approvals"),
+]

--- a/itou/www/controls/views.py
+++ b/itou/www/controls/views.py
@@ -1,0 +1,42 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, render
+
+# from django.core.exceptions import PermissionDenied
+from django.urls import reverse
+
+from itou.job_applications.models import JobApplication
+from itou.utils.perms.institution import get_current_institution_or_404
+from itou.utils.perms.siae import get_current_siae_or_404
+from itou.utils.urls import get_safe_url
+
+
+@login_required
+def review_self_approvals(request, template_name="controls/review_self_approvals.html"):
+    institution = get_current_institution_or_404(request)
+    context = {
+        "institution": institution,
+    }
+    return render(request, template_name, context)
+
+
+@login_required
+def self_approvals_list(request, template_name="controls/self_approvals_list.html"):
+    siae = get_current_siae_or_404(request)
+
+    back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
+    context = {
+        "siae": siae,
+        "approval_list": [1, 2],
+        "back_url": back_url,
+    }
+    return render(request, template_name, context)
+
+
+@login_required
+def self_approvals(request, approval_id, template_name="controls/self_approvals.html"):
+    siae = get_current_siae_or_404(request)
+    queryset = JobApplication.objects.select_related("job_seeker", "eligibility_diagnosis", "approval", "to_siae")
+    job_application = get_object_or_404(queryset, approval_id=approval_id, to_siae=siae)
+
+    context = {"siae": siae, "job_application": job_application}
+    return render(request, template_name, context)


### PR DESCRIPTION
### Quoi ?

Mettre en place le contrôle à postériori des Pass IAE auto-prescrits par des SIAE

### Pourquoi ?

Pour vérifier la conformité des Pass IAE par les contrôleurs DDETS, à partir des justificatifs fournis par les SIAE.


### Comment ?

* Echantillonner les Pass IAE autoprescrits sur un departement,
* Notifier les SIAE concernées,
* Accéder à la liste des Pass IAE concernés,
* Téléverser les pièces justificatives nécessaires,
* Gérer le workflow contrôleurs <-> SIAE
* Gérer la durée des pièces conservées

