### PR TITLE
Plus de logs et de vérifications concernant les erreurs de déchiffrement

### DIFF
--- a/itou/job_applications/tasks.py
+++ b/itou/job_applications/tasks.py
@@ -69,7 +69,7 @@ def notify_pole_emploi_pass(job_application, job_seeker, mode=POLE_EMPLOI_PASS_A
         return False
 
     # despite some earlier checks, we keep having invalid encrypted indentifier errors
-    if encrypted_nir == "":
+    if not encrypted_nir:
         log = JobApplicationPoleEmploiNotificationLog(
             job_application=job_application,
             status=JobApplicationPoleEmploiNotificationLog.STATUS_FAIL_SEARCH_INDIVIDUAL,


### PR DESCRIPTION
### Quoi ?

Plus de logs d’erreur et de vérifications concernant l’identifiant chiffré transmis à Pole Emploi.

### Pourquoi ?

Les correctifs déployés ces derniers jours (vérifier si le paramètre `encrypted_nir` est vide) n’aident pas à faire disparaitre définitivement le problème des erreurs E_ERR_EX042_PROBLEME_DECHIFFREMEMENT, alors que ça devrait être le cas.

Ces logs ont pourt but de permettre d’identifier si la cause est chez nous (mauvais traitement des cas d’erreur) ou bien si des identifiants chiffrés valides sont mal décodés en face.