### PR TITLE
Ajout d'un contrôle sur la validité des départements de candidats

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -548,7 +548,11 @@ class SiaePrescriberFilterJobApplicationsForm(FilterJobApplicationsForm):
 
     def _get_choices_for_departments(self):
         job_seekers = self.job_applications_qs.get_unique_fk_objects("job_seeker")
-        departments = {(user.department, DEPARTMENTS.get(user.department)) for user in job_seekers if user.department}
+        departments = {
+            (user.department, DEPARTMENTS.get(user.department))
+            for user in job_seekers
+            if user.department in DEPARTMENTS
+        }
         return sorted(departments, key=lambda l: l[1])
 
     def _get_choices_for_jobs(self):


### PR DESCRIPTION
### Quoi ?

Ajout d'un contrôle sur les départements des candidats pour générer la liste des cases à cocher.

### Pourquoi ?

Certains candidats ont un code postal commençant par deux zéros ce qui produit un département inconnu -> "00".

### Comment ?

Avec une condition qui n'ajoute que les départements présents dans le dictionnaire `DEPARTMENTS`.
