### PR TITLE
Ajout d'une seconde page stats pour les employeurs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -560,6 +560,7 @@ METABASE_DASHBOARD_IDS = {
     "stats_dreets_iae": 117,
     "stats_public": 119,
     "stats_siae_etp": 128,
+    "stats_siae_hiring": 165,
 }
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(os.environ.get("PILOTAGE_DASHBOARDS_WHITELIST", "[]"))
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -559,7 +559,7 @@ METABASE_DASHBOARD_IDS = {
     "stats_dgefp_af": 142,
     "stats_dreets_iae": 117,
     "stats_public": 119,
-    "stats_siae": 128,
+    "stats_siae_etp": 128,
 }
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(os.environ.get("PILOTAGE_DASHBOARDS_WHITELIST", "[]"))
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -448,7 +448,11 @@
                         {% if can_view_stats_siae %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_siae_etp' %}">Voir les données de ma structure</a>
+                                <a href="{% url 'stats:stats_siae_etp' %}">Voir les données de ma structure (extranet ASP)</a>
+                            </li>
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_siae_hiring' %}">Voir les données de recrutement de ma structure (Plateforme de l'inclusion)</a>
                                 <span class="badge badge-info">Nouveau</span>
                             </li>
                         {% endif %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -448,7 +448,7 @@
                         {% if can_view_stats_siae %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_siae' %}">Voir les données de ma structure</a>
+                                <a href="{% url 'stats:stats_siae_etp' %}">Voir les données de ma structure</a>
                                 <span class="badge badge-info">Nouveau</span>
                             </li>
                         {% endif %}

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -4,7 +4,8 @@ import jwt
 from django.conf import settings
 
 
-SIAE_FILTER_KEY = "identifiant_de_la_structure"
+ASP_SIAE_FILTER_KEY = "identifiant_de_la_structure"
+C1_SIAE_FILTER_KEY = "identifiant_de_la_structure_(c1)"
 DEPARTMENT_FILTER_KEY = "d%C3%A9partement"
 REGION_FILTER_KEY = "r%C3%A9gion"
 

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -17,5 +17,5 @@ urlpatterns = [
     path("dgefp/af/", views.stats_dgefp_af, name="stats_dgefp_af"),
     path("pilotage/<int:dashboard_id>/", views.stats_pilotage, name="stats_pilotage"),
     path("poc_matomo_custom_url/", views.poc_matomo_custom_url, name="test_matomo_custom_url"),
-    path("siae/", views.stats_siae, name="stats_siae"),
+    path("siae/", views.stats_siae_etp, name="stats_siae_etp"),
 ]

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -17,5 +17,6 @@ urlpatterns = [
     path("dgefp/af/", views.stats_dgefp_af, name="stats_dgefp_af"),
     path("pilotage/<int:dashboard_id>/", views.stats_pilotage, name="stats_pilotage"),
     path("poc_matomo_custom_url/", views.poc_matomo_custom_url, name="test_matomo_custom_url"),
-    path("siae/", views.stats_siae_etp, name="stats_siae_etp"),
+    path("siae/etp/", views.stats_siae_etp, name="stats_siae_etp"),
+    path("siae/hiring/", views.stats_siae_hiring, name="stats_siae_hiring"),
 ]

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -64,7 +64,7 @@ def stats_pilotage(request, dashboard_id, template_name="stats/stats_pilotage.ht
 
 
 @login_required
-def stats_siae(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_siae_etp(request, template_name=_STATS_HTML_TEMPLATE):
     """
     SIAE stats shown to their own members.
     They can only view data for their own SIAE.


### PR DESCRIPTION
### Quoi ?

Ajout d'une seconde page stats pour les employeurs.

### Pourquoi ?

A la demande de Yannick, pour enrichir l'expérimentation C2 actuelle auprès d'une liste blanche d'employeurs.

### Captures d'écran

![image](https://user-images.githubusercontent.com/10533583/161929725-7495e2cf-5a31-49e3-90cd-6cae6b82214d.png)

![image](https://user-images.githubusercontent.com/10533583/161929757-761808c7-3fcf-456d-a976-2276c0003c35.png)

