### PR TITLE
Ajout de liens notion/slack dans le template de PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,11 @@ Indiquer le problème que nous sommes en train de résoudre et les objectifs mé
 
 Attirer l'attention sur les décisions d'architecture ou de conception importantes.
 
+### Liens utiles
+
+- [action notion](PASTE-URL-HERE)
+- [discussion slack](PASTE-URL-HERE)
+
 ### Captures d'écran (optionnel)
 
 Utile pour les changements liés à l'UI.


### PR DESCRIPTION
### Quoi ?

Ajout de liens notion/slack dans le template de PR.

### Pourquoi ?

Pour encourager à penser à mettre le lien de la PR vers l'action notion.

### Comment ?

Merci le template de PR.

### Captures d'écran (optionnel)

```
### Liens utiles

- [action notion](FIXME-URL)
- [discussion slack](FIXME-URL)
```
