### PR TITLE
Les emails reçus par les employeurs non soumis aux règles d’éligibilité IAE ne sont pas tous adaptés à leur profil

### DIFF
--- a/itou/common_apps/notifications/tests.py
+++ b/itou/common_apps/notifications/tests.py
@@ -80,3 +80,21 @@ class NotificationsBaseClassTest(TestCase):
 
         receivers = [receiver for message in mail.outbox for receiver in message.to]
         self.assertEqual(self.notification.email.to, receivers)
+
+
+class NewSpontaneousJobAppEmployersNotificationTest(TestCase):
+    def test_mail_content_when_subject_to_eligibility_rules(self):
+        siae = SiaeWithMembershipFactory(subject_to_eligibility=True)
+        notification = NewSpontaneousJobAppEmployersNotification(
+            job_application=JobApplicationFactory(to_siae=siae),
+        )
+
+        self.assertIn("PASS IAE", notification.email.body)
+
+    def test_mail_content_when_not_subject_to_eligibility_rules(self):
+        siae = SiaeWithMembershipFactory(not_subject_to_eligibility=True)
+        notification = NewSpontaneousJobAppEmployersNotification(
+            job_application=JobApplicationFactory(to_siae=siae),
+        )
+
+        self.assertNotIn("PASS IAE", notification.email.body)

--- a/itou/siaes/factories.py
+++ b/itou/siaes/factories.py
@@ -51,6 +51,16 @@ class SiaeFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Siae
 
+    class Params:
+        subject_to_eligibility = factory.Trait(
+            kind=factory.fuzzy.FuzzyChoice(models.Siae.ELIGIBILITY_REQUIRED_KINDS),
+        )
+        not_subject_to_eligibility = factory.Trait(
+            kind=factory.fuzzy.FuzzyChoice(
+                [kind for kind, _ in models.Siae.KIND_CHOICES if kind not in models.Siae.ELIGIBILITY_REQUIRED_KINDS]
+            ),
+        )
+
     # Don't start a SIRET with 0.
     siret = factory.fuzzy.FuzzyText(length=13, chars=string.digits, prefix="1")
     naf = factory.fuzzy.FuzzyChoice(NAF_CODES)

--- a/itou/templates/apply/email/new_for_siae_body.txt
+++ b/itou/templates/apply/email/new_for_siae_body.txt
@@ -50,9 +50,9 @@ Le candidat lui même.
 Candidature envoyée à l'entreprise {{ job_application.to_siae.display_name }}, {{ job_application.to_siae.city }}. Identifiant sur les emplois de l'inclusion : {{ job_application.to_siae.pk }}.
 
 --------------------
-
+{% if job_application.to_siae.is_subject_to_eligibility_rules %}
 Toute demande de PASS IAE doit être effectuée au plus tard le jour de l'embauche. Les demandes rétroactives ne sont pas autorisées.
-
+{% endif %}
 Vous pouvez désactiver les notifications depuis votre espace utilisateur (rubrique "Mon espace" > "Mes notifications" ).
 
 {% endblock body %}

--- a/itou/templates/approvals/email/deliver_body.txt
+++ b/itou/templates/approvals/email/deliver_body.txt
@@ -1,6 +1,7 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% block body %}
 
+{% if job_application.to_siae.is_subject_to_eligibility_rules %}
 Merci d'avoir confirmé l'embauche d'un candidat sur les emplois de l'inclusion. Vous trouverez ci-dessous votre PASS IAE (il équivaut à l'agrément Pôle emploi conformément aux articles L 5132-1 à L 5132-17 du code du travail) :
 
 PASS IAE N° : {{ job_application.approval.number_with_spaces }}
@@ -30,5 +31,10 @@ Afin de nous aider à évaluer la performance de notre service, accepteriez-vous
 Prenez 30 secondes pour nous donner votre avis ! Cliquez sur : {{ siae_survey_link }}
 
 Merci de votre participation et à très bientôt sur les emplois de l'inclusion !
+{% else %}
+Merci d'avoir confirmé l'embauche d'un candidat sur les emplois de l'inclusion.
+
+Votre contact : {{ itou_assistance_url }}
+{% endif %}
 
 {% endblock body %}

--- a/itou/templates/approvals/email/deliver_subject.txt
+++ b/itou/templates/approvals/email/deliver_subject.txt
@@ -1,4 +1,8 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
+{% if job_application.to_siae.is_subject_to_eligibility_rules %}
 PASS IAE pour {{ job_application.job_seeker.get_full_name }} et avis sur les emplois de l'inclusion
+{% else %}
+Confirmation de l'embauche
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
### Quoi ?

Lorsque les EA/EATT/geiq/OPCS reçoivent une candidature et valident une embauche, les mails qu’elles reçoivent sont très orientés IAE. 

Les emails pour lesquels il faut retirer les mentions sur le pass IAE sont les suivants :

- nouvelle candidature
- candidature acceptée

Ne pas envoyer le mail avec le détail du Pass lors de la confirmation d’embauche.
Cette règle est valable aussi pour les GEIQ.

### Pourquoi ?

Lors de la réception d’une nouvelle candidature, les EA/GEIQ/OPCS reçoivent un e-mail qui parle de l’éligibilité IAE et parfois du PASS IAE or, ils ne sont pas concernés par l’éligibilité IAE, ni par le PASS IAE
