### PR TITLE
Lancement du script Metabase quotidien plus tôt pour qu'il termine bien avant l'arrivée des premiers utilisateurs matinaux

### DIFF
--- a/.github/workflows/populate-metabase-itou.yml
+++ b/.github/workflows/populate-metabase-itou.yml
@@ -9,7 +9,9 @@ name: 🌈 Populate metabase itou
 on:
   workflow_dispatch: # allows us to run this action manually
   schedule:
-    - cron: '12 0 * * *' # Run this workflow at 0:12am every day
+    # Run this workflow every night.
+    # 19:00 here means 22:00 or 23:00 in France depending on winter/summer time.
+    - cron: '0 19 * * *'
 
 # How to run this:
 # Locally:


### PR DESCRIPTION
### Quoi ?

Lancement du script Metabase quotidien plus tôt pour qu'il termine bien avant l'arrivée des premiers utilisateurs matinaux.

### Pourquoi ?

Avant ce changement, et après le récent décalage d'heure d'été, le script commencait à 4h du mat et se terminait jusqu'à 9h du mat.

### Comment ?

En le lancant à 11h du soir plutôt que 4h du mat.