### PR TITLE
Déblocage de l'admin des fiches SIAE

### DIFF
--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -26,7 +26,7 @@ class JobsInline(admin.TabularInline):
     model = models.Siae.jobs.through
     extra = 1
     raw_id_fields = ("appellation", "siae", "location")
-    readonly_fields = ("created_at", "updated_at")
+    readonly_fields = ("created_at", "updated_at", "location")
 
 
 class FinancialAnnexesInline(admin.TabularInline):


### PR DESCRIPTION
### Quoi ?

Déblocage de l'admin des fiches SIAE.

### Pourquoi ?

Depuis quelques jours le support ne peut plus faire aucune modif de SIAE, avec à chaque fois une erreur cryptique :

![image](https://user-images.githubusercontent.com/10533583/161070631-40319d6c-db04-4e37-a303-c5e97b999e1b.png)

### Comment ?

En fait le problème est sur le champ "location" des fiches de poste. On peut le voir en scrollant :

![image](https://user-images.githubusercontent.com/10533583/161070783-0a8f24a2-f706-4887-be64-49d423c138ac.png)

Le quick fix ici est de rentre ce champ read only pour débloquer le support asap. On trouvera peut-être mieux plus tard.