### PR TITLE
Contrôle a posteriori, Pack SIAE : notification et liste des justificatifs demandés (cartes 1 à 3)

### DIFF
--- a/itou/siae_evaluations/enums.py
+++ b/itou/siae_evaluations/enums.py
@@ -1,3 +1,5 @@
+from django.db import models
+
 from itou.siaes.models import Siae
 
 
@@ -24,3 +26,7 @@ class EvaluationJobApplicationsBoundariesNumber:
     MAX = 100
     SELECTION_PERCENTAGE = 20
     SELECTED_MAX = int(MAX * SELECTION_PERCENTAGE / 100)
+
+
+class EvaluationJobApplicationsState(models.TextChoices):
+    PENDING = "PENDING"

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -225,6 +225,19 @@ class EvaluationCampaign(models.Model):
         return get_email_message(to, context, subject, body)
 
 
+class EvaluatedSiaeQuerySet(models.QuerySet):
+    def for_siae(self, siae):
+        return self.filter(siae=siae)
+
+    def in_progress(self):
+        return self.exclude(evaluation_campaign__evaluations_asked_at=None).filter(evaluation_campaign__ended_at=None)
+
+
+class EvaluatedSiaeManager(models.Manager):
+    def has_active_campaign(self, siae):
+        return self.for_siae(siae).in_progress().exists()
+
+
 class EvaluatedSiae(models.Model):
 
     evaluation_campaign = models.ForeignKey(
@@ -239,6 +252,8 @@ class EvaluatedSiae(models.Model):
         on_delete=models.CASCADE,
         related_name="evaluated_siaes",
     )
+
+    objects = EvaluatedSiaeManager.from_queryset(EvaluatedSiaeQuerySet)()
 
     class Meta:
         verbose_name = "Entreprise"

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -288,6 +288,11 @@ class EvaluatedJobApplication(models.Model):
     def __str__(self):
         return f"{self.job_application}"
 
+    @property
+    def state(self):
+        # property in progress, new conditionnal state will be added further
+        return evaluation_enums.EvaluationJobApplicationsState.PENDING
+
 
 class EvaluatedAdministrativeCriteria(models.Model):
 

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -432,6 +432,26 @@ class EvaluationCampaignEmailMethodsTest(TestCase):
         )
         self.assertIn(f"avant le {dateformat.format(date, 'd E Y')}", email.subject)
 
+    def test_get_email_eligible_siae(self):
+        siae = SiaeWith2MembershipsFactory()
+        evaluated_siae = EvaluatedSiaeFactory(siae=siae)
+        email = evaluated_siae.get_email_eligible_siae()
+
+        self.assertEqual(email.to, list(evaluated_siae.siae.active_admin_members))
+        self.assertEqual(
+            email.subject,
+            (
+                "Contrôle a posteriori sur vos embauches réalisées "
+                + f"du {dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_start_at, 'd E Y')} "
+                + f"au {dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_end_at, 'd E Y')}"
+            ),
+        )
+        self.assertIn(siae.name, email.body)
+        self.assertIn(siae.kind, email.body)
+        self.assertIn(siae.convention.siret_signature, email.body)
+        self.assertIn(dateformat.format(timezone.now() + relativedelta(weeks=6), "d E Y"), email.body)
+
+
 class EvaluatedSiaeQuerySetTest(TestCase):
     def test_for_siae(self):
         siae1 = SiaeFactory()

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -466,3 +466,9 @@ class EvaluatedSiaeManagerTest(TestCase):
 
         evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign__evaluations_asked_at=fake_now)
         self.assertTrue(EvaluatedSiae.objects.has_active_campaign(evaluated_siae.siae))
+
+
+class EvaluatedJobApplicationModelTest(TestCase):
+    def test_state(self):
+        evaluated_job_application = EvaluatedJobApplicationFactory()
+        self.assertEqual(evaluation_enums.EvaluationJobApplicationsState.PENDING, evaluated_job_application.state)

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -415,6 +415,20 @@
                 </div>
             </div>
 
+            {% if has_active_campaign %}
+                <div class="card">
+                    <p class="h4 card-header">Contrôle a posteriori <span class="badge badge-info">Nouveau</span></p>
+                    <div class="card-body">
+                        <ul class="list-unstyled">
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'siae_evaluations_views:siae_job_applications_list' %}">Justifier mes auto-prescriptions</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            {% endif %}
+
         {% endif %}{# end of if user.is_siae_staff #}
 
         {% if user.is_labor_inspector %}

--- a/itou/templates/siae_evaluations/email/eligible_siaes_body.txt
+++ b/itou/templates/siae_evaluations/email/eligible_siaes_body.txt
@@ -1,0 +1,44 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+
+Bonjour,
+
+Votre structure {{ siae.kind }} ID {{siae.id}} {{ siae.name }} (SIRET : {{ siae.convention.siret_signature }}) est soumise à la procédure de contrôle a posteriori sur les embauches réalisées en auto-prescription du {{campaign.evaluated_period_start_at|date:"d E Y"}} au {{campaign.evaluated_period_end_at|date:"d E Y"}}.
+
+Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez enregistrés lors de ces embauches.
+
+Vous avez jusqu’au {{ end_date|date:"d E Y" }} (6 semaines) pour transmettre les justificatifs à votre DDETS.
+
+Comment ça marche ?
+
+
+1- Visualiser la liste des embauches concernées par la procédure de contrôle :
+
+Depuis le tableau de bord de votre structure à la rubrique “ Contrôle a posteriori”
+cliquez sur “Justifier mes auto-prescriptions”.
+La liste des embauches concernées par la procédure est affichée.
+
+Accès direct à votre liste d’auto-prescriptions : {{ url }}
+
+2- Transmettez vos justificatifs en ligne
+
+Pour chaque embauche, cliquez sur “Ajouter ses justificatifs”,
+les critères que vous avez enregistrés sont affichés.
+Sélectionnez le ou les critères que vous souhaitez justifier (un nombre minimum de justificatifs est requis en fonction du type de critères et de SIAE).
+Déposez le ou les justificatifs demandés.
+
+3- Validez votre dossier de contrôle :
+
+Lorsque tous les justificatifs sont ajoutés, cliquez sur “Soumettre à validation” pour les transmettre à votre DDETS.
+
+Vous serez notifié(e) par e-mail lorsque la DDETS aura vérifié vos justificatifs.
+
+En cas de question sur les critères ou les justificatifs vous devez vous adresser uniquement à votre DDETS.
+
+Cordialement,
+
+{% if itou_environment != "PROD"%}
+[{{itou_environment}}] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [{{itou_environment}}]
+{% endif %}
+
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/eligible_siaes_subject.txt
+++ b/itou/templates/siae_evaluations/email/eligible_siaes_subject.txt
@@ -1,0 +1,6 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+
+Contrôle a posteriori sur vos embauches réalisées du {{campaign.evaluated_period_start_at|date:"d E Y"}} au {{campaign.evaluated_period_end_at|date:"d E Y"}}
+
+{% endblock %}

--- a/itou/templates/siae_evaluations/includes/list_item.html
+++ b/itou/templates/siae_evaluations/includes/list_item.html
@@ -8,7 +8,7 @@
             <div class="col-md-5 text-right">
                 <p class="small mb-0">
                     {% if item.state == "PENDING" %}
-                        <p class="badge badge-warning">à traiter</b></p>
+                        <p class="badge badge-warning">A traiter</b></p>
                     {% endif %}
                 </p>
             </div>

--- a/itou/templates/siae_evaluations/includes/list_item.html
+++ b/itou/templates/siae_evaluations/includes/list_item.html
@@ -1,0 +1,35 @@
+<div class="card my-5">
+
+    <div class="card-header">
+        <div class="row">
+            <div class="col-md-7">
+                <h3 class="h2">{{ item.job_application.job_seeker.get_full_name|title }}</h3>
+            </div>
+            <div class="col-md-5 text-right">
+                <p class="small mb-0">
+                    {% if item.state == "PENDING" %}
+                        <p class="badge badge-warning">à traiter</b></p>
+                    {% endif %}
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <div class="card-body">
+        <div class="row">
+            <div class="col-md-7">
+                <p class="m-0">Numéro de PASS IAE (agrément) :&nbsp;<b>{{ item.job_application.approval.number_with_spaces }}</b></p>
+            </div>
+
+        </div>
+
+        {% if item.state == "PENDING" %}
+            <div>
+                <a href="#" class="btn btn-outline-primary float-right">Ajouter ses justificatifs</a>
+            </div>
+
+        {% endif %}
+
+    </div>
+
+</div>

--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -40,7 +40,7 @@
                             </div>
                             <div class="col-4">
                                 <a class="btn btn-outline-primary" href="#">
-                                    soumettre à validation
+                                    Soumettre à validation
                                 </a>
                             </div>
                         </div>

--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -1,0 +1,75 @@
+{% extends "layout/content.html" %}
+{% load format_filters %}
+{% load bootstrap4 %}
+{% load static %}
+
+{% block title %}Liste de mes auto-prescriptions à justifier{{ block.super }}{% endblock %}
+
+{% block content %}
+
+    <div class="row mt-3">
+
+        <div class="col-2 mt-2">
+            {# placeholder #}
+        </div>
+        <div class="col-8 mt-2">
+
+            <h1 class="h1">
+                Justifier mes auto-prescriptions
+            </h1>
+            {% if evaluated_job_applications %}
+                <p>
+                    <div class="alert alert-info" role="status">
+                        <p class="font-weight-bold">Précision</p>
+                        <p>On entend par auto-prescription toutes les embauches pour lesquelles vous avez validé vous-mêmes les critères administratifs d'éligibilité IAE.</p>
+                    </div>
+                </p>
+
+
+                <div class="row mt-3">
+                    <div class="col-12 mt-2">
+                        <p class="h2">
+                            Liste de mes auto-prescriptions à justifier</p>
+
+                        <div class='row'>
+                            <div class="col-8">
+                                <p>Contrôle initié le {{evaluations_asked_at|date:"d F Y"}}</p>
+                                <p>Lorsque vous aurez ajouté <strong>tous vos justificatifs</strong>,
+                                    veuillez les soumettre à validation, la DDETS effectuera un contrôle
+                                    de ceux-ci et reviendra vers vous.</p>
+                            </div>
+                            <div class="col-4">
+                                <a class="btn btn-outline-primary" href="#">
+                                    soumettre à validation
+                                </a>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12">
+                                {% for evaluated_job_application in evaluated_job_applications %}
+
+                                    {% with item=evaluated_job_application %}
+
+                                        {% include "siae_evaluations/includes/list_item.html" %}
+                                    {% endwith %}
+
+                                {% endfor %}
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            {% else %}
+                <p>Vous n'avez aucun contrôle en cours.</p>
+            {% endif %}
+
+            {% if back_url %}
+                <p class="mt-4">
+                    <a href="{{ back_url }}">Retour</a>
+                </p>
+            {% endif %}
+        </div>
+    </div>
+
+
+{% endblock %}

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
 from itou.employee_record.enums import Status
 from itou.employee_record.factories import EmployeeRecordFactory
@@ -17,7 +18,7 @@ from itou.job_applications.notifications import (
     NewSpontaneousJobAppEmployersNotification,
 )
 from itou.prescribers import factories as prescribers_factories
-from itou.siae_evaluations.factories import EvaluationCampaignFactory
+from itou.siae_evaluations.factories import EvaluatedSiaeFactory, EvaluationCampaignFactory
 from itou.siaes.factories import (
     SiaeAfterGracePeriodFactory,
     SiaeFactory,
@@ -184,6 +185,11 @@ class DashboardViewTest(TestCase):
 
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Contrôle a posteriori")
+
+        fake_now = timezone.now()
+        EvaluatedSiaeFactory(siae=siae, evaluation_campaign__evaluations_asked_at=fake_now)
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertContains(response, "Contrôle a posteriori")
 
 
 class EditUserInfoViewTest(TestCase):

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -15,7 +15,7 @@ from itou.employee_record.models import EmployeeRecord
 from itou.institutions.models import Institution
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.prescribers.models import PrescriberOrganization
-from itou.siae_evaluations.models import EvaluationCampaign
+from itou.siae_evaluations.models import EvaluatedSiae, EvaluationCampaign
 from itou.siaes.models import Siae
 from itou.utils.password_validation import FRANCE_CONNECT_PASSWORD_EXPLANATION
 from itou.utils.perms.institution import get_current_institution_or_404
@@ -40,6 +40,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         current_org = get_current_siae_or_404(request)
         can_show_financial_annexes = current_org.convention_can_be_accessed_by(request.user)
         can_show_employee_records = current_org.can_use_employee_record
+        has_active_campaign = EvaluatedSiae.objects.has_active_campaign(current_org)
 
         job_applications_categories = [
             {

--- a/itou/www/siae_evaluations_views/tests.py
+++ b/itou/www/siae_evaluations_views/tests.py
@@ -1,11 +1,16 @@
 from django.test import TestCase
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import dateformat, timezone
 
 from itou.institutions.factories import InstitutionMembershipFactory
 from itou.siae_evaluations import enums as evaluation_enums
-from itou.siae_evaluations.factories import EvaluationCampaignFactory
+from itou.siae_evaluations.factories import (
+    EvaluatedJobApplicationFactory,
+    EvaluatedSiaeFactory,
+    EvaluationCampaignFactory,
+)
 from itou.siae_evaluations.models import EvaluationCampaign
+from itou.siaes.factories import SiaeMembershipFactory
 from itou.users.factories import DEFAULT_PASSWORD
 from itou.www.siae_evaluations_views.forms import SetChosenPercentForm
 
@@ -101,3 +106,49 @@ class SamplesSelectionViewTest(TestCase):
         updated_evaluation_campaign = EvaluationCampaign.objects.get(pk=evaluation_campaign.pk)
         self.assertIsNotNone(updated_evaluation_campaign.percent_set_at)
         self.assertEqual(updated_evaluation_campaign.chosen_percent, post_data["chosen_percent"])
+
+
+class SiaeJobApplicationListViewTest(TestCase):
+    def setUp(self):
+        membership = SiaeMembershipFactory()
+        self.user = membership.user
+        self.siae = membership.siae
+        self.url = reverse("siae_evaluations_views:siae_job_applications_list")
+
+    def test_access(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+
+        # siae without active campaign
+        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["evaluations_asked_at"])
+        self.assertFalse(response.context["evaluated_job_applications"])
+        self.assertContains(response, "Vous n'avez aucun contrôle en cours.")
+
+        # siae with active campaign
+        evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign__evaluations_asked_at=timezone.now(), siae=self.siae)
+        evaluated_job_application = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
+
+        with self.assertNumQueries(10):
+            response = self.client.get(self.url)
+
+        self.assertEqual(
+            evaluated_siae.evaluation_campaign.evaluations_asked_at, response.context["evaluations_asked_at"]
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            evaluated_job_application,
+            response.context["evaluated_job_applications"][0],
+        )
+        self.assertEqual(
+            reverse("dashboard:index"),
+            response.context["back_url"],
+        )
+
+        self.assertContains(
+            response,
+            f"Contrôle initié le "
+            f"{dateformat.format(evaluated_siae.evaluation_campaign.evaluations_asked_at, 'd E Y').lower()}",
+        )

--- a/itou/www/siae_evaluations_views/urls.py
+++ b/itou/www/siae_evaluations_views/urls.py
@@ -8,4 +8,5 @@ app_name = "siae_evaluations_views"
 
 urlpatterns = [
     path("samples_selection", views.samples_selection, name="samples_selection"),
+    path("siae_job_applications_list", views.siae_job_applications_list, name="siae_job_applications_list"),
 ]

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -1,13 +1,15 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.db.models import Min
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils import timezone
 
 from itou.siae_evaluations import enums as evaluation_enums
-from itou.siae_evaluations.models import EvaluationCampaign
+from itou.siae_evaluations.models import EvaluatedJobApplication, EvaluatedSiae, EvaluationCampaign
 from itou.utils.perms.institution import get_current_institution_or_404
+from itou.utils.perms.siae import get_current_siae_or_404
 from itou.utils.urls import get_safe_url
 from itou.www.siae_evaluations_views.forms import SetChosenPercentForm
 
@@ -40,5 +42,33 @@ def samples_selection(request, template_name="siae_evaluations/samples_selection
         "max": evaluation_enums.EvaluationChosenPercent.MAX,
         "back_url": back_url,
         "form": form,
+    }
+    return render(request, template_name, context)
+
+
+@login_required
+def siae_job_applications_list(request, template_name="siae_evaluations/siae_job_applications_list.html"):
+    evaluations_asked_at = False
+    evaluated_job_applications = False
+
+    evaluated_siaes = (
+        EvaluatedSiae.objects.for_siae(get_current_siae_or_404(request))
+        .in_progress()
+        .prefetch_related("evaluation_campaign")
+    )
+
+    if evaluated_siaes:
+        evaluations_asked_at = evaluated_siaes.aggregate(date=Min("evaluation_campaign__evaluations_asked_at")).get(
+            "date"
+        )
+        evaluated_job_applications = EvaluatedJobApplication.objects.filter(
+            evaluated_siae__in=evaluated_siaes
+        ).select_related("job_application", "job_application__job_seeker", "job_application__approval")
+
+    back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
+    context = {
+        "evaluated_job_applications": evaluated_job_applications,
+        "evaluations_asked_at": evaluations_asked_at,
+        "back_url": back_url,
     }
     return render(request, template_name, context)


### PR DESCRIPTION
### Quoi ?

Informer les user admin des SIAEs du contrôle et leur donner accès à la liste des embauches soumises au contrôle.

### Pourquoi ?

1. En tant que SIAE soumise au contrôle je veux être alertée par mail du lancement de la procédure.
2. En tant que SIAE je veux un accès à l’espace dédié au contrôle.
3. En tant que SIAE je veux visualiser la liste de mes embauches soumises au contrôle

### Comment ?

* notification email des membres admin de la SIAE lors du peuplement de la campagne
* ajout d'un lien dans le dashboard de la SIAE à tous les membres de la SIAE, pour accéder à la liste des autoprescriptions contrôlées
* ajout d'une page de liste paginée des autoprescriptions contrôlées

### Notes :
- Cette PR s'arrête à cette liste, elle n'inclue pas les liens vers les pages de détails des autoprescriptions, ni de choix des critères administratifs justifiés.
- Les filtres ne seront pas implémenter dans les écrans du Pack SIAE
- La pagination ne sera pas implémenter dans les écrans  du Pack SIAE