### PR TITLE
Agréments : recherche par NIR en plus du pole_emploi_id

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -316,7 +316,7 @@ class PoleEmploiApprovalAdmin(admin.ModelAdmin):
         "is_valid",
         "created_at",
     )
-    search_fields = ("pk", "pole_emploi_id", "number", "first_name", "last_name", "birth_name")
+    search_fields = ("pk", "pole_emploi_id", "nir", "number", "first_name", "last_name", "birth_name")
     list_filter = (IsValidFilter,)
     date_hierarchy = "birthdate"
 

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -993,20 +993,20 @@ class PoleEmploiApprovalManager(models.Manager):
         - there can be an inversion of first and last name fields
         - imported data can be poorly structured (first and last names in the same field)
 
-        The only solution to ID a person between information systems would be to have
-        a unique ID per user known by everyone (Itou, PE and the job seeker).
+        In many cases, we can identify the user based on its NIR number, when the PoleEmploiApproval
+        has this information (which is the case 90% of the time) and we also have it.
 
-        Yet we don't have such an identifier.
-
-        As a workaround, we rely on the combination of `pole_emploi_id` (non-unique
-        but it is assumed that every job seeker knows his number) and `birthdate`.
+        We'll also return the PE Approvals based on the combination of `pole_emploi_id`
+        (non-unique but it is assumed that every job seeker knows his number) and `birthdate`.
 
         Their input formats can be checked to limit the risk of errors.
         """
         # Save some SQL queries.
-        if not user.pole_emploi_id or not user.birthdate:
+        if not user.nir and (not user.pole_emploi_id and user.birthdate):
             return self.none()
-        return self.filter(pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate).order_by("-start_at")
+        return self.filter(Q(nir=user.nir) | Q(pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate)).order_by(
+            "-start_at"
+        )
 
     def without_nir_ntt_or_nia(self):
         return self.filter(Q(nir=None) & Q(ntt_nia=None))

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -1043,6 +1043,28 @@ class JobApplicationWorkflowTest(TestCase):
         # Approval delivered -> Pole Emploi is notified
         notify_mock.assert_called()
 
+    def test_accept_job_application_sent_by_job_seeker_with_already_existing_valid_approval_with_nir(
+        self, notify_mock
+    ):
+        job_seeker = JobSeekerFactory(pole_emploi_id="", birthdate=None)
+        pe_approval = PoleEmploiApprovalFactory(nir=job_seeker.nir)
+        job_application = JobApplicationSentByJobSeekerFactory(
+            job_seeker=job_seeker, state=JobApplicationWorkflow.STATE_PROCESSING
+        )
+        job_application.accept(user=job_application.to_siae.members.first())
+        self.assertIsNotNone(job_application.approval)
+        self.assertEqual(job_application.approval.number, pe_approval.number)
+        self.assertTrue(job_application.approval_number_sent_by_email)
+        self.assertEqual(job_application.approval_delivery_mode, job_application.APPROVAL_DELIVERY_MODE_AUTOMATIC)
+        # Check sent emails.
+        self.assertEqual(len(mail.outbox), 2)
+        # Email sent to the job seeker.
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
+        # Email sent to the employer.
+        self.assertIn(self.sent_pass_email_subject, mail.outbox[1].subject)
+        # Approval delivered -> Pole Emploi is notified
+        notify_mock.assert_called()
+
     def test_accept_job_application_sent_by_job_seeker_with_already_existing_valid_approval_in_the_future(
         self, notify_mock
     ):

--- a/itou/users/factories.py
+++ b/itou/users/factories.py
@@ -28,13 +28,13 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.User
 
-    username = factory.Sequence("user_name{0}".format)
-    first_name = factory.Sequence("first_name{0}".format)
-    last_name = factory.Sequence("last_name{0}".format)
-    email = factory.Sequence("email{0}@domain.com".format)
+    username = factory.Faker("user_name")
+    first_name = factory.Faker("first_name")
+    last_name = factory.Faker("last_name")
+    email = factory.Faker("email")
     password = factory.PostGenerationMethodCall("set_password", DEFAULT_PASSWORD)
     birthdate = factory.fuzzy.FuzzyDate(datetime.date(1968, 1, 1), datetime.date(2000, 1, 1))
-    phone = factory.fuzzy.FuzzyText(length=10, chars=string.digits)
+    phone = factory.Faker("phone_number", locale="fr_FR")
 
 
 class JobSeekerFactory(UserFactory):

--- a/itou/users/factories.py
+++ b/itou/users/factories.py
@@ -47,8 +47,12 @@ class JobSeekerFactory(UserFactory):
     @factory.lazy_attribute
     def nir(self):
         gender = random.choice([1, 2])
-        year = self.birthdate.strftime("%y")
-        month = self.birthdate.strftime("%m")
+        if self.birthdate:
+            year = self.birthdate.strftime("%y")
+            month = self.birthdate.strftime("%m")
+        else:
+            year = "87"
+            month = "06"
         department = str(random.randint(1, 99)).zfill(2)
         random_1 = str(random.randint(0, 399)).zfill(3)
         random_2 = str(random.randint(0, 399)).zfill(3)


### PR DESCRIPTION
### Quoi ?

Effectuer une recherche d'agrément par NIR avant de laisser la possibilité (comme aujourd'hui) de rechercher par ID PE.

### Pourquoi ?

Cela permettrait de réduire significativement la charge du support qui crée des PASS manuellement en faisant une recherche d'agrément à la main, quand elle pourrait souvent etre faite par NIR.

### Comment ?
En l'ajoutant à la recherche actuelle par ID pole emploi.

### Recette

J'ai créé  des membres dans la structure de type EI "Garage Martinet Siège" qui sont à valider.

Dans l'ancienne version, on n'a accès (dans "Gérer la candidature") que à une liste manuelle de critères.
Ici, comme on trouve un Agrément PE contenant le NIR de chacun de ces 5 candidats, on a la possibilité de créer le PASS IAE automatiquement.

https://c1-review-vperron-look-for-nir.cleverapps.io/apply/siae/list?states=new&states=processing