### PR TITLE
Accélération des pages d'administration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -62,6 +62,7 @@ THIRD_PARTY_APPS = [
     "drf_spectacular",
     "django_filters",
     "import_export",
+    "silk",
 ]
 
 
@@ -122,7 +123,13 @@ ITOU_MIDDLEWARE = [
     "itou.utils.perms.middleware.ItouCurrentOrganizationMiddleware",
 ]
 
-MIDDLEWARE = DJANGO_MIDDLEWARE + ITOU_MIDDLEWARE
+MIDDLEWARE = (
+    DJANGO_MIDDLEWARE
+    + ITOU_MIDDLEWARE
+    + [
+        "silk.middleware.SilkyMiddleware",
+    ]
+)
 
 # URLs.
 # ------------------------------------------------------------------------------
@@ -718,3 +725,5 @@ EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 9, 27, tzinf
 # This is disabled by default, overidden in prod settings, and can be set
 # via local dev settings or env vars for a temporary environment.
 EMPLOYEE_RECORD_TRANSFER_ENABLED = bool(os.environ.get("EMPLOYEE_RECORD_TRANSFER_ENABLED", False))
+
+SILKY_PYTHON_PROFILER = True

--- a/config/urls.py
+++ b/config/urls.py
@@ -12,6 +12,7 @@ from itou.www.signup import views as signup_views
 register_converter(SiretConverter, "siret")
 
 urlpatterns = [
+    path("silk/", include("silk.urls", namespace="silk")),
     path("admin/", admin.site.urls),
     # --------------------------------------------------------------------------------------
     # allauth URLs. Order is important because some URLs are overriden.

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -127,6 +127,7 @@ class StartDateFilter(admin.SimpleListFilter):
 class ApprovalAdmin(admin.ModelAdmin):
     form = ApprovalAdminForm
     list_display = ("pk", "number", "user", "birthdate", "start_at", "end_at", "is_valid", "created_at")
+    list_select_related = ("user",)
     search_fields = ("pk", "number", "user__first_name", "user__last_name", "user__email")
     list_filter = (
         IsValidFilter,

--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -74,6 +74,12 @@ class JobApplicationAdmin(admin.ModelAdmin):
     inlines = (JobsInline, TransitionLogInline, UUIDSupportRemarkInline)
     search_fields = ("pk", "to_siae__siret", "job_seeker__email", "sender__email")
 
+    list_select_related = (
+        "to_siae",
+        "job_seeker",
+        "sender",
+    )
+
     def get_form(self, request, obj=None, **kwargs):
         """
         Override a field's `help_text` to display a link to the PASS IAE delivery interface.

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -19,12 +19,13 @@ from itou.utils.admin import PkSupportRemarkInline
 class SiaeMembersInline(MembersInline):
     model = models.Siae.members.through
     readonly_fields = ("is_active", "created_at", "updated_at", "updated_by", "joined_at", "notifications")
+    raw_id_fields = ("user",)
 
 
 class JobsInline(admin.TabularInline):
     model = models.Siae.jobs.through
     extra = 1
-    raw_id_fields = ("appellation",)
+    raw_id_fields = ("appellation", "siae", "location")
     readonly_fields = ("created_at", "updated_at")
 
 
@@ -218,7 +219,7 @@ class SiaeJobDescription(admin.ModelAdmin):
         "is_active",
         "nb_open_positions",
     )
-    raw_id_fields = ("appellation", "siae")
+    raw_id_fields = ("appellation", "siae", "location")
     search_fields = (
         "pk",
         "siae__siret",


### PR DESCRIPTION
### Quoi ?

Accélérer les pages d'admin les plus problématiques.

### Pourquoi ?

Responsables de DDOS en production.

### Comment ?

Il faut faire attention à ne pas surcharger les pages, utiliser des select_related, des raw ID fields, etc. L'admin n'est pas un fourre-tout.