### PR TITLE
Les entrées CRON de clevercloud sont toujours pétées

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,6 +1,6 @@
 [
   "1 0 * * * $ROOT/clevercloud/update-prescriber-organization-with-api-entreprise.sh",
-  "25 6-22/1 * * 1,2,3,4,5 $ROOT/clevercloud/download_employee_records.sh",
-  "55 6-22/2 * * 1,2,3,4,5 $ROOT/clevercloud/upload_employee_records.sh",
+  "25 8,10,12,14,16,18 * * 1,2,3,4,5 $ROOT/clevercloud/download_employee_records.sh",
+  "55 8,10,12,14,16,18 * * 1,2,3,4,5 $ROOT/clevercloud/upload_employee_records.sh",
   "5 23 * * 1,2,3,4,5 $ROOT/clevercloud/archive_employee_records.sh"
 ]


### PR DESCRIPTION
### Quoi ?

Changement des ranhes sur le cron cleverclous (suite)

### Pourquoi ?

Voir : https://github.com/betagouv/itou/pull/1220

### Comment ?

Modification des ranges sur les heures

