### PR TITLE
Modification du paramètre `status` dans l'API fiche salarié. 

### DIFF
--- a/itou/api/employee_record_api/viewsets.py
+++ b/itou/api/employee_record_api/viewsets.py
@@ -106,20 +106,16 @@ class EmployeeRecordViewSet(viewsets.ReadOnlyModelViewSet):
 
     def _filter_by_query_params(self, request, queryset):
         """
-        Register query parameters result filtering.
-
-        Only using employee record `status` is available for now
+        Register query parameters result filtering:
+        - only using employee record `status` is available for now.
+        - `status` query param can be an array of value.
         """
         params = request.query_params
 
-        if status := params.get("status"):
-            status_filter = {
-                "ready": EmployeeRecord.Status.READY,
-                "sent": EmployeeRecord.Status.SENT,
-                "rejected": EmployeeRecord.Status.REJECTED,
-            }.get(status.lower(), EmployeeRecord.Status.PROCESSED)
+        if status := params.getlist("status", ""):
+            status_filter = [s.upper() for s in status]
 
-            return queryset.filter(status=status_filter)
+            return queryset.filter(status__in=status_filter)
 
         # => Add as many params as necessary here (PASS IAE number, SIRET, fuzzy name ...)
 

--- a/itou/api/employee_record_api/viewsets.py
+++ b/itou/api/employee_record_api/viewsets.py
@@ -67,6 +67,7 @@ class EmployeeRecordViewSet(viewsets.ReadOnlyModelViewSet):
     Ce paramètre est un tableau permettant de filtrer les fiches retournées par leur statut
 
     Les valeurs possibles pour ce paramètre sont :
+
     - `NEW` : nouvelle fiche en cours de saisie,
     - `READY` : la fiche est prête à être transmise à l'ASP,
     - `SENT` : la fiche a été transmise et est en attente de traitement,
@@ -132,7 +133,7 @@ class EmployeeRecordViewSet(viewsets.ReadOnlyModelViewSet):
         if status := params.getlist("status", ""):
             status_filter = [s.upper() for s in status]
 
-            return queryset.filter(status__in=status_filter)
+            return queryset.filter(status__in=status_filter).order_by("-created_at")
 
         # => Add as many params as necessary here (PASS IAE number, SIRET, fuzzy name ...)
 

--- a/itou/api/employee_record_api/viewsets.py
+++ b/itou/api/employee_record_api/viewsets.py
@@ -60,6 +60,23 @@ class EmployeeRecordViewSet(viewsets.ReadOnlyModelViewSet):
     - seulement dans un environnement de développement
     - si l'utilisateur connecté est membre d'une ou plusieurs SIAE éligible aux fiches salarié
 
+    # Paramètres
+    Les paramètres suivants sont utilisables en paramètres de requête (query string):
+
+    ## `status` : statut des fiches salarié
+    Ce paramètre est un tableau permettant de filtrer les fiches retournées par leur statut
+
+    Les valeurs possibles pour ce paramètre sont :
+    - `NEW` : nouvelle fiche en cours de saisie,
+    - `READY` : la fiche est prête à être transmise à l'ASP,
+    - `SENT` : la fiche a été transmise et est en attente de traitement,
+    - `PROCESSED` : la fiche a correctement été intégrée par l'ASP,
+    - `REJECTED` : la fiche est retournée en erreur après transmission.
+
+    ### Exemples
+    - ajouter `?status=NEW` à l'URL pour les nouvelles fiches.
+    - ajouter `?status=NEW&status=READY` pour les nouvelles fiches et celles prêtes pour la transmission.
+
     """
 
     # Above doc section is in french for Swagger / OAS auto doc generation


### PR DESCRIPTION
### Quoi ?

Modification du paramètre `status` de l'API pour permettre de passer plusieurs valeurs (tableau).

### Pourquoi ?

Suite à demande des utilisateurs.

### Comment ?

Permettre de passer plusieurs valeurs en paramètre de requête. 
Par ex. `?status=NEW&status=READY` pour obtenir la liste agrégée des deux états.
