### PR TITLE
Mise à jour de la dépendance Python Redis

### DIFF
--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,5 +1,5 @@
 # Debian Buster slim variant.
-FROM python:3.9.2-slim-buster
+FROM python:3.9.12-slim-buster
 
 ENV DOCKER_DEFAULT_PLATFORM=linux/amd64
 # Inspiration


### PR DESCRIPTION
### Quoi ?

Passage du paquet Python Redis à la dernière version, la 4.2.2.

### Pourquoi ?

Une erreur dans la CI est lié à la version du paquet Python Pickle qui est une dépendance du paquet Redis.

### Comment ?

En mettant à jour le paquet redis, le paquet pickle est lui aussi mis à jour.
