### PR TITLE
Mise à jour de l'indicateur ETP consommés

### DIFF
--- a/itou/metabase/management/commands/sql/013_heures_etp_salaries_par_mois.sql
+++ b/itou/metabase/management/commands/sql/013_heures_etp_salaries_par_mois.sql
@@ -14,7 +14,6 @@ Ces indicateurs sont déclinés par type de public cible:
     - département et région de l'annexe financière
   
 Un filtre est appliqué pour récupérer un historique de 2 ans en plus de l'année en cours
-
 */
 with constantes as 
 ( 
@@ -22,7 +21,7 @@ select
     max(date_part('year', date_saisie)) as annee_en_cours
 from 
     saisies_mensuelles_IAE
-)
+) 
     select 
         identifiant_salarie,
         nombre_etp_consommes,
@@ -42,11 +41,16 @@ from
         nom_departement_af,
         nom_region_af,
         af_numero_convention,
-        af_numero_annexe_financiere
+        af_numero_annexe_financiere,
+        zrr,
+        qpv,
+        tranche_age,
+        rqth
+    
 from 
     constantes 
     cross join 
         saisies_mensuelles_IAE
 where 
     nombre_heures_travaillees > 0 
-    and date_part('year', date_saisie) >= annee_en_cours - 2
+    and date_part('year', date_saisie) >= annee_en_cours - 2 


### PR DESCRIPTION
### Quoi ?

Ajout des variables QPV, RQTH, tranche d'âge, ZRR dans le tableau de bord statistiques employeur

### Pourquoi ?

Les SIAE souhaitent accéder aux indicateurs RQTH, ZRR et QPV pour leur pilotage interne et pour répondre aux sollicitations des institutions.
