### PR TITLE
Ajout d'une route temporaire pour tester les custom URLs Matomo

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -180,6 +180,9 @@
                     _paq.push(['setCustomVariable', {{ forloop.counter }}, '{{ key }}', '{{ value }}', 'page']);
                 {% endfor %}
                 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+                {% if matomo_custom_url %}
+                    _paq.push(['setCustomUrl', '{{ matomo_custom_url }}']);
+                {% endif %}
                 _paq.push(['trackPageView']);
                 _paq.push(['enableLinkTracking']);
                 (function() {

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -15,5 +15,6 @@ urlpatterns = [
     path("dgefp/diagnosis_control/", views.stats_dgefp_diagnosis_control, name="stats_dgefp_diagnosis_control"),
     path("dgefp/af/", views.stats_dgefp_af, name="stats_dgefp_af"),
     path("pilotage/<int:dashboard_id>/", views.stats_pilotage, name="stats_pilotage"),
+    path("poc_matomo_custom_url/", views.poc_matomo_custom_url, name="test_matomo_custom_url"),
     path("siae/", views.stats_siae, name="stats_siae"),
 ]

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -230,3 +230,11 @@ def stats_dgefp_af(request, template_name=_STATS_HTML_TEMPLATE):
         "stats_base_url": settings.METABASE_SITE_URL,
     }
     return render(request, template_name, context)
+
+
+def poc_matomo_custom_url(request, template_name=_STATS_HTML_TEMPLATE):
+    """
+    Simple public route to test Matomo custom URL feature.
+    """
+    context = {"matomo_custom_url": "/matomo-custom-urls-actually-do-work.html"}
+    return render(request, template_name, context)


### PR DESCRIPTION
### Quoi ?

Ajout d'une route temporaire pour tester les custom URLs Matomo.

### Pourquoi ?

Les custom URLs Matomo sont potentiellement une killer feature pour le C2.

Par exemple toutes les DDETS voient leurs stats sur la même URL `/stats/ddets/` mais dans Matomo on voudrait pouvoir grouper par région et/ou département. Du coup une custom URL `/stats/ddets/<REGION>/<DPT>/` serait parfaite pour cela, sans modifier quoi que ce soit à l'URL réelle.

### Comment ?

Ici on ajoute une route dédiée à un tout premier test vu que malheureusement on ne sait pas trop tester Matomo depuis local dev. Si ça fonctionne, on 🔪  cette route bien sûr et on passera aux vraies routes.

