### PR TITLE
Evolutions du cron quotidien Metabase

### DIFF
--- a/.github/workflows/populate-metabase-itou.yml
+++ b/.github/workflows/populate-metabase-itou.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: 🏷 Setup worker to run django command
       run: |
-        echo 'CC_WORKER_COMMAND=./manage.py populate_metabase_itou --verbosity 2' >> $GITHUB_ENV
+        echo 'CC_WORKER_COMMAND=mkdir -p ./shared_bucket/populate_metabase_itou && ./manage.py populate_metabase_itou --verbosity 2 |& tee -a ./shared_bucket/populate_metabase_itou/output_$(date '+%Y-%m-%d_%H-%M-%S').log' >> $GITHUB_ENV
         # By default, workers always restart on failure. We want to avoid an infinite loop if it happens.
         echo 'CC_WORKER_RESTART=no' >> $GITHUB_ENV
 

--- a/.github/workflows/populate-metabase-itou.yml
+++ b/.github/workflows/populate-metabase-itou.yml
@@ -34,6 +34,15 @@ jobs:
   populate_metabase:
     runs-on: ubuntu-latest
 
+    # Default github action workflow timeout is 6 hours (360 minutes). If the script lasts longer than this for any reason,
+    # the github action will be killed but the clever instance will keep running forever as the last job supposed to
+    # delete it was never runned. This is why we set a very large timer here (24 hours == 1440 minutes) because
+    # clever instances are expensive but github actions are not. Cutting financial costs is the reponsibility of the
+    # last job, not of github.
+    # Unfortunately this does not work, the new timeout value is silently ignored and github keeps killing the job
+    # after the default 6 hours. This will need to be investigated further.
+    timeout-minutes: 1440
+
     steps:
     - name: 📥 Checkout to the latest version on $DEPLOY_BRANCH
       uses: actions/checkout@v2.3.4
@@ -87,8 +96,12 @@ jobs:
     - name: 🚀 Deploy app to Clever Cloud
       run: $CLEVER_CLI deploy --alias $CRON_TASK_APP_NAME --branch $DEPLOY_BRANCH --force
 
+    # This script was taking less than 3h (10800s) until https://github.com/betagouv/itou/pull/1154 introduced
+    # significant performance degradation due to several additional joins. The script now takes 5h instead of 3h
+    # even after some optimization. We set the timeout at 5h45 (20700s), just below 6h, because there is
+    # an unresolved issue with a different timeout system, see `timeout-minutes` above.
     - name: 🕒 Wait a reasonable amount of time for the script to complete
-      run: sleep 10800
+      run: sleep 20700
 
     - name: 🔪 Delete the app once the work is done
       run:

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -320,7 +320,9 @@ class Command(BaseCommand):
         Populate job applications table with various statistics.
         """
         queryset = (
-            JobApplication.objects.select_related("to_siae", "sender_siae", "sender_prescriber_organization")
+            JobApplication.objects.select_related(
+                "to_siae", "sender_siae", "sender_prescriber_organization", "approval", "approval__created_by"
+            )
             .prefetch_related("logs")
             .filter(created_from_pe_approval=False, to_siae__pk__in=self.active_siae_pks)
             .all()
@@ -376,7 +378,7 @@ class Command(BaseCommand):
         the SAFIR code.
         """
         queryset1 = Approval.objects.prefetch_related(
-            "user", "user__job_applications", "user__job_applications__to_siae"
+            "user", "user__job_applications", "user__job_applications__to_siae", "created_by"
         ).all()
         queryset2 = PoleEmploiApproval.objects.filter(
             start_at__gte=_approvals.POLE_EMPLOI_APPROVAL_MINIMUM_START_DATE
@@ -397,6 +399,8 @@ class Command(BaseCommand):
         queryset = (
             User.objects.filter(is_job_seeker=True)
             .prefetch_related(
+                "approvals",
+                "approvals__created_by",
                 "eligibility_diagnoses",
                 "eligibility_diagnoses__administrative_criteria",
                 "eligibility_diagnoses__author_prescriber_organization",

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -321,7 +321,7 @@ class Command(BaseCommand):
         """
         queryset = (
             JobApplication.objects.select_related(
-                "to_siae", "sender_siae", "sender_prescriber_organization", "approval", "approval__created_by"
+                "to_siae", "sender_siae", "sender_prescriber_organization", "approval"
             )
             .prefetch_related("logs")
             .filter(created_from_pe_approval=False, to_siae__pk__in=self.active_siae_pks)
@@ -378,7 +378,7 @@ class Command(BaseCommand):
         the SAFIR code.
         """
         queryset1 = Approval.objects.prefetch_related(
-            "user", "user__job_applications", "user__job_applications__to_siae", "created_by"
+            "user", "user__job_applications", "user__job_applications__to_siae"
         ).all()
         queryset2 = PoleEmploiApproval.objects.filter(
             start_at__gte=_approvals.POLE_EMPLOI_APPROVAL_MINIMUM_START_DATE
@@ -400,7 +400,6 @@ class Command(BaseCommand):
             User.objects.filter(is_job_seeker=True)
             .prefetch_related(
                 "approvals",
-                "approvals__created_by",
                 "eligibility_diagnoses",
                 "eligibility_diagnoses__administrative_criteria",
                 "eligibility_diagnoses__author_prescriber_organization",


### PR DESCRIPTION
### Quoi ?

- Envoi de l'ouput dans notre bucket. Kudos Vincent et Sébastien.
- Augmentation de la durée du script (3h => 7h => optimisations => 5h) constatée suite à https://github.com/betagouv/itou/pull/1154
- Meilleure gestion des timeouts mais le nouveau `timeout-minutes` reste encore à faire fonctionner.

