### PR TITLE
Configuration Pytest et non versionnement de .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ envs/dev.env
 envs/prod.env
 envs/secrets.env
 envs/staging.env
+.envrc
 
 # Config
 config/settings/dev.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings.test
+python_files = test*.py
+addopts = --reuse-db --verbose --capture=no

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -37,6 +37,8 @@ django-admin-logs==1.0.2  # https://pypi.org/project/django-admin-logs/
 # ------------------------------------------------------------------------------
 requests-mock==1.9.3  # https://github.com/jamielennox/requests-mock
 respx==0.19.0  # https://lundberg.github.io/respx/
+pytest==7.1.2  # https://github.com/pytest-dev/pytest
+pytest-django== 4.5.2 # https://github.com/pytest-dev/pytest-django/
 
 # Data extracts
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
### Quoi ?

Ajout d'un fichier de configuration Pytest pour nos amis VScodiens.
Modification du .gitignore pour ne pas versionner le .envrc.

### Pourquoi ?

Suite à l'excellent atelier de Victor.
