### PR TITLE
Ajout d'une colonne "DateRattachement" dans l'extract des utilisateurs C2

### DIFF
--- a/itou/users/management/commands/extract_c2_users.py
+++ b/itou/users/management/commands/extract_c2_users.py
@@ -51,6 +51,7 @@ class Command(BaseCommand):
             "Prénom": user.first_name,
             "Nom": user.last_name,
             "Admin": membership.is_admin,
+            "DateRattachement": membership.created_at.date(),
             "Département": DEPARTMENTS[org.department] if org.department else None,
             "Région": org.region,
         }


### PR DESCRIPTION
### Quoi ?

Ajout d'une colonne "DateRattachement" dans l'extract des utilisateurs C2.

### Pourquoi ?

Pour aider Annie à identifier les nouveaux utilisateurs qui arrivent dans cet extract semaine après semaine.

Pas de revue nécessaire... pas besoin.