### PR TITLE
Suspension: Fix last accepted job application date issue for user

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -247,11 +247,8 @@ class Approval(CommonApprovalMixin):
         )
 
     def can_be_suspended_by_siae(self, siae):
-        return (
-            self.can_be_suspended
-            # Only the SIAE currently hiring the job seeker can suspend a PASS IAE.
-            and self.user.last_hire_was_made_by_siae(siae)
-        )
+        # Only the SIAE currently hiring the job seeker can suspend a PASS IAE.
+        return self.can_be_suspended and self.user.last_hire_was_made_by_siae(siae)
 
     @cached_property
     def last_in_progress_suspension(self):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -563,7 +563,7 @@ class User(AbstractUser, AddressMixin):
         #
         # Some candidates may not have accepted job applications
         # Assuming its the case can lead to issues downstream
-        return self.job_applications.accepted().order_by("created_at", "hiring_start_at").last()
+        return self.job_applications.accepted().order_by("hiring_start_at").last()
 
     @cached_property
     def jobseeker_hash_id(self):


### PR DESCRIPTION
### Quoi ?

Le bouton suspendre un PASS IAE est parfois inaccessible pour les SIAE.

### Pourquoi ?

Réparation d'une régression, voir carte:
https://www.notion.so/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=28a2b530834a415eb834c424c52a8025
### Comment ?

Modification du tri par date (voir code).