### PR TITLE
Evolutions Metabase

### DIFF
--- a/itou/metabase/management/commands/_job_seekers.py
+++ b/itou/metabase/management/commands/_job_seekers.py
@@ -4,6 +4,7 @@ from operator import attrgetter
 
 from django.utils import timezone
 
+from itou.approvals.models import Approval
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.metabase.management.commands._utils import (
@@ -249,3 +250,15 @@ for criteria in AdministrativeCriteria.objects.order_by("id").all():
             "fn": partial(get_latest_diagnosis_criteria, criteria_id=criteria.id),
         }
     ]
+
+
+TABLE_COLUMNS += [
+    {
+        "name": "injection_ai",
+        "type": "boolean",
+        "comment": "Provient des injections AI",
+        "fn": lambda o: o.approvals_wrapper.latest_approval.is_from_ai_stock
+        if isinstance(o.approvals_wrapper.latest_approval, Approval)
+        else False,
+    },
+]


### PR DESCRIPTION
### Quoi ?

Evolutions Metabase, avec au menu :

- Note : les SIAE inactives n'étaient déjà pas envoyées avant cette PR.
- Les fiches de poste des SIAE inactives ne sont plus envoyées.
- Les candidatures avec une SIAE destinatrice inactive ne sont plus envoyées.
- Les liaisons fiche de poste / candidature portant sur une candidature avec une SIAE destinatrice inactive ne sont plus envoyées.
- Note : les candidatures créées lors de l'import d'un agrément Pole Emploi n'étaient déjà pas envoyées avant cette PR.
- Les liaisons fiche de poste / candidature portant sur une candidature créée lors de l'import d'un agrément Pole Emploi ne sont plus envoyées.
- Ajout du nouveau champ `candidats.injection_ai` qui était déjà présent dans les tables `candidatures` et `agréments`.

### Pourquoi ?

Pour faire avancer le C2, à la demande de Soumia et Yannick.

### Tickets

https://www.notion.so/Evaluer-la-n-cessit-de-retirer-les-fiches-de-poste-des-SIAE-inactives-de-la-table-fiche-de-poste-3295cfc5bd0440e9bec12a32a226b61c

https://www.notion.so/Ajouter-une-colonne-similaire-celle-de-la-table-candidatures-dans-la-table-candidats-pour-identi-fb597574a1a348bc8d62ca40c604dd10
