### PR TITLE
Inscription de demandeur d'emploi: ne pas crasher en cas de préexistence d'un NIR (et petits patchs)

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -85,5 +85,3 @@ if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:
     import debug_toolbar
 
     urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
-    # In the local developpemnt environment, we enable the default callback URLs
-    urlpatterns = [path("", include("itou.france_connect.urls"))] + urlpatterns

--- a/itou/job_applications/tasks.py
+++ b/itou/job_applications/tasks.py
@@ -58,7 +58,7 @@ def notify_pole_emploi_pass(job_application, job_seeker):
     try:
         token = JobApplicationPoleEmploiNotificationLog.get_token()
         sleep(SLEEP_DELAY)
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-except
         logger.error("! fetching token raised exception=%s", e)
         log.status = JobApplicationPoleEmploiNotificationLog.STATUS_FAIL_AUTHENTICATION
         log.details = str(e)
@@ -71,7 +71,7 @@ def notify_pole_emploi_pass(job_application, job_seeker):
         logger.info("> got encrypted_nir=%s", encrypted_nir)
         sleep(SLEEP_DELAY)
     except PoleEmploiMiseAJourPassIAEException as e:
-        logger.error("! fetching encrypted NIR raised http_code=%s message=%s", e.http_code, e.response_code)
+        logger.info("! fetching encrypted NIR raised http_code=%s message=%s", e.http_code, e.response_code)
         log = JobApplicationPoleEmploiNotificationLog(
             job_application=job_application,
             status=JobApplicationPoleEmploiNotificationLog.STATUS_FAIL_SEARCH_INDIVIDUAL,
@@ -86,7 +86,7 @@ def notify_pole_emploi_pass(job_application, job_seeker):
         logger.info("> pass nir=%s updated successfully", job_application.job_seeker.nir)
         sleep(SLEEP_DELAY)
     except PoleEmploiMiseAJourPassIAEException as e:
-        logger.error("! updating pass iae raised http_code=%s message=%s", e.http_code, e.response_code)
+        logger.info("! updating pass iae raised http_code=%s message=%s", e.http_code, e.response_code)
         log.status = JobApplicationPoleEmploiNotificationLog.STATUS_FAIL_NOTIFY_POLE_EMPLOI
         # We log the encrypted nir in case its not empty but
         # it leads to an E_ERR_EX042_PROBLEME_DECHIFFREMEMENT anyway


### PR DESCRIPTION
### Quoi ?

Durant le parcours de création d'un demandeur d'emploi il arrive (rarement) que des erreurs 500 soient remontées pour cause de préexistence d'un autre utilisateur portant le même NIR.

Il faudrait idéalement:
- ne pas planter, mais le signaler à l'utilisateur;
- alternativement empecher via le parcours que ce probleme se présente. 

### Pourquoi ?
Ca empeche certains demandeurs d'emploi de se créer un compte.

### Comment ?
Je ne suis pas certain de ma solution à ce [pronblème remonté via Sentry](https://sentry.io/organizations/itou/issues/2959654373/events/bd4d6f5b9d9c4085be6a1a33e599492a/?project=6164438&query=is%3Aunresolved&sort=freq&statsPeriod=14d).

En effet le souci arrive dans la vue `apply:step_job_seeker` qui vient IMMEDIATEMENT après la vue `apply:step_job_seeker_nir` qui vérifie déjà que l'on ne connaît pas d'utilisateur avec ce NIR.

Autrement dit, un utilisateur est créé avec le NIR demandé dans le tunnel:
- APRES la verification de préexistence de l'utilisateur dans `step_job_seeker_nir`
- AVANT l'enregistrement du NIR sur l'utilisateur dont on a trouvé le mail dans `step_job_seeker`

On n'a pas beaucoup d'erreurs, mais bon. Je suppose qu'il s'agit d'onglets laissés ouverts:
- après une recherche infructueuse de candidat par NIR
- puis ledit NIR est renseigné dans un autre onglet/par le support/etc
- mais du coup l'etape d'après est une recherche par e-mail qui peut aboutir à retourner un "clone" n'ayant pas le NIR

Est-ce que l'analyse semble correcte ? Auquel cas je suis preneur d'un avis sur la meilleure solution. 
Celle que j'ai mise en place actuellement ne me plaît pas du tout. C'est donc un draft.