### PR TITLE
Log des tokens lors des appels à l’API PE

### DIFF
--- a/itou/job_applications/tasks.py
+++ b/itou/job_applications/tasks.py
@@ -62,7 +62,7 @@ def notify_pole_emploi_pass(job_application, job_seeker, mode=POLE_EMPLOI_PASS_A
         log = JobApplicationPoleEmploiNotificationLog(
             job_application=job_application,
             status=JobApplicationPoleEmploiNotificationLog.STATUS_FAIL_SEARCH_INDIVIDUAL,
-            details=f"{e.http_code} {e.response_code}",
+            details=f"{e.http_code} {e.response_code} {token}",
         )
         log.save()
         return False
@@ -72,10 +72,10 @@ def notify_pole_emploi_pass(job_application, job_seeker, mode=POLE_EMPLOI_PASS_A
         sleep(1)
     except PoleEmploiMiseAJourPassIAEException as e:
         log.status = JobApplicationPoleEmploiNotificationLog.STATUS_FAIL_NOTIFY_POLE_EMPLOI
-        log.details = f"{e.http_code} {e.response_code}"
+        log.details = f"{e.http_code} {e.response_code} {token}"
         log.save()
         return False
-
+    log.details += token
     log.save()
     return True
 


### PR DESCRIPTION
### Quoi ?

Log des tokens lors des appels à l’API PE

### Pourquoi ?

Pour identifier si nous avons bien un token différent ou identique lors des appels en mode test, afin de voir si l’erreur peut venir de chez nous ou non.

