### PR TITLE
Contrôle a posteriori, Pack DDETS : notification ouverture de la phase de transmission des justificatifs (carte 1/5)

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -219,6 +219,7 @@ class EvaluationCampaign(models.Model):
 
             connection = mail.get_connection()
             emails = [evaluated_siae.get_email_eligible_siae() for evaluated_siae in evaluated_siaes]
+            emails += [self.get_email_institution_opening_siae()]
             connection.send_messages(emails)
 
     def get_email_institution_notification(self, ratio_selection_end_at):
@@ -229,6 +230,18 @@ class EvaluationCampaign(models.Model):
         }
         subject = "siae_evaluations/email/email_institution_notification_subject.txt"
         body = "siae_evaluations/email/email_institution_notification_body.txt"
+        return get_email_message(to, context, subject, body)
+
+    def get_email_institution_opening_siae(self):
+        to = self.institution.active_members
+        context = {
+            # end_date for eligible siaes to return their documents of proofs is 6 weeks after notification
+            "end_date": timezone.now() + relativedelta(weeks=6),
+            "evaluated_period_start_at": self.evaluated_period_start_at,
+            "evaluated_period_end_at": self.evaluated_period_end_at,
+        }
+        subject = "siae_evaluations/email/email_institution_opening_siae_subject.txt"
+        body = "siae_evaluations/email/email_institution_opening_siae_body.txt"
         return get_email_message(to, context, subject, body)
 
 

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -453,6 +453,16 @@ class EvaluationCampaignEmailMethodsTest(TestCase):
         self.assertIn(siae.convention.siret_signature, email.body)
         self.assertIn(dateformat.format(timezone.now() + relativedelta(weeks=6), "d E Y"), email.body)
 
+    def test_get_email_institution_opening_siae(self):
+        institution = InstitutionWith2MembershipFactory()
+        evaluation_campaign = EvaluationCampaignFactory(institution=institution)
+
+        email = evaluation_campaign.get_email_institution_opening_siae()
+        self.assertEqual(email.to, list(institution.active_members))
+        self.assertIn(dateformat.format(timezone.now() + relativedelta(weeks=6), "d E Y"), email.body)
+        self.assertIn(dateformat.format(evaluation_campaign.evaluated_period_start_at, "d E Y"), email.body)
+        self.assertIn(dateformat.format(evaluation_campaign.evaluated_period_end_at, "d E Y"), email.body)
+
 
 class EvaluatedSiaeQuerySetTest(TestCase):
     def test_for_siae(self):

--- a/itou/templates/layout/base_email_text_body.txt
+++ b/itou/templates/layout/base_email_text_body.txt
@@ -3,7 +3,7 @@
 {% block body %}{% endblock %}
 
 ---
-{% if itou_environment == "DEMO"%}[DEMO] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEMO]{% endif %}
+{% if itou_environment != "PROD"%}[{{itou_environment}}] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [{{itou_environment}}]{% endif %}
 Les emplois de l'inclusion
 {{ itou_protocol }}://{{ itou_fqdn }}
 

--- a/itou/templates/siae_evaluations/email/eligible_siaes_body.txt
+++ b/itou/templates/siae_evaluations/email/eligible_siaes_body.txt
@@ -22,16 +22,17 @@ Accès direct à votre liste d’auto-prescriptions : {{ url }}
 
 2- Transmettez vos justificatifs en ligne
 
-Pour chaque embauche, cliquez sur “Ajouter ses justificatifs”,
-les critères que vous avez enregistrés sont affichés.
+Pour chaque embauche, cliquez sur “Sélectionner les critères”, les critères que vous avez enregistrés sont affichés.
 Sélectionnez le ou les critères que vous souhaitez justifier (un nombre minimum de justificatifs est requis en fonction du type de critères et de SIAE).
-Déposez le ou les justificatifs demandés.
+Ensuite cliquez sur  “Ajouter un justificatif”  pour déposer le justificatif demandé.
 
 3- Validez votre dossier de contrôle :
 
 Lorsque tous les justificatifs sont ajoutés, cliquez sur “Soumettre à validation” pour les transmettre à votre DDETS.
 
 Vous serez notifié(e) par e-mail lorsque la DDETS aura vérifié vos justificatifs.
+
+Voir le mode d’emploi : https://communaute.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
 
 En cas de question sur les critères ou les justificatifs vous devez vous adresser uniquement à votre DDETS.
 

--- a/itou/templates/siae_evaluations/email/eligible_siaes_body.txt
+++ b/itou/templates/siae_evaluations/email/eligible_siaes_body.txt
@@ -37,8 +37,4 @@ En cas de question sur les critères ou les justificatifs vous devez vous adress
 
 Cordialement,
 
-{% if itou_environment != "PROD"%}
-[{{itou_environment}}] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [{{itou_environment}}]
-{% endif %}
-
 {% endblock %}

--- a/itou/templates/siae_evaluations/email/email_institution_notification_body.txt
+++ b/itou/templates/siae_evaluations/email/email_institution_notification_body.txt
@@ -13,8 +13,5 @@ Le choix du taux de SIAE à contrôler est possible jusqu’au {{ratio_selection
 
 Cordialement,
 
-{% if itou_environment != "PROD"%}
-[{{itou_environment}}] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [{{itou_environment}}]
-{% endif %}
 
 {% endblock %}

--- a/itou/templates/siae_evaluations/email/email_institution_opening_siae_body.txt
+++ b/itou/templates/siae_evaluations/email/email_institution_opening_siae_body.txt
@@ -1,0 +1,30 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+
+Bonjour,
+
+
+La procédure de  transmission des justificatifs dans le cadre du contrôle a posteriori sur les embauches réalisées en auto-prescription embauches réalisées entre le {{evaluated_period_start_at|date:"d E Y"}} et le {{evaluated_period_end_at|date:"d E Y"}}, est ouverte pour les SIAE.
+
+Vous pouvez consulter la liste des SIAE qui ont été aléatoirement sélectionnées pour cette campagne de contrôle. Cette liste a été établie sur la base du taux de SIAE à contrôler que vous aviez préalablement validé.
+
+Cette phase de transmission et vérification des justificatifs est ouverte jusqu’au {{ end_date|date:"d E Y" }}. Passé ce délai les justificatifs non fournis par les SIAE seront enregistrés comme manquants.
+
+Comment ça marche ? 
+
+1- Consultez la liste des SIAE soumises au contrôle et suivez l’avancée du dossier
+Dans votre tableau de bord, à la rubrique “ Contrôler les pièces justificatives” vous trouverez la liste des SIAE qui doivent justifier certaines de leurs auto-prescriptions.
+
+2- Suivez et vérifiez les pièces justificatives transmises par les SIAE 
+Vous recevez une notification e-mail chaque fois qu’une SIAE transmet l’intégralité des justificatifs demandés.
+Vous pouvez consulter les justificatifs pour chaque salarié, les valider ou les rejeter en expliquant la raison.
+
+3- Valider le contrôle
+Après avoir traité toutes les justificatifs d’une SIAE, vous pouvez finaliser le contrôle en cliquant sur le bouton “Valider”. La SIAE sera automatiquement notifiée.
+
+
+Vous trouverez plus d’informations dans ce mode d’emploi :  https://communaute.inclusion.beta.gouv.fr/doc/emplois/mode-demploi-sur-le-controle-a-posteriori-pour-les-ddets/
+
+Cordialement,
+
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/email_institution_opening_siae_subject.txt
+++ b/itou/templates/siae_evaluations/email/email_institution_opening_siae_subject.txt
@@ -1,0 +1,6 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+
+[Contrôle a posteriori] Ouverture de la phase de transmission des justificatifs
+
+{% endblock %}


### PR DESCRIPTION
### Quoi ?

Envoi d'un email aux DDETS lorsque les SIAE peuvent téléverser leurs justiicatifs. C'est-à-dire au moment où les campagnes sont populated.

### Pourquoi ?

- En tant que DDETS  je veux être alertée par mail du lancement de la procédure de transmission des justificatifs

### Comment ?

- Ajout d'un template de mail
- Envoi de l'email aux DDETS lors de l'appel à la méthode `populate` de `EvaluationCampaign`

### Note:
 - mise à jour du contenu de l'email de notification aux Siaes (PR initiale 1223)
