### PR TITLE
Correction des erreurs occasionnelles sur la recherche d’agréments

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -542,10 +542,15 @@ class User(AbstractUser, AddressMixin):
     def last_accepted_job_application(self):
         if not self.is_job_seeker:
             return None
+        # Some candidates may not have accepted job applications
+        # Assuming its the case can lead to issues downstream
+        accepted_job_applications = self.job_applications.accepted()
+        if accepted_job_applications.count() == 0:
+            return None
         # Last accepted job application is based on creation and hiring dates.
         # There were cases of identical job application creation dates in production,
         # leading to bad ordering (listed in DB natural "insertion" order).
-        return self.job_applications.accepted().latest("created_at", "hiring_start_at")
+        return accepted_job_applications.latest("created_at", "hiring_start_at")
 
     @cached_property
     def jobseeker_hash_id(self):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -542,15 +542,14 @@ class User(AbstractUser, AddressMixin):
     def last_accepted_job_application(self):
         if not self.is_job_seeker:
             return None
-        # Some candidates may not have accepted job applications
-        # Assuming its the case can lead to issues downstream
-        accepted_job_applications = self.job_applications.accepted()
-        if accepted_job_applications.count() == 0:
-            return None
+
         # Last accepted job application is based on creation and hiring dates.
         # There were cases of identical job application creation dates in production,
         # leading to bad ordering (listed in DB natural "insertion" order).
-        return accepted_job_applications.latest("created_at", "hiring_start_at")
+        #
+        # Some candidates may not have accepted job applications
+        # Assuming its the case can lead to issues downstream
+        return self.job_applications.accepted().order_by("created_at", "hiring_start_at").last()
 
     @cached_property
     def jobseeker_hash_id(self):

--- a/itou/www/approvals_views/tests/test_pe_approval.py
+++ b/itou/www/approvals_views/tests/test_pe_approval.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from itou.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
 from itou.approvals.models import Approval
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.models import JobApplicationWorkflow
 from itou.siaes.factories import SiaeMembershipFactory, SiaeWithMembershipFactory
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
 from itou.users.models import User
@@ -119,8 +119,9 @@ class PoleEmploiApprovalSearchTest(TestCase):
         ja.save()
 
         self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
-        with self.assertRaises(JobApplication.DoesNotExist):
-            response = self.client.get(self.url, {"number": self.approval.number})  # noqa
+        # Our approval should not be usable without a job application
+        response = self.client.get(self.url, {"number": self.approval.number})
+        self.assertNotContains(response, "Continuer")
 
     def test_has_matching_pass_iae_that_belongs_to_another_siae(self):
         """


### PR DESCRIPTION
## Quoi

Correctif des `JobApplication.DoesNotExist sur /approvals/pe-approval/search`
https://sentry.io/organizations/itou/issues/3003707981/events/?project=6164438

## Pourquoi

Lors de la recherche d’un pass, 

```
job_application = approval.user.last_accepted_job_application
```

plante quand on a un Pass IAE mais pas de candidature acceptée.


## Comment

TDD:

- à partir d’un cas trouvé dans les logs, j’ai pu reproduire localement, debugger et localiser le problème: `approval.user.job_applications.accepted() == JobApplicationQuerySet []`
- J’ai écris un test de caractérisation, 
- Fix du problème et évolution du test associé
