### PR TITLE
Correctif sur l'import SIAE.

### DIFF
--- a/itou/siaes/management/commands/import_siae.py
+++ b/itou/siaes/management/commands/import_siae.py
@@ -262,9 +262,8 @@ class Command(BaseCommand):
             Siae.objects.filter(
                 auth_email="",
             )
-            .exclude(
-                siaemembership__user__is_active=True,
-                siaemembership__is_active=False,
+            .exclude(  # Exclude siae which have at least one active member.
+                siaemembership__is_active=True,
             )
             .distinct()
         ):

--- a/itou/siaes/tests/tests_import_siae_command.py
+++ b/itou/siaes/tests/tests_import_siae_command.py
@@ -146,9 +146,6 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         self.assertEqual((siae.source, siae.siret, siae.kind), (Siae.SOURCE_ASP, SIRET, Siae.KIND_ACI))
 
     def test_check_signup_possible_for_a_siae_without_members_but_with_auth_email(self):
-        """
-        There is an auth_email thus regular signup is possible, no error.
-        """
         instance = lazy_import_siae_command()
         SiaeFactory(auth_email="tadaaa")
         with self.assertNumQueries(1):
@@ -156,11 +153,6 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         self.assertEqual(instance.fatal_errors, 0)
 
     def test_check_signup_possible_for_a_siae_without_members_nor_auth_email(self):
-        """
-        There is no auth_email thus no regular signup,
-        and no member thus no invitation possible.
-        This should throw an error.
-        """
         instance = lazy_import_siae_command()
         SiaeFactory(auth_email="")
         with self.assertNumQueries(1):
@@ -168,10 +160,6 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         self.assertEqual(instance.fatal_errors, 1)
 
     def test_check_signup_possible_for_a_siae_with_members_but_no_auth_email_case_one(self):
-        """
-        Case one: one active member and one inactive member.
-        The active member can still invite people thus no error.
-        """
         instance = lazy_import_siae_command()
         siae = SiaeWith2MembershipsFactory(auth_email="")
         members = siae.siaemembership_set.all()
@@ -183,9 +171,6 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         self.assertEqual(instance.fatal_errors, 0)
 
     def test_check_signup_possible_for_a_siae_with_members_but_no_auth_email_case_two(self):
-        """
-        Case two: two inactive members, thus no invitation possible, this should throw an error.
-        """
         instance = lazy_import_siae_command()
         siae = SiaeWith2MembershipsFactory(auth_email="")
         members = siae.siaemembership_set.all()
@@ -197,9 +182,6 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         self.assertEqual(instance.fatal_errors, 1)
 
     def test_check_signup_possible_for_a_siae_with_members_but_no_auth_email_case_three(self):
-        """
-        Case three: two active members can both invite people thus no error.
-        """
         instance = lazy_import_siae_command()
         SiaeWith2MembershipsFactory(auth_email="")
         with self.assertNumQueries(1):

--- a/itou/siaes/tests/tests_import_siae_command.py
+++ b/itou/siaes/tests/tests_import_siae_command.py
@@ -193,3 +193,13 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         with self.assertNumQueries(1):
             instance.check_whether_signup_is_possible_for_all_siaes()
         self.assertEqual(instance.fatal_errors, 1)
+
+    def test_check_signup_possible_for_a_siae_with_members_but_no_auth_email_case_three(self):
+        """
+        Case three: two active members can both invite people thus no error.
+        """
+        instance = self.get_import_siae_command_instance()
+        SiaeWith2MembershipsFactory(auth_email="")
+        with self.assertNumQueries(1):
+            instance.check_whether_signup_is_possible_for_all_siaes()
+        self.assertEqual(instance.fatal_errors, 0)


### PR DESCRIPTION
### Quoi ?

Correctif sur l'import SIAE.

### Pourquoi ?

Cette semaine Supportix (@ikarius) a remonté que l'import SIAE indique à tort qu'une grande quantité de structures sont "injoignables" par manque d'email d'authentification et/ou de membres pour inviter de nouveaux membres. Voir [ce thread](https://itou-inclusion.slack.com/archives/CQ6D0QPPZ/p1649746761291299) pour l'output.

Ce comportement incorrect a été introduit par la PR récente https://github.com/betagouv/itou/pull/1204 qui a introduit un code plus optimisé et plusieurs tests, malheurement ces tests ont un (gros) trou dans la raquette, un cas trivial très courant (que des membres actif et pas d'`auth_email`) qui devrait ne pas produire d'erreur, mais qui en produit.

### Comment ?

- Refactorisation préparatoire et séparation des tests pour que les différents cas et comptages d'erreur soient plus clairs.
- Ajout d'un test cassant du nouveau cas (que des membres actif et pas d'`auth_email`) _en TDD_.
- Correctif du code pour faire passer le test cassant.

## Comment faire la revue ?

Commit par commit pour bien différencier le refactoring préparatoire du nouveau test cassant et du fix lui-même.

### Notes

La méthode est toujours suffisamment rapide, cf en local dev `Method check_whether_signup_is_possible_for_all_siaes took 1.58 seconds to complete`.