### PR TITLE
Mise à jour des liens vers communaute.inclusion.beta.gouv.fr

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1236,7 +1236,7 @@ class ApprovalsWrapper:
 
     # Error messages.
     WAITING_PERIOD_DOC_LINK = get_external_link_markup(
-        url=f"{settings.ITOU_DOC_URL}/qui-est-eligible-iae-criteres-eligibilite/derogation-au-delai-de-carence",
+        url=f"{settings.ITOU_COMMUNITY_URL }/doc/emplois/derogation-au-delai-de-carence/",
         text="En savoir plus sur la dérogation du délai de carence",
     )
     ERROR_CANNOT_OBTAIN_NEW_FOR_USER = mark_safe(

--- a/itou/templates/apply/includes/info_csv.html
+++ b/itou/templates/apply/includes/info_csv.html
@@ -2,7 +2,7 @@
     <div class="card-body">
         <p class="card-text">
             {% include "includes/icon.html" with icon="info" %}
-            <a href="{{ ITOU_DOC_URL }}/mon-mode-demploi-prescripteur/exporter-mes-candidatures-sur-excel">
+            <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/exporter-mes-candidatures-sur-excel-2/">
                 Consultez le mode d'emploi pour lire le fichier
             </a>
         </p>

--- a/itou/templates/apply/process_eligibility.html
+++ b/itou/templates/apply/process_eligibility.html
@@ -14,7 +14,7 @@
 
     <ol>
         <li>
-            Avoir réalisé un diagnostic socio-professionnel (dans le cadre d'un entretien, vous pouvez vous appuyer sur le <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#diagnostic_de_reference" target="_blank" rel="noreferrer noopener">document diagnostic socio-professionnel de référence</a>)
+            Avoir réalisé un diagnostic socio-professionnel (dans le cadre d'un entretien, vous pouvez vous appuyer sur le <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/diagnostic-socio-professionnel/" target="_blank" rel="noreferrer noopener">document diagnostic socio-professionnel de référence</a>)
         </li>
         <li>
             Sélectionner le ou les critères administratifs
@@ -29,7 +29,7 @@
         </ol>
 
         <p>
-            Si le candidat ne remplit pas les conditions administratives, <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite/derogation-criteres" target="_blank" rel="noreferrer noopener">orientez-le vers un prescripteur habilité</a>.
+            Si le candidat ne remplit pas les conditions administratives, <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/derogation-aux-criteres-administratifs/" target="_blank" rel="noreferrer noopener">orientez-le vers un prescripteur habilité</a>.
         </p>
 
         <div class="alert alert-warning">

--- a/itou/templates/apply/submit_step_eligibility.html
+++ b/itou/templates/apply/submit_step_eligibility.html
@@ -14,7 +14,7 @@
 
     <ol>
         <li>
-            Avoir réalisé un diagnostic socio-professionnel (dans le cadre d'un entretien, vous pouvez vous appuyer sur le <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#diagnostic_de_reference" target="_blank" rel="noreferrer noopener">document diagnostic socio-professionnel de référence</a>)
+            Avoir réalisé un diagnostic socio-professionnel (dans le cadre d'un entretien, vous pouvez vous appuyer sur le <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/diagnostic-socio-professionnel/" target="_blank" rel="noreferrer noopener">document diagnostic socio-professionnel de référence</a>)
         </li>
         <li>
             Préciser la situation administrative du candidat (facultatif)

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -266,7 +266,7 @@
                                 <li class="card-text mb-3">
                                     <i class="ri-award-line ri-lg"></i>
                                     <span>
-                                        {{ current_prescriber_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique#diagnostic_de_reference" target="_blank" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
+                                        {{ current_prescriber_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/diagnostic-socio-professionnel/" target="_blank" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
                                     </span>
                                 </li>
                             {% endif %}
@@ -398,7 +398,7 @@
                         {% if current_siae.is_subject_to_eligibility_rules %}
                             <li class="card-text mb-3">
                                 <i class="ri-book-open-line ri-lg mr-1"></i>
-                                <a href="{{ ITOU_DOC_URL }}/qui-est-eligible-iae-criteres-eligibilite#criteres-administratifs-de-niveau-1" target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
+                                <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/les-criteres-deligibilite/" target="_blank" title="Liste des critères d'éligibilité (ouverture dans un nouvel onglet)">
                                     Liste des critères d'éligibilité
                                 </a>
                             </li>

--- a/itou/templates/home/home.html
+++ b/itou/templates/home/home.html
@@ -48,7 +48,7 @@
                             </h3>
                         </div>
                         <div class="card-footer">
-                            <a class="btn btn-primary stretched-link" href="{{ ITOU_DOC_URL }}/" target="_blank" title="En savoir plus (ouverture dans un nouvel onglet)">
+                            <a class="btn btn-primary stretched-link" href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/" target="_blank" title="En savoir plus (ouverture dans un nouvel onglet)">
                                 En savoir plus
                             </a>
                         </div>

--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -21,7 +21,7 @@
                         <a href="{% url 'releases:list' %}">Journal des modifications</a>
                     </li>
                     <li>
-                        <a href="{{ ITOU_DOC_URL }}/qui-peut-beneficier-des-contrats-dinsertion-par-lactivite-economique" rel="noopener" target="_blank" title="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">
+                        <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/1829-2/" rel="noopener" target="_blank" title="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">
                             Qui peut bénéficier des contrats d'IAE ?
                         </a>
                         <i class="ri-external-link-line ml-1 font-weight-bold"></i>
@@ -56,11 +56,11 @@
                 <div class="s-footer-help__col col-12 col-lg-auto">
                     <ul>
                         <li><span>Nous suivre</span></li>
-                        <li><a href="https://twitter.com/inclusion_gouv" rel="noopener" target="_blank"  title="Rejoignez-nous sur Twitter (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-twitter.svg' %}" height="25" alt="Rejoignez-nous sur Twitter"></a></li>
-                        <li><a href="https://www.linkedin.com/company/inclusion-gouv/" rel="noopener" target="_blank"  title="Rejoignez-nous sur Linkedin (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-linkedin.svg' %}" height="25" alt="Rejoignez-nous sur Linkedin"></a></li>
-                        <li><a href="https://www.facebook.com/inclusion.gouv/" rel="noopener" target="_blank"  title="Rejoignez-nous sur Facebook (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-facebook.svg' %}" height="25" alt="Rejoignez-nous sur Facebook"></a></li>
-                        <li><a href="https://www.instagram.com/inclusion_gouv/" rel="noopener" target="_blank"  title="Rejoignez-nous sur Instagram (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-instagram.svg' %}" height="25" alt="Rejoignez-nous sur Instagram"></a></li>
-                        <li><a href="https://www.youtube.com/channel/UC06_yIYfzAiDOMTemH9q3OQ" rel="noopener" target="_blank"  title="Rejoignez-nous sur Youtube (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-youtube.svg' %}" height="25" alt="Rejoignez-nous sur Youtube"></a></li>
+                        <li><a href="https://twitter.com/inclusion_gouv" rel="noopener" target="_blank" title="Rejoignez-nous sur Twitter (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-twitter.svg' %}" height="25" alt="Rejoignez-nous sur Twitter"></a></li>
+                        <li><a href="https://www.linkedin.com/company/inclusion-gouv/" rel="noopener" target="_blank" title="Rejoignez-nous sur Linkedin (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-linkedin.svg' %}" height="25" alt="Rejoignez-nous sur Linkedin"></a></li>
+                        <li><a href="https://www.facebook.com/inclusion.gouv/" rel="noopener" target="_blank" title="Rejoignez-nous sur Facebook (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-facebook.svg' %}" height="25" alt="Rejoignez-nous sur Facebook"></a></li>
+                        <li><a href="https://www.instagram.com/inclusion_gouv/" rel="noopener" target="_blank" title="Rejoignez-nous sur Instagram (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-instagram.svg' %}" height="25" alt="Rejoignez-nous sur Instagram"></a></li>
+                        <li><a href="https://www.youtube.com/channel/UC06_yIYfzAiDOMTemH9q3OQ" rel="noopener" target="_blank" title="Rejoignez-nous sur Youtube (ouverture dans un nouvel onglet)"><img src="{% static_theme_images 'picto-youtube.svg' %}" height="25" alt="Rejoignez-nous sur Youtube"></a></li>
                     </ul>
                 </div>
             </div>
@@ -78,12 +78,12 @@
                 <div class="s-footer-nav__col col-7 col-lg-4 d-flex align-items-center justify-content-end justify-content-lg-start">
                     <div class="d-inline-block text-center">
                         <span class="d-block">
-                            <a href="https://inclusion.beta.gouv.fr/" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet" >
+                            <a href="https://inclusion.beta.gouv.fr/" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet">
                                 <img src="{% static_theme_images 'logo-plateforme-inclusion.svg' %}" height="60" alt="Plateforme de l'inclusion">
                             </a>
                         </span>
                         <span class="d-block mt-2">
-                            <a href="https://beta.gouv.fr/" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet" >
+                            <a href="https://beta.gouv.fr/" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet">
                                 <img src="{% static_theme_images 'logo-accelere-betagouv.svg' %}" alt="Accéléré par Beta.gouv.fr">
                             </a>
                         </span>

--- a/itou/templates/layout/_header.html
+++ b/itou/templates/layout/_header.html
@@ -69,7 +69,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="{{ ITOU_DOC_URL }}/" rel="noopener" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)">
+                            <a href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/" rel="noopener" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)">
                                 <span>Documentation</span>
                                 <i class="ri-arrow-right-up-line ri-lg"></i>
                             </a>

--- a/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
+++ b/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
@@ -10,7 +10,7 @@ Si vous êtes bien un prescripteur habilité, nous avons besoin d'une preuve de 
 
 - si vous êtes une organisation habilitée par le préfet : merci de nous communiquer par retour de mail l'arrêté préfectoral portant mention de votre habilitation à valider l'éligibilité IAE des candidats. Pensez à nous communiquer l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
 
-- si votre organisation appartient à la liste des organisations habilitées au national ({{ itou_doc_url }}/pourquoi-une-plateforme-de-linclusion/qui-sont-les-differents-prescripteurs/prescripteur-habilite#liste-des-prescripteurs-habilites-en-national) : merci de nous communiquer par retour de mail le type de structure et l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
+- si votre organisation appartient à la liste des organisations habilitées au national ({{ itou_community_url }}/doc/emplois/liste-des-prescripteurs-habilites/) : merci de nous communiquer par retour de mail le type de structure et l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
 
 - si vous êtes une organisation conventionnée par un Conseil départemental pour le suivi des BRSA : vous devez demander au Conseil départemental de nous contacter via {{ itou_assistance_url }}, rubrique « Habilitation / Prescripteur » afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail). Communiquez à cette personne l'ID de votre structure en lui demandant de le mentionner dans l'e-mail attestant de votre habilitation pour que nous fassions le rapprochement
 

--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -16,7 +16,7 @@
             Les organisations habilitées permettent à leurs collaborateurs de valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique. Cette habilitation est officialisée par arrêté préfectoral.
         </p>
         <p class="mb-0">
-            <a href="{{ ITOU_DOC_URL }}/pourquoi-une-plateforme-de-linclusion/qui-sont-les-differents-prescripteurs" rel="noopener" target="_blank" title="En savoir plus sur les différents prescripteurs (ouverture dans un nouvel onglet)">En savoir plus sur les différents prescripteurs {% include "includes/icon.html" with icon="external-link" %}</a>
+            <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/prescripteur-habilite/" rel="noopener" target="_blank" title="En savoir plus sur les différents prescripteurs (ouverture dans un nouvel onglet)">En savoir plus sur les différents prescripteurs {% include "includes/icon.html" with icon="external-link" %}</a>
         </p>
     </div>
 

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -17,11 +17,7 @@
     {% endif %}
 
     <script src="{{ stats_base_url }}/app/iframeResizer.js"></script>
-    <iframe
-        src="{{ iframeurl }}"
-        width="100%"
-        onload="iFrameResize({}, this)"
-        frameborder="0">
+    <iframe src="{{ iframeurl }}" width="100%" onload="iFrameResize({}, this)" frameborder="0">
     </iframe>
 
     <div class="mt-5 mb-3 mb-lg-5">
@@ -36,7 +32,7 @@
         <h4 class="h5">Vous n’êtes pas sûr(e) de comprendre les termes/sigles utilisés ?</h4>
         <p>
             L'ensemble des termes/sigles utilisés ici est défini dans le
-            <a href="https://doc.inclusion.beta.gouv.fr/glossaire-inclusion" rel="noopener" target="_blank" title="Le glossaire de l’inclusion (ouverture dans un nouvel onglet)">
+            <a href="{{ ITOU_COMMUNITY_URL }}/doc/communaute/glossaire-de-linclusion/" rel="noopener" target="_blank" title="Le glossaire de l’inclusion (ouverture dans un nouvel onglet)">
                 glossaire de l’inclusion
             </a>.
         </p>

--- a/itou/templates/storage/s3_upload_form.html
+++ b/itou/templates/storage/s3_upload_form.html
@@ -13,16 +13,7 @@
 <p class="small mt-0">
     {% include "includes/icon.html" with icon="help-circle" size="16" class="mr-1" %}
     Ce fichier n'est pas un PDF ?
-    <a
-        href="https://doc.inclusion.beta.gouv.fr/mon-mode-demploi-prescripteur/postuler-pour-un-candidat#ajouter-un-cv-a-la-candidature"
-        target="_blank"
-        rel="noopener"
-        class="matomo-event"
-        matomo-category="ajout-fichier-candidature"
-        matomo-action="clic"
-        matomo-option="clic-sur-lien-aide-pdf"
-        title="Découvrez comment le convertir (ouverture dans un nouvel onglet)"
-    >
+    <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/postuler-pour-un-candidat-prescrire/#ajouter-un-cv-a-la-candidature" target="_blank" rel="noopener" class="matomo-event" matomo-category="ajout-fichier-candidature" matomo-action="clic" matomo-option="clic-sur-lien-aide-pdf" title="Découvrez comment le convertir (ouverture dans un nouvel onglet)">
         Découvrez comment le convertir.
     </a>
 </p>

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -40,6 +40,7 @@ def get_email_text_template(template, context):
             "itou_environment": settings.ITOU_ENVIRONMENT,
             "itou_fqdn": settings.ITOU_FQDN,
             "itou_protocol": settings.ITOU_PROTOCOL,
+            "itou_community_url": settings.ITOU_COMMUNITY_URL,
         }
     )
     return remove_extra_line_breaks(get_template(template).render(context).strip())

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -290,8 +290,8 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
             elif not job_application.hiring_without_approval:
                 external_link = get_external_link_markup(
                     url=(
-                        f"{settings.ITOU_DOC_URL}/pourquoi-une-plateforme-de-linclusion/"
-                        "pass-iae-agrement-plus-simple-cest-a-dire#verification-des-demandes-de-pass-iae"
+                        f"{settings.ITOU_COMMUNITY_URL }/doc/emplois/pass-iae-comment-ca-marche/"
+                        "#verification-des-demandes-de-pass-iae"
                     ),
                     text="consulter notre espace documentation",
                 )


### PR DESCRIPTION
### Quoi ?

Modifictations URL dans les templates, emails et views.

### Pourquoi ?

Les pages de documentation utilisateurs sont migrées de "https://doc.inclusion.beta.gouv.fr" vers "https://communaute.inclusion.beta.gouv.fr"

### Comment ?

une par une :firecracker: 