### PR TITLE
Ajout de custom URLs Matomo sur toutes les stats.

### DIFF
--- a/itou/common_apps/address/departments.py
+++ b/itou/common_apps/address/departments.py
@@ -1,5 +1,7 @@
 import re
 
+import unidecode
+
 
 REGIONS = {
     "Auvergne-Rhône-Alpes": ["01", "03", "07", "15", "26", "38", "42", "43", "63", "69", "73", "74"],
@@ -184,20 +186,20 @@ def format_district(post_code, department):
 def format_region_for_matomo(region):
     if not region:
         return "Region-inconnue"
-    # E.g. `Provence-Alpes-Côte d&#x27;Azur` becomes `Provence-Alpes-C-te-d-Azur`.
-    return re.sub("[^A-Za-z0-9-]+", "-", region)
+    # E.g. `Provence-Alpes-Côte d&#x27;Azur` becomes `Provence-Alpes-Cote-d-Azur`.
+    return re.sub("[^A-Za-z0-9-]+", "-", unidecode.unidecode(region))
 
 
 def format_department_for_matomo(department):
     if not department or department not in DEPARTMENTS:
         return "Departement-inconnu"
-    # E.g. `13 - Bouches-du-Rhône` becomes `13---Bouches-du-Rh-ne`.
-    return re.sub("[^A-Za-z0-9-]+", "-", DEPARTMENTS[department])
+    # E.g. `13 - Bouches-du-Rhône` becomes `13---Bouches-du-Rhone`.
+    return re.sub("[^A-Za-z0-9-]+", "-", unidecode.unidecode(DEPARTMENTS[department]))
 
 
 def format_region_and_department_for_matomo(department):
     formatted_department = format_department_for_matomo(department)
     region = DEPARTMENT_TO_REGION.get(department)
     formatted_region = format_region_for_matomo(region)
-    # E.g. `/stats/ddets/iae/Provence-Alpes-C-te-d-Azur/04---Alpes-de-Haute-Provence`
+    # E.g. `/stats/ddets/iae/Provence-Alpes-Cote-d-Azur/04---Alpes-de-Haute-Provence`
     return f"{formatted_region}/{formatted_department}"

--- a/itou/common_apps/address/departments.py
+++ b/itou/common_apps/address/departments.py
@@ -182,9 +182,6 @@ def format_district(post_code, department):
 
 
 def format_region_for_matomo(region):
-    """
-    Format and sanitize region name for use in a Matomo custom URL.
-    """
     if not region:
         return "Region-inconnue"
     # E.g. `Provence-Alpes-Côte d&#x27;Azur` becomes `Provence-Alpes-C-te-d-Azur`.
@@ -192,9 +189,6 @@ def format_region_for_matomo(region):
 
 
 def format_department_for_matomo(department):
-    """
-    Format and sanitize department name for use in a Matomo custom URL.
-    """
     if not department or department not in DEPARTMENTS:
         return "Departement-inconnu"
     # E.g. `13 - Bouches-du-Rhône` becomes `13---Bouches-du-Rh-ne`.
@@ -202,9 +196,6 @@ def format_department_for_matomo(department):
 
 
 def format_region_and_department_for_matomo(department):
-    """
-    Format and sanitize region+department name for use in a Matomo custom URL.
-    """
     formatted_department = format_department_for_matomo(department)
     region = DEPARTMENT_TO_REGION.get(department)
     formatted_region = format_region_for_matomo(region)

--- a/itou/common_apps/address/departments.py
+++ b/itou/common_apps/address/departments.py
@@ -1,3 +1,6 @@
+import re
+
+
 REGIONS = {
     "Auvergne-Rhône-Alpes": ["01", "03", "07", "15", "26", "38", "42", "43", "63", "69", "73", "74"],
     "Bourgogne-Franche-Comté": ["21", "25", "39", "58", "70", "71", "89", "90"],
@@ -176,3 +179,34 @@ def format_district(post_code, department):
     # Could use ordinal from humanize but it would be overkill
     number = int(post_code) - (int(department) * 1000)
     return "1er" if number == 1 else f"{number}e"
+
+
+def format_region_for_matomo(region):
+    """
+    Format and sanitize region name for use in a Matomo custom URL.
+    """
+    if not region:
+        return "Region-inconnue"
+    # E.g. `Provence-Alpes-Côte d&#x27;Azur` becomes `Provence-Alpes-C-te-d-Azur`.
+    return re.sub("[^A-Za-z0-9-]+", "-", region)
+
+
+def format_department_for_matomo(department):
+    """
+    Format and sanitize department name for use in a Matomo custom URL.
+    """
+    if not department or department not in DEPARTMENTS:
+        return "Departement-inconnu"
+    # E.g. `13 - Bouches-du-Rhône` becomes `13---Bouches-du-Rh-ne`.
+    return re.sub("[^A-Za-z0-9-]+", "-", DEPARTMENTS[department])
+
+
+def format_region_and_department_for_matomo(department):
+    """
+    Format and sanitize region+department name for use in a Matomo custom URL.
+    """
+    formatted_department = format_department_for_matomo(department)
+    region = DEPARTMENT_TO_REGION.get(department)
+    formatted_region = format_region_for_matomo(region)
+    # E.g. `/stats/ddets/iae/Provence-Alpes-C-te-d-Azur/04---Alpes-de-Haute-Provence`
+    return f"{formatted_region}/{formatted_department}"

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -16,7 +16,6 @@ urlpatterns = [
     path("dgefp/diagnosis_control/", views.stats_dgefp_diagnosis_control, name="stats_dgefp_diagnosis_control"),
     path("dgefp/af/", views.stats_dgefp_af, name="stats_dgefp_af"),
     path("pilotage/<int:dashboard_id>/", views.stats_pilotage, name="stats_pilotage"),
-    path("poc_matomo_custom_url/", views.poc_matomo_custom_url, name="test_matomo_custom_url"),
     path("siae/etp/", views.stats_siae_etp, name="stats_siae_etp"),
     path("siae/hiring/", views.stats_siae_hiring, name="stats_siae_hiring"),
 ]

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -39,27 +39,64 @@ from itou.utils.perms.prescriber import get_current_org_or_404
 from itou.utils.perms.siae import get_current_siae_or_404
 
 
-# Each signed dashboard has the same look (at the moment)
-_STATS_HTML_TEMPLATE = "stats/stats.html"
+def get_stats_siae_current_org(request):
+    current_org = get_current_siae_or_404(request)
+    if not request.user.can_view_stats_siae(current_org=current_org):
+        raise PermissionDenied
+    return current_org
 
 
-def stats_public(request, template_name=_STATS_HTML_TEMPLATE):
+def get_stats_ddets_department(request):
+    current_org = get_current_institution_or_404(request)
+    if not request.user.can_view_stats_ddets(current_org=current_org):
+        raise PermissionDenied
+    department = request.user.get_stats_ddets_department(current_org=current_org)
+    return department
+
+
+def ensure_stats_dgefp_permission(request):
+    current_org = get_current_institution_or_404(request)
+    if not request.user.can_view_stats_dgefp(current_org=current_org):
+        raise PermissionDenied
+
+
+def get_params_for_departement(department):
+    return {
+        DEPARTMENT_FILTER_KEY: DEPARTMENTS[department],
+        REGION_FILTER_KEY: DEPARTMENT_TO_REGION[department],
+    }
+
+
+def get_params_for_whole_country():
+    return {
+        DEPARTMENT_FILTER_KEY: list(DEPARTMENTS.values()),
+        REGION_FILTER_KEY: list(REGIONS.keys()),
+    }
+
+
+def render_stats(request, context, params={}, template_name="stats/stats.html"):
+    base_context = {
+        "iframeurl": metabase_embedded_url(request=request, params=params),
+        "stats_base_url": settings.METABASE_SITE_URL,
+    }
+    # Key value pairs in context override preexisting pairs in base_context.
+    base_context.update(context)
+    return render(request, template_name, base_context)
+
+
+def stats_public(request):
     """
     Public basic stats (signed and embedded version)
-    Public link:
-    https://stats.inclusion.beta.gouv.fr/public/dashboard/f1527a13-1508-498d-8014-b2fe487a3a70
     """
     context = {
-        "iframeurl": metabase_embedded_url(request=request),
         "page_title": "Statistiques",
-        "stats_base_url": settings.METABASE_SITE_URL,
         "is_stats_public": True,
     }
-    return render(request, template_name, context)
+    return render_stats(request=request, context=context)
 
 
 @xframe_options_exempt
-def stats_pilotage(request, dashboard_id, template_name="stats/stats_pilotage.html"):
+def stats_pilotage(request, dashboard_id):
     """
     All these dashboard are publicly available on `PILOTAGE_SITE_URL`.
     We do it because we want to allow users to download chart data which
@@ -70,53 +107,50 @@ def stats_pilotage(request, dashboard_id, template_name="stats/stats_pilotage.ht
 
     context = {
         "iframeurl": metabase_embedded_url(dashboard_id=dashboard_id, with_title=True),
-        "stats_base_url": settings.METABASE_SITE_URL,
     }
-    return render(request, template_name, context)
+    return render_stats(request=request, context=context, template_name="stats/stats_pilotage.html")
 
 
 @login_required
-def stats_siae_etp(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_siae_etp(request):
     """
     SIAE stats shown to their own members.
     They can only view data for their own SIAE.
     These stats are about ETP data from the ASP.
     """
-    current_org = get_current_siae_or_404(request)
-    if not request.user.can_view_stats_siae(current_org=current_org):
-        raise PermissionDenied
-    params = {ASP_SIAE_FILTER_KEY: current_org.convention.asp_id}
+    current_org = get_stats_siae_current_org(request)
     context = {
-        "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": "Données de ma structure (extranet ASP)",
-        "stats_base_url": settings.METABASE_SITE_URL,
         "matomo_custom_url": f"/stats/siae/etp/{format_region_and_department_for_matomo(current_org.department)}",
     }
-    return render(request, template_name, context)
+    return render_stats(
+        request=request,
+        context=context,
+        params={ASP_SIAE_FILTER_KEY: current_org.convention.asp_id},
+    )
 
 
 @login_required
-def stats_siae_hiring(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_siae_hiring(request):
     """
     SIAE stats shown to their own members.
     They can only view data for their own SIAE.
     These stats are about hiring and are built directly from C1 data.
     """
-    current_org = get_current_siae_or_404(request)
-    if not request.user.can_view_stats_siae(current_org=current_org):
-        raise PermissionDenied
-    params = {C1_SIAE_FILTER_KEY: str(current_org.id)}
+    current_org = get_stats_siae_current_org(request)
     context = {
-        "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": "Données de recrutement de ma structure (Plateforme de l'inclusion)",
-        "stats_base_url": settings.METABASE_SITE_URL,
         "matomo_custom_url": f"/stats/siae/hiring/{format_region_and_department_for_matomo(current_org.department)}",
     }
-    return render(request, template_name, context)
+    return render_stats(
+        request=request,
+        context=context,
+        params={C1_SIAE_FILTER_KEY: str(current_org.id)},
+    )
 
 
 @login_required
-def stats_cd(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_cd(request):
     """
     CD ("Conseil Départemental") stats shown to relevant members.
     They can only view data for their own departement.
@@ -125,175 +159,129 @@ def stats_cd(request, template_name=_STATS_HTML_TEMPLATE):
     if not request.user.can_view_stats_cd(current_org=current_org):
         raise PermissionDenied
     department = request.user.get_stats_cd_department(current_org=current_org)
-    params = {
-        DEPARTMENT_FILTER_KEY: DEPARTMENTS[department],
-        REGION_FILTER_KEY: DEPARTMENT_TO_REGION[department],
-    }
+    params = get_params_for_departement(department)
     context = {
-        "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": f"Données de mon département : {DEPARTMENTS[department]}",
-        "stats_base_url": settings.METABASE_SITE_URL,
         "matomo_custom_url": f"/stats/cd/{format_region_and_department_for_matomo(department)}",
     }
-    return render(request, template_name, context)
+    return render_stats(request=request, context=context, params=params)
 
 
 @login_required
-def stats_ddets_iae(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_ddets_iae(request):
     """
     DDETS ("Directions départementales de l’emploi, du travail et des solidarités") stats shown to relevant members.
     They can only view data for their own departement.
     This dashboard shows data about IAE in general.
     """
-    current_institution = get_current_institution_or_404(request)
-    if not request.user.can_view_stats_ddets(current_org=current_institution):
-        raise PermissionDenied
-    department = request.user.get_stats_ddets_department(current_org=current_institution)
-    params = {
-        DEPARTMENT_FILTER_KEY: DEPARTMENTS[department],
-        REGION_FILTER_KEY: DEPARTMENT_TO_REGION[department],
-    }
+    department = get_stats_ddets_department(request)
+    params = get_params_for_departement(department)
     context = {
-        "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": f"Données de mon département : {DEPARTMENTS[department]}",
-        "stats_base_url": settings.METABASE_SITE_URL,
         "matomo_custom_url": f"/stats/ddets/iae/{format_region_and_department_for_matomo(department)}",
     }
-    return render(request, template_name, context)
+    return render_stats(request=request, context=context, params=params)
 
 
 @login_required
-def stats_ddets_diagnosis_control(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_ddets_diagnosis_control(request):
     """
     DDETS ("Directions départementales de l’emploi, du travail et des solidarités") stats shown to relevant members.
     They can only view data for their own departement.
     This dashboard shows data about diagnosis control ("Contrôle a posteriori").
     """
-    current_institution = get_current_institution_or_404(request)
-    if not request.user.can_view_stats_ddets(current_org=current_institution):
-        raise PermissionDenied
-    department = request.user.get_stats_ddets_department(current_org=current_institution)
-    params = {
-        DEPARTMENT_FILTER_KEY: DEPARTMENTS[department],
-        REGION_FILTER_KEY: DEPARTMENT_TO_REGION[department],
-    }
+    department = get_stats_ddets_department(request)
+    params = get_params_for_departement(department)
     context = {
-        "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": "Données 2021 du contrôle a posteriori",
-        "stats_base_url": settings.METABASE_SITE_URL,
         "back_url": reverse("siae_evaluations_views:samples_selection"),
         "show_diagnosis_control_message": True,
         "matomo_custom_url": f"/stats/ddets/diagnosis_control/{format_region_and_department_for_matomo(department)}",
     }
-    return render(request, template_name, context)
+    return render_stats(request=request, context=context, params=params)
 
 
 @login_required
-def stats_ddets_hiring(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_ddets_hiring(request):
     """
     DDETS ("Directions départementales de l’emploi, du travail et des solidarités") stats shown to relevant members.
     They can only view data for their own departement.
     This dashboard shows data about hiring ("Facilitation de l'embauche").
     """
-    current_institution = get_current_institution_or_404(request)
-    if not request.user.can_view_stats_ddets(current_org=current_institution):
-        raise PermissionDenied
-    department = request.user.get_stats_ddets_department(current_org=current_institution)
+    department = get_stats_ddets_department(request)
     params = {
         DEPARTMENT_FILTER_KEY: DEPARTMENTS[department],
     }
     context = {
-        "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": f"Données facilitation de l'embauche de mon département : {DEPARTMENTS[department]}",
-        "stats_base_url": settings.METABASE_SITE_URL,
         "matomo_custom_url": f"/stats/ddets/hiring/{format_region_and_department_for_matomo(department)}",
     }
-    return render(request, template_name, context)
+    return render_stats(request=request, context=context, params=params)
 
 
 @login_required
-def stats_dreets_iae(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_dreets_iae(request):
     """
     DREETS ("Directions régionales de l’économie, de l’emploi, du travail et des solidarités") stats shown to
     relevant members. They can only view data for their own region and can filter by department.
     This dashboard shows data about IAE in general.
     """
-    current_institution = get_current_institution_or_404(request)
-    if not request.user.can_view_stats_dreets(current_org=current_institution):
+    current_org = get_current_institution_or_404(request)
+    if not request.user.can_view_stats_dreets(current_org=current_org):
         raise PermissionDenied
-    region = request.user.get_stats_dreets_region(current_org=current_institution)
+    region = request.user.get_stats_dreets_region(current_org=current_org)
     departments = [DEPARTMENTS[dpt] for dpt in REGIONS[region]]
     params = {
         DEPARTMENT_FILTER_KEY: departments,
         REGION_FILTER_KEY: region,
     }
     context = {
-        "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": f"Données de ma région : {region}",
-        "stats_base_url": settings.METABASE_SITE_URL,
         "matomo_custom_url": f"/stats/dreets/iae/{format_region_for_matomo(region)}",
     }
-    return render(request, template_name, context)
+    return render_stats(request=request, context=context, params=params)
 
 
 @login_required
-def stats_dgefp_iae(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_dgefp_iae(request):
     """
     DGEFP ("délégation générale à l'Emploi et à la Formation professionnelle") stats shown to relevant members.
     They can view all data and filter by region and/or department.
     This dashboard shows data about IAE in general.
     """
-    current_institution = get_current_institution_or_404(request)
-    if not request.user.can_view_stats_dgefp(current_org=current_institution):
-        raise PermissionDenied
-    params = {
-        DEPARTMENT_FILTER_KEY: list(DEPARTMENTS.values()),
-        REGION_FILTER_KEY: list(REGIONS.keys()),
-    }
+    ensure_stats_dgefp_permission(request)
+    params = get_params_for_whole_country()
     context = {
-        "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": "Données des régions",
-        "stats_base_url": settings.METABASE_SITE_URL,
     }
-    return render(request, template_name, context)
+    return render_stats(request=request, context=context, params=params)
 
 
 @login_required
-def stats_dgefp_diagnosis_control(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_dgefp_diagnosis_control(request):
     """
     DGEFP ("délégation générale à l'Emploi et à la Formation professionnelle") stats shown to relevant members.
     They can view all data and filter by region and/or department.
     This dashboard shows data about diagnosis control ("Contrôle a posteriori").
     """
-    current_institution = get_current_institution_or_404(request)
-    if not request.user.can_view_stats_dgefp(current_org=current_institution):
-        raise PermissionDenied
-    params = {
-        DEPARTMENT_FILTER_KEY: list(DEPARTMENTS.values()),
-        REGION_FILTER_KEY: list(REGIONS.keys()),
-    }
+    ensure_stats_dgefp_permission(request)
+    params = get_params_for_whole_country()
     context = {
-        "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": "Données 2021 (version bêta) du contrôle a posteriori",
-        "stats_base_url": settings.METABASE_SITE_URL,
         "show_diagnosis_control_message": True,
     }
-    return render(request, template_name, context)
+    return render_stats(request=request, context=context, params=params)
 
 
 @login_required
-def stats_dgefp_af(request, template_name=_STATS_HTML_TEMPLATE):
+def stats_dgefp_af(request):
     """
     DGEFP ("délégation générale à l'Emploi et à la Formation professionnelle") stats shown to relevant members.
     They can view all data and filter by region and/or department.
     This dashboard shows data about financial annexes ("af").
     """
-    current_institution = get_current_institution_or_404(request)
-    if not request.user.can_view_stats_dgefp(current_org=current_institution):
-        raise PermissionDenied
+    ensure_stats_dgefp_permission(request)
     context = {
-        "iframeurl": metabase_embedded_url(request=request),
         "page_title": "Annexes financières actives",
-        "stats_base_url": settings.METABASE_SITE_URL,
     }
-    return render(request, template_name, context)
+    return render_stats(request=request, context=context)

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -297,11 +297,3 @@ def stats_dgefp_af(request, template_name=_STATS_HTML_TEMPLATE):
         "stats_base_url": settings.METABASE_SITE_URL,
     }
     return render(request, template_name, context)
-
-
-def poc_matomo_custom_url(request, template_name=_STATS_HTML_TEMPLATE):
-    """
-    Simple public route to test Matomo custom URL feature.
-    """
-    context = {"matomo_custom_url": "/matomo-custom-urls-actually-do-work.html"}
-    return render(request, template_name, context)

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -20,7 +20,13 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.clickjacking import xframe_options_exempt
 
-from itou.common_apps.address.departments import DEPARTMENT_TO_REGION, DEPARTMENTS, REGIONS
+from itou.common_apps.address.departments import (
+    DEPARTMENT_TO_REGION,
+    DEPARTMENTS,
+    REGIONS,
+    format_region_and_department_for_matomo,
+    format_region_for_matomo,
+)
 from itou.utils.apis.metabase import (
     ASP_SIAE_FILTER_KEY,
     C1_SIAE_FILTER_KEY,
@@ -84,6 +90,7 @@ def stats_siae_etp(request, template_name=_STATS_HTML_TEMPLATE):
         "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": "Données de ma structure (extranet ASP)",
         "stats_base_url": settings.METABASE_SITE_URL,
+        "matomo_custom_url": f"/stats/siae/etp/{format_region_and_department_for_matomo(current_org.department)}",
     }
     return render(request, template_name, context)
 
@@ -103,6 +110,7 @@ def stats_siae_hiring(request, template_name=_STATS_HTML_TEMPLATE):
         "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": "Données de recrutement de ma structure (Plateforme de l'inclusion)",
         "stats_base_url": settings.METABASE_SITE_URL,
+        "matomo_custom_url": f"/stats/siae/hiring/{format_region_and_department_for_matomo(current_org.department)}",
     }
     return render(request, template_name, context)
 
@@ -125,6 +133,7 @@ def stats_cd(request, template_name=_STATS_HTML_TEMPLATE):
         "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": f"Données de mon département : {DEPARTMENTS[department]}",
         "stats_base_url": settings.METABASE_SITE_URL,
+        "matomo_custom_url": f"/stats/cd/{format_region_and_department_for_matomo(department)}",
     }
     return render(request, template_name, context)
 
@@ -148,6 +157,7 @@ def stats_ddets_iae(request, template_name=_STATS_HTML_TEMPLATE):
         "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": f"Données de mon département : {DEPARTMENTS[department]}",
         "stats_base_url": settings.METABASE_SITE_URL,
+        "matomo_custom_url": f"/stats/ddets/iae/{format_region_and_department_for_matomo(department)}",
     }
     return render(request, template_name, context)
 
@@ -173,6 +183,7 @@ def stats_ddets_diagnosis_control(request, template_name=_STATS_HTML_TEMPLATE):
         "stats_base_url": settings.METABASE_SITE_URL,
         "back_url": reverse("siae_evaluations_views:samples_selection"),
         "show_diagnosis_control_message": True,
+        "matomo_custom_url": f"/stats/ddets/diagnosis_control/{format_region_and_department_for_matomo(department)}",
     }
     return render(request, template_name, context)
 
@@ -195,6 +206,7 @@ def stats_ddets_hiring(request, template_name=_STATS_HTML_TEMPLATE):
         "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": f"Données facilitation de l'embauche de mon département : {DEPARTMENTS[department]}",
         "stats_base_url": settings.METABASE_SITE_URL,
+        "matomo_custom_url": f"/stats/ddets/hiring/{format_region_and_department_for_matomo(department)}",
     }
     return render(request, template_name, context)
 
@@ -219,6 +231,7 @@ def stats_dreets_iae(request, template_name=_STATS_HTML_TEMPLATE):
         "iframeurl": metabase_embedded_url(request=request, params=params),
         "page_title": f"Données de ma région : {region}",
         "stats_base_url": settings.METABASE_SITE_URL,
+        "matomo_custom_url": f"/stats/dreets/iae/{format_region_for_matomo(region)}",
     }
     return render(request, template_name, context)
 


### PR DESCRIPTION
### Quoi ?

Ajout de custom URLs Matomo sur toutes les stats.

### Pourquoi ?

Quand Annie du C2 consulte les stats des stats (¬_¬) dans Matomo, par exemple pour les stats "DDETS IAE", elle voit un seul chiffre de visites pour l'URL `/stats/ddets/iae`. Avec les nouvelles custom URLs, l'URL virtuelle (vue uniquement par Matomo) sera du type `/stats/ddets/iae/<REGION>/<DEPARTEMENT>`. Du coup Annie pourra ventiler le chiffre de visites pas région et par département.

### Captures d'écran

Les visites dans Matomo :

![image](https://user-images.githubusercontent.com/10533583/162236776-5e5f9129-d459-4d80-beeb-3393cdbcf3f0.png)

Après cette PR, on pourra déplier ce traffic directement à cet endroit, par région puis par département, et ce pour chaque type de stats.
