### PR TITLE
Technique: corriger le chargement des villes dans les fusions de code

### DIFF
--- a/clevercloud/review-app-after-success.sh
+++ b/clevercloud/review-app-after-success.sh
@@ -11,7 +11,14 @@ if [ "$SKIP_FIXTURES" = true ] ; then
 fi
 
 echo "Loading cities"
-PGPASSWORD=$POSTGRESQL_ADDON_PASSWORD pg_restore -d $POSTGRESQL_ADDON_DB -h $POSTGRESQL_ADDON_HOST -p $POSTGRESQL_ADDON_PORT -U $POSTGRESQL_ADDON_USER --if-exists --clean --no-owner --no-privileges $APP_HOME/itou/fixtures/postgres/cities.sql
+PGPASSWORD=$POSTGRESQL_ADDON_PASSWORD \
+    psql \
+    --dbname $POSTGRESQL_ADDON_DB \
+    --host $POSTGRESQL_ADDON_HOST \
+    --port $POSTGRESQL_ADDON_PORT \
+    --username $POSTGRESQL_ADDON_USER \
+    --file $APP_HOME/itou/fixtures/postgres/cities.sql \
+    --quiet
 
 # `ls $APP_HOME` does not work as the current user
 # does not have execution rights on the $APP_HOME directory.


### PR DESCRIPTION
### Quoi ?

Cf le titre.

### Pourquoi ?

C'est cassé depuis [cette PR](https://github.com/betagouv/itou/pull/1221).

### Comment ?

En portant la modification aussi dans ce script.
J'en profite pour clarifier et mettre des options longues.