### PR TITLE
Rendre plus robuste le code de l'API Pole Emploi le temps de l'envoi des PASS IAE

### DIFF
--- a/itou/approvals/management/commands/send_all_approvals_to_pe.py
+++ b/itou/approvals/management/commands/send_all_approvals_to_pe.py
@@ -1,10 +1,9 @@
 import datetime
 
 from django.core.management.base import BaseCommand
-from django.db.models import CharField, Q, Subquery
+from django.db.models import CharField, Q
 from django.db.models.functions import Length
 
-from itou.approvals.models import Approval
 from itou.job_applications.models import (
     JobApplication,
     JobApplicationPoleEmploiNotificationLog,
@@ -25,12 +24,9 @@ class Command(BaseCommand):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
     def handle(self, wet_run=False, **options):
-        # only send Pole Emploi the approvals tied to an accepted job_application
-        approvals = Approval.objects.filter(start_at__lt=PE_API_START_DATE)
         job_applications = JobApplication.objects.filter(
-            approval__pk__in=Subquery(approvals.values("pk")), state=JobApplicationWorkflow.STATE_ACCEPTED
+            approval__start_at__lte=PE_API_START_DATE, state=JobApplicationWorkflow.STATE_ACCEPTED
         )
-        self.stdout.write(f"approvals          count={approvals.count()}")
         self.stdout.write(f"job_applications   count={job_applications.count()}")
 
         CharField.register_lookup(Length)
@@ -42,7 +38,10 @@ class Command(BaseCommand):
         self.stdout.write(f"> with valid users count={with_valid_users.count()}")
 
         not_already_sent = with_valid_users.exclude(
-            jobapplicationpoleemploinotificationlog__status=JobApplicationPoleEmploiNotificationLog.STATUS_OK
+            jobapplicationpoleemploinotificationlog__status__in=[
+                JobApplicationPoleEmploiNotificationLog.STATUS_OK,
+                JobApplicationPoleEmploiNotificationLog.STATUS_FAIL_SEARCH_INDIVIDUAL,
+            ]
         )
         self.stdout.write(f"> not already sent count={not_already_sent.count()}")
         for job_application in not_already_sent:


### PR DESCRIPTION
### Quoi ?

Arreter de crasher sans raison pour des erreurs coté PE et aller le plus loin possible.

### Pourquoi ?
Actuellement pour des erreurs bêtes, le script cesse totalement meme en plein nuit.
Or nous avons 100000 PASS à envoyer, il serait urbain que le script continue le plus possible.
On repassera sur les derniers cas dans une seconde et troisième passe; pas de "retry" pour l'instant.

### Comment ?
En gérant les cas d'erreur.

Le code de l'API est un peu spécial: pas robuste, plein de doublons pas totalement équivalents, pas vraiment testé.

Il est prévu que je fasse une passe derrière (juste après en réalité) pour adapter, tester, factoriser ce code et le rendre plus robuste, eventuellement avec des `retry`.  Car nous allons devoir envoyer aussi tous les agréments PE et ça va piquer.

En attendant j'ai besoin que ce code soit amélioré car sur ma fast machine, Clever fait des redéploiements sauvages et je perds ces petites adaptations temporaires.