### PR TITLE
Nouvelle interface pour les résultats de recherche employeurs

### DIFF
--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -55,7 +55,7 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
             # A list of jobs were passed in, use them.
             for siae_job_description in extracted:
                 if isinstance(siae_job_description, Appellation):
-                    siae_job_description = SiaeJobDescription.objects.create(
+                    siae_job_description, _ = SiaeJobDescription.objects.get_or_create(
                         siae=self.to_siae, appellation=siae_job_description
                     )
                 self.selected_jobs.add(siae_job_description)

--- a/itou/templates/search/includes/prescribers_search_filters.html
+++ b/itou/templates/search/includes/prescribers_search_filters.html
@@ -1,7 +1,8 @@
 {% load bootstrap4 %}
-<div class="card my-4">
-    <a id="js-search-filter-button" class="btn btn-primary d-block d-md-none" href="#search-filter-form" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="collapseFilter">
-        Filtres des résultats <i class="ri-filter-line"></i>
+<div class="card mt-4">
+    <a id="js-search-filter-button" class="btn btn-primary btn-ico d-block d-md-none" href="#search-filter-form" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="collapseFilter">
+        <span>Filtres des résultats</span>
+        <i class="ri-filter-line"></i>
     </a>
     <div id="search-filter-form" class="card-body collapse show">
         {% bootstrap_field form.distance form_group_class="form-group" label_class="h4 font-weight-bold text-muted" %}

--- a/itou/templates/search/includes/prescribers_search_form.html
+++ b/itou/templates/search/includes/prescribers_search_form.html
@@ -2,7 +2,7 @@
 
 {% bootstrap_form_errors form type="all" %}
 <div class="row no-gutters my-3 itou-banner-blue{% if align == 'center' %} justify-content-sm-center{% endif %}">
-    <div class="col col-12 col-sm-8 col-md-6 mb-1">
+    <div class="col-12 col-md mb-2">
         {{ form.city }}
         <div class="input-group">
             <div class="input-group-prepend bg-white">
@@ -20,7 +20,7 @@
             {{ form.city_name }}
         </div>
     </div>
-    <div class="col col-12 col-sm-8 ml-0 mt-2 col-md-2 ml-md-2 mt-md-0">
+    <div class="col-12 col-md-3 col-lg-2 mb-2 pl-md-3">
         <button type="submit" class="btn btn-primary form-control js-search-button" title="Rechercher">
             Rechercher
         </button>

--- a/itou/templates/search/includes/siaes_search_filters.html
+++ b/itou/templates/search/includes/siaes_search_filters.html
@@ -1,28 +1,34 @@
 {% load bootstrap4 %}
-<div class="card my-4">
-    <a id="js-search-filter-button" class="btn btn-primary d-block d-md-none" href="#search-filter-form" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="search-filter-form">
-        Filtres des résultats <i class="ri-filter-line"></i>
+<div class="card mt-4">
+    <a id="js-search-filter-button" class="btn btn-primary btn-ico d-block d-md-none" href="#search-filter-form" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="search-filter-form">
+        <span>Filtres des résultats</span>
+        <i class="ri-filter-line"></i>
     </a>
     <div id="search-filter-form" class="card-body collapse show">
         {% bootstrap_field form.distance form_group_class="form-group" label_class="h3 font-weight-bold text-muted" %}
 
         {% if form.departments %}
+            <hr>
             {% bootstrap_field form.departments form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
         {% endif %}
 
         {# getattr and list still painful in Django template #}
         {% if form.districts_13 %}
+            <hr>
             {% bootstrap_field form.districts_13 form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
         {% endif %}
 
         {% if form.districts_69 %}
+            <hr>
             {% bootstrap_field form.districts_69 form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
         {% endif %}
 
         {% if form.districts_75 %}
+            <hr>
             {% bootstrap_field form.districts_75 form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
         {% endif %}
 
+        <hr>
         {% bootstrap_field form.kinds form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
     </div>
 </div>

--- a/itou/templates/search/includes/siaes_search_form.html
+++ b/itou/templates/search/includes/siaes_search_form.html
@@ -2,7 +2,7 @@
 
 {% bootstrap_form_errors form type="all" %}
 <div class="row no-gutters my-3 itou-banner-blue{% if align == 'center' %} justify-content-sm-center{% endif %}">
-    <div class="col col-12 col-sm-8 col-md-6 mb-1">
+    <div class="col-12 col-md mb-2">
         {{ form.city }}
         <div class="input-group">
             <div class="input-group-prepend bg-white">
@@ -20,7 +20,7 @@
             {{ form.city_name }}
         </div>
     </div>
-    <div class="col col-12 col-sm-8 ml-0 mt-2 col-md-2 ml-md-2 mt-md-0">
+    <div class="col-12 col-md-3 col-lg-2 mb-2 pl-md-3">
         <button type="submit" class="btn btn-primary btn-block js-search-button" title="Rechercher">
             Rechercher
         </button>

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -31,7 +31,7 @@
 
         {% if form.is_valid %}
             <h2 class="h2">
-                Employeurs solidaires à <b>{{ distance }} km</b> du centre de <b>{{ city }}</b>
+                Employeurs solidaires à <strong>{{ distance }} km</strong> du centre de <strong>{{ city }}</strong>
             </h2>
         {% endif %}
 
@@ -57,7 +57,7 @@
                 {% empty %}
                     <div class="card my-4">
                         <div class="card-body">
-                            Aucun résultat avec les filtres actuels.
+                            <p>Aucun résultat avec les filtres actuels.</p>
                         </div>
                     </div>
                 {% endfor %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -26,8 +26,6 @@
 {% endblock %}
 
 {% block content %}
-    <h1 class="h1">Rechercher des employeurs solidaires</h1>
-
     <form id="search-form" method="get" action="" class="d-block mb-5">
         {% include "search/includes/siaes_search_form.html" with form=form %}
 
@@ -37,18 +35,13 @@
             </h2>
         {% endif %}
 
-        <p>
-            <small>
-                Les résultats de recherche affichent en priorité les entreprises qui ont reçu peu de candidatures par rapport aux métiers proposés.
-            </small>
+        <p class="fs-sm">
+            Les résultats de recherche affichent en priorité les entreprises qui ont reçu peu de candidatures par rapport aux métiers proposés.
         </p>
 
-        <p class="font-weight-bold text-muted mb-0 h3" id="siae-number-results" role="status">
-            {% with siaes_page.number as current_page and siaes_page.paginator.num_pages as total_pages and siaes_page.paginator.count as counter %}
-                <b>{{ counter }}</b> résultat{% if counter > 1 %}s{% endif %}
-                {% if siaes_page.paginator.num_pages > 1 %}
-                    - Page <b>{{ current_page }}</b>/{{ total_pages }}
-                {% endif %}
+        <p class="font-weight-bold mb-0 text-primary text-right" id="siae-number-results" role="status">
+            {% with number_of_results=siaes_page|length %}
+                {{ number_of_results }} résultat{{ number_of_results|pluralize }} sur {{ siaes_page.paginator.count }}
             {% endwith %}
         </p>
 

--- a/itou/templates/siaes/card.html
+++ b/itou/templates/siaes/card.html
@@ -35,7 +35,7 @@
 
             {% if siae.count_active_job_descriptions > 0 and not siae.block_job_applications %}
                 <hr>
-                {% include "siaes/includes/_list_siae_actives_jobs.html" with jobs_descriptions=jobs_descriptions siae=siae %}
+                {% include "siaes/includes/_list_siae_actives_jobs.html" with jobs_descriptions=jobs_descriptions %}
             {% endif %}
 
             {% if not siae.block_job_applications %}

--- a/itou/templates/siaes/includes/_card_siae.html
+++ b/itou/templates/siaes/includes/_card_siae.html
@@ -1,7 +1,7 @@
 {% comment %} takes 2 arguments siae <Siae> and jobs_descriptions <List of SiaeJobDescription> {% endcomment %}
 <div class="card my-4">
-    <div class="bg-emploi-lightest p-4">
-        <p class="d-flex flex-wrap fs-sm">
+    <div class="bg-emploi-lightest p-3 p-md-4">
+        <p class="d-flex flex-wrap fs-sm mb-2">
             <span class="flex-grow-1 text-primary">
                 {% if siae.is_opcs %}
                     <span>Offres clauses sociales</span>
@@ -9,50 +9,43 @@
                     <b>{{ siae.kind }}</b> - {{ siae.get_kind_display }}
                 {% endif %}
             </span>
-            <span>
-                {% if siae.kind in ea_eatt_kinds %}
-                    <span class="badge badge-pill badge-emploi-light">Priorité aux bénéficiaires de la RQTH</span>
-                {% endif %}
-            </span>
+            {% if siae.kind in ea_eatt_kinds %}
+                <span class="badge badge-sm badge-pill badge-accent-03 text-primary">Priorité aux bénéficiaires de la RQTH</span>
+            {% endif %}
         </p>
-        <h3 class="h2 card-title">
-            <a class="d-inline-block matomo-event"
-                href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}"
-                data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-structure">
-                {{ siae.display_name }}
-            </a>
+        <h3 class="h2 mb-2">
+            <a class="matomo-event" href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}" data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-structure">{{ siae.display_name }}</a>
             {# Display non-user-edited name too, but only if it's not the same text #}
             {% if siae.brand and siae.brand|lower != siae.name|lower %}<small class="text-muted">({{ siae.name|title }})</small>{% endif %}
         </h3>
-        <h4 class="h5 card-subtitle mb-2 text-muted">{{ siae.address_on_one_line }}</h4>
-        <p class="d-flex flex-lg-row flex-column mb-0">
-            <span class="mb-0 flex-grow-1 text-muted fs-sm">
-                <span class="badge badge-pill badge-primary">à {{ siae.distance|floatformat:"-1"|default:"12" }} km</span> de votre lieu de recherche.
+        <h4 class="h5 mb-2 text-muted">{{ siae.address_on_one_line }}</h4>
+        <p class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center mb-0">
+            <span class="align-self-start">
+                <span class="badge badge-sm badge-pill badge-primary">à {{ siae.distance|floatformat:"-1"|default:"12" }} km</span>
+                <span class="text-muted fs-sm ml-1">de votre lieu de recherche.</span>
             </span>
             {% if jobs_descriptions %}
-                <a class="ml-auto font-weight-bold matomo-event"  href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}"
+                <a class="d-none d-md-inline font-weight-bold matomo-event mt-3 mt-md-0"  href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}"
                     data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-metiers">
                     Voir tous les métiers ({{ jobs_descriptions|length }})
                 </a>
             {% endif %}
         </p>
     </div>
-    <div class="card-body">
+    <div class="card-body p-3 p-md-4">
         {% if siae.count_active_job_descriptions > 0 and not siae.block_job_applications %}
             {% include "siaes/includes/_list_siae_actives_jobs.html" with jobs_descriptions=jobs_descriptions %}
         {% elif not siae.block_job_applications %}
-            <div class="text-with-btn">
+            <div class="d-flex justify-content-between align-items-center">
                 <span>Cette structure vous intéresse ?</span>
-                <div class="btn-group btn-group-sm float-right" role="group">
-                    <a class="btn btn-primary"
-                        href="{% url 'apply:start' siae_pk=siae.pk %}{% if back_url %}?back_url={{ back_url }}{% endif %}"
-                        title="Proposer votre candidature auprès de l'employeur solidaire {{ siae.display_name }}">
-                        Proposer votre candidature
-                    </a>
-                </div>
+                <a class="btn btn-sm btn-primary"
+                    href="{% url 'apply:start' siae_pk=siae.pk %}{% if back_url %}?back_url={{ back_url }}{% endif %}"
+                    title="Proposer votre candidature auprès de l'employeur solidaire {{ siae.display_name }}">
+                    Proposer votre candidature
+                </a>
             </div>
         {% else %}
-            <i>Cet employeur ne traite plus de nouvelles candidatures pour le moment</i>
+            <p class="mb-0"><i>Cet employeur ne traite plus de nouvelles candidatures pour le moment</i></p>
         {% endif %}
     </div>
 </div>

--- a/itou/templates/siaes/includes/_card_siae.html
+++ b/itou/templates/siaes/includes/_card_siae.html
@@ -39,7 +39,7 @@
     </div>
     <div class="card-body">
         {% if siae.count_active_job_descriptions > 0 and not siae.block_job_applications %}
-            {% include "siaes/includes/_list_siae_actives_jobs.html" with jobs_descriptions=jobs_descriptions siae=siae %}
+            {% include "siaes/includes/_list_siae_actives_jobs.html" with jobs_descriptions=jobs_descriptions %}
         {% elif not siae.block_job_applications %}
             <div class="text-with-btn">
                 <span>Cette structure vous intéresse ?</span>

--- a/itou/templates/siaes/includes/_card_siae.html
+++ b/itou/templates/siaes/includes/_card_siae.html
@@ -1,32 +1,41 @@
 {% comment %} takes 2 arguments siae <Siae> and jobs_descriptions <List of SiaeJobDescription> {% endcomment %}
 <div class="card my-4">
-    <div class="bg-gray-400 p-3">
-        <h3 class="card-title">
-            {% if siae.is_opcs %}
-                <b>Offres clauses sociales</b>
-            {% else %}
-                <b><abbr title="{{ siae.get_kind_display }}">{{ siae.kind }}</abbr></b>
-            {% endif %}
-            -
-            <a href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}" class="matomo-event" data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-structure">
+    <div class="bg-emploi-lightest p-4">
+        <p class="d-flex flex-wrap fs-sm">
+            <span class="flex-grow-1 text-primary">
+                {% if siae.is_opcs %}
+                    <span>Offres clauses sociales</span>
+                {% else %}
+                    <b>{{ siae.kind }}</b> - {{ siae.get_kind_display }}
+                {% endif %}
+            </span>
+            <span>
+                {% if siae.kind in ea_eatt_kinds %}
+                    <span class="badge badge-pill badge-emploi-light">Priorité aux bénéficiaires de la RQTH</span>
+                {% endif %}
+            </span>
+        </p>
+        <h3 class="h2 card-title">
+            <a class="d-inline-block matomo-event"
+                href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}"
+                data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-structure">
                 {{ siae.display_name }}
             </a>
-            {# Display non-user-edited name too. #}
-            {% if siae.brand %}<small class="text-muted">({{ siae.name|title }})</small>{% endif %}
+            {# Display non-user-edited name too, but only if it's not the same text #}
+            {% if siae.brand and siae.brand|lower != siae.name|lower %}<small class="text-muted">({{ siae.name|title }})</small>{% endif %}
         </h3>
         <h4 class="h5 card-subtitle mb-2 text-muted">{{ siae.address_on_one_line }}</h4>
-        {% if siae.kind in ea_eatt_kinds %}
-            <small>
-                <span class="badge badge-info my-3">Priorité aux bénéficiaires de RQTH</span>
-            </small>
-            <br />
-        {% endif %}
-        <p class="small mb-0">
-            <span class="badge badge-dark mb-3">{{ siae.distance|floatformat:"-1"|default:"12" }} km</span> de votre lieu de recherche.
+        <p class="d-flex flex-lg-row flex-column mb-0">
+            <span class="mb-0 flex-grow-1 text-muted fs-sm">
+                <span class="badge badge-pill badge-primary">à {{ siae.distance|floatformat:"-1"|default:"12" }} km</span> de votre lieu de recherche.
+            </span>
+            {% if jobs_descriptions %}
+                <a class="ml-auto font-weight-bold matomo-event"  href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}"
+                    data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-metiers">
+                    Voir tous les métiers ({{ jobs_descriptions|length }})
+                </a>
+            {% endif %}
         </p>
-        {% if jobs_descriptions %}
-            {% include "siaes/includes/_list_siae_jobs.html" with siae=siae jobs_descriptions=jobs_descriptions %}
-        {% endif %}
     </div>
     <div class="card-body">
         {% if siae.count_active_job_descriptions > 0 and not siae.block_job_applications %}

--- a/itou/templates/siaes/includes/_list_siae_actives_jobs.html
+++ b/itou/templates/siaes/includes/_list_siae_actives_jobs.html
@@ -1,20 +1,20 @@
 {% comment %} takes 1 argument: jobs_descriptions=<List of SiaeJobDescription> {% endcomment %}
 
-<p class="h5 text-uppercase pb-2">{{ jobs_descriptions|length }} recrutement{{ jobs_descriptions|pluralize }} en cours</p>
+<p class="h5 text-uppercase">{{ jobs_descriptions|length }} recrutement{{ jobs_descriptions|pluralize }} en cours</p>
 
-<ul class="list-group">
+<ul class="list-group list-group-flush">
     {% for job in jobs_descriptions|slice:":5" %}
         {% include "siaes/includes/_list_siae_actives_jobs_row.html" with job=job %}
     {% endfor %}
 </ul>
 {% if jobs_descriptions|length > 5 %}
-    <ul class="list-group collapse" id="collapse_{{ forloop.counter0 }}">
+    <ul class="list-group list-group-flush collapse" id="collapse_{{ forloop.counter0 }}">
         {% for job in jobs_descriptions|slice:"5:" %}
             {% include "siaes/includes/_list_siae_actives_jobs_row.html" with job=job is_appended=forloop.first %}
         {% endfor %}
     </ul>
     <div class="mt-3 text-center">
-        <button type="button" class="btn collapsed collapse-caret p-0"
+        <button type="button" class="btn collapsed has-collapse-caret p-0"
             data-toggle="collapse" data-target="#collapse_{{ forloop.counter0 }}"
             aria-expanded="false" aria-controls="collapse_{{ forloop.counter0 }}">
             <span>Afficher tout</span>

--- a/itou/templates/siaes/includes/_list_siae_actives_jobs.html
+++ b/itou/templates/siaes/includes/_list_siae_actives_jobs.html
@@ -1,34 +1,23 @@
 {% comment %} takes 2 arguments: siae=<Siae> and jobs_descriptions=<List of SiaeJobDescription> {% endcomment %}
 
-<p class="h3 pb-2">Recrutement{{ jobs_descriptions|pluralize }} en cours</p>
+<p class="h5 text-uppercase pb-2">{{ jobs_descriptions|length }} recrutement{{ jobs_descriptions|pluralize }} en cours</p>
 
-{% if not siae.block_job_applications %}
-    {% for job in jobs_descriptions %}
-        <a class="matomo-event btn btn-outline-primary mb-2"
-            href="{% if job.pk %}{{job.get_absolute_url}}{% else %}#{% endif %}?back_url={{ request.get_full_path|urlencode }}"
-            data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-metiers">
-            {{ job.display_name }}
-        </a>
-        {% if job.is_popular %}
-            <small>
-                <span class="ml-3">
-                    <i class="ri-stack-line mr-1 text-danger"></i>
-                    Plus de {{ job.POPULAR_THRESHOLD }} candidatures reçues
-                </span>
-            </small>
-        {% endif %}
-        <br >
-        {# Collapsing block start (more than 5 jobs descriptions) #}
-        {% if forloop.counter == 5 and not forloop.last %}
-            <div class="pt-2 mb-2">
-                <button class="btn collapsed collapse-caret p-0" data-toggle="collapse" data-target="#collapse_{{ forloop.parentloop.counter0 }}" type="button" aria-expanded="false" aria-controls="collapse_{{ forloop.parentloop.counter0 }}">
-                    <span class="h5">Voir tous les recrutements en cours ({{ forloop.revcounter0 }} de plus)</span>
-                </button>
-            </div>
-            <div class="collapse" id="collapse_{{forloop.parentloop.counter0}}">
-        {% elif forloop.last and forloop.counter > 5 %}
-            {# Collapsing block end #}
-            </div>
-        {% endif %}
+<ul class="list-group">
+    {% for job in jobs_descriptions|slice:":5" %}
+        {% include "siaes/includes/_list_siae_actives_jobs_row.html" with job=job %}
     {% endfor %}
+</ul>
+{% if jobs_descriptions|length > 5 %}
+    <ul class="list-group collapse" id="collapse_{{ forloop.counter0 }}">
+        {% for job in jobs_descriptions|slice:"5:" %}
+            {% include "siaes/includes/_list_siae_actives_jobs_row.html" with job=job is_appended=forloop.first %}
+        {% endfor %}
+    </ul>
+    <div class="mt-3 text-center">
+        <button type="button" class="btn collapsed collapse-caret p-0"
+            data-toggle="collapse" data-target="#collapse_{{ forloop.counter0 }}"
+            aria-expanded="false" aria-controls="collapse_{{ forloop.counter0 }}">
+            <span>Afficher tout</span>
+        </button>
+    </div>
 {% endif %}

--- a/itou/templates/siaes/includes/_list_siae_actives_jobs.html
+++ b/itou/templates/siaes/includes/_list_siae_actives_jobs.html
@@ -1,4 +1,4 @@
-{% comment %} takes 2 arguments: siae=<Siae> and jobs_descriptions=<List of SiaeJobDescription> {% endcomment %}
+{% comment %} takes 1 argument: jobs_descriptions=<List of SiaeJobDescription> {% endcomment %}
 
 <p class="h5 text-uppercase pb-2">{{ jobs_descriptions|length }} recrutement{{ jobs_descriptions|pluralize }} en cours</p>
 

--- a/itou/templates/siaes/includes/_list_siae_actives_jobs_row.html
+++ b/itou/templates/siaes/includes/_list_siae_actives_jobs_row.html
@@ -1,21 +1,17 @@
 {% comment %} takes 2 arguments: job=<SiaeJobDescription> is_appended=<Bool> {% endcomment %}
 
-<li class="list-group-item list-group-item-action border-left-0 border-right-0 p-2{% if is_appended %} border-top-0{% endif %}">
-    <a class="d-flex flex-wrap text-decoration-none matomo-event"
+<li class="list-group-item list-group-item-action p-2{% if is_appended %} border-top{% endif %}">
+    <a class="d-flex flex-wrap align-items-center text-decoration-none matomo-event"
         href="{% if job.pk %}{{job.get_absolute_url}}{% else %}#{% endif %}?back_url={{ request.get_full_path|urlencode }}"
         data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-metiers">
-        <span class="d-flex align-items-center mr-1">
-            <strong class="font-weight-bold">{{ job.display_name }}</strong>
-        </span>
+        <span class="font-weight-bold mr-1 mr-md-2">{{ job.display_name }}</span>
         {% if job.is_popular %}
-            <span class="d-flex align-items-center">
-                <span class="badge badge-pill badge-warning-light ml-auto fs-sm">
-                    <i class="ri-group-line mr-1"></i>
-                    {{ job.POPULAR_THRESHOLD }}+<span class="ml-1">candidatures</span>
-                </span>
+            <span class="badge badge-sm badge-pill badge-pilotage text-primary">
+                <i class="ri-group-line mr-1"></i>
+                {{ job.POPULAR_THRESHOLD }}+<span class="ml-1">candidatures</span>
             </span>
         {% endif %}
-        <span class="d-flex align-items-center py-1 ml-auto fs-sm text-nowrap">
+        <span class="ml-auto fs-sm text-nowrap">
             <i class="ri-map-pin-2-line ri-sm mr-1"></i>
             {% if job.location %}
                 {{ job.location }}

--- a/itou/templates/siaes/includes/_list_siae_actives_jobs_row.html
+++ b/itou/templates/siaes/includes/_list_siae_actives_jobs_row.html
@@ -1,0 +1,27 @@
+{% comment %} takes 2 arguments: job=<SiaeJobDescription> is_appended=<Bool> {% endcomment %}
+
+<li class="list-group-item list-group-item-action border-left-0 border-right-0 p-2{% if is_appended %} border-top-0{% endif %}">
+    <a class="d-flex flex-wrap text-decoration-none matomo-event"
+        href="{% if job.pk %}{{job.get_absolute_url}}{% else %}#{% endif %}?back_url={{ request.get_full_path|urlencode }}"
+        data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-metiers">
+        <span class="d-flex align-items-center mr-1">
+            <strong class="font-weight-bold">{{ job.display_name }}</strong>
+        </span>
+        {% if job.is_popular %}
+            <span class="d-flex align-items-center">
+                <span class="badge badge-pill badge-warning-light ml-auto fs-sm">
+                    <i class="ri-group-line mr-1"></i>
+                    {{ job.POPULAR_THRESHOLD }}+<span class="ml-1">candidatures</span>
+                </span>
+            </span>
+        {% endif %}
+        <span class="d-flex align-items-center py-1 ml-auto fs-sm text-nowrap">
+            <i class="ri-map-pin-2-line ri-sm mr-1"></i>
+            {% if job.location %}
+                {{ job.location }}
+            {% else %}
+                {{ job.siae.city|title }} ({{ job.siae.department }})
+            {% endif %}
+        </span>
+    </a>
+</li>

--- a/itou/templates/siaes/includes/_list_siae_jobs.html
+++ b/itou/templates/siaes/includes/_list_siae_jobs.html
@@ -1,6 +1,6 @@
 {% comment %} takes 2 arguments siae <Siae> and jobs_descriptions <List of SiaeJobDescription> {% endcomment %}
 <div class="py-3">
-    <button class="mb-1 p-0 btn btn-link collapsed collapse-caret" data-toggle="collapse"  data-target="#collapse{{siae.id}}" type="button" aria-expanded="false" aria-controls="collapse{{siae.id}}">
+    <button class="mb-1 p-0 btn btn-link collapsed collapse-caret text-left" data-toggle="collapse"  data-target="#collapse{{siae.id}}" type="button" aria-expanded="false" aria-controls="collapse{{siae.id}}">
         <span class="h5">Voir les métiers exercés au sein de la structure</span>
     </button>
     <ul class="collapse" id="collapse{{siae.id}}">

--- a/itou/templates/siaes/job_description_card.html
+++ b/itou/templates/siaes/job_description_card.html
@@ -53,12 +53,11 @@
                     <hr>
                     <div class="pt-4 text-left">
                         <h2 class="h1">Consulter le(s) recrutement(s) en cours dans cette structure</h2>
-                        {% for other_job in others_active_jobs %}
-                            <a href="{{ other_job.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}" class="matomo-event btn btn-outline-primary mb-2" data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-metiers">
-                                {{ other_job.display_name }}
-                            </a>
-                            <br >
-                        {% endfor %}
+                        <ul class="list-group">
+                            {% for other_job in others_active_jobs %}
+                                {% include "siaes/includes/_list_siae_actives_jobs_row.html" with job=other_job %}
+                            {% endfor %}
+                        </ul>
                     </div>
                 {% endif %}
 

--- a/itou/www/search/tests.py
+++ b/itou/www/search/tests.py
@@ -30,12 +30,12 @@ class SearchSiaeTest(TestCase):
         response = self.client.get(self.url, {"city": city_slug})
 
         self.assertContains(response, "Employeurs solidaires à 25 km du centre de Paris (75)")
-        self.assertContains(response, "<b>2</b> résultats")
+        self.assertContains(response, "2 résultats sur 2")
         self.assertContains(response, "Arrondissements de Paris")
 
         # Filter on district
         response = self.client.get(self.url, {"city": city_slug, "districts_75": ["75001"]})
-        self.assertContains(response, "<b>1</b> résultat")
+        self.assertContains(response, "1 résultat sur 1")
         self.assertContains(response, siae_1.display_name)
 
     def test_kind(self):
@@ -43,7 +43,7 @@ class SearchSiaeTest(TestCase):
         SiaeFactory(department="44", coords=city.coords, post_code="44117", kind=Siae.KIND_AI)
 
         response = self.client.get(self.url, {"city": city.slug, "kinds": [Siae.KIND_AI]})
-        self.assertContains(response, "<b>1</b> résultat")
+        self.assertContains(response, "1 résultat sur 1")
 
         response = self.client.get(self.url, {"city": city.slug, "kinds": [Siae.KIND_EI]})
         self.assertContains(response, "Aucun résultat")
@@ -65,26 +65,26 @@ class SearchSiaeTest(TestCase):
 
         # 100 km
         response = self.client.get(self.url, {"city": guerande.slug, "distance": 100})
-        self.assertContains(response, "<b>3</b> résultats")
+        self.assertContains(response, "3 résultats sur 3")
         self.assertContains(response, SIAE_VANNES.capitalize())
         self.assertContains(response, SIAE_GUERANDE.capitalize())
         self.assertContains(response, SIAE_SAINT_ANDRE.capitalize())
 
         # 15 km
         response = self.client.get(self.url, {"city": guerande.slug, "distance": 15})
-        self.assertContains(response, "<b>2</b> résultats")
+        self.assertContains(response, "2 résultats sur 2")
         self.assertContains(response, SIAE_GUERANDE.capitalize())
         self.assertContains(response, SIAE_SAINT_ANDRE.capitalize())
 
         # 100 km and 44
         response = self.client.get(self.url, {"city": guerande.slug, "distance": 100, "departments": ["44"]})
-        self.assertContains(response, "<b>2</b> résultats")
+        self.assertContains(response, "2 résultats sur 2")
         self.assertContains(response, SIAE_GUERANDE.capitalize())
         self.assertContains(response, SIAE_SAINT_ANDRE.capitalize())
 
         # 100 km and 56
         response = self.client.get(self.url, {"city": vannes.slug, "distance": 100, "departments": ["56"]})
-        self.assertContains(response, "<b>1</b> résultat")
+        self.assertContains(response, "1 résultat sur 1")
         self.assertContains(response, SIAE_VANNES.capitalize())
 
     def test_order_by(self):
@@ -134,7 +134,7 @@ class SearchSiaeTest(TestCase):
         SiaeFactory(department="44", coords=city.coords, post_code="44117", kind=Siae.KIND_OPCS)
 
         response = self.client.get(self.url, {"city": city.slug})
-        self.assertContains(response, "<b>1</b> résultat")
+        self.assertContains(response, "1 résultat sur 1")
         self.assertContains(response, "Offres clauses sociales")
 
 


### PR DESCRIPTION
### Quoi ?

Améliorer l'UX et UI des résultats de recherche d'employeurs.

### Pourquoi ?

- Manque de visibilité des postes ouverts au recrutement, en particulier lorsqu'ils sont nombreux
- Redondance dans l'affichage des postes en recrutement et de l'ensemble des postes de la structure.
- Nécessité d'afficher la localisation du poste

### Comment ?

Modifier les cards de résultats pour :
- afficher les 5 premiers postes sous forme de liste plus étroite.
- Afficher la commune à droite du nom du poste
- Distinguer davantage les infos générales de la structure des recrutements en cours
- Retirer la possibilité d'expand "Voir les métiers exercés au sein de la structure" à l'échelle de la carte et rapporter tous les métiers sur la page de la fiche structure.


### Captures d'écran (optionnel)

Résultats page 1
![Résultats-de-recherche-employeurs-V2_p1 png](https://user-images.githubusercontent.com/20045330/166951400-98b79696-45cd-4289-a41f-4075f9228742.png)

Résultats page 2
![Résultats-de-recherche-employeurs-V2_p2 png](https://user-images.githubusercontent.com/20045330/166951420-cb1f039f-c139-4275-8aff-33af955d0868.png)

Effet de bord dans la page de la structure, j'ai gardé vu que ça rend quand même bien ^^.
![Résultats-de-recherche-employeurs-V2_side_effect_siae](https://user-images.githubusercontent.com/20045330/166951438-6f97a437-6350-4c96-bc77-2623534d0cf1.png)

### Autre (optionnel)

J'ai dû fait quelques écart par rapport à la maquette mais (normalement) sans dévier du _Pourquoi_ et du _Comment_.


