### PR TITLE
Correctif pour les appels à l’API pole emploi

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -948,11 +948,8 @@ class JobApplicationPoleEmploiNotificationLog(models.Model):
     @staticmethod
     def get_token() -> str:
         """returns the necessary token for Updating PoleEmploi, or raise exceptions"""
+        # Sandbox token value: "passIAE api_testmaj-pass-iaev1"
         maj_pass_iae_api_scope = "passIAE api_maj-pass-iaev1"
-        # The sandbox mode involves a slightly different scope
-        # if settings.API_ESD_MISE_A_JOUR_PASS_MODE != "production":
-        #     maj_pass_iae_api_scope = "passIAE api_testmaj-pass-iaev1"
-        # It is not obvious but we can ask for one token only with all the necessary rights
         token_recherche_et_maj = get_access_token(
             f"api_rechercheindividucertifiev1 rechercherIndividuCertifie {maj_pass_iae_api_scope}"
         )

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -950,8 +950,8 @@ class JobApplicationPoleEmploiNotificationLog(models.Model):
         """returns the necessary token for Updating PoleEmploi, or raise exceptions"""
         maj_pass_iae_api_scope = "passIAE api_maj-pass-iaev1"
         # The sandbox mode involves a slightly different scope
-        if settings.API_ESD_MISE_A_JOUR_PASS_MODE != "production":
-            maj_pass_iae_api_scope = "passIAE api_testmaj-pass-iaev1"
+        # if settings.API_ESD_MISE_A_JOUR_PASS_MODE != "production":
+        #     maj_pass_iae_api_scope = "passIAE api_testmaj-pass-iaev1"
         # It is not obvious but we can ask for one token only with all the necessary rights
         token_recherche_et_maj = get_access_token(
             f"api_rechercheindividucertifiev1 rechercherIndividuCertifie {maj_pass_iae_api_scope}"

--- a/itou/job_applications/tasks.py
+++ b/itou/job_applications/tasks.py
@@ -63,7 +63,7 @@ def notify_pole_emploi_pass(job_application, job_seeker, mode=POLE_EMPLOI_PASS_A
         log = JobApplicationPoleEmploiNotificationLog(
             job_application=job_application,
             status=JobApplicationPoleEmploiNotificationLog.STATUS_FAIL_SEARCH_INDIVIDUAL,
-            details=f"{e.http_code} {e.response_code} {token} {settings.API_ESD_MISE_A_JOUR_PASS_MODE}",
+            details=f"http_code={e.http_code} response_code={e.response_code} token={token} mode={settings.API_ESD_MISE_A_JOUR_PASS_MODE}",  # noqa
         )
         log.save()
         return False
@@ -73,10 +73,10 @@ def notify_pole_emploi_pass(job_application, job_seeker, mode=POLE_EMPLOI_PASS_A
         sleep(1)
     except PoleEmploiMiseAJourPassIAEException as e:
         log.status = JobApplicationPoleEmploiNotificationLog.STATUS_FAIL_NOTIFY_POLE_EMPLOI
-        log.details = f"{e.http_code} {e.response_code} Token: {token} Mode: {settings.API_ESD_MISE_A_JOUR_PASS_MODE}"
+        log.details = f"http_code={e.http_code} response_code={e.response_code} token={token} mode={settings.API_ESD_MISE_A_JOUR_PASS_MODE}"  # noqa
         log.save()
         return False
-    log.details += f" {token} {settings.API_ESD_MISE_A_JOUR_PASS_MODE}"
+    log.details += f" token={token} mode={settings.API_ESD_MISE_A_JOUR_PASS_MODE}"
     log.save()
     return True
 

--- a/itou/job_applications/tasks.py
+++ b/itou/job_applications/tasks.py
@@ -73,7 +73,7 @@ def notify_pole_emploi_pass(job_application, job_seeker, mode=POLE_EMPLOI_PASS_A
         sleep(1)
     except PoleEmploiMiseAJourPassIAEException as e:
         log.status = JobApplicationPoleEmploiNotificationLog.STATUS_FAIL_NOTIFY_POLE_EMPLOI
-        log.details = f"{e.http_code} {e.response_code} {token}  {settings.API_ESD_MISE_A_JOUR_PASS_MODE}"
+        log.details = f"{e.http_code} {e.response_code} Token: {token} Mode: {settings.API_ESD_MISE_A_JOUR_PASS_MODE}"
         log.save()
         return False
     log.details += f" {token} {settings.API_ESD_MISE_A_JOUR_PASS_MODE}"

--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -254,9 +254,8 @@ def mise_a_jour_pass_iae(job_application, pass_approved_code, encrypted_identifi
 
     # The production URL
     url = f"{settings.API_ESD_BASE_URL}/maj-pass-iae/v1/passIAE/miseAjour"
-    # if settings.API_ESD_MISE_A_JOUR_PASS_MODE != "production":
-    #     # The test URL in recette, sandboxed mode
-    #     url = f"{settings.API_ESD_BASE_URL}/testmaj-pass-iae/v1/passIAE/miseAjour"  # noqa
+    # Sandbox URL, should it be used again:
+    # f"{settings.API_ESD_BASE_URL}/testmaj-pass-iae/v1/passIAE/miseAjour"
 
     headers = {"Authorization": token, "Content-Type": "application/json"}  # noqa
 

--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -173,7 +173,7 @@ class PoleEmploiIndividuResult:
     def is_valid(self):
         # This specific value is provided by Pole Emploi as part of their API spec
         CODE_SORTIE_INDIVIDU_TROUVE = "S001"
-        return self.code_sortie == CODE_SORTIE_INDIVIDU_TROUVE
+        return self.code_sortie == CODE_SORTIE_INDIVIDU_TROUVE and self.id_national_demandeur != ""
 
     @staticmethod
     def from_data(data):
@@ -254,9 +254,9 @@ def mise_a_jour_pass_iae(job_application, pass_approved_code, encrypted_identifi
 
     # The production URL
     url = f"{settings.API_ESD_BASE_URL}/maj-pass-iae/v1/passIAE/miseAjour"
-    if settings.API_ESD_MISE_A_JOUR_PASS_MODE != "production":
-        # The test URL in recette, sandboxed mode
-        url = f"{settings.API_ESD_BASE_URL}/testmaj-pass-iae/v1/passIAE/miseAjour"  # noqa
+    # if settings.API_ESD_MISE_A_JOUR_PASS_MODE != "production":
+    #     # The test URL in recette, sandboxed mode
+    #     url = f"{settings.API_ESD_BASE_URL}/testmaj-pass-iae/v1/passIAE/miseAjour"  # noqa
 
     headers = {"Authorization": token, "Content-Type": "application/json"}  # noqa
 


### PR DESCRIPTION
## Quoi
Amélioration des logs et correction du bug qui fait qu’on envoie des identifiants vides

## Pourquoi

Cela crée des erreurs

## Comment

 - Plus de logs. Les erreurs S100 sont les seules qui n’incluent pas le token/mode, pour une raison qui m’échappe
 - Suppression du mode bac à sable de nos appels. Nous ne faisons pas d’appel en mode test de toute facons.
