### PR TITLE
Synchronisation du groupe de permissions du support externe

### DIFF
--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -1,140 +1,97 @@
+# pylint: disable=import-outside-toplevel
 from django.contrib.auth.models import Group, Permission
 from django.core.management.base import BaseCommand
+from django.db import transaction
+
+
+PERMS_ALL = {"add", "change", "delete", "view"}
+PERMS_DELETE = {"change", "delete", "view"}
+PERMS_ADD = {"add", "change", "view"}
+PERMS_EDIT = {"change", "view"}
+PERMS_READ = {"view"}
+
+
+def get_permissions_dict():
+    # lazy-import necessary models. Better than using string since we can then use introspection
+    # and tooling will help us with refactoring, dead code and models, etc.
+    import allauth.account.models as account_models
+
+    import itou.approvals.models as approvals_models
+    import itou.asp.models as asp_models
+    import itou.cities.models as cities_models
+    import itou.eligibility.models as eligibility_models
+    import itou.employee_record.models as employee_record_models
+    import itou.institutions.models as institution_models
+    import itou.invitations.models as invitation_models
+    import itou.job_applications.models as job_applications_models
+    import itou.jobs.models as jobs_models
+    import itou.prescribers.models as prescribers_models
+    import itou.siaes.models as siaes_models
+    import itou.users.models as users_models
+
+    return {
+        "itou-admin": {
+            account_models.EmailAddress: PERMS_ADD,
+            approvals_models.Approval: PERMS_ALL,
+            approvals_models.PoleEmploiApproval: PERMS_READ,
+            approvals_models.Suspension: PERMS_ALL,
+            approvals_models.Prolongation: PERMS_ALL,
+            cities_models.City: PERMS_READ,
+            employee_record_models.EmployeeRecord: PERMS_EDIT,
+            eligibility_models.AdministrativeCriteria: PERMS_READ,
+            eligibility_models.EligibilityDiagnosis: PERMS_ADD,
+            eligibility_models.SelectedAdministrativeCriteria: PERMS_ALL,
+            institution_models.Institution: PERMS_ADD,
+            institution_models.InstitutionMembership: PERMS_ALL,
+            invitation_models.LaborInspectorInvitation: PERMS_DELETE,
+            invitation_models.PrescriberWithOrgInvitation: PERMS_DELETE,
+            invitation_models.SiaeStaffInvitation: PERMS_DELETE,
+            job_applications_models.JobApplication: PERMS_READ,
+            job_applications_models.JobApplicationTransitionLog: PERMS_READ,
+            jobs_models.Appellation: PERMS_READ,
+            jobs_models.Rome: PERMS_READ,
+            prescribers_models.PrescriberMembership: PERMS_ALL,
+            prescribers_models.PrescriberOrganization: PERMS_ADD,
+            siaes_models.Siae: PERMS_ADD,
+            siaes_models.SiaeConvention: PERMS_EDIT,
+            siaes_models.SiaeFinancialAnnex: PERMS_READ,
+            siaes_models.SiaeJobDescription: PERMS_ALL,
+            siaes_models.SiaeMembership: PERMS_ALL,
+            users_models.User: PERMS_ADD,
+            users_models.JobSeekerProfile: PERMS_EDIT,
+        }
+        | {
+            model: PERMS_READ
+            for model in (
+                asp_models.Commune,
+                asp_models.Country,
+                asp_models.Department,
+            )
+        }
+    }
+
+
+def to_perm_codenames(model, perms_set):
+    return [f"{perm}_{model._meta.model_name}" for perm in perms_set]
 
 
 class Command(BaseCommand):
-    """
-    Synchronize groups and permissions.
-
-    To run the command:
-        django-admin sync_group_and_perms
-    """
 
     help = "Synchronize groups and permissions."
 
+    @transaction.atomic
     def handle(self, **options):
 
-        # This group contains the permissions assigned to the Itou team members.
-        GROUP_NAME = "itou-admin"
-
-        perms_codenames = [
-            # account.EmailAddress
-            "add_emailaddress",
-            "change_emailaddress",
-            "view_emailaddress",
-            # approvals.Approval
-            "add_approval",
-            "change_approval",
-            "delete_approval",
-            "view_approval",
-            # approvals.PoleEmploiApproval
-            "view_poleemploiapproval",
-            # approvals.Suspension
-            "add_suspension",
-            "change_suspension",
-            "delete_suspension",
-            "view_suspension",
-            # approvals.Prolongation
-            "add_prolongation",
-            "change_prolongation",
-            "delete_prolongation",
-            "view_prolongation",
-            # cities.City
-            "view_city",
-            # employee_record.EmployeeRecord
-            "view_employeerecord",
-            "change_employeerecord",
-            # eligibility.AdministrativeCriteria
-            "view_administrativecriteria",
-            # eligibility.EligibilityDiagnosis
-            "add_eligibilitydiagnosis",
-            "change_eligibilitydiagnosis",
-            "view_eligibilitydiagnosis",
-            # eligibility.SelectedAdministrativeCriteria
-            "add_selectedadministrativecriteria",
-            "change_selectedadministrativecriteria",
-            "delete_selectedadministrativecriteria",
-            "view_selectedadministrativecriteria",
-            # institutions.Institution
-            "add_institution",
-            "change_institution",
-            "view_institution",
-            # institutions.InstitutionMembership
-            "add_institutionmembership",
-            "change_institutionmembership",
-            "delete_institutionmembership",
-            "view_institutionmembership",
-            # invitations.LaborInspectorInvitation
-            "change_laborinspectorinvitation",
-            "delete_laborinspectorinvitation",
-            "view_laborinspectorinvitation",
-            # invitations.PrescriberWithOrgInvitation
-            "change_prescriberwithorginvitation",
-            "delete_prescriberwithorginvitation",
-            "view_prescriberwithorginvitation",
-            # invitations.SiaeStaffInvitation
-            "change_siaestaffinvitation",
-            "delete_siaestaffinvitation",
-            "view_siaestaffinvitation",
-            # job_applications.JobApplication
-            "view_jobapplication",
-            "view_jobapplicationtransitionlog",
-            # jobs.Appellation
-            "view_appellation",
-            # jobs.Rome
-            "view_rome",
-            # prescribers.PrescriberMembership
-            "add_prescribermembership",
-            "change_prescribermembership",
-            "delete_prescribermembership",
-            "view_prescribermembership",
-            # prescribers.PrescriberOrganization
-            "add_prescriberorganization",
-            "change_prescriberorganization",
-            "view_prescriberorganization",
-            # siaes.Siae
-            "add_siae",
-            "change_siae",
-            "view_siae",
-            # siaes.SiaeConvention
-            "change_siaeconvention",
-            "view_siaeconvention",
-            # siaes.SiaeFinancialAnnex
-            "view_siaefinancialannex",
-            # siaes.SiaeJobDescription
-            "add_siaejobdescription",
-            "change_siaejobdescription",
-            "delete_siaejobdescription",
-            "view_siaejobdescription",
-            # siaes.SiaeMembership
-            "add_siaemembership",
-            "change_siaemembership",
-            "delete_siaemembership",
-            "view_siaemembership",
-            # users.User
-            "add_user",
-            "change_user",
-            "view_user",
-            # users.JobseekerProfile
-            "view_jobseekerprofile",
-            "change_jobseekerprofile",
-            # ASP
-            "view_commune",
-            "view_country",
-            "view_department",
-            "view_educationlevel",
-            "view_measure",
-            "view_employertype",
-        ]
-
-        perms = Permission.objects.filter(codename__in=perms_codenames)
-
-        group, created = Group.objects.get_or_create(name=GROUP_NAME)
-
-        group.permissions.clear()
-        group.permissions.add(*perms)
-
-        if created:
-            self.stdout.write(f"Group '{GROUP_NAME}' created.")
-        self.stdout.write(f"Permissions of '{GROUP_NAME}' updated.")
-        self.stdout.write("Done!")
+        for group, raw_permissions in get_permissions_dict().items():
+            all_codenames = [
+                perm_code for model, perms in raw_permissions.items() for perm_code in to_perm_codenames(model, perms)
+            ]
+            perms = Permission.objects.filter(codename__in=all_codenames)
+            group, created = Group.objects.get_or_create(name=group)
+            group.permissions.clear()
+            group.permissions.add(*perms)
+            if created:
+                self.stdout.write(f"group name={group} created")
+            else:
+                self.stdout.write(f"permissions of group={group} updated")
+        self.stdout.write("All done!")

--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -36,6 +36,9 @@ def get_permissions_dict():
             approvals_models.PoleEmploiApproval: PERMS_READ,
             approvals_models.Suspension: PERMS_ALL,
             approvals_models.Prolongation: PERMS_ALL,
+            asp_models.Commune: PERMS_READ,
+            asp_models.Country: PERMS_READ,
+            asp_models.Department: PERMS_READ,
             cities_models.City: PERMS_READ,
             employee_record_models.EmployeeRecord: PERMS_EDIT,
             eligibility_models.AdministrativeCriteria: PERMS_READ,
@@ -59,15 +62,43 @@ def get_permissions_dict():
             siaes_models.SiaeMembership: PERMS_ALL,
             users_models.User: PERMS_ADD,
             users_models.JobSeekerProfile: PERMS_EDIT,
-        }
-        | {
+        },
+        "itou-support-externe": {
             model: PERMS_READ
             for model in (
+                account_models.EmailAddress,
+                approvals_models.Approval,
+                approvals_models.PoleEmploiApproval,
+                approvals_models.Suspension,
+                approvals_models.Prolongation,
                 asp_models.Commune,
                 asp_models.Country,
                 asp_models.Department,
+                cities_models.City,
+                employee_record_models.EmployeeRecord,
+                eligibility_models.AdministrativeCriteria,
+                eligibility_models.EligibilityDiagnosis,
+                eligibility_models.SelectedAdministrativeCriteria,
+                institution_models.Institution,
+                institution_models.InstitutionMembership,
+                invitation_models.LaborInspectorInvitation,
+                invitation_models.PrescriberWithOrgInvitation,
+                invitation_models.SiaeStaffInvitation,
+                job_applications_models.JobApplication,
+                job_applications_models.JobApplicationTransitionLog,
+                jobs_models.Appellation,
+                jobs_models.Rome,
+                prescribers_models.PrescriberMembership,
+                prescribers_models.PrescriberOrganization,
+                siaes_models.Siae,
+                siaes_models.SiaeConvention,
+                siaes_models.SiaeFinancialAnnex,
+                siaes_models.SiaeJobDescription,
+                siaes_models.SiaeMembership,
+                users_models.User,
+                users_models.JobSeekerProfile,
             )
-        }
+        },
     }
 
 

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -856,10 +856,14 @@ class TestSyncPermsTestCase(TestCase):
             output,
             [
                 "group name=itou-admin created\n",
+                "group name=itou-support-externe created\n",
                 "All done!\n",
             ],
         )
-        self.assertEqual(Group.objects.all().count(), 1)
-        group = Group.objects.get()
-        self.assertEqual(group.name, "itou-admin")
-        self.assertEqual(group.permissions.count(), 76)
+        self.assertEqual(Group.objects.all().count(), 2)
+        admin_group = Group.objects.all()[0]
+        self.assertEqual(admin_group.name, "itou-admin")
+        self.assertEqual(admin_group.permissions.count(), 76)
+        support_group = Group.objects.all()[1]
+        self.assertEqual(support_group.name, "itou-support-externe")
+        self.assertEqual(support_group.permissions.count(), 31)


### PR DESCRIPTION
### Quoi ?

Ajouter le support externe au script de synchro des permissions.

### Pourquoi ?
On ne doit pas gérer cela manuellement dans l'admin, c'est dangereux et on perd notre maîtrise des droits des utilisateurs.


### Comment ?
En utilisant une commande qui le sremet d'aplomb à chaque déploiement.

