### PR TITLE
Modification du critère d’éligibilité réfugié

### DIFF
--- a/itou/eligibility/migrations/0009_rename_refugee_administrative_criteria.py
+++ b/itou/eligibility/migrations/0009_rename_refugee_administrative_criteria.py
@@ -1,0 +1,31 @@
+from django.db import migrations
+
+
+def migrate_data_forward(apps, schema_editor):  # pylint: disable=unused-argument
+    AdministrativeCriteria = apps.get_model("eligibility", "AdministrativeCriteria")
+    AdministrativeCriteria.objects.filter(name="Réfugié statutaire, protégé subsidiaire ou demandeur d'asile").update(
+        name="Réfugié statutaire, bénéficiaire d'une protection temporaire, protégé subsidiaire ou demandeur d'asile",
+        written_proof="Titre de séjour valide ou demande de renouvellement du titre de séjour. "
+        "Pour les demandeurs d'asile : autorisation temporaire de travail. "
+        "Pour les bénéficiaires d'une protection temporaire : autorisation provisoire de séjour.",
+    )
+
+
+def migrate_data_backward(apps, schema_editor):  # pylint: disable=unused-argument
+    AdministrativeCriteria = apps.get_model("eligibility", "AdministrativeCriteria")
+    AdministrativeCriteria.objects.filter(
+        name="Réfugié statutaire, bénéficiaire d'une protection temporaire, protégé subsidiaire ou demandeur d'asile"
+    ).update(
+        name="Réfugié statutaire, protégé subsidiaire ou demandeur d'asile",
+        written_proof="Titre de séjour valide ou demande de renouvellement du titre de séjour. "
+        "Pour les demandeurs d'asile : autorisation temporaire de travail",
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("eligibility", "0008_rename_rsa_administrative_criteria"),
+    ]
+
+    operations = [migrations.RunPython(migrate_data_forward, migrate_data_backward)]


### PR DESCRIPTION
### Quoi ?

Changement du nom et du texte des justificatifs sur le critère administratif réfugié.

### Pourquoi ?

Suite à l’Arrêté du 12 avril 2022 modifiant l'arrêté du 1er septembre 2021 fixant la liste des critères d'éligibilité des personnes à un parcours d'insertion par l'activité économique

### Comment ?

Création d'une migration pour la mise à jour du critère concerné.

### Captures d'écrans

Formulaire d'éligibilité :

![critere_refugie](https://user-images.githubusercontent.com/17601807/165730456-8663acf8-ca77-49f0-90ab-cda83dd57102.png)


