### PR TITLE
Mise à jour du délai de retroactivité des suspensions

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -445,7 +445,9 @@ class Suspension(models.Model):
     # Max duration: 12 months (could be adjusted according to user feedback).
     # 12-months suspensions can be consecutive and there can be any number of them.
     MAX_DURATION_MONTHS = 12
-    MAX_RETROACTIVITY_DURATION_DAYS = 30
+    # Temporary update for support team needs. operated on march. Target value should be 30.
+    # More information on https://github.com/betagouv/itou/pull/1163
+    MAX_RETROACTIVITY_DURATION_DAYS = 365
 
     class Reason(models.TextChoices):
         # Displayed choices

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -164,7 +164,8 @@ class SuspensionForm(forms.ModelForm):
                 (
                     "Au format JJ/MM/AAAA, par exemple 20/12/1978."
                     "<br>"
-                    "La suspension ne peut pas commencer dans le futur."
+                    "La suspension ne doit pas chevaucher une suspension déjà existante."
+                    " Elle ne peut pas commencer dans le futur."
                 )
             ),
             "end_at": mark_safe(
@@ -190,10 +191,8 @@ class SuspensionForm(forms.ModelForm):
         next_min_start_at = Suspension.next_min_start_at(self.approval, suspension_pk, referent_date, True)
         if start_at < next_min_start_at:
             raise ValidationError(
-                f"Pour la date de début de suspension, vous pouvez remonter "
-                f"{Suspension.MAX_RETROACTIVITY_DURATION_DAYS} jours avant la date de saisie "
-                f"et elle ne doit pas chevaucher une suspension déjà existante. "
-                f"Date de début minimum : {next_min_start_at.strftime('%d/%m/%Y')}."
+                f"Vous ne pouvez pas saisir une date de début de suspension "
+                f"qui précède le {next_min_start_at.strftime('%d/%m/%Y')}."
             )
 
         return start_at


### PR DESCRIPTION
### Quoi ?

Les suspensions sont modifiables retroactivement dans un certain délais.

### Pourquoi ?

- Allonger la durée de rétroactivité possible.
- Simplifier le message d'alerte à l'utilisateur dans le formulaire de saisie / mise à jour.

### Comment ?

Mise à jour de la valeur de la constante MAX_RETROACTIVITY_DURATION_DAYS
Les tests existants couvrent déjà l'ensemble des cas métiers.
