### PR TITLE
Les entrées CRON de clevercloud sont pétées

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,6 +1,6 @@
 [
   "1 0 * * * $ROOT/clevercloud/update-prescriber-organization-with-api-entreprise.sh",
-  "25 6-22/1 * * 1-5 $ROOT/clevercloud/download_employee_records.sh",
-  "55 6-22/2 * * 1-5 $ROOT/clevercloud/upload_employee_records.sh",
-  "5 23 * * 1-5 $ROOT/clevercloud/archive_employee_records.sh"
+  "25 6-22/1 * * 1,2,3,4,5 $ROOT/clevercloud/download_employee_records.sh",
+  "55 6-22/2 * * 1,2,3,4,5 $ROOT/clevercloud/upload_employee_records.sh",
+  "5 23 * * 1,2,3,4,5 $ROOT/clevercloud/archive_employee_records.sh"
 ]


### PR DESCRIPTION
### Quoi ?

Une syntaxe alternative pour gérer les "range" dans le fichier CRON de clevercloud.

### Pourquoi ?

Les entrées contenant des expressions "range" (par ex. `1-5` pour les 5 premiers jours de la semaine) ne fonctionnent plus.

### Comment ?

Remplacer les range par la série de valeurs correspondantes.
Dans le cas présent, `1-5` devient `1.2.3.4.5`

### Autre

C'est une régression de la part de clevercloud. 
Il a été demandé de nous prévenir lors d'un retour à un fonctionnement normal.
