### PR TITLE
Ajout de stats PE qui permettent à tout membre d'agence PE de consulter les stats de son département

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -537,18 +537,25 @@ STATS_SIAE_USER_PK_WHITELIST = json.loads(os.environ.get("STATS_SIAE_USER_PK_WHI
 
 # Metabase embedded dashboards
 METABASE_DASHBOARD_IDS = {
+    # Public stats.
+    "stats_public": 119,
+    # Employer stats.
+    "stats_siae_etp": 128,
+    "stats_siae_hiring": 165,
+    # Prescriber stats.
     "stats_cd": 118,
+    "stats_pe": 162,
+    # Institution stats - DDETS - department level.
     "stats_ddets_iae": 117,
     "stats_ddets_diagnosis_control": 144,
     "stats_ddets_hiring": 160,
+    # Institution stats - DREETS - region level.
+    "stats_dreets_iae": 117,
+    "stats_dreets_hiring": 160,
+    # Institution stats - DGEFP - nation level.
     "stats_dgefp_iae": 117,
     "stats_dgefp_diagnosis_control": 144,
     "stats_dgefp_af": 142,
-    "stats_dreets_iae": 117,
-    "stats_dreets_hiring": 160,
-    "stats_public": 119,
-    "stats_siae_etp": 128,
-    "stats_siae_hiring": 165,
 }
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(os.environ.get("PILOTAGE_DASHBOARDS_WHITELIST", "[]"))
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -463,11 +463,14 @@
                             </li>
                         {% endif %}
                         {% if can_view_stats_pe %}
+                            {% comment %}
+                            {# FIXME uncomment once ready for release #}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_pe' %}">Voir les données IAE de mon département</a>
                                 <span class="badge badge-info">Nouveau</span>
                             </li>
+                            {% endcomment %}
                         {% endif %}
                         {% if can_view_stats_ddets %}
                             <li class="card-text mb-3">

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -463,14 +463,11 @@
                             </li>
                         {% endif %}
                         {% if can_view_stats_pe %}
-                            {% comment %}
-                            {# FIXME uncomment once ready for release #}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_pe' %}">Voir les données IAE de mon département</a>
                                 <span class="badge badge-info">Nouveau</span>
                             </li>
-                            {% endcomment %}
                         {% endif %}
                         {% if can_view_stats_ddets %}
                             <li class="card-text mb-3">

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -462,6 +462,16 @@
                                 <a href="{% url 'stats:stats_cd' %}">Voir les données IAE de mon département</a>
                             </li>
                         {% endif %}
+                        {% if can_view_stats_pe %}
+                            {% comment %}
+                            {# FIXME uncomment once ready for release #}
+                            <li class="card-text mb-3">
+                                <i class="ri-pulse-line ri-lg mr-1"></i>
+                                <a href="{% url 'stats:stats_pe' %}">Voir les données IAE de mon département</a>
+                                <span class="badge badge-info">Nouveau</span>
+                            </li>
+                            {% endcomment %}
+                        {% endif %}
                         {% if can_view_stats_ddets %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -413,7 +413,8 @@ class User(AbstractUser, AddressMixin):
         return (
             self.can_view_stats_siae(current_org=current_org)
             or self.can_view_stats_cd(current_org=current_org)
-            or self.can_view_stats_pe(current_org=current_org)
+            # FIXME Uncomment once ready for release.
+            # or self.can_view_stats_pe(current_org=current_org)
             or self.can_view_stats_ddets(current_org=current_org)
             or self.can_view_stats_dreets(current_org=current_org)
             or self.can_view_stats_dgefp(current_org=current_org)

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -413,8 +413,7 @@ class User(AbstractUser, AddressMixin):
         return (
             self.can_view_stats_siae(current_org=current_org)
             or self.can_view_stats_cd(current_org=current_org)
-            # FIXME Uncomment once ready for release.
-            # or self.can_view_stats_pe(current_org=current_org)
+            or self.can_view_stats_pe(current_org=current_org)
             or self.can_view_stats_ddets(current_org=current_org)
             or self.can_view_stats_dreets(current_org=current_org)
             or self.can_view_stats_dgefp(current_org=current_org)

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -413,6 +413,8 @@ class User(AbstractUser, AddressMixin):
         return (
             self.can_view_stats_siae(current_org=current_org)
             or self.can_view_stats_cd(current_org=current_org)
+            # FIXME Uncomment once ready for release.
+            # or self.can_view_stats_pe(current_org=current_org)
             or self.can_view_stats_ddets(current_org=current_org)
             or self.can_view_stats_dreets(current_org=current_org)
             or self.can_view_stats_dgefp(current_org=current_org)
@@ -463,6 +465,20 @@ class User(AbstractUser, AddressMixin):
         CD as in "Conseil Départemental".
         """
         if not self.can_view_stats_cd(current_org=current_org):
+            raise PermissionDenied
+        return current_org.department
+
+    def can_view_stats_pe(self, current_org):
+        return (
+            self.is_prescriber
+            and isinstance(current_org, PrescriberOrganization)
+            and current_org.kind == current_org.Kind.PE
+            and current_org.is_authorized
+            and current_org.authorization_status == current_org.AuthorizationStatus.VALIDATED
+        )
+
+    def get_stats_pe_department(self, current_org):
+        if not self.can_view_stats_pe(current_org=current_org):
             raise PermissionDenied
         return current_org.department
 

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -96,6 +96,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_view_stats_dashboard_widget": request.user.can_view_stats_dashboard_widget(current_org=current_org),
         "can_view_stats_siae": request.user.can_view_stats_siae(current_org=current_org),
         "can_view_stats_cd": request.user.can_view_stats_cd(current_org=current_org),
+        "can_view_stats_pe": request.user.can_view_stats_pe(current_org=current_org),
         "can_view_stats_ddets": request.user.can_view_stats_ddets(current_org=current_org),
         "can_view_stats_dreets": request.user.can_view_stats_dreets(current_org=current_org),
         "can_view_stats_dgefp": request.user.can_view_stats_dgefp(current_org=current_org),

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -6,17 +6,24 @@ from itou.www.stats import views
 app_name = "stats"
 
 urlpatterns = [
+    # Public stats.
     path("", views.stats_public, name="stats_public"),
+    path("pilotage/<int:dashboard_id>/", views.stats_pilotage, name="stats_pilotage"),
+    # Employer stats.
+    path("siae/etp/", views.stats_siae_etp, name="stats_siae_etp"),
+    path("siae/hiring/", views.stats_siae_hiring, name="stats_siae_hiring"),
+    # Prescriber stats.
     path("cd/", views.stats_cd, name="stats_cd"),
+    path("pe/", views.stats_pe, name="stats_pe"),
+    # Institution stats - DDETS - department level.
     path("ddets/iae/", views.stats_ddets_iae, name="stats_ddets_iae"),
     path("ddets/diagnosis_control/", views.stats_ddets_diagnosis_control, name="stats_ddets_diagnosis_control"),
     path("ddets/hiring/", views.stats_ddets_hiring, name="stats_ddets_hiring"),
+    # Institution stats - DREETS - region level.
     path("dreets/iae/", views.stats_dreets_iae, name="stats_dreets_iae"),
     path("dreets/hiring/", views.stats_dreets_hiring, name="stats_dreets_hiring"),
+    # Institution stats - DGEFP - nation level.
     path("dgefp/iae/", views.stats_dgefp_iae, name="stats_dgefp_iae"),
     path("dgefp/diagnosis_control/", views.stats_dgefp_diagnosis_control, name="stats_dgefp_diagnosis_control"),
     path("dgefp/af/", views.stats_dgefp_af, name="stats_dgefp_af"),
-    path("pilotage/<int:dashboard_id>/", views.stats_pilotage, name="stats_pilotage"),
-    path("siae/etp/", views.stats_siae_etp, name="stats_siae_etp"),
-    path("siae/hiring/", views.stats_siae_hiring, name="stats_siae_hiring"),
 ]

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -185,6 +185,27 @@ def stats_cd(request):
 
 
 @login_required
+def stats_pe(request):
+    """
+    PE ("Pôle emploi") stats shown to relevant members.
+    They can view data for their whole departement, not only their agency.
+    They cannot view data for other departments than their own.
+    """
+    current_org = get_current_org_or_404(request)
+    if not request.user.can_view_stats_pe(current_org=current_org):
+        raise PermissionDenied
+    department = request.user.get_stats_pe_department(current_org=current_org)
+    params = {
+        DEPARTMENT_FILTER_KEY: DEPARTMENTS[department],
+    }
+    context = {
+        "page_title": f"Données de mon département : {DEPARTMENTS[department]}",
+        "matomo_custom_url": f"/stats/pe/{format_region_and_department_for_matomo(department)}",
+    }
+    return render_stats(request=request, context=context, params=params)
+
+
+@login_required
 def stats_ddets_iae(request):
     """
     DDETS ("Directions départementales de l’emploi, du travail et des solidarités") stats shown to relevant members.


### PR DESCRIPTION
### Quoi ?

Ajout de stats PE qui permettent à tout membre d'agence PE de consulter les stats de son département.

La fonctionnalité est cachée mais accessible par l'URL secrète `stats/pe`.

Le commit pour publier la fonctionnalité est préparé (et reverté) dans cette PR même.

### Pourquoi ?

Pour offrir leurs toutes premières stats Metabase aux agences PE pardi !

### Comment ?

En s'inspirant fortement de l'existant et similaire tableau de bord des CD.

### Captures d'écran

![image](https://user-images.githubusercontent.com/10533583/163825120-13c05d82-4bde-4a13-a444-f293377368ed.png)

![image](https://user-images.githubusercontent.com/10533583/163825162-1fec5402-dde6-4102-8305-600ad342136f.png)


### Autre (optionnel)

https://www.notion.so/Publier-le-TB-tensions-de-recrutement-pour-les-agences-PE-en-standby-116a07968e654e84be8528b6481f4315
