### PR TITLE
Ajout d'une nouvelle github action Metabase pratique pour nos data analysts C2

### DIFF
--- a/.github/workflows/build-metabase-final-tables.yml
+++ b/.github/workflows/build-metabase-final-tables.yml
@@ -84,8 +84,9 @@ jobs:
     - name: 🚀 Deploy app to Clever Cloud
       run: $CLEVER_CLI deploy --alias $CRON_TASK_APP_NAME --branch $DEPLOY_BRANCH --force
 
+    # Command typically completes in 500s.
     - name: 🕒 Wait a reasonable amount of time for the script to complete
-      run: sleep 1800
+      run: sleep 1200
 
     - name: 🔪 Delete the app once the work is done
       run:

--- a/.github/workflows/build-metabase-final-tables.yml
+++ b/.github/workflows/build-metabase-final-tables.yml
@@ -1,26 +1,21 @@
-name: 🌈 Populate metabase itou
+name: 🌈 Build metabase final tables
 
-# Runs "populate_metabase_itou".
+# Runs "build_metabase_final_tables".
 # A github action takes care of the cron task that:
 # - creates a machine on demand
-# - runs the desired command via a worker
-# - waits a reasonable amount of time for the script to complete
+# - runs the desired command
 # - destroys the machine once the update is done
 on:
   workflow_dispatch: # allows us to run this action manually
-  schedule:
-    # Run this workflow every night.
-    # 19:00 here means 22:00 or 23:00 in France depending on winter/summer time.
-    - cron: '0 19 * * *'
 
 # How to run this:
 # Locally:
 # - download and install locally "act" (https://github.com/nektos/act)
 # - create a file "act.secrets" with all the necessary secrets (see the env variables below)
-# - "act --secret-file ./act.secrets -j populate_metabase_itou" will run the job populate_metabase_itou with the specified environment variables
+# - "act --secret-file ./act.secrets -j build_metabase_final_tables" will run the job build_metabase_final_tables with the specified environment variables
 # In production:
 # - automatically, as a cron job configured above
-# - with github cli (https://cli.github.com/manual/): gh workflow run populate-metabase-itou.yml
+# - with github cli (https://cli.github.com/manual/): gh workflow run build-metabase-final-tables.yml
 # - with github’s web UI: https://github.com/betagouv/itou/actions
 env:
   CLEVER_TOOLS_DOWNLOAD_URL: https://clever-tools.clever-cloud.com/releases/latest/clever-tools-latest_linux.tar.gz
@@ -33,17 +28,8 @@ env:
   PYTHON_VERSION: 3.9
 
 jobs:
-  populate_metabase_itou:
+  build_metabase_final_tables:
     runs-on: ubuntu-latest
-
-    # Default github action workflow timeout is 6 hours (360 minutes). If the script lasts longer than this for any reason,
-    # the github action will be killed but the clever instance will keep running forever as the last job supposed to
-    # delete it was never runned. This is why we set a very large timer here (24 hours == 1440 minutes) because
-    # clever instances are expensive but github actions are not. Cutting financial costs is the reponsibility of the
-    # last job, not of github.
-    # Unfortunately this does not work, the new timeout value is silently ignored and github keeps killing the job
-    # after the default 6 hours. This will need to be investigated further.
-    timeout-minutes: 1440
 
     steps:
     - name: 📥 Checkout to the latest version on $DEPLOY_BRANCH
@@ -56,15 +42,15 @@ jobs:
 
     - name: 🏷 Setup app name
       run:
-        echo "CRON_TASK_APP_NAME=`echo \"c1-cron-daily-$(date +%y-%m-%d-%Hh-%M)"`" >> $GITHUB_ENV
+        echo "CRON_TASK_APP_NAME=`echo \"c1-build-metabase-final-tables-$(date +%y-%m-%d-%Hh-%M)"`" >> $GITHUB_ENV
 
     - name: 🏷 Setup worker to run django command
       run: |
-        echo 'CC_WORKER_COMMAND=mkdir -p ./shared_bucket/populate_metabase_itou && ./manage.py populate_metabase_itou --verbosity 2 |& tee -a ./shared_bucket/populate_metabase_itou/output_$(date '+%Y-%m-%d_%H-%M-%S').log' >> $GITHUB_ENV
+        echo 'CC_WORKER_COMMAND=mkdir -p ./shared_bucket/build_metabase_final_tables && ./manage.py build_metabase_final_tables --verbosity 2 |& tee -a ./shared_bucket/build_metabase_final_tables/output_$(date '+%Y-%m-%d_%H-%M-%S').log' >> $GITHUB_ENV
         # By default, workers always restart on failure. We want to avoid an infinite loop if it happens.
         echo 'CC_WORKER_RESTART=no' >> $GITHUB_ENV
 
-    - name: 🧫 Create a cron app on Clever Cloud on a strong machine
+    - name: 🧫 Create a cron app on Clever Cloud on a small machine
       run: |
         curl $CLEVER_TOOLS_DOWNLOAD_URL > $CLEVER_TAR_FILE
         tar -xvf $CLEVER_TAR_FILE
@@ -79,7 +65,7 @@ jobs:
         # have precedence over configuration addons
         $CLEVER_CLI env set CC_PYTHON_VERSION ${{ env.PYTHON_VERSION }} --alias $CRON_TASK_APP_NAME
         $CLEVER_CLI link $CRON_TASK_APP_NAME --org $CRON_APPS_ORGANIZATION_NAME
-        $CLEVER_CLI scale --flavor XL
+        $CLEVER_CLI scale --flavor S
 
     # We need at the minimum a database and redis in order to boot the app, as well as all the necessary
     # environment variables a configuration addon provides us
@@ -98,12 +84,8 @@ jobs:
     - name: 🚀 Deploy app to Clever Cloud
       run: $CLEVER_CLI deploy --alias $CRON_TASK_APP_NAME --branch $DEPLOY_BRANCH --force
 
-    # This script was taking less than 3h (10800s) until https://github.com/betagouv/itou/pull/1154 introduced
-    # significant performance degradation due to several additional joins. The script now takes 5h instead of 3h
-    # even after some optimization. We set the timeout at 5h45 (20700s), just below 6h, because there is
-    # an unresolved issue with a different timeout system, see `timeout-minutes` above.
     - name: 🕒 Wait a reasonable amount of time for the script to complete
-      run: sleep 20700
+      run: sleep 1800
 
     - name: 🔪 Delete the app once the work is done
       run:

--- a/itou/metabase/management/commands/_utils.py
+++ b/itou/metabase/management/commands/_utils.py
@@ -214,9 +214,9 @@ def build_custom_table(table_name, sql_request, dry_run):
     switch_table_atomically(table_name=table_name)
 
 
-def build_custom_tables(dry_run):
+def build_final_tables(dry_run):
     """
-    Build custom tables one by one by playing SQL requests in `sql` folder.
+    Build final custom tables one by one by playing SQL requests in `sql` folder.
 
     Typically:
     - 001_fluxIAE_DateDerniereMiseAJour.sql

--- a/itou/metabase/management/commands/_utils.py
+++ b/itou/metabase/management/commands/_utils.py
@@ -14,6 +14,7 @@ from itou.metabase.management.commands._database_tables import (
     get_new_table_name,
     switch_table_atomically,
 )
+from itou.siaes.management.commands._import_siae.utils import timeit
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -191,6 +192,7 @@ def chunked_queryset(queryset, chunk_size=10000):
     yield queryset.filter(pk__gte=start_pk)
 
 
+@timeit
 def build_custom_table(table_name, sql_request, dry_run):
     """
     Build a new table with given sql_request.

--- a/itou/metabase/management/commands/build_metabase_final_tables.py
+++ b/itou/metabase/management/commands/build_metabase_final_tables.py
@@ -11,6 +11,7 @@ having to complete a long `populate_metabase_itou` command which takes several h
 from django.core.management.base import BaseCommand
 
 from itou.metabase.management.commands._utils import build_final_tables
+from itou.siaes.management.commands._import_siae.utils import timeit
 
 
 class Command(BaseCommand):
@@ -35,6 +36,7 @@ class Command(BaseCommand):
             "--dry-run", dest="dry_run", action="store_true", help="Populate alternate tables with sample data"
         )
 
+    @timeit
     def handle(self, dry_run=False, **options):
         build_final_tables(dry_run=dry_run)
         self.stdout.write("-" * 80)

--- a/itou/metabase/management/commands/build_metabase_final_tables.py
+++ b/itou/metabase/management/commands/build_metabase_final_tables.py
@@ -1,0 +1,41 @@
+"""
+Command runned manually from time to time by C2 data analysts via a github action.
+
+This commands only runs the quick final SQL requests otherwise completed at the end of
+the daily `populate_metabase_itou` and the weekly `populate_metabase_fluxiae` commands.
+
+This is convenient for our data analysts to quickly apply their latest merged PR changes without
+having to complete a long `populate_metabase_itou` command which takes several hours.
+"""
+
+from django.core.management.base import BaseCommand
+
+from itou.metabase.management.commands._utils import build_final_tables
+
+
+class Command(BaseCommand):
+    """
+    Run Metabase final SQL requests.
+
+    The `dry-run` mode is useful for quickly testing changes and iterating.
+    It builds tables with a dry prefix added to their name, to avoid
+    touching any real table, and injects only a sample of data.
+
+    To populate alternate tables with sample data:
+        django-admin build_metabase_final_tables --dry-run
+
+    When ready:
+        django-admin build_metabase_final_tables
+    """
+
+    help = "Build Metabase final tables."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run", dest="dry_run", action="store_true", help="Populate alternate tables with sample data"
+        )
+
+    def handle(self, dry_run=False, **options):
+        build_final_tables(dry_run=dry_run)
+        self.stdout.write("-" * 80)
+        self.stdout.write("Done.")

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -64,7 +64,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from itou.metabase.management.commands._dataframes import store_df
-from itou.metabase.management.commands._utils import build_custom_tables
+from itou.metabase.management.commands._utils import build_final_tables
 from itou.siaes.management.commands._import_siae.utils import get_fluxiae_df, get_fluxiae_referential_filenames, timeit
 from itou.utils.slack import send_slack_message
 
@@ -133,7 +133,7 @@ class Command(BaseCommand):
         self.populate_fluxiae_view(vue_name="fluxIAE_Structure")
 
         # Build custom tables by running raw SQL queries on existing tables.
-        build_custom_tables(dry_run=self.dry_run)
+        build_final_tables(dry_run=self.dry_run)
 
         send_slack_message(
             ":white_check_mark: Fin de la mise à jour hebdomadaire de Metabase avec les"

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -61,6 +61,7 @@ from itou.metabase.management.commands._utils import (
     convert_boolean_to_int,
 )
 from itou.prescribers.models import PrescriberOrganization
+from itou.siaes.management.commands._import_siae.utils import timeit
 from itou.siaes.models import Siae, SiaeJobDescription
 from itou.users.models import User
 from itou.utils.slack import send_slack_message
@@ -429,6 +430,7 @@ class Command(BaseCommand):
         df = get_df_from_rows(rows)
         store_df(df=df, table_name=table_name, dry_run=self.dry_run)
 
+    @timeit
     def report_data_inconsistencies(self):
         """
         Report data inconsistencies that were previously ignored during `populate_approvals` method in order to avoid
@@ -449,6 +451,7 @@ class Command(BaseCommand):
                 "manual resolution, see command output"
             )
 
+    @timeit
     def build_final_tables(self):
         build_final_tables(dry_run=self.dry_run)
 
@@ -495,6 +498,7 @@ class Command(BaseCommand):
             " dernières données C1 :white_check_mark:"
         )
 
+    @timeit
     def handle(self, dry_run=False, **options):
         self.dry_run = dry_run
         self.populate_metabase_itou()

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -55,7 +55,7 @@ from itou.metabase.management.commands._database_tables import (
 from itou.metabase.management.commands._dataframes import get_df_from_rows, store_df
 from itou.metabase.management.commands._utils import (
     anonymize,
-    build_custom_tables,
+    build_final_tables,
     chunked_queryset,
     compose,
     convert_boolean_to_int,
@@ -449,8 +449,8 @@ class Command(BaseCommand):
                 "manual resolution, see command output"
             )
 
-    def build_custom_tables(self):
-        build_custom_tables(dry_run=self.dry_run)
+    def build_final_tables(self):
+        build_final_tables(dry_run=self.dry_run)
 
     def populate_metabase_itou(self):
         if not settings.ALLOW_POPULATING_METABASE:
@@ -479,7 +479,7 @@ class Command(BaseCommand):
             self.populate_rome_codes,
             self.populate_insee_codes,
             self.populate_departments,
-            self.build_custom_tables,
+            self.build_final_tables,
             self.report_data_inconsistencies,
         ]
 


### PR DESCRIPTION
### Quoi ?

Ajout d'une nouvelle github action Metabase pratique pour nos data analysts C2.

### Pourquoi ?

Après avoir fusionné leurs changements (PR sur les requêtes SQL de fin d'import Metabase), nos data analystes doivent actuellement :
- soit attendre le lendemain matin que le `populate_metabase_itou` de la nuit ait tourné
- soit lancer manuellement la github action `populate_metabase_itou` qui prend plusieurs heures (3-6h)

Ils voudraient un moyen de lancer uniquement les requêtes SQL de fin d'import (15-30min) pour voir plus vite leurs changements.

### Comment ?

En ajoutant une nouvelle github action `build_metabase_final_tables` qui fait exactement cela.

### Notes

Il n'est pas vraiment possible de tester la github action avant son arrivée dans `master`.  Il est du coup possible qu'une seconde PR de correctifs suive. ¯\_(ツ)_/¯

### Autre

https://www.notion.so/En-tant-que-data-analyst-sur-le-C2-je-voudrais-lancer-uniquement-les-requ-tes-SQL-de-fin-d-import-Me-c32189b105bc48f58e7e49836fd97e4b