### PR TITLE
Ajout d'un FQDN à la custom URL Matomo

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -181,7 +181,7 @@
                 {% endfor %}
                 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
                 {% if matomo_custom_url %}
-                    _paq.push(['setCustomUrl', '{{ matomo_custom_url }}']);
+                    _paq.push(['setCustomUrl', location.origin + '{{ matomo_custom_url }}']);
                 {% endif %}
                 _paq.push(['trackPageView']);
                 _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
### Quoi ?

Ajout d'un FQDN à la custom URL Matomo.

### Pourquoi ?

La custom URL Matomo existante échoue silencieusement (aucune trace côté Matomo). Un FQDN a de bonne chances de la faire tomber en marche.

### Comment ?

Merci `location.origin`.

### Pas de revue (trop trivial)