### PR TITLE
Éviter les erreurs d'unicité aléatoires sur les tests

### DIFF
--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,5 +1,5 @@
 # Debian Buster slim variant.
-FROM python:3.9.2-slim-buster
+FROM python:3.9.12-slim-buster
 
 ENV DOCKER_DEFAULT_PLATFORM=linux/amd64
 # Inspiration

--- a/itou/users/factories.py
+++ b/itou/users/factories.py
@@ -28,10 +28,10 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.User
 
-    username = factory.Faker("user_name")
+    username = factory.Sequence("user_name{0}".format)
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
-    email = factory.Faker("email")
+    email = factory.Sequence("email{0}@domain.com".format)
     password = factory.PostGenerationMethodCall("set_password", DEFAULT_PASSWORD)
     birthdate = factory.fuzzy.FuzzyDate(datetime.date(1968, 1, 1), datetime.date(2000, 1, 1))
     phone = factory.Faker("phone_number", locale="fr_FR")


### PR DESCRIPTION
### Quoi ?

Débloquer les CI en évitant les erreurs d'unicité sur les tests.

### Pourquoi ?

Des erreurs d'unicité apparaissent inopinément sur les tests.

### Comment ?

En remettant les séquences sur le `username` et l'email sur la factory user.

J'en profite pour aligner la version de l'image Docker de dév avec la version Python de la CI. 