### PR TITLE
Contrôle a posteriori, Pack DDETS : liste des siae contrôlées (carte 2/5)

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -90,9 +90,6 @@ class EvaluationCampaignQuerySet(models.QuerySet):
 
 
 class EvaluationCampaignManager(models.Manager):
-    def has_active_campaign(self, institution):
-        return self.for_institution(institution).in_progress().exists()
-
     def first_active_campaign(self, institution):
         return self.for_institution(institution).in_progress().first()
 
@@ -254,8 +251,7 @@ class EvaluatedSiaeQuerySet(models.QuerySet):
 
 
 class EvaluatedSiaeManager(models.Manager):
-    def has_active_campaign(self, siae):
-        return self.for_siae(siae).in_progress().exists()
+    pass
 
 
 class EvaluatedSiae(models.Model):

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -122,34 +122,6 @@ class EvaluationCampaignQuerySetTest(TestCase):
 
 
 class EvaluationCampaignManagerTest(TestCase):
-    def test_institution_with_campaign_in_progress(self):
-        institution = InstitutionFactory()
-        EvaluationCampaignFactory(institution=institution)
-        self.assertTrue(EvaluationCampaign.objects.has_active_campaign(institution))
-
-    def test_institution_without_any_campaign(self):
-        institution = InstitutionFactory()
-        self.assertFalse(EvaluationCampaign.objects.has_active_campaign(institution))
-
-    def test_institution_with_ended_campaign(self):
-        ended_at = timezone.now() - relativedelta(years=1)
-        institution = InstitutionFactory()
-        EvaluationCampaignFactory(institution=institution, ended_at=ended_at)
-        self.assertFalse(EvaluationCampaign.objects.has_active_campaign(institution))
-
-    def test_institution_with_ended_and_in_progress_campaign(self):
-        now = timezone.now()
-        ended_at = now - relativedelta(years=1)
-        institution = InstitutionFactory()
-        EvaluationCampaignFactory(
-            institution=institution,
-            ended_at=ended_at,
-        )
-        EvaluationCampaignFactory(
-            institution=institution,
-        )
-        self.assertTrue(EvaluationCampaign.objects.has_active_campaign(institution))
-
     def test_first_active_campaign(self):
         institution = InstitutionFactory()
         now = timezone.now()
@@ -487,17 +459,6 @@ class EvaluatedSiaeQuerySetTest(TestCase):
         # evaluations_asked_at is not None, ended_at is None
         EvaluatedSiaeFactory(evaluation_campaign__evaluations_asked_at=fake_now, evaluation_campaign__ended_at=None)
         self.assertEqual(1, EvaluatedSiae.objects.in_progress().count())
-
-
-class EvaluatedSiaeManagerTest(TestCase):
-    def test_has_active_campaign(self):
-        fake_now = timezone.now()
-
-        evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign__ended_at=fake_now)
-        self.assertFalse(EvaluatedSiae.objects.has_active_campaign(evaluated_siae.siae))
-
-        evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign__evaluations_asked_at=fake_now)
-        self.assertTrue(EvaluatedSiae.objects.has_active_campaign(evaluated_siae.siae))
 
 
 class EvaluatedSiaeModelTest(TestCase):

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -538,10 +538,20 @@
                 <p class="h4 card-header">Contrôle a posteriori <span class="badge badge-info">Nouveau</span></p>
                 <div class="card-body">
                     <ul class="list-unstyled">
-                        <li class="card-text mb-3">
-                            <i class="ri-pulse-line ri-lg mr-1"></i>
-                            <a href="{% url 'siae_evaluations_views:samples_selection' %}">Sélectionner l'échantillon</a>
-                        </li>
+                        {% for active_campaign in active_campaigns %}
+                            {% if active_campaign.evaluations_asked_at %}
+                                <li class="card-text mb-3">
+                                    <i class="ri-file-copy-2-line ri-lg mr-1"></i>
+                                    <a href="{% url 'siae_evaluations_views:institution_evaluated_siae_list' active_campaign.pk %}">Contrôler les pièces justificatives</a>
+                                </li>
+                            {% else %}
+                                <li class="card-text mb-3">
+                                    <i class="ri-pulse-line ri-lg mr-1"></i>
+                                    <a href="{% url 'siae_evaluations_views:samples_selection' %}">Sélectionner l'échantillon</a>
+                                </li>
+                            {% endif %}
+                        {% endfor %}
+
                     </ul>
                 </div>
             </div>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -415,7 +415,7 @@
                 </div>
             </div>
 
-            {% if has_active_campaign %}
+            {% if active_campaigns %}
                 <div class="card">
                     <p class="h4 card-header">Contrôle a posteriori <span class="badge badge-info">Nouveau</span></p>
                     <div class="card-body">
@@ -533,7 +533,7 @@
 
         {% endif %}
 
-        {% if can_view_stats_ddets and has_active_campaign %}
+        {% if can_view_stats_ddets and active_campaigns %}
             <div class="card">
                 <p class="h4 card-header">Contrôle a posteriori <span class="badge badge-info">Nouveau</span></p>
                 <div class="card-body">

--- a/itou/templates/siae_evaluations/includes/siae_infos.html
+++ b/itou/templates/siae_evaluations/includes/siae_infos.html
@@ -1,0 +1,16 @@
+<div class="row">
+    <div class="col-md-9">
+        <h3 >
+
+            {{evaluated_siae}}
+
+        </h3>
+    </div>
+    <div class="col-md-3 text-right">
+        <p class="small mb-0">
+            {% if evaluated_siae.state == "PENDING" %}
+                <p class="badge badge-emploi">en attente</b></p>
+            {% endif %}
+        </p>
+    </div>
+</div>

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
@@ -1,0 +1,54 @@
+{% extends "layout/content.html" %}
+
+{% load bootstrap4 %}
+{% load static %}
+
+{% block title %}{% endblock %}
+
+
+{% block messages %}
+    {% bootstrap_messages %}
+{% endblock %}
+
+{% block content %}
+    <div class="row">
+
+        <div class="col-2 ">
+            {# placeholder #}
+        </div>
+        <div class="col-8">
+            <div class="row mt-3">
+                <div class="col-12">
+
+                    <h1 class="h1">
+                        Contrôler les pièces justificatives
+                    </h1>
+                    <h3 class="h3">
+                        Liste des Siae à contrôler
+                    </h3>
+                    <p>Contrôle initié le {{evaluated_siaes.0.evaluation_campaign.evaluations_asked_at|date:"d F Y"}}</p>
+                </div>
+            </div>
+
+            {% for evaluated_siae in evaluated_siaes %}
+                <div class="row mt-3">
+                    <div class="col-12">
+                        <div class="card"  >
+                            <div class="card-header">
+                                {% include "siae_evaluations/includes/siae_infos.html" with evaluated_siae=evaluated_siae%}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+            {% if back_url %}
+                <p class="mt-4">
+                    <a href="{{ back_url }}">Retour</a>
+                </p>
+            {% endif %}
+        </div>
+    </div>
+
+
+{% endblock %}
+

--- a/itou/templates/siae_evaluations/samples_selection.html
+++ b/itou/templates/siae_evaluations/samples_selection.html
@@ -59,7 +59,7 @@
                 Validation de l'échantillon des SIAE
             </p>
 
-            {% if has_active_campaign and evaluation_campaign.percent_set_at%}
+            {% if evaluation_campaign and evaluation_campaign.percent_set_at%}
                 <p>
                     <div class="alert alert-success" role="status">
                         <p>Votre contrôle a posteriori sur la période du {{evaluation_campaign.evaluated_period_start_at|date:"d F Y"}}
@@ -69,7 +69,7 @@
                         </p>
                     </div>
                 </p>
-            {% elif has_active_campaign %}
+            {% elif evaluation_campaign %}
                 <p>
                     Pour initier le contrôle a posteriori des auto-prescriptions, nous avons besoin de connaître le pourcentage
                     de SIAE que vous souhaitez contrôler. Vous ne pourrez choisir qu'une fois, ensuite, nous effectuerons une sélection

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -173,9 +173,22 @@ class DashboardViewTest(TestCase):
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Contrôle a posteriori")
 
-        EvaluationCampaignFactory(institution=institution)
+        evaluation_campaign = EvaluationCampaignFactory(institution=institution)
         response = self.client.get(reverse("dashboard:index"))
         self.assertContains(response, "Contrôle a posteriori")
+        self.assertContains(response, reverse("siae_evaluations_views:samples_selection"))
+
+        evaluation_campaign.evaluations_asked_at = timezone.now()
+        evaluation_campaign.save(update_fields=["evaluations_asked_at"])
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertContains(response, "Contrôle a posteriori")
+        self.assertContains(
+            response,
+            reverse(
+                "siae_evaluations_views:institution_evaluated_siae_list",
+                kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
+            ),
+        )
 
     def test_dashboard_siae_evaluations_siae_access(self):
         # preset for incoming new pages

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -31,7 +31,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
     can_show_employee_records = False
     job_applications_categories = []
     num_rejected_employee_records = 0
-    has_active_campaign = False
+    active_campaigns = []
 
     # `current_org` can be a Siae, a PrescriberOrganization or an Institution.
     current_org = None
@@ -40,7 +40,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         current_org = get_current_siae_or_404(request)
         can_show_financial_annexes = current_org.convention_can_be_accessed_by(request.user)
         can_show_employee_records = current_org.can_use_employee_record
-        has_active_campaign = EvaluatedSiae.objects.has_active_campaign(current_org)
+        active_campaigns = EvaluatedSiae.objects.for_siae(current_org).in_progress()
 
         job_applications_categories = [
             {
@@ -86,7 +86,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
 
     if request.user.is_labor_inspector:
         current_org = get_current_institution_or_404(request)
-        has_active_campaign = EvaluationCampaign.objects.has_active_campaign(current_org)
+        active_campaigns = EvaluationCampaign.objects.for_institution(current_org).in_progress()
 
     context = {
         "lemarche_regions": settings.LEMARCHE_OPEN_REGIONS,
@@ -102,7 +102,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_view_stats_dreets": request.user.can_view_stats_dreets(current_org=current_org),
         "can_view_stats_dgefp": request.user.can_view_stats_dgefp(current_org=current_org),
         "num_rejected_employee_records": num_rejected_employee_records,
-        "has_active_campaign": has_active_campaign,
+        "active_campaigns": active_campaigns,
     }
 
     return render(request, template_name, context)

--- a/itou/www/siae_evaluations_views/urls.py
+++ b/itou/www/siae_evaluations_views/urls.py
@@ -8,6 +8,11 @@ app_name = "siae_evaluations_views"
 
 urlpatterns = [
     path("samples_selection", views.samples_selection, name="samples_selection"),
+    path(
+        "institution_evaluated_siae_list/<int:evaluation_campaign_pk>/",
+        views.institution_evaluated_siae_list,
+        name="institution_evaluated_siae_list",
+    ),
     path("siae_job_applications_list", views.siae_job_applications_list, name="siae_job_applications_list"),
     path(
         "siae_select_criteria/<int:evaluated_job_application_pk>/",

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -21,7 +21,6 @@ from itou.www.siae_evaluations_views.forms import SetChosenPercentForm, SubmitEv
 def samples_selection(request, template_name="siae_evaluations/samples_selection.html"):
     institution = get_current_institution_or_404(request)
     evaluation_campaign = EvaluationCampaign.objects.first_active_campaign(institution)
-    has_active_campaign = EvaluationCampaign.objects.has_active_campaign(institution)
 
     back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
 
@@ -40,7 +39,6 @@ def samples_selection(request, template_name="siae_evaluations/samples_selection
     context = {
         "institution": institution,
         "evaluation_campaign": evaluation_campaign,
-        "has_active_campaign": has_active_campaign,
         "min": evaluation_enums.EvaluationChosenPercent.MIN,
         "max": evaluation_enums.EvaluationChosenPercent.MAX,
         "back_url": back_url,


### PR DESCRIPTION
### Quoi ?

Accéder à la liste des Siae sélectionnées dans un contrôle a posteriori

### Pourquoi ?

- En tant que DDETS  je veux visualiser et suivre la liste des SIAE à contrôler

### Comment ?

- refactoring : suppression des méthodes `has_active_campaign` pour preparer la simplification du code à venir (accès aux campagnes par pk)
- ajout vue de liste des `EvaluatedSiae` d'une `EvaluationCampaign`
- ajout d'un lien dans le dashboard des DDETS pour accéder à cette vue

### Note : version minimalistic pour le lancement