### PR TITLE
Mise à jour vers Django 4.0.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.3.2  # https://github.com/avian2/unidecode
 # Django
 # ------------------------------------------------------------------------------
 
-django==4.0.3  # https://www.djangoproject.com/
+django==4.0.4  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.46.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
### Quoi ?

Mise à jour de sécurité

### Pourquoi ?

Sécurité essentiellement, voir https://www.djangoproject.com/weblog/2022/apr/11/security-releases/

### Comment ?

Passage en version 4.0.4

