### PR TITLE
PASS IAE : Supprimer le code lié au COVID et confinement

### DIFF
--- a/itou/approvals/management/commands/merge_pe_approvals.py
+++ b/itou/approvals/management/commands/merge_pe_approvals.py
@@ -1,6 +1,5 @@
 from django.core.management.base import BaseCommand
 from django.db import connection
-from psycopg2 import sql  # noqa
 from tqdm import tqdm
 
 from itou.approvals.models import MergedPoleEmploiApproval, PoleEmploiApproval
@@ -30,12 +29,9 @@ class Command(BaseCommand):
             # We need to find the exact duration:
             # - the oldest start date
             # - the most recent end date
-            # - if we have a suspension during covid lockdown, we need to add 3 months
             pe_approval = PoleEmploiApproval()
             pe_approval.start_at = min([a.start_at for a in matching_approvals])
             pe_approval.end_at = max([a.end_at for a in matching_approvals])
-            if pe_approval.overlaps_covid_lockdown:
-                pe_approval.end_at = pe_approval.get_extended_covid_end_at(pe_approval.end_at)
 
             # and we can copy all the other data we have during the SQL insert
             approval = matching_approvals.first()

--- a/itou/eligibility/models.py
+++ b/itou/eligibility/models.py
@@ -220,7 +220,7 @@ class EligibilityDiagnosis(models.Model):
     @property
     def considered_to_expire_at(self):
         if self.job_seeker.approvals_wrapper.has_valid:
-            return self.job_seeker.approvals_wrapper.latest_approval.extended_end_at
+            return self.job_seeker.approvals_wrapper.latest_approval.end_at
         return self.expires_at
 
     @classmethod

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -52,7 +52,7 @@
 
         {# Validity. #}
         <li{% if not approval.is_suspended %} class="text-success"{% endif %}>
-            Valide du {{ approval.start_at|date:"d/m/Y" }} au {{ approval.extended_end_at|date:"d/m/Y" }}
+            Valide du {{ approval.start_at|date:"d/m/Y" }} au {{ approval.end_at|date:"d/m/Y" }}
         </li>
 
         {# Delivery date. #}
@@ -119,7 +119,7 @@
 {% elif approval.is_in_waiting_period %}
 
     <p class="text-danger">
-        <b>Expiré</b> le {{ approval.extended_end_at|date:"d/m/Y" }} (depuis {{ approval.extended_end_at|timesince }})
+        <b>Expiré</b> le {{ approval.end_at|date:"d/m/Y" }} (depuis {{ approval.end_at|timesince }})
     </p>
 
     {% if user.is_siae_staff %}

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from django.utils.http import urlencode
 
 from itou.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
-from itou.approvals.models import ApprovalsWrapper, PoleEmploiApproval
+from itou.approvals.models import ApprovalsWrapper
 from itou.cities.factories import create_test_cities
 from itou.cities.models import City
 from itou.eligibility.models import EligibilityDiagnosis
@@ -247,9 +247,7 @@ class ApplyAsJobSeekerTest(TestCase):
         Apply as jobseeker to a SIAE (not a GEIQ) with an approval in waiting period.
         Waiting period cannot be bypassed.
         """
-
-        # Avoid COVID lockdown specific cases
-        now_date = PoleEmploiApproval.LOCKDOWN_START_AT - relativedelta(months=1)
+        now_date = timezone.now().date() - relativedelta(months=1)
         now = timezone.datetime(year=now_date.year, month=now_date.month, day=now_date.day, tzinfo=timezone.utc)
 
         with mock.patch("django.utils.timezone.now", side_effect=lambda: now):


### PR DESCRIPTION
### Quoi ?
Retrait du code qui ajoute automatiquement 3 mois à la durée des PASS IAE délivrés pendant le confinement.

### Pourquoi ?
Nous ne sommes plus confinés et cela pose des problèmes de double extension.

### Comment ?
En retirant tout le code associé.