### PR TITLE
Recherche d'agréments PE par NIR : version corrigée

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -316,7 +316,7 @@ class PoleEmploiApprovalAdmin(admin.ModelAdmin):
         "is_valid",
         "created_at",
     )
-    search_fields = ("pk", "pole_emploi_id", "number", "first_name", "last_name", "birth_name")
+    search_fields = ("pk", "pole_emploi_id", "nir", "number", "first_name", "last_name", "birth_name")
     list_filter = (IsValidFilter,)
     date_hierarchy = "birthdate"
 

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -993,20 +993,20 @@ class PoleEmploiApprovalManager(models.Manager):
         - there can be an inversion of first and last name fields
         - imported data can be poorly structured (first and last names in the same field)
 
-        The only solution to ID a person between information systems would be to have
-        a unique ID per user known by everyone (Itou, PE and the job seeker).
+        In many cases, we can identify the user based on its NIR number, when the PoleEmploiApproval
+        has this information (which is the case 90% of the time) and we also have it.
 
-        Yet we don't have such an identifier.
-
-        As a workaround, we rely on the combination of `pole_emploi_id` (non-unique
-        but it is assumed that every job seeker knows his number) and `birthdate`.
+        We'll also return the PE Approvals based on the combination of `pole_emploi_id`
+        (non-unique but it is assumed that every job seeker knows his number) and `birthdate`.
 
         Their input formats can be checked to limit the risk of errors.
         """
         # Save some SQL queries.
-        if not user.pole_emploi_id or not user.birthdate:
+        if not user.nir and (not user.pole_emploi_id and user.birthdate):
             return self.none()
-        return self.filter(pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate).order_by("-start_at")
+        return self.filter(Q(nir=user.nir) | Q(pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate)).order_by(
+            "-start_at"
+        )
 
     def without_nir_ntt_or_nia(self):
         return self.filter(Q(nir=None) & Q(ntt_nia=None))

--- a/itou/job_applications/tests.py
+++ b/itou/job_applications/tests.py
@@ -1043,6 +1043,28 @@ class JobApplicationWorkflowTest(TestCase):
         # Approval delivered -> Pole Emploi is notified
         notify_mock.assert_called()
 
+    def test_accept_job_application_sent_by_job_seeker_with_already_existing_valid_approval_with_nir(
+        self, notify_mock
+    ):
+        job_seeker = JobSeekerFactory(pole_emploi_id="", birthdate=None)
+        pe_approval = PoleEmploiApprovalFactory(nir=job_seeker.nir)
+        job_application = JobApplicationSentByJobSeekerFactory(
+            job_seeker=job_seeker, state=JobApplicationWorkflow.STATE_PROCESSING
+        )
+        job_application.accept(user=job_application.to_siae.members.first())
+        self.assertIsNotNone(job_application.approval)
+        self.assertEqual(job_application.approval.number, pe_approval.number)
+        self.assertTrue(job_application.approval_number_sent_by_email)
+        self.assertEqual(job_application.approval_delivery_mode, job_application.APPROVAL_DELIVERY_MODE_AUTOMATIC)
+        # Check sent emails.
+        self.assertEqual(len(mail.outbox), 2)
+        # Email sent to the job seeker.
+        self.assertIn(self.accept_email_subject_job_seeker, mail.outbox[0].subject)
+        # Email sent to the employer.
+        self.assertIn(self.sent_pass_email_subject, mail.outbox[1].subject)
+        # Approval delivered -> Pole Emploi is notified
+        notify_mock.assert_called()
+
     def test_accept_job_application_sent_by_job_seeker_with_already_existing_valid_approval_in_the_future(
         self, notify_mock
     ):

--- a/itou/users/factories.py
+++ b/itou/users/factories.py
@@ -47,8 +47,12 @@ class JobSeekerFactory(UserFactory):
     @factory.lazy_attribute
     def nir(self):
         gender = random.choice([1, 2])
-        year = self.birthdate.strftime("%y")
-        month = self.birthdate.strftime("%m")
+        if self.birthdate:
+            year = self.birthdate.strftime("%y")
+            month = self.birthdate.strftime("%m")
+        else:
+            year = "87"
+            month = "06"
         department = str(random.randint(1, 99)).zfill(2)
         random_1 = str(random.randint(0, 399)).zfill(3)
         random_2 = str(random.randint(0, 399)).zfill(3)


### PR DESCRIPTION
### Quoi ?

Réintroduire la recherche par NIR, exemptée du bug que l'on a constaté en production.

### Pourquoi ?
Elle avait été retirée jeudi dernier suite à des soucis en production.

### Comment ?
Il fallait absolument corriger le bug introduit, qui faisait remonter le plus ancien agrément PE comportant un NIR vide quel que soti le demandeur d'emploi à NIR vide.

Ceci est désormais testé.

**A LIRE COMMIT PAR COMMIT**
- le commit initial, réintroduit
- son fix