### PR TITLE
HOTFIX : ajout d'un champ manquant dans les fiches de postes pour les OPCS

### DIFF
--- a/itou/templates/siaes/edit_job_description.html
+++ b/itou/templates/siaes/edit_job_description.html
@@ -42,6 +42,9 @@
             {% bootstrap_field form.custom_name %}
             {% bootstrap_field form.location_label %}
             {% bootstrap_field form.location_code %}
+            {% if form.market_context_description %}
+                {% bootstrap_field form.market_context_description %}
+            {% endif %}
             {% bootstrap_field form.contract_type %}
             <div id="_other_contract_type_group">
                 {% bootstrap_field form.other_contract_type %}


### PR DESCRIPTION
### Quoi ?

Le champ concernant la description du contexte de marché pour les OPCS est absent du formulaire (régression).

### Pourquoi ?

Lors de l'ajout de la modification du type de contrat, la structure du gabarit à changé, et le champ est passé à la trappe.

### Comment ?

Simple ajout du champ dans le gabarit dans le cas d'un OPCS.

