### PR TITLE
Bascule pour utiliser les agréments PoleEmploi fusionnés

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1116,6 +1116,7 @@ class PoleEmploiApproval(CommonApprovalMixin):
     objects = PoleEmploiApprovalManager.from_queryset(CommonApprovalQuerySet)()
 
     class Meta:
+        db_table = "merged_approvals_poleemploiapproval"
         verbose_name = "Agrément Pôle emploi"
         verbose_name_plural = "Agréments Pôle emploi"
         ordering = ["-start_at"]


### PR DESCRIPTION
### Quoi ?

Modifications minimalistes pour exploiter la table des agréments fusionnés

### Pourquoi ?

On a simplifié les données des agréments PE et on souhaite maintenant exploiter cette nouvelle table.

### Comment ?

Ici, on dit juste que `PoleEmploiApproval` doit utiliser la table fusionnée.

Pour aller plus loin dans le nettoyage (ce que je ne fais pas pour le moment, au cas où), on pourra ensuite:
 - supprimer le modèle `MergedPoleEmploiApproval`
 - supprimer les commandes `merge_pe_approvals`, `update_nir_from_pe_data` et `update_pe_approvals_from_asp_data`. Ces 3 commandes ont servi à l’import des données.
 - éventuellement supprimer l’ancienne table des agréments (`approvals_poleemploiapproval`) et renommer la nouvelle table `merged_approvals_poleemploiapproval` en `approvals_poleemploiapproval`.