### PR TITLE
Refuser la connexion Django pour les utilisateurs SSO

### DIFF
--- a/itou/www/login/forms.py
+++ b/itou/www/login/forms.py
@@ -1,4 +1,5 @@
 from allauth.account.forms import LoginForm
+from django import forms
 
 
 class ItouLoginForm(LoginForm):
@@ -7,3 +8,12 @@ class ItouLoginForm(LoginForm):
         self.fields["password"].widget.attrs["placeholder"] = "**********"
         self.fields["login"].widget.attrs["placeholder"] = "adresse@email.fr"
         self.fields["login"].label = "Adresse e-mail"
+
+    def clean(self):
+        # Parent method performs authentication on form success.
+        super().clean()
+        if self.user and self.user.has_sso_provider:
+            identity_provider = self.user.get_identity_provider_display()
+            error_message = f"Votre compte est relié à {identity_provider}. Merci de vous connecter avec ce service."
+            raise forms.ValidationError(error_message)
+        return self.cleaned_data

--- a/itou/www/login/tests.py
+++ b/itou/www/login/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
+from itou.users import enums as users_enums
 from itou.users.factories import (
     DEFAULT_PASSWORD,
     JobSeekerFactory,
@@ -8,6 +9,7 @@ from itou.users.factories import (
     PrescriberFactory,
     SiaeStaffFactory,
 )
+from itou.www.login.forms import ItouLoginForm
 
 
 class ItouLoginTest(TestCase):
@@ -49,6 +51,26 @@ class ItouLoginTest(TestCase):
         url = reverse("account_login") + "?account_type=hater"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
+
+
+class ItouLoginFormTest(TestCase):
+    def test_error_if_user_has_sso_provider(self):
+        """
+        A user has created an account with another identity provider but tries to connect with Django.
+        He should not be able to do it.
+        You may wonder how does he know his password? Not that simple but possible.
+        This clever user reset his password AND confirmed his e-mail. Voilà.
+        We should block him upstream but this means hard work (overriding default Allauth views),
+        too long for this quite uncommon use case.
+        """
+        user = PrescriberFactory(identity_provider=users_enums.IdentityProvider.FRANCE_CONNECT)
+        form_data = {
+            "login": user.email,
+            "password": DEFAULT_PASSWORD,
+        }
+        form = ItouLoginForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("FranceConnect", form.errors["__all__"][0])
 
 
 class PrescriberLoginTest(TestCase):


### PR DESCRIPTION
### Quoi ?

Refuser la connexion d’un utilisateur qui a utilisé France Connect ou PE Connect mais qui essaye de se connecter via le formulaire normal.

### Pourquoi ?

Actuellement, c'est possible (voir le ticket).

### Comment ?

Je propose d’afficher le message d’erreur suivant :

> Votre compte est relié à {fournisseur d’identité}.
> Merci de vous connecter avec ce service.

![image](https://user-images.githubusercontent.com/6150920/163574313-929e9f9d-2589-4734-83f9-c8f133879b9e.png)
