### PR TITLE
Boost release 41 (voir détails PR pour changelog)

### DIFF
--- a/itou/allauth_adapters/peamu/views.py
+++ b/itou/allauth_adapters/peamu/views.py
@@ -80,9 +80,7 @@ class PEAMUOAuth2CallbackView(OAuth2CallbackView):
                 login.state = SocialLogin.unstash_state(request)
             return complete_social_login(request, login)
         except (PermissionDenied, OAuth2Error, RequestException, ProviderException) as e:
-            # This log is useful, 3.6k events for 75 users in 18 days but we have to disable it
-            # to not reach the Sentry limit. The issue is tracked in Trello.
-            # logger.error("Unknown error in PEAMU dispatch with exception '%s'.", e)
+            logger.error("Unknown error in PEAMU dispatch with exception '%s'.", e)
             return render_authentication_error(request, self.adapter.provider_id, exception=e)
 
 

--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -285,9 +285,9 @@ def import_user_pe_data(
             elif status == ExternalDataImport.STATUS_PARTIAL:
                 logger.warning("Could only fetch partial results for %s", user)
             else:
-                logger.error("Could not fetch any data for %s: not data stored", user)
+                logger.warning("Could not fetch any data for %s: not data stored", user)
         except Exception as e:
-            logger.error("Data import for %s failed: %s", user, e)
+            logger.warning("Data import for %s failed: %s", user, e)
             pe_data_import.status = ExternalDataImport.STATUS_FAILED
             pe_data_import.save()
 

--- a/itou/templates/account/account_type_selection.html
+++ b/itou/templates/account/account_type_selection.html
@@ -1,0 +1,61 @@
+{% extends "layout/content.html" %}
+{% load redirection_fields %}
+{% load static %}
+
+{% block title %}Connexion{{ block.super }}{% endblock %}
+
+{% block content %}
+    <div class="card-deck card-deck-itou">
+        <div class="card">
+            <div class="card-body">
+                <h3 class="h4 card-title font-weight-light">
+                    <span class="d-block">Vous êtes un employeur solidaire</span>
+                </h3>
+            </div>
+            <div class="card-footer">
+                <a class="btn btn-primary" href="{% url 'login:siae_staff' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                    Se connecter
+                </a>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-body">
+                <h3 class="h4 card-title font-weight-light">
+                    Vous êtes prescripteur ou orienteur
+                </h3>
+            </div>
+            <div class="card-footer">
+                <a class="btn btn-primary" href="{% url 'login:prescriber' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                    Se connecter
+                </a>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-body">
+                <h3 class="h4 card-title font-weight-light">
+                    Vous êtes inspecteur du travail
+                </h3>
+            </div>
+            <div class="card-footer">
+                <a class="btn btn-primary" href="{% url 'login:labor_inspector' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                    Se connecter
+                </a>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-body">
+                <h3 class="h4 card-title font-weight-light">
+                    Vous êtes candidat en recherche d'emploi
+                </h3>
+            </div>
+            <div class="card-footer">
+                <a class="btn btn-primary" href="{% url 'login:job_seeker' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                    Se connecter
+                </a>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -62,7 +62,7 @@
     {% if current_siae and not current_siae.is_active %}
         <div class="alert alert-warning mb-0" role="status">
             <p class="mb-0">
-                La DGEFP nous indique que votre structure {% if current_siae.siret %}(inscrite avec le numéro SIRET : {{ current_siae.siret }}) {% endif %}n'est plus conventionnée.<br>
+                Votre structure {% if current_siae.siret %}(inscrite avec le numéro SIRET : {{ current_siae.siret }}) {% endif %}n'est plus conventionnée.<br>
                 Par conséquent, elle n'apparaît plus dans les résultats de recherche et plus aucun collaborateur ne peut la rejoindre.<br>
                 À compter du {{ current_siae.grace_period_end_date|date:"d F Y" }}, l'accès à ce tableau de bord ne sera plus possible.<br>
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -331,7 +331,7 @@
                             </li>
                         {% endif %}
                         <li class="card-text mb-3">
-                            {% include "includes/icon.html" with icon="briefcase" %}
+                            <i class="ri-briefcase-3-line ri-lg mr-1"></i>
                             <a class="title-with-badge" href="{% url 'siaes_views:job_description_list' %}" title="Gérer les métiers et recrutements">Gérer les métiers et recrutements </a>
                         </li>
                         {% if can_show_financial_annexes %}

--- a/itou/templates/siaes/edit_job_description.html
+++ b/itou/templates/siaes/edit_job_description.html
@@ -35,7 +35,19 @@
             {% endif %}
 
             {% csrf_token %}
-            {% bootstrap_form form %}
+
+            {# Not using compact form because of `other_contract_type` field dynamic behaviour #}
+            {% bootstrap_field form.job_appellation %}
+            {% bootstrap_field form.job_appellation_code %}
+            {% bootstrap_field form.custom_name %}
+            {% bootstrap_field form.location_label %}
+            {% bootstrap_field form.location_code %}
+            {% bootstrap_field form.contract_type %}
+            <div id="_other_contract_type_group">
+                {% bootstrap_field form.other_contract_type %}
+            </div>
+            {% bootstrap_field form.hours_per_week %}
+            {% bootstrap_field form.open_positions %}
 
             {% buttons %}
                 <div align="right" class="pt-3">
@@ -50,12 +62,19 @@
     {{ block.super }}
     <script src="{% static "js/job_autocomplete.js" %}"></script>
     <script>
-        $("#id_contract_type").change(function() {
+        function disable_other_contract_type() {
             var isDisabled = $("#id_contract_type").val() !== "OTHER"
             $("#id_other_contract_type").attr("disabled", isDisabled)
             if (isDisabled) {
                 $("#id_other_contract_type").val("")
+                $("#_other_contract_type_group").hide()
+            } else {
+                $("#_other_contract_type_group").show()
             }
-        })
+        }
+        // When page is loaded, do:
+        disable_other_contract_type()
+        // Then, on any change:
+        $("#id_contract_type").change(disable_other_contract_type)
     </script>
 {% endblock %}

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -16,7 +16,9 @@ class ItouLoginView(LoginView):
     """
 
     form_class = ItouLoginForm
-    template_name = "account/login_generic.html"
+
+    # Allow users to choose their account type
+    template_name = "account/account_type_selection.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -66,6 +68,8 @@ class ItouLoginView(LoginView):
 
 
 class PrescriberLoginView(ItouLoginView):
+    template_name = "account/login_generic.html"
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         extra_context = {
@@ -78,6 +82,8 @@ class PrescriberLoginView(ItouLoginView):
 
 
 class SiaeStaffLoginView(ItouLoginView):
+    template_name = "account/login_generic.html"
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         extra_context = {
@@ -90,6 +96,8 @@ class SiaeStaffLoginView(ItouLoginView):
 
 
 class LaborInspectorLoginView(ItouLoginView):
+    template_name = "account/login_generic.html"
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         extra_context = {


### PR DESCRIPTION
### Quoi ?

- retrait des mentions à la DGEFP sur le dashboard
- retrait des imports de données `external-data` des remontée Sentry (avant un retrait définitif ?)
- ajout d'un comportement dynamique sur le champ "Autre type de contrat" dans le formulaire des fiches de poste
- si l'utilisateur n'est pas connecté pour postuler à une offre (après une recherche), ou autre accès non-identifié, un choix du type de connexion lui est proposé (SIAE, prescripteur, Inspecteur ou candidat)

### Pourquoi ?

Modifications "boost" pour la release 41

### Comment ?

Avec patience et application.

