### PR TITLE
Refactorisation/simplification du logger dans les commandes.

### DIFF
--- a/itou/approvals/management/commands/batch_notify_pe.py
+++ b/itou/approvals/management/commands/batch_notify_pe.py
@@ -1,17 +1,16 @@
 import datetime
-import logging
 
-from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from itou.approvals.models import Approval
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.utils.management_commands import ItouBaseCommand
 
 
 DATE_FORMAT = "%d/%m/%y"
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     Notify
 
@@ -33,20 +32,6 @@ class Command(BaseCommand):
         parser.add_argument(
             "--dry-run", dest="dry_run", action="store_true", help="Only print the valid approvals that start today"
         )
-
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity > 1:
-            self.logger.setLevel(logging.DEBUG)
 
     def parse_start_date_str(self, start_date_str):
         """Parses the user-provided start date.

--- a/itou/approvals/management/commands/batch_notify_pe.py
+++ b/itou/approvals/management/commands/batch_notify_pe.py
@@ -1,16 +1,17 @@
 import datetime
 
+from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from itou.approvals.models import Approval
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 
 
 DATE_FORMAT = "%d/%m/%y"
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     Notify
 

--- a/itou/approvals/management/commands/import_pe_approvals.py
+++ b/itou/approvals/management/commands/import_pe_approvals.py
@@ -1,10 +1,10 @@
 import datetime
 
 import pandas as pd
-from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from itou.approvals.models import PoleEmploiApproval
+from itou.utils.management_commands import ItouBaseCommand
 
 
 FLUSH_SIZE = 5000
@@ -50,7 +50,7 @@ def load_and_sort(file_path):
     return df
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     Import Pole emploi's approvals (or `agrément` in French) into the database.
 
@@ -75,6 +75,7 @@ class Command(BaseCommand):
         parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 
     def handle(self, file_path, wet_run=False, **options):
+        self.set_logger(options.get("verbosity"))
         now = timezone.now().date()
 
         count_before = PoleEmploiApproval.objects.count()

--- a/itou/approvals/management/commands/import_pe_approvals.py
+++ b/itou/approvals/management/commands/import_pe_approvals.py
@@ -5,7 +5,6 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from itou.approvals.models import PoleEmploiApproval
-from itou.utils.management_commands import DeprecatedLoggerMixin
 
 
 FLUSH_SIZE = 5000
@@ -51,7 +50,7 @@ def load_and_sort(file_path):
     return df
 
 
-class Command(DeprecatedLoggerMixin, BaseCommand):
+class Command(BaseCommand):
     """
     Import Pole emploi's approvals (or `agrément` in French) into the database.
 
@@ -76,7 +75,6 @@ class Command(DeprecatedLoggerMixin, BaseCommand):
         parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 
     def handle(self, file_path, wet_run=False, **options):
-        self.set_logger(options.get("verbosity"))
         now = timezone.now().date()
 
         count_before = PoleEmploiApproval.objects.count()

--- a/itou/approvals/management/commands/import_pe_approvals.py
+++ b/itou/approvals/management/commands/import_pe_approvals.py
@@ -1,10 +1,11 @@
 import datetime
 
 import pandas as pd
+from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from itou.approvals.models import PoleEmploiApproval
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 
 
 FLUSH_SIZE = 5000
@@ -50,7 +51,7 @@ def load_and_sort(file_path):
     return df
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     Import Pole emploi's approvals (or `agrément` in French) into the database.
 

--- a/itou/asp/management/commands/gen_asp_ref_fixtures.py
+++ b/itou/asp/management/commands/gen_asp_ref_fixtures.py
@@ -5,13 +5,13 @@ This could be a "one shot" action but we don't know for sure
 if these reference files are likely to change.
 """
 import json
-import logging
 import os
 from datetime import datetime
 
 import pandas as pd
 from django.conf import settings
-from django.core.management.base import BaseCommand
+
+from itou.utils.management_commands import ItouBaseCommand
 
 
 _FIXTURES_DIR = "itou/asp/fixtures"
@@ -26,7 +26,7 @@ def parse_asp_date(dt):
     return None
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     Generation of ASP reference files fixtures
 
@@ -58,20 +58,6 @@ class Command(BaseCommand):
         parser.add_argument("--insee_departments")
         parser.add_argument("--insee_countries")
         parser.add_argument("--siae_kinds")
-
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity > 1:
-            self.logger.setLevel(logging.DEBUG)
 
     def log(self, message):
         self.logger.debug(message)

--- a/itou/asp/management/commands/gen_asp_ref_fixtures.py
+++ b/itou/asp/management/commands/gen_asp_ref_fixtures.py
@@ -10,8 +10,9 @@ from datetime import datetime
 
 import pandas as pd
 from django.conf import settings
+from django.core.management.base import BaseCommand
 
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 
 
 _FIXTURES_DIR = "itou/asp/fixtures"
@@ -26,7 +27,7 @@ def parse_asp_date(dt):
     return None
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     Generation of ASP reference files fixtures
 

--- a/itou/cities/management/commands/import_cities.py
+++ b/itou/cities/management/commands/import_cities.py
@@ -2,11 +2,12 @@ import json
 import os
 
 from django.contrib.gis.geos import GEOSGeometry
+from django.core.management.base import BaseCommand
 from django.template.defaultfilters import slugify
 
 from itou.cities.models import City
 from itou.common_apps.address.departments import DEPARTMENTS, department_from_postcode
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -22,7 +23,7 @@ MISSING_COORDS = {
 }
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     Import French cities data from a JSON file into the database.
 

--- a/itou/cities/management/commands/import_cities.py
+++ b/itou/cities/management/commands/import_cities.py
@@ -1,13 +1,12 @@
 import json
-import logging
 import os
 
 from django.contrib.gis.geos import GEOSGeometry
-from django.core.management.base import BaseCommand
 from django.template.defaultfilters import slugify
 
 from itou.cities.models import City
 from itou.common_apps.address.departments import DEPARTMENTS, department_from_postcode
+from itou.utils.management_commands import ItouBaseCommand
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -23,7 +22,7 @@ MISSING_COORDS = {
 }
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     Import French cities data from a JSON file into the database.
 
@@ -39,20 +38,6 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="Only print data to import")
-
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity > 1:
-            self.logger.setLevel(logging.DEBUG)
 
     def handle(self, dry_run=False, **options):
 

--- a/itou/employee_record/management/commands/process_asp_report_file.py
+++ b/itou/employee_record/management/commands/process_asp_report_file.py
@@ -1,14 +1,15 @@
 import json
 import os.path as os_path
 
+from django.core.management.base import BaseCommand
 from rest_framework.renderers import JSONRenderer
 
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch
 from itou.employee_record.serializers import EmployeeRecordSerializer
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     Manually process an employee record ASP report file
 

--- a/itou/employee_record/management/commands/process_asp_report_file.py
+++ b/itou/employee_record/management/commands/process_asp_report_file.py
@@ -1,31 +1,19 @@
 import json
-import logging
 import os.path as os_path
 
-from django.core.management.base import BaseCommand
 from rest_framework.renderers import JSONRenderer
 
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch
 from itou.employee_record.serializers import EmployeeRecordSerializer
+from itou.utils.management_commands import ItouBaseCommand
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     Manually process an employee record ASP report file
 
     *SHOULD BE TEMPORARY*
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
 
     def add_arguments(self, parser):
         """
@@ -40,6 +28,7 @@ class Command(BaseCommand):
         - duplicates status code and label are updated if needed
         - other error cases are processed the usual way
         """
+        self.set_logger(options.get("verbosity"))
         input_file = options.get("input_file")
         renderer = JSONRenderer()
 

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -4,7 +4,6 @@ from os import path
 
 import pysftp
 from django.conf import settings
-from django.core.management.base import BaseCommand
 from django.utils import timezone
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
@@ -13,6 +12,7 @@ from itou.employee_record.mocks.test_serializers import TestEmployeeRecordBatchS
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch
 from itou.employee_record.serializers import EmployeeRecordBatchSerializer, EmployeeRecordSerializer
 from itou.utils.iterators import chunks
+from itou.utils.management_commands import ItouBaseCommand
 
 
 # Global SFTP connection options
@@ -23,7 +23,7 @@ if settings.ASP_FS_KNOWN_HOSTS and path.exists(settings.ASP_FS_KNOWN_HOSTS):
     connection_options = pysftp.CnOpts(knownhosts=settings.ASP_FS_KNOWN_HOSTS)
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     Employee record management command
     ---
@@ -32,17 +32,6 @@ class Command(BaseCommand):
     - download feedback files of previous upload operations
     - perform dry-run operations
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
 
     def add_arguments(self, parser):
         """
@@ -354,6 +343,8 @@ class Command(BaseCommand):
         """
         Employee Record Management Command
         """
+        self.set_logger(options.get("verbosity"))
+
         if not settings.EMPLOYEE_RECORD_TRANSFER_ENABLED:
             self.logger.info(
                 "This management command can't be used in this environment. Update Django settings if needed."

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -4,6 +4,7 @@ from os import path
 
 import pysftp
 from django.conf import settings
+from django.core.management.base import BaseCommand
 from django.utils import timezone
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
@@ -12,7 +13,7 @@ from itou.employee_record.mocks.test_serializers import TestEmployeeRecordBatchS
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch
 from itou.employee_record.serializers import EmployeeRecordBatchSerializer, EmployeeRecordSerializer
 from itou.utils.iterators import chunks
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 
 
 # Global SFTP connection options
@@ -23,7 +24,7 @@ if settings.ASP_FS_KNOWN_HOSTS and path.exists(settings.ASP_FS_KNOWN_HOSTS):
     connection_options = pysftp.CnOpts(knownhosts=settings.ASP_FS_KNOWN_HOSTS)
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     Employee record management command
     ---

--- a/itou/jobs/management/commands/import_appellations_for_romes.py
+++ b/itou/jobs/management/commands/import_appellations_for_romes.py
@@ -1,8 +1,10 @@
 import json
 import os
 
+from django.core.management.base import BaseCommand
+
 from itou.jobs.models import Appellation, Rome
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -10,7 +12,7 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 JSON_FILE = f"{CURRENT_DIR}/data/appellations_for_romes.json"
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     Import ROMEs appellations into the database.
 

--- a/itou/jobs/management/commands/import_appellations_for_romes.py
+++ b/itou/jobs/management/commands/import_appellations_for_romes.py
@@ -1,10 +1,8 @@
 import json
-import logging
 import os
 
-from django.core.management.base import BaseCommand
-
 from itou.jobs.models import Appellation, Rome
+from itou.utils.management_commands import ItouBaseCommand
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -12,7 +10,7 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 JSON_FILE = f"{CURRENT_DIR}/data/appellations_for_romes.json"
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     Import ROMEs appellations into the database.
 
@@ -28,20 +26,6 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="Only print data to import")
-
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity > 1:
-            self.logger.setLevel(logging.DEBUG)
 
     def handle(self, dry_run=False, **options):
 

--- a/itou/jobs/management/commands/import_romes.py
+++ b/itou/jobs/management/commands/import_romes.py
@@ -1,8 +1,10 @@
 import json
 import os
 
+from django.core.management.base import BaseCommand
+
 from itou.jobs.models import Rome
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -10,7 +12,7 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 JSON_FILE = f"{CURRENT_DIR}/data/romes.json"
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     Import ROMEs into the database.
 

--- a/itou/jobs/management/commands/import_romes.py
+++ b/itou/jobs/management/commands/import_romes.py
@@ -1,10 +1,8 @@
 import json
-import logging
 import os
 
-from django.core.management.base import BaseCommand
-
 from itou.jobs.models import Rome
+from itou.utils.management_commands import ItouBaseCommand
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -12,7 +10,7 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 JSON_FILE = f"{CURRENT_DIR}/data/romes.json"
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     Import ROMEs into the database.
 
@@ -28,20 +26,6 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="Only print data to import")
-
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity > 1:
-            self.logger.setLevel(logging.DEBUG)
 
     def handle(self, dry_run=False, **options):
 

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -85,10 +85,10 @@ class Command(BaseCommand):
     touching any real table, and injects only a sample of data.
 
     To populate alternate tables with sample data:
-        django-admin populate_metabase_fluxiae --verbosity=2 --dry-run
+        django-admin populate_metabase_fluxiae --dry-run
 
     When ready:
-        django-admin populate_metabase_fluxiae --verbosity=2
+        django-admin populate_metabase_fluxiae
     """
 
     help = "Populate metabase database with fluxIAE data."
@@ -97,23 +97,6 @@ class Command(BaseCommand):
         parser.add_argument(
             "--dry-run", dest="dry_run", action="store_true", help="Populate alternate tables with sample data"
         )
-
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity > 1:
-            self.logger.setLevel(logging.DEBUG)
-
-    def log(self, message):
-        self.logger.debug(message)
 
     @timeit
     def populate_fluxiae_view(self, vue_name, skip_first_row=True):
@@ -127,7 +110,7 @@ class Command(BaseCommand):
     @timeit
     def populate_metabase_fluxiae(self):
         if not settings.ALLOW_POPULATING_METABASE:
-            self.log("Populating metabase is not allowed in this environment.")
+            self.stdout.write("Populating metabase is not allowed in this environment.")
             return
 
         send_slack_message(
@@ -158,8 +141,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, dry_run=False, **options):
-        self.set_logger(options.get("verbosity"))
         self.dry_run = dry_run
         self.populate_metabase_fluxiae()
-        self.log("-" * 80)
-        self.log("Done.")
+        self.stdout.write("-" * 80)
+        self.stdout.write("Done.")

--- a/itou/siaes/management/commands/import_ea_eatt.py
+++ b/itou/siaes/management/commands/import_ea_eatt.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 import pandas as pd
 from django.core.management.base import BaseCommand
@@ -147,7 +145,6 @@ class Command(BaseCommand):
 
     To debug:
         django-admin import_ea_eatt --dry-run
-        django-admin import_ea_eatt --dry-run --verbosity=2
 
     To populate the database:
         django-admin import_ea_eatt
@@ -158,28 +155,8 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="Only print data to import")
 
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity > 1:
-            self.logger.setLevel(logging.DEBUG)
-
-    def log(self, message):
-        self.stdout.write(message)
-
     @timeit
     def handle(self, dry_run=False, **options):
-
-        self.set_logger(options.get("verbosity"))
-
         ea_eatt_df = get_ea_eatt_df()
         sync_structures(
             df=ea_eatt_df,
@@ -189,5 +166,5 @@ class Command(BaseCommand):
             dry_run=dry_run,
         )
 
-        self.log("-" * 80)
-        self.log("Done.")
+        self.stdout.write("-" * 80)
+        self.stdout.write("Done.")

--- a/itou/siaes/management/commands/import_geiq.py
+++ b/itou/siaes/management/commands/import_geiq.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 import pandas as pd
 from django.core.management.base import BaseCommand
@@ -97,7 +95,6 @@ class Command(BaseCommand):
 
     To debug:
         django-admin import_geiq --dry-run
-        django-admin import_geiq --dry-run --verbosity=2
 
     To populate the database:
         django-admin import_geiq
@@ -108,32 +105,12 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="Only print data to import")
 
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity > 1:
-            self.logger.setLevel(logging.DEBUG)
-
-    def log(self, message):
-        self.stdout.write(message)
-
     @timeit
     def handle(self, dry_run=False, **options):
-
-        self.set_logger(options.get("verbosity"))
-
         geiq_df = get_geiq_df()
         sync_structures(
             df=geiq_df, source=Siae.SOURCE_GEIQ, kinds=[Siae.KIND_GEIQ], build_structure=build_geiq, dry_run=dry_run
         )
 
-        self.log("-" * 80)
-        self.log("Done.")
+        self.stdout.write("-" * 80)
+        self.stdout.write("Done.")

--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -1,18 +1,17 @@
 import csv
 import datetime
-import logging
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
 from django.db.models import Case, F, Value, When
 from django.urls import reverse
 from tqdm import tqdm
 
 from itou.job_applications.models import JobApplication
 from itou.users.models import User
+from itou.utils.management_commands import ItouBaseCommand
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     Deduplicate job seekers.
 
@@ -53,20 +52,6 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="Only display data to deduplicate")
         parser.add_argument("--no-csv", dest="no_csv", action="store_true", help="Do not export results in CSV")
-
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity >= 1:
-            self.logger.setLevel(logging.DEBUG)
 
     def handle_easy_duplicates(self, duplicates, target, nirs):
         """

--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -2,16 +2,17 @@ import csv
 import datetime
 
 from django.conf import settings
+from django.core.management.base import BaseCommand
 from django.db.models import Case, F, Value, When
 from django.urls import reverse
 from tqdm import tqdm
 
 from itou.job_applications.models import JobApplication
 from itou.users.models import User
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     Deduplicate job seekers.
 

--- a/itou/users/management/commands/extract_c2_users.py
+++ b/itou/users/management/commands/extract_c2_users.py
@@ -1,6 +1,5 @@
 import csv
 import datetime
-import logging
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -26,20 +25,6 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--no-csv", dest="no_csv", action="store_true", help="Do not export results in CSV")
-
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity >= 1:
-            self.logger.setLevel(logging.DEBUG)
 
     def to_csv(self, filename, data, description):
         if self.no_csv:
@@ -71,8 +56,6 @@ class Command(BaseCommand):
         }
 
     def handle(self, no_csv=False, **options):
-
-        self.set_logger(options.get("verbosity"))
 
         self.no_csv = no_csv
 

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -3,7 +3,6 @@
 
 import csv
 import datetime
-import logging
 import re
 import uuid
 from pathlib import Path
@@ -11,7 +10,6 @@ from pathlib import Path
 import pandas as pd
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.management.base import BaseCommand
 from django.db import IntegrityError, transaction
 from django.db.models import F, Q
 from tqdm import tqdm
@@ -22,6 +20,7 @@ from itou.common_apps.address.departments import department_from_postcode
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.models import Siae
 from itou.users.models import User
+from itou.utils.management_commands import ItouBaseCommand
 from itou.utils.validators import validate_nir
 
 
@@ -56,7 +55,7 @@ DATE_FORMAT = "%Y-%m-%d"
 # DATE_FORMAT = "%d/%m/%Y"
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     On December 1st, 2021, every AI were asked to present a PASS IAE for each of their employees.
     Before that date, they were able to hire without one. To catch up with the ongoing stock,
@@ -113,20 +112,6 @@ class Command(BaseCommand):
             action="store",
             help="Absolute path of the CSV file to import",
         )
-
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity >= 1:
-            self.logger.setLevel(logging.DEBUG)
 
     def get_ratio(self, first_value, second_value):
         return round((first_value / second_value) * 100, 2)

--- a/itou/users/management/commands/import_ai_employees.py
+++ b/itou/users/management/commands/import_ai_employees.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pandas as pd
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.management.base import BaseCommand
 from django.db import IntegrityError, transaction
 from django.db.models import F, Q
 from tqdm import tqdm
@@ -20,7 +21,7 @@ from itou.common_apps.address.departments import department_from_postcode
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.models import Siae
 from itou.users.models import User
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 from itou.utils.validators import validate_nir
 
 
@@ -55,7 +56,7 @@ DATE_FORMAT = "%Y-%m-%d"
 # DATE_FORMAT = "%d/%m/%Y"
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     On December 1st, 2021, every AI were asked to present a PASS IAE for each of their employees.
     Before that date, they were able to hire without one. To catch up with the ongoing stock,

--- a/itou/users/management/commands/update_nir_from_pass.py
+++ b/itou/users/management/commands/update_nir_from_pass.py
@@ -3,7 +3,6 @@
 
 import csv
 import datetime
-import logging
 import re
 from pathlib import Path
 
@@ -11,10 +10,10 @@ import pandas as pd
 import unidecode
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.core.management.base import BaseCommand
 from tqdm import tqdm
 
 from itou.approvals.models import Approval
+from itou.utils.management_commands import ItouBaseCommand
 from itou.utils.validators import validate_nir
 
 
@@ -25,7 +24,7 @@ NIR_COL = "ppn_numero_inscription"
 APPROVAL_COL = "agr_numero_agrement"
 
 
-class Command(BaseCommand):
+class Command(ItouBaseCommand):
     """
     Update job seekers' account with their NIR (social security number) if an approval has been issued.
 
@@ -62,20 +61,6 @@ class Command(BaseCommand):
             action="store",
             help="Absolute path of the XLSX file to import",
         )
-
-    def set_logger(self, verbosity):
-        """
-        Set logger level based on the verbosity option.
-        """
-        handler = logging.StreamHandler(self.stdout)
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = False
-        self.logger.addHandler(handler)
-
-        self.logger.setLevel(logging.INFO)
-        if verbosity >= 1:
-            self.logger.setLevel(logging.DEBUG)
 
     def get_ratio(self, first_value, second_value):
         return round((first_value / second_value) * 100, 2)

--- a/itou/users/management/commands/update_nir_from_pass.py
+++ b/itou/users/management/commands/update_nir_from_pass.py
@@ -10,10 +10,11 @@ import pandas as pd
 import unidecode
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.management.base import BaseCommand
 from tqdm import tqdm
 
 from itou.approvals.models import Approval
-from itou.utils.management_commands import ItouBaseCommand
+from itou.utils.management_commands import DeprecatedLoggerMixin
 from itou.utils.validators import validate_nir
 
 
@@ -24,7 +25,7 @@ NIR_COL = "ppn_numero_inscription"
 APPROVAL_COL = "agr_numero_agrement"
 
 
-class Command(ItouBaseCommand):
+class Command(DeprecatedLoggerMixin, BaseCommand):
     """
     Update job seekers' account with their NIR (social security number) if an approval has been issued.
 

--- a/itou/utils/management_commands.py
+++ b/itou/utils/management_commands.py
@@ -1,11 +1,11 @@
 import logging
 
-from django.core.management.base import BaseCommand
 
-
-class ItouBaseCommand(BaseCommand):
+class DeprecatedLoggerMixin:
     """
-    A generic class for management commands, gathering all shared stuff (loggers etc).
+    A mixin used to inject deprecated logger stuff in some of our old management commands.
+
+    Do *not* use it for new commands! Use directly `self.stdout.write()` instead.
     """
 
     def set_logger(self, verbosity):

--- a/itou/utils/management_commands.py
+++ b/itou/utils/management_commands.py
@@ -1,0 +1,23 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+
+class ItouBaseCommand(BaseCommand):
+    """
+    A generic class for management commands, gathering all shared stuff (loggers etc).
+    """
+
+    def set_logger(self, verbosity):
+        """
+        Set logger level based on the verbosity option.
+        """
+        handler = logging.StreamHandler(self.stdout)
+
+        self.logger = logging.getLogger(__name__)
+        self.logger.propagate = False
+        self.logger.addHandler(handler)
+
+        self.logger.setLevel(logging.INFO)
+        if verbosity is not None and verbosity >= 1:
+            self.logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
### Quoi ?

Refactorisation/simplification du logger dans les commandes.

### Pourquoi ?

Sur suggestion de Vincent et de Victor dans cette autre PR : https://github.com/betagouv/itou/pull/1178

### Comment ?

- Pour les quelques commandes que je maitrise, j'ai carrément viré la méthode `self.set_logger()` et à la place simplement utilisé les `self.stdout.write()` recommandés par Victor.
- Pour les nombreuses autres commandes que je ne maitrise pas bien et/ou qui utilisent vraiment plusieurs niveaux de logging et pas juste un seul, j'ai factorisé la méthode commune `self.set_logger()` dans un `ItouBaseCommand` partagé, c'est toujours ça de simplifié.