### PR TITLE
Corriger la fixture PE Approvals

### DIFF
--- a/itou/fixtures/django/12_pe_approvals.json
+++ b/itou/fixtures/django/12_pe_approvals.json
@@ -7,7 +7,7 @@
       "end_at": "2022-02-01",
       "created_at": "2020-02-02T10:34:22Z",
       "pe_structure_code": "13150",
-      "number": "490052010146P01",
+      "number": "490052010146",
       "pole_emploi_id": "7654321A",
       "first_name": "Jacques",
       "last_name": "Henry",


### PR DESCRIPTION
### Quoi ?

Corriger la fixture PE approvals.

### Pourquoi ?
`number` fait 15 caractères or maintenant la limite est à 12.

### Comment ?
En modifiant la fixture.