### PR TITLE
Refonte des paramètre de l’API Pole Emploi

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -379,6 +379,10 @@ API_ESD_BASE_URL = os.environ.get("API_ESD_BASE_URL", "https://api.emploi-store.
 # Pole emploi mise à jour API can be run in sandboxed mode (updates are not saved to the database,
 # but the API confirms everything was alright), or in production mode (updates ARE saved)
 # the values can be: sandbox|production
+#
+# In order to ensure we do no send dummy data to PE (from the review apps, demo, automated tests… anything)
+# We force the value to sandbox so that, in the worst case, if the API is enabled on a service that it should not,
+# it does not pollute PE’s services
 API_ESD_MISE_A_JOUR_PASS_MODE = os.environ.get("API_ESD_MISE_A_JOUR_PASS_MODE", "sandbox")
 API_ESD_SHOULD_PERFORM_MISE_A_JOUR_PASS = os.environ.get("API_ESD_SHOULD_PERFORM_MISE_A_JOUR_PASS", "False") == "True"
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -372,10 +372,14 @@ API_ENTREPRISE_TOKEN = os.environ.get("API_ENTREPRISE_TOKEN")
 # Production settings:
 ## API_ESD_AUTH_BASE_URL="https://entreprise.pole-emploi.fr"
 ## API_ESD_BASE_URL="https://api.emploi-store.fr/partenaire"
-API_ESD_KEY = os.environ.get("API_ESD_KEY", "")
-API_ESD_SECRET = os.environ.get("API_ESD_SECRET", "")
-API_ESD_AUTH_BASE_URL = os.environ.get("API_ESD_AUTH_BASE_URL", "https://entreprise.pole-emploi.fr")
-API_ESD_BASE_URL = os.environ.get("API_ESD_BASE_URL", "https://api.emploi-store.fr/partenaire")
+API_ESD = {
+    "AUTH_BASE_URL": os.environ.get("API_ESD_AUTH_BASE_URL"),
+    "KEY": os.environ.get("API_ESD_KEY", ""),
+    "SECRET": os.environ.get("API_ESD_SECRET", ""),
+    "BASE_URL": os.environ.get("API_ESD_BASE_URL"),
+    "MISE_A_JOUR_PASS_MODE": "production",
+}
+
 # Pole emploi mise à jour API can be run in sandboxed mode (updates are not saved to the database,
 # but the API confirms everything was alright), or in production mode (updates ARE saved)
 # the values can be: sandbox|production
@@ -383,8 +387,7 @@ API_ESD_BASE_URL = os.environ.get("API_ESD_BASE_URL", "https://api.emploi-store.
 # In order to ensure we do no send dummy data to PE (from the review apps, demo, automated tests… anything)
 # We force the value to sandbox so that, in the worst case, if the API is enabled on a service that it should not,
 # it does not pollute PE’s services
-API_ESD_MISE_A_JOUR_PASS_MODE = os.environ.get("API_ESD_MISE_A_JOUR_PASS_MODE", "sandbox")
-API_ESD_SHOULD_PERFORM_MISE_A_JOUR_PASS = os.environ.get("API_ESD_SHOULD_PERFORM_MISE_A_JOUR_PASS", "False") == "True"
+# API_ESD_MISE_A_JOUR_PASS_MODE = os.environ.get("API_ESD_MISE_A_JOUR_PASS_MODE", "sandbox")
 
 
 # PE Connect aka PEAMU - technically one of ESD's APIs.
@@ -397,7 +400,7 @@ API_ESD_SHOULD_PERFORM_MISE_A_JOUR_PASS = os.environ.get("API_ESD_SHOULD_PERFORM
 PEAMU_AUTH_BASE_URL = "https://authentification-candidat.pole-emploi.fr"
 SOCIALACCOUNT_PROVIDERS = {
     "peamu": {
-        "APP": {"key": "peamu", "client_id": API_ESD_KEY, "secret": API_ESD_SECRET},
+        "APP": {"key": "peamu", "client_id": API_ESD["KEY"], "secret": API_ESD["SECRET"]},
     },
 }
 SOCIALACCOUNT_EMAIL_VERIFICATION = "none"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -377,17 +377,7 @@ API_ESD = {
     "KEY": os.environ.get("API_ESD_KEY", ""),
     "SECRET": os.environ.get("API_ESD_SECRET", ""),
     "BASE_URL": os.environ.get("API_ESD_BASE_URL"),
-    "MISE_A_JOUR_PASS_MODE": "production",
 }
-
-# Pole emploi mise à jour API can be run in sandboxed mode (updates are not saved to the database,
-# but the API confirms everything was alright), or in production mode (updates ARE saved)
-# the values can be: sandbox|production
-#
-# In order to ensure we do no send dummy data to PE (from the review apps, demo, automated tests… anything)
-# We force the value to sandbox so that, in the worst case, if the API is enabled on a service that it should not,
-# it does not pollute PE’s services
-# API_ESD_MISE_A_JOUR_PASS_MODE = os.environ.get("API_ESD_MISE_A_JOUR_PASS_MODE", "sandbox")
 
 
 # PE Connect aka PEAMU - technically one of ESD's APIs.

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -38,9 +38,6 @@ FRANCE_CONNECT_CLIENT_SECRET = "FC_CLIENT_SECRET_123"
 # Approvals
 AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL = "colette@ratatouille.com"
 
-# We enable the notifications in the test environment so that can ensure the correct API calls are performed,
-# but those calls are mocked so that no real data is sent to Pole Emploi
-API_ESD["MISE_A_JOUR_PASS_MODE"] = "production"  # noqa F405
 # We override those urls in test in order to ensure that, should everything go wrong, we do not send stuff to
 # PE’s production databases
 # API_ESD["AUTH_BASE_URL"] = "https://some-authentication-domain.fr"  # noqa F405

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -11,10 +11,8 @@ STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 # Prevent calls to external APIs but keep a valid scheme
 API_BAN_BASE_URL = None
 API_ENTREPRISE_BASE_URL = "http://example.com"
-API_ESD_KEY = None
-API_ESD_SECRET = None
-API_ENTREPRISE_RECIPIENT = 12345
 API_ENTREPRISE_TOKEN = 12345
+API_ENTREPRISE_RECIPIENT = 12345
 
 # Disable logging and traceback in unit tests for readability.
 # https://docs.python.org/3/library/logging.html#logging.disable
@@ -42,8 +40,11 @@ AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL = "colette@ratatouille.com"
 
 # We enable the notifications in the test environment so that can ensure the correct API calls are performed,
 # but those calls are mocked so that no real data is sent to Pole Emploi
-API_ESD_SHOULD_PERFORM_MISE_A_JOUR_PASS = True
-
+API_ESD["MISE_A_JOUR_PASS_MODE"] = "production"  # noqa F405
+# We override those urls in test in order to ensure that, should everything go wrong, we do not send stuff to
+# PE’s production databases
+# API_ESD["AUTH_BASE_URL"] = "https://some-authentication-domain.fr"  # noqa F405
+# API_ESD["BASE_URL"] = "https://some-base-domain.fr/partenaire"  # noqa F405
 
 # Leave any uploaded files appear legit as soon as they are hosted on "server.com"
 # The developer then does not need to worry about any resume link using this domain,

--- a/envs/dev.env.template
+++ b/envs/dev.env.template
@@ -29,6 +29,3 @@ DJANGO_SETTINGS_MODULE=config.settings.dev
 DJANGO_DEBUG=True
 ITOU_LOG_LEVEL=DEBUG
 DJANGO_SECRET_KEY=******************dev_secret_key******************
-
-API_ESD_MISE_A_JOUR_PASS_MODE="sandbox"
-API_ESD_SHOUlD_PERFORM_MISE_A_JOUR_PASS=False

--- a/itou/allauth_adapters/peamu/adapter.py
+++ b/itou/allauth_adapters/peamu/adapter.py
@@ -18,7 +18,7 @@ class PEAMUOAuth2Adapter(OAuth2Adapter):
 
     authorize_url = f"{settings.PEAMU_AUTH_BASE_URL}/connexion/oauth2/authorize"
     access_token_url = f"{settings.PEAMU_AUTH_BASE_URL}/connexion/oauth2/access_token"
-    profile_url = f"{settings.API_ESD_BASE_URL}/peconnect-individu/v1/userinfo"
+    profile_url = f"{settings.API_ESD['BASE_URL']}/peconnect-individu/v1/userinfo"
     headers = {"Accept": "application/json", "Content-Type": "application/x-www-form-urlencoded"}
 
     def complete_login(self, request, app, token, **kwargs):

--- a/itou/allauth_adapters/peamu/tests.py
+++ b/itou/allauth_adapters/peamu/tests.py
@@ -8,11 +8,15 @@ from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
 from django.core import mail
+from django.test import override_settings
 
 from itou.allauth_adapters.peamu.provider import PEAMUProvider
 from itou.users.models import User
 
 
+@override_settings(
+    API_ESD={"BASE_URL": "https://some.auth.domain", "AUTH_BASE_URL": "https://some-authentication-domain.fr"}
+)  # noqa
 class PEAMUTests(OAuth2TestsMixin, TestCase):
     provider_id = PEAMUProvider.id
 

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -10,9 +10,6 @@ from itou.external_data.models import ExternalDataImport, JobSeekerExternalData
 
 
 # PE Connect API data retrieval tools
-
-API_ESD_BASE_URL = settings.API_ESD_BASE_URL
-
 ESD_USERINFO_API = "peconnect-individu/v1/userinfo"
 ESD_COORDS_API = "peconnect-coordonnees/v1/coordonnees"
 ESD_STATUS_API = "peconnect-statut/v1/statut"
@@ -36,7 +33,7 @@ def _call_api(api_path, token):
     Make a sync call to an API
     For further processing, returning something else than `None` is considered a success
     """
-    url = f"{API_ESD_BASE_URL}/{api_path}"
+    url = f"{settings.API_ESD['BASE_URL']}/{api_path}"
     response = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=settings.REQUESTS_TIMEOUT)
     if response.status_code == 200:
         result = response.json()

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -19,7 +19,6 @@ from itou.eligibility.models import EligibilityDiagnosis, SelectedAdministrative
 from itou.job_applications.tasks import huey_notify_pole_employ
 from itou.utils.apis.esd import get_access_token
 from itou.utils.apis.pole_emploi import (
-    POLE_EMPLOI_PASS_APPROVED,
     PoleEmploiIndividu,
     PoleEmploiMiseAJourPassIAEException,
     recherche_individu_certifie_api,
@@ -949,8 +948,8 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         email.send()
 
     def notify_pole_emploi_accepted(self) -> bool:
-        if settings.API_ESD_SHOULD_PERFORM_MISE_A_JOUR_PASS:
-            return huey_notify_pole_employ(self, POLE_EMPLOI_PASS_APPROVED)
+        if settings.API_ESD["MISE_A_JOUR_PASS_MODE"] == "production":
+            return huey_notify_pole_employ(self)
         return False
 
 

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -948,7 +948,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         email.send()
 
     def notify_pole_emploi_accepted(self) -> bool:
-        if settings.API_ESD["MISE_A_JOUR_PASS_MODE"] == "production":
+        if settings.API_ESD["BASE_URL"]:
             return huey_notify_pole_employ(self)
         return False
 

--- a/itou/jobs/management/commands/generate_appellations_for_romes.py
+++ b/itou/jobs/management/commands/generate_appellations_for_romes.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
                 self.stdout.write(f"Processing {rome_code}")
 
                 token = get_access_token("api_romev1 nomenclatureRome")
-                url = f"{settings.API_ESD_BASE_URL}/rome/v1/metier/{rome_code}/appellation"
+                url = f"{settings.API_ESD['BASE_URL']}/rome/v1/metier/{rome_code}/appellation"
                 r = httpx.get(url, headers={"Authorization": token})
                 r.raise_for_status()
 

--- a/itou/jobs/management/commands/generate_romes.py
+++ b/itou/jobs/management/commands/generate_romes.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
     def handle(self, **options):
 
         token = get_access_token("api_romev1 nomenclatureRome")
-        url = f"{settings.API_ESD_BASE_URL}/rome/v1/metier"
+        url = f"{settings.API_ESD['BASE_URL']}/rome/v1/metier"
         r = httpx.get(url, headers={"Authorization": token})
         r.raise_for_status()
 

--- a/itou/utils/apis/esd.py
+++ b/itou/utils/apis/esd.py
@@ -27,13 +27,13 @@ def get_access_token(scope):
             return token.value
 
     auth_request = httpx.post(
-        f"{settings.API_ESD_AUTH_BASE_URL}/connexion/oauth2/access_token",
+        f"{settings.API_ESD['AUTH_BASE_URL']}/connexion/oauth2/access_token",
         params={"realm": "/partenaire"},
         data={
             "grant_type": "client_credentials",
-            "client_id": settings.API_ESD_KEY,
-            "client_secret": settings.API_ESD_SECRET,
-            "scope": f"application_{settings.API_ESD_KEY} {scope}",
+            "client_id": settings.API_ESD["KEY"],
+            "client_secret": settings.API_ESD["SECRET"],
+            "scope": f"application_{settings.API_ESD['KEY']} {scope}",
         },
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )


### PR DESCRIPTION
### Quoi ?

Refonte technique des paramètres `API_ESD_*` (lié aux appels aux APIs pole-emploi.io)  pour être plus robuste.

### Pourquoi ?

Pour mieux gérer les cas d’erreurs et planter au démarrage de l’appli en cas de problème. 

Contexte: les valeurs par défaut (sandbox) sont problèmatique dans l’environnement de production.
Quelle que soit la valeur par défaut, elle sera problématique:
 - J’avais prévu le cas où une machine imprévue envoie des données chez PE, d’où le mode sandbox
 - je n’avais PAS prévu qu’une machine ayant la possibilité d’envoyer les bonnes données à PE soit mal configurées… ce qui est arrivé

### Comment ?

Refonte dans un style plus idiomatique django

