### PR TITLE
Ajout d'un nouveau tableau de bord "Facilitation de l'embauche" pour les DDETS

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -554,6 +554,7 @@ METABASE_DASHBOARD_IDS = {
     "stats_cd": 118,
     "stats_ddets_iae": 117,
     "stats_ddets_diagnosis_control": 144,
+    "stats_ddets_hiring": 160,
     "stats_dgefp_iae": 117,
     "stats_dgefp_diagnosis_control": 144,
     "stats_dgefp_af": 142,

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -443,12 +443,6 @@
                 <p class="h4 card-header">Statistiques et pilotage</p>
                 <div class="card-body">
                     <ul class="list-unstyled">
-                        <li class="card-text mb-3">
-                            <i class="ri-pulse-line ri-lg mr-1"></i>
-                            <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Accéder au Pilotage de l'inclusion (ouverture dans un nouvel onglet)">
-                                Accéder au Pilotage de l'inclusion
-                            </a>
-                        </li>
                         {% if can_view_stats_siae %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
@@ -499,6 +493,12 @@
                                 <span class="badge badge-info">Nouveau</span>
                             </li>
                         {% endif %}
+                        <li class="card-text mb-3">
+                            <i class="ri-pulse-line ri-lg mr-1"></i>
+                            <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Accéder au Pilotage de l'inclusion (ouverture dans un nouvel onglet)">
+                                Accéder au Pilotage de l'inclusion
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -470,6 +470,10 @@
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_ddets_diagnosis_control' %}">Voir mes données 2021 du contrôle a posteriori (version bêta)</a>
+                            </li>
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_ddets_hiring' %}">Données facilitation de l'embauche</a>
                                 <span class="badge badge-info">Nouveau</span>
                             </li>
                         {% endif %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -453,7 +453,7 @@
                         {% if can_view_stats_cd %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_cd' %}">Voir mes données IAE</a>
+                                <a href="{% url 'stats:stats_cd' %}">Voir les données IAE de mon département</a>
                             </li>
                         {% endif %}
                         {% if can_view_stats_ddets %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -459,13 +459,13 @@
                         {% if can_view_stats_cd %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_cd' %}">Données IAE</a>
+                                <a href="{% url 'stats:stats_cd' %}">Voir mes données IAE</a>
                             </li>
                         {% endif %}
                         {% if can_view_stats_ddets %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_ddets_iae' %}">Données IAE</a>
+                                <a href="{% url 'stats:stats_ddets_iae' %}">Voir les données IAE de mon département</a>
                             </li>
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
@@ -473,20 +473,20 @@
                             </li>
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_ddets_hiring' %}">Données facilitation de l'embauche</a>
+                                <a href="{% url 'stats:stats_ddets_hiring' %}">Voir les données facilitation de l'embauche</a>
                                 <span class="badge badge-info">Nouveau</span>
                             </li>
                         {% endif %}
                         {% if can_view_stats_dreets %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_dreets_iae' %}">Données IAE</a>
+                                <a href="{% url 'stats:stats_dreets_iae' %}">Voir les données IAE de ma région</a>
                             </li>
                         {% endif %}
                         {% if can_view_stats_dgefp %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_dgefp_iae' %}">Données IAE</a>
+                                <a href="{% url 'stats:stats_dgefp_iae' %}">Voir les données IAE France entière</a>
                             </li>
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
@@ -495,7 +495,7 @@
                             </li>
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_dgefp_af' %}">Annexes financières actives</a>
+                                <a href="{% url 'stats:stats_dgefp_af' %}">Voir les données des annexes financières actives</a>
                                 <span class="badge badge-info">Nouveau</span>
                             </li>
                         {% endif %}

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path("cd/", views.stats_cd, name="stats_cd"),
     path("ddets/iae/", views.stats_ddets_iae, name="stats_ddets_iae"),
     path("ddets/diagnosis_control/", views.stats_ddets_diagnosis_control, name="stats_ddets_diagnosis_control"),
+    path("ddets/hiring/", views.stats_ddets_hiring, name="stats_ddets_hiring"),
     path("dreets/iae/", views.stats_dreets_iae, name="stats_dreets_iae"),
     path("dgefp/iae/", views.stats_dgefp_iae, name="stats_dgefp_iae"),
     path("dgefp/diagnosis_control/", views.stats_dgefp_diagnosis_control, name="stats_dgefp_diagnosis_control"),

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -125,6 +125,7 @@ def stats_ddets_iae(request, template_name=_STATS_HTML_TEMPLATE):
     return render(request, template_name, context)
 
 
+@login_required
 def stats_ddets_diagnosis_control(request, template_name=_STATS_HTML_TEMPLATE):
     """
     DDETS ("Directions départementales de l’emploi, du travail et des solidarités") stats shown to relevant members.
@@ -193,6 +194,7 @@ def stats_dgefp_iae(request, template_name=_STATS_HTML_TEMPLATE):
     return render(request, template_name, context)
 
 
+@login_required
 def stats_dgefp_diagnosis_control(request, template_name=_STATS_HTML_TEMPLATE):
     """
     DGEFP ("délégation générale à l'Emploi et à la Formation professionnelle") stats shown to relevant members.

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -149,6 +149,28 @@ def stats_ddets_diagnosis_control(request, template_name=_STATS_HTML_TEMPLATE):
 
 
 @login_required
+def stats_ddets_hiring(request, template_name=_STATS_HTML_TEMPLATE):
+    """
+    DDETS ("Directions départementales de l’emploi, du travail et des solidarités") stats shown to relevant members.
+    They can only view data for their own departement.
+    This dashboard shows data about hiring ("Facilitation de l'embauche").
+    """
+    current_institution = get_current_institution_or_404(request)
+    if not request.user.can_view_stats_ddets(current_org=current_institution):
+        raise PermissionDenied
+    department = request.user.get_stats_ddets_department(current_org=current_institution)
+    params = {
+        DEPARTMENT_FILTER_KEY: DEPARTMENTS[department],
+    }
+    context = {
+        "iframeurl": metabase_embedded_url(request=request, params=params),
+        "page_title": f"Données facilitation de l'embauche de mon département : {DEPARTMENTS[department]}",
+        "stats_base_url": settings.METABASE_SITE_URL,
+    }
+    return render(request, template_name, context)
+
+
+@login_required
 def stats_dreets_iae(request, template_name=_STATS_HTML_TEMPLATE):
     """
     DREETS ("Directions régionales de l’économie, de l’emploi, du travail et des solidarités") stats shown to


### PR DESCRIPTION
### Quoi ?

Ajout d'un nouveau tableau de bord "Facilitation de l'embauche" pour les DDETS.

### Pourquoi ?

A la demande de Yannick pour le C2.

### Comment ?

Très similairement aux autres TDB DDETS existants. A nouveau une DDETS ne voit que les données de son département.

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/10533583/159259113-da2107a1-7759-4a68-a1c6-234d0ce2c9f4.png)


![image](https://user-images.githubusercontent.com/10533583/159242266-664dbd3c-5172-47d9-81d1-021b13e92e0b.png)
