### PR TITLE
Correction des tests sur les dates de fin de contrats optionnelles

### DIFF
--- a/itou/www/employee_record_views/tests/test_create.py
+++ b/itou/www/employee_record_views/tests/test_create.py
@@ -156,7 +156,7 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, f"Fin du contrat : <b>{hiring_end_at.strftime('%d')}")
+        self.assertContains(response, f"Fin du contrat : <b>{hiring_end_at.strftime('%e').lstrip()}")
 
     def test_no_hiring_end_at_in_header(self):
         self.job_application.hiring_end_at = None

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -76,7 +76,7 @@ class ListEmployeeRecordsTest(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, f"Fin de contrat : <b>{hiring_end_at.strftime('%d')}")
+        self.assertContains(response, f"Fin de contrat : <b>{hiring_end_at.strftime('%e').lstrip()}")
 
     def test_employee_records_without_hiring_end_at(self):
         """

--- a/itou/www/employee_record_views/tests/test_summary.py
+++ b/itou/www/employee_record_views/tests/test_summary.py
@@ -29,7 +29,7 @@ class SummaryEmployeeRecordsTest(TestCase):
         self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, f"Fin du contrat : <b>{hiring_end_at.strftime('%d')}")
+        self.assertContains(response, f"Fin du contrat : <b>{hiring_end_at.strftime('%e').lstrip()}")
 
     def test_no_hiring_end_at_in_header(self):
         self.job_application.hiring_end_at = None


### PR DESCRIPTION
### Quoi ?

Test des dates de fin de contrat optionnelles dans les pages `employee_record_views`

### Pourquoi ?

Le test qui vérifie la date de fin de contrat, quand elle est connue, recherchait "02" et non "2" pour les jours entre 1 et 9

### Comment ?

Mise à jour du formatage 
