### PR TITLE
Ajout d'une seconde vue stats "Facilitation de l'embauche" pour les DREETS

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -545,6 +545,7 @@ METABASE_DASHBOARD_IDS = {
     "stats_dgefp_diagnosis_control": 144,
     "stats_dgefp_af": 142,
     "stats_dreets_iae": 117,
+    "stats_dreets_hiring": 160,
     "stats_public": 119,
     "stats_siae_etp": 128,
     "stats_siae_hiring": 165,

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -478,6 +478,11 @@
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_dreets_iae' %}">Voir les données IAE de ma région</a>
                             </li>
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_dreets_hiring' %}">Voir les données facilitation de l'embauche</a>
+                                <span class="badge badge-info">Nouveau</span>
+                            </li>
                         {% endif %}
                         {% if can_view_stats_dgefp %}
                             <li class="card-text mb-3">

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path("ddets/diagnosis_control/", views.stats_ddets_diagnosis_control, name="stats_ddets_diagnosis_control"),
     path("ddets/hiring/", views.stats_ddets_hiring, name="stats_ddets_hiring"),
     path("dreets/iae/", views.stats_dreets_iae, name="stats_dreets_iae"),
+    path("dreets/hiring/", views.stats_dreets_hiring, name="stats_dreets_hiring"),
     path("dgefp/iae/", views.stats_dgefp_iae, name="stats_dgefp_iae"),
     path("dgefp/diagnosis_control/", views.stats_dgefp_diagnosis_control, name="stats_dgefp_diagnosis_control"),
     path("dgefp/af/", views.stats_dgefp_af, name="stats_dgefp_af"),


### PR DESCRIPTION
### Quoi ?

Ajout d'une seconde vue stats "Facilitation de l'embauche" pour les DREETS.

### Pourquoi ?

A la demande de Yannick. Cette vue déjà consultable par les DDETS est très demandée par les DREETS.

### Captures d'écran

![image](https://user-images.githubusercontent.com/10533583/163962990-742e945e-f49b-4893-8af6-5574970e0bec.png)


![image](https://user-images.githubusercontent.com/10533583/163962897-e4f0f362-246c-4dbb-a354-dd86fd0a45de.png)


### Liens

Action notion : https://www.notion.so/TB160-L-ouvrir-aux-DREETS-98df54ab0ff84dd7a0a05838e0f1a4e9
