### PR TITLE
Rendre les menus déroulants défilants quand ils contiennent trop d'éléments

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -111,7 +111,21 @@ duet-date-picker.is-invalid~.invalid-feedback {
 }
 
 
-/* Missing Boostrap utilities
+/* Dropdown menus.
+--------------------------------------------------------------------------- */
+
+/*
+Make dropdown menus scrollable in case there are too many items.
+Credits go to https://stackoverflow.com/a/19229738
+*/
+
+.dropdown-menu {
+    max-height: 360px;
+    overflow-y: auto;
+}
+
+
+/* Missing Boostrap utilities.
 --------------------------------------------------------------------------- */
 
 @media (min-width: 768px) {
@@ -153,7 +167,7 @@ duet-date-picker.is-invalid~.invalid-feedback {
 }
 
 
-/* Browser-specific issues
+/* Browser-specific issues.
 --------------------------------------------------------------------------- */
 
 
@@ -188,7 +202,7 @@ _:-ms-fullscreen,
 }
 
 
-/* JavaScript disabled
+/* JavaScript disabled.
 ---------------------------------------------------------------------------- */
 
 
@@ -280,7 +294,7 @@ Usage:
 }
 
 
-/* Dropzone component used to upload files to an S3 bucket
+/* Dropzone component used to upload files to an S3 bucket.
 --------------------------------------------------------------------------- */
 
 
@@ -305,7 +319,7 @@ Usage:
     top: auto !important;
 }
 
-/* To be integrated to the global theme
+/* To be integrated to the global theme.
 --------------------------------------------------------------------------- */
 
 .list-group-item {
@@ -324,8 +338,10 @@ Usage:
 .title-with-badge .badge{
     font-size: 1rem;
 }
-/* To be discussed
+
+/* To be discussed.
 --------------------------------------------------------------------------- */
+
 .collapse-caret, .collapse-caret:hover{
     text-decoration: unset;
 }

--- a/itou/templates/layout/_nav_btn_items.html
+++ b/itou/templates/layout/_nav_btn_items.html
@@ -89,7 +89,9 @@
                                     class="dropdown-item text-primary {% if s.pk == current_siae.pk %} font-weight-bold disabled{% endif %}"
                                     type="submit"
                                     name="siae_id"
-                                    value="{{ s.pk }}"><span class="badge badge-primary">{{ s.kind }}</span> {{ s.display_name }}
+                                    value="{{ s.pk }}">
+                                    <span class="badge badge-primary">{{ s.kind }}</span>
+                                    {{ s.display_name }}
                                 </button>
                             </li>
                         {% endfor %}
@@ -114,7 +116,9 @@
                                     class="dropdown-item text-primary {% if po.pk == current_prescriber_organization.pk %} font-weight-bold disabled{% endif %}"
                                     type="submit"
                                     name="prescriber_organization_id"
-                                    value="{{ po.pk }}">{{ po.display_name }} <span class="badge badge-primary">{{ s.kind }}</span>
+                                    value="{{ po.pk }}">
+                                    <span class="badge badge-primary">{{ po.kind }}</span>
+                                    {{ po.display_name }}
                                 </button>
                             </li>
                         {% endfor %}
@@ -139,7 +143,9 @@
                                     class="dropdown-item text-primary {% if i.pk == current_institution.pk %} font-weight-bold disabled{% endif %}"
                                     type="submit"
                                     name="institution_id"
-                                    value="{{ i.pk }}">{{ i.display_name }} <span class="badge badge-primary">{{ i.kind }}</span>
+                                    value="{{ i.pk }}">
+                                    <span class="badge badge-primary">{{ i.kind }}</span>
+                                    {{ i.display_name }}
                                 </button>
                             </li>
                         {% endfor %}

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -38,6 +38,7 @@ def get_current_organization_and_perms(request):
                 .all()
             )
             user_siaes = [membership.siae for membership in memberships]
+
             for membership in memberships:
                 if membership.siae_id == siae_pk:
                     siae = membership.siae
@@ -87,6 +88,11 @@ def get_current_organization_and_perms(request):
                 if membership.institution.pk == institution_pk:
                     current_institution = membership.institution
                     user_is_institution_admin = membership.is_admin
+
+    # Sort items nicely for dropdown menu.
+    user_siaes.sort(key=lambda o: (o.kind, o.display_name))
+    user_prescriberorganizations.sort(key=lambda o: (o.kind, o.display_name))
+    user_institutions.sort(key=lambda o: (o.kind, o.display_name))
 
     context = {
         "current_prescriber_organization": prescriber_organization,

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -135,12 +135,12 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
             self.assertDictEqual(expected, result)
 
     def test_siae_multiple_memberships(self):
-
-        siae1 = SiaeWithMembershipFactory()
+        # Specify name to ensure alphabetical sorting order.
+        siae1 = SiaeWithMembershipFactory(name="1")
         user = siae1.members.first()
         self.assertTrue(siae1.has_admin(user))
 
-        siae2 = SiaeFactory()
+        siae2 = SiaeFactory(name="2")
         siae2.members.add(user)
         self.assertFalse(siae2.has_admin(user))
 
@@ -193,12 +193,12 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
             self.assertDictEqual(expected, result)
 
     def test_prescriber_organization_multiple_membership(self):
-
-        organization1 = PrescriberOrganizationWithMembershipFactory()
+        # Specify name to ensure alphabetical sorting order.
+        organization1 = PrescriberOrganizationWithMembershipFactory(name="1")
         user = organization1.members.first()
         self.assertTrue(user.prescribermembership_set.get(organization=organization1).is_admin)
 
-        organization2 = PrescriberOrganizationWithMembershipFactory()
+        organization2 = PrescriberOrganizationWithMembershipFactory(name="2")
         organization2.members.add(user)
 
         request = self.go_to_dashboard(
@@ -251,10 +251,11 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
             self.assertDictEqual(expected, result)
 
     def test_labor_inspector_multiple_institutions(self):
-        institution1 = InstitutionWithMembershipFactory()
+        # Specify name to ensure alphabetical sorting order.
+        institution1 = InstitutionWithMembershipFactory(name="1")
         user = institution1.members.first()
         self.assertTrue(user.institutionmembership_set.get(institution=institution1).is_admin)
-        institution2 = InstitutionFactory()
+        institution2 = InstitutionFactory(name="2")
         institution2.members.add(user)
         self.assertFalse(institution2.has_admin(user))
 


### PR DESCRIPTION
### Quoi ?

Rendre les menus déroulants défilants quand ils contiennent trop d'éléments.

PLUS autres améliorations sur suggestion de @vperron voir screenshots plus bas.

### Pourquoi ?

Quand un utilisateur est attaché à de nombreuses structures, le menu "Changer de structure" est si long qu'il en devient ingérable, il est même parfois techniquement impossible d'atteindre les derniers éléments (cas vécu avec le compte institution de Soumia).

### Comment ?

Au dela d'une certaine longueur, le menu devient automatiquement défilant.

### Captures d'écran

On a que deux menus déroulants sur le C1 à ce jour :

![image](https://user-images.githubusercontent.com/10533583/158782275-0643d881-5f19-4242-9f21-52b45b2b647c.png)

Le menu "Mon espace" n'est pas affecté par ce fix :

![image](https://user-images.githubusercontent.com/10533583/158782449-6e83c0da-6591-4eab-9446-117a8084e3b6.png)

Le menu "Changer de structure" avant ce fix (attention les yeux ça pique) :

![image](https://user-images.githubusercontent.com/10533583/158782632-4baaf71f-250a-46b2-ac92-1b0a5fcb883e.png)

Le menu "Changer de structure" après ce fix :

![image](https://user-images.githubusercontent.com/10533583/158782568-01c0b0ed-3027-47f7-b994-bb262f5d6cfa.png)

### Autres améliorations sur suggestion de @vperron 

On montre toujours le kind en premier et on trie par (kind, display_name).

#### Employeur

![image](https://user-images.githubusercontent.com/10533583/158789274-6021f267-81bb-4950-a99b-aaa52cb7c073.png)

#### Prescripteur

![image](https://user-images.githubusercontent.com/10533583/158789967-4a363e15-b5cf-401c-bdc0-06f9336818ce.png)

#### Institution

![image](https://user-images.githubusercontent.com/10533583/158788919-113d2fd9-58ae-4f4c-829e-a0fe3b16a0b5.png)
