### PR TITLE
WIP fixes flaky test

### DIFF
--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -1078,7 +1078,7 @@ class SuspensionModelTest(TestCase):
             self.assertEqual(len(result), 4)
 
     def test_next_min_start_date(self):
-        today = timezone.now()
+        today = datetime.date.today()
         start_at = today - relativedelta(days=10)
 
         job_application_1 = JobApplicationWithApprovalFactory(hiring_start_at=today)
@@ -1092,19 +1092,17 @@ class SuspensionModelTest(TestCase):
         # What should be the expected suspension mimimum start date ?
 
         min_start_at = Suspension.next_min_start_at(job_application_1.approval)
-        self.assertEqual(min_start_at, today.date())
+        self.assertEqual(min_start_at, today)
 
         # Same rules apply for PE approval and PASS IAE
         min_start_at = Suspension.next_min_start_at(job_application_2.approval)
-        self.assertEqual(min_start_at, start_at.date())
+        self.assertEqual(min_start_at, start_at)
         min_start_at = Suspension.next_min_start_at(job_application_3.approval)
-        self.assertEqual(min_start_at, start_at.date())
+        self.assertEqual(min_start_at, start_at)
 
         # Fix a type error when creating a suspension:
         min_start_at = Suspension.next_min_start_at(job_application_4.approval)
-        self.assertEqual(
-            min_start_at, today.date() - datetime.timedelta(days=Suspension.MAX_RETROACTIVITY_DURATION_DAYS)
-        )
+        self.assertEqual(min_start_at, today - datetime.timedelta(days=Suspension.MAX_RETROACTIVITY_DURATION_DAYS))
 
 
 class SuspensionModelTestTrigger(TestCase):

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -1078,7 +1078,7 @@ class SuspensionModelTest(TestCase):
             self.assertEqual(len(result), 4)
 
     def test_next_min_start_date(self):
-        today = datetime.date.today()
+        today = timezone.localdate()
         start_at = today - relativedelta(days=10)
 
         job_application_1 = JobApplicationWithApprovalFactory(hiring_start_at=today)

--- a/itou/employee_record/tests/tests_notifications.py
+++ b/itou/employee_record/tests/tests_notifications.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import timedelta
 
 from django.test.testcases import TestCase
 from django.utils import timezone
@@ -16,7 +16,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # A normal case
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
         approval = employee_record.approval
-        today = date.today()
+        today = timezone.localdate()
 
         approval.start_at = today + timedelta(days=1)
         approval.save()
@@ -31,7 +31,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # Another normal case
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
         approval = employee_record.approval
-        today = timezone.now().date()
+        today = timezone.localdate()
 
         approval.end_at = today + timedelta(days=2)
         approval.save()
@@ -46,7 +46,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # (which is the last one)
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
         approval = employee_record.approval
-        today = date.today()
+        today = timezone.localdate()
 
         approval.start_at = today + timedelta(days=1)
         approval.save()
@@ -68,7 +68,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
         approval = employee_record.approval
 
-        approval.created_at = timezone.now()
+        approval.created_at = timezone.localtime()
         approval.save()
 
         self.assertEqual(1, EmployeeRecord.objects.count())
@@ -78,7 +78,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # If a date modification occurs on an approval NOT linked to any employee record,
         # then no notification object must be created.
         approval = ApprovalFactory()
-        today = timezone.now().date()
+        today = timezone.localdate()
 
         approval.end_at = today + timedelta(days=2)
         approval.save()
@@ -92,7 +92,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
             with self.subTest(status):
                 employee_record = EmployeeRecordFactory(status=status)
                 approval = employee_record.approval
-                today = timezone.now().date()
+                today = timezone.localtime()
 
                 approval.created_at = today + timedelta(days=2)
                 approval.save()
@@ -113,6 +113,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         employee_record_2.save()
 
         approval.end_at = timezone.now().date() + timedelta(days=2)
+        approval.end_at = timezone.localdate() + timedelta(days=2)
         approval.save()
 
         self.assertEqual(2, EmployeeRecordUpdateNotification.objects.new().count())
@@ -124,7 +125,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # must also create a new employee record update notification.
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
         approval = employee_record.approval
-        start_at = timezone.now().date()
+        start_at = timezone.localdate()
 
         SuspensionFactory(
             approval=approval,

--- a/itou/employee_record/tests/tests_notifications.py
+++ b/itou/employee_record/tests/tests_notifications.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import date, timedelta
 
 from django.test.testcases import TestCase
 from django.utils import timezone
@@ -16,7 +16,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # A normal case
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
         approval = employee_record.approval
-        today = timezone.now().date()
+        today = date.today()
 
         approval.start_at = today + timedelta(days=1)
         approval.save()
@@ -46,7 +46,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # (which is the last one)
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
         approval = employee_record.approval
-        today = timezone.now().date()
+        today = date.today()
 
         approval.start_at = today + timedelta(days=1)
         approval.save()


### PR DESCRIPTION
### Quoi ?

Correction de plusieus test instables.

### Pourquoi ?

- problème aux alentours de minuit avec des `date` et `timezone`,
- ça bloque la C.I. la nuit.

### Comment ?

Mettre des timezones à la place de dates n'est (vraiment) pas une bonne idée.

