### PR TITLE
Refonte de la gestion des sessions dans le parcours prescripteur

### DIFF
--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -2,7 +2,6 @@ import datetime
 from unittest import mock
 
 from dateutil.relativedelta import relativedelta
-from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -53,7 +52,7 @@ class ApplyAsJobSeekerTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "siae_pk": siae.pk,
         }
@@ -69,7 +68,7 @@ class ApplyAsJobSeekerTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -96,7 +95,7 @@ class ApplyAsJobSeekerTest(TestCase):
         self.assertEqual(user.nir, nir)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "job_seeker_pk": user.pk,
             "siae_pk": siae.pk,
@@ -308,7 +307,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "siae_pk": siae.pk,
         }
@@ -324,7 +323,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -347,7 +346,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "nir": nir,
             "siae_pk": siae.pk,
@@ -397,7 +396,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         new_job_seeker = User.objects.get(email=post_data["email"])
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "job_seeker_pk": new_job_seeker.pk,
             "nir": new_job_seeker.nir,
@@ -512,7 +511,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "siae_pk": siae.pk,
         }
@@ -528,7 +527,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -628,7 +627,7 @@ class ApplyAsPrescriberTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "siae_pk": siae.pk,
         }
@@ -644,7 +643,7 @@ class ApplyAsPrescriberTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -666,7 +665,7 @@ class ApplyAsPrescriberTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "nir": nir,
             "siae_pk": siae.pk,
@@ -732,7 +731,7 @@ class ApplyAsPrescriberTest(TestCase):
         new_job_seeker = User.objects.get(email=post_data["email"])
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "job_seeker_pk": new_job_seeker.pk,
             "nir": new_job_seeker.nir,
@@ -965,7 +964,7 @@ class ApplyAsSiaeTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "siae_pk": siae.pk,
         }
@@ -981,7 +980,7 @@ class ApplyAsSiaeTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "siae_pk": siae.pk,
             "sender_pk": user.pk,
@@ -1004,7 +1003,7 @@ class ApplyAsSiaeTest(TestCase):
         response = self.client.post(next_url, data=post_data)
         self.assertEqual(response.status_code, 302)
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "nir": nir,
             "siae_pk": siae.pk,
@@ -1054,7 +1053,7 @@ class ApplyAsSiaeTest(TestCase):
         new_job_seeker = User.objects.get(email=post_data["email"])
 
         session = self.client.session
-        session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
+        session_data = session[f"job_application-{siae.pk}"]
         expected_session_data = self.default_session_data | {
             "job_seeker_pk": new_job_seeker.pk,
             "nir": new_job_seeker.nir,

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -29,7 +29,7 @@ class ApplyAsJobSeekerTest(TestCase):
             "back_url": None,
             "job_seeker_pk": None,
             "nir": None,
-            "to_siae_pk": None,
+            "siae_pk": None,
             "sender_pk": None,
             "sender_kind": None,
             "sender_siae_pk": None,
@@ -55,7 +55,7 @@ class ApplyAsJobSeekerTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
         }
         self.assertDictEqual(session_data, expected_session_data)
 
@@ -71,7 +71,7 @@ class ApplyAsJobSeekerTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_JOB_SEEKER,
         }
@@ -99,7 +99,7 @@ class ApplyAsJobSeekerTest(TestCase):
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
             "job_seeker_pk": user.pk,
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_JOB_SEEKER,
         }
@@ -283,7 +283,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
             "back_url": None,
             "job_seeker_pk": None,
             "nir": None,
-            "to_siae_pk": None,
+            "siae_pk": None,
             "sender_pk": None,
             "sender_kind": None,
             "sender_siae_pk": None,
@@ -310,7 +310,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
         }
         self.assertDictEqual(session_data, expected_session_data)
 
@@ -326,7 +326,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_PRESCRIBER,
             "sender_prescriber_organization_pk": prescriber_organization.pk,
@@ -350,7 +350,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
             "nir": nir,
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_PRESCRIBER,
             "sender_prescriber_organization_pk": prescriber_organization.pk,
@@ -401,7 +401,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         expected_session_data = self.default_session_data | {
             "job_seeker_pk": new_job_seeker.pk,
             "nir": new_job_seeker.nir,
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_PRESCRIBER,
             "sender_prescriber_organization_pk": prescriber_organization.pk,
@@ -514,7 +514,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
         }
         self.assertDictEqual(session_data, expected_session_data)
 
@@ -530,7 +530,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_PRESCRIBER,
             "sender_prescriber_organization_pk": prescriber_organization.pk,
@@ -606,7 +606,7 @@ class ApplyAsPrescriberTest(TestCase):
             "back_url": None,
             "job_seeker_pk": None,
             "nir": None,
-            "to_siae_pk": None,
+            "siae_pk": None,
             "sender_pk": None,
             "sender_kind": None,
             "sender_siae_pk": None,
@@ -630,7 +630,7 @@ class ApplyAsPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
         }
         self.assertDictEqual(session_data, expected_session_data)
 
@@ -646,7 +646,7 @@ class ApplyAsPrescriberTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_PRESCRIBER,
         }
@@ -669,7 +669,7 @@ class ApplyAsPrescriberTest(TestCase):
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
             "nir": nir,
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_PRESCRIBER,
         }
@@ -736,7 +736,7 @@ class ApplyAsPrescriberTest(TestCase):
         expected_session_data = self.default_session_data | {
             "job_seeker_pk": new_job_seeker.pk,
             "nir": new_job_seeker.nir,
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_PRESCRIBER,
         }
@@ -929,7 +929,7 @@ class ApplyAsSiaeTest(TestCase):
             "back_url": None,
             "job_seeker_pk": None,
             "nir": None,
-            "to_siae_pk": None,
+            "siae_pk": None,
             "sender_pk": None,
             "sender_kind": None,
             "sender_siae_pk": None,
@@ -967,7 +967,7 @@ class ApplyAsSiaeTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
         }
         self.assertDictEqual(session_data, expected_session_data)
 
@@ -983,7 +983,7 @@ class ApplyAsSiaeTest(TestCase):
         session = self.client.session
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_SIAE_STAFF,
             "sender_siae_pk": siae.pk,
@@ -1007,7 +1007,7 @@ class ApplyAsSiaeTest(TestCase):
         session_data = session[settings.ITOU_SESSION_JOB_APPLICATION_KEY]
         expected_session_data = self.default_session_data | {
             "nir": nir,
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_SIAE_STAFF,
             "sender_siae_pk": siae.pk,
@@ -1058,7 +1058,7 @@ class ApplyAsSiaeTest(TestCase):
         expected_session_data = self.default_session_data | {
             "job_seeker_pk": new_job_seeker.pk,
             "nir": new_job_seeker.nir,
-            "to_siae_pk": siae.pk,
+            "siae_pk": siae.pk,
             "sender_pk": user.pk,
             "sender_kind": JobApplication.SENDER_KIND_SIAE_STAFF,
             "sender_siae_pk": siae.pk,

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -8,8 +8,8 @@ app_name = "apply"
 
 urlpatterns = [
     # Submit.
-    path("<int:siae_pk>/start", submit_views.start, name="start"),
-    path("<int:siae_pk>/step_sender", submit_views.step_sender, name="step_sender"),
+    path("<int:siae_pk>/start", submit_views.StartStepView.as_view(), name="start"),
+    path("<int:siae_pk>/step_sender", submit_views.SenderStepView.as_view(), name="step_sender"),
     path("<int:siae_pk>/step_job_seeker", submit_views.step_job_seeker, name="step_job_seeker"),
     path(
         "<int:siae_pk>/step_check_job_seeker_nir",
@@ -29,7 +29,11 @@ urlpatterns = [
     ),
     path("<int:siae_pk>/step_eligibility", submit_views.step_eligibility, name="step_eligibility"),
     path("<int:siae_pk>/step_application", submit_views.step_application, name="step_application"),
-    path("<int:siae_pk>/step_application_sent", submit_views.step_application_sent, name="step_application_sent"),
+    path(
+        "<int:siae_pk>/step_application_sent",
+        submit_views.ApplicationSentStepView.as_view(),
+        name="step_application_sent",
+    ),
     # List.
     path("job_seeker/list", list_views.list_for_job_seeker, name="list_for_job_seeker"),
     path("prescriber/list", list_views.list_for_prescriber, name="list_for_prescriber"),

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -40,7 +40,7 @@ def valid_session_required(function=None):
     def decorated(request, *args, **kwargs):
         session_data = request.session.get(settings.ITOU_SESSION_JOB_APPLICATION_KEY)
         if not session_data or (session_data["to_siae_pk"] != kwargs["siae_pk"]):
-            raise PermissionDenied
+            raise PermissionDenied("invalid session data")
         return function(request, *args, **kwargs)
 
     return decorated
@@ -316,7 +316,9 @@ def step_check_job_seeker_info(request, siae_pk, template_name="apply/submit_ste
 
 @login_required
 @valid_session_required
-def step_create_job_seeker(request, siae_pk, template_name="apply/submit_step_job_seeker_create.html"):
+def step_create_job_seeker(
+    request, siae_pk, template_name="apply/submit_step_job_seeker_create.html"
+):  # pylint: disable=unused-argument
     """
     Create a job seeker if he can't be found in the DB.
     """
@@ -353,7 +355,9 @@ def step_create_job_seeker(request, siae_pk, template_name="apply/submit_step_jo
 
 @login_required
 @valid_session_required
-def step_check_prev_applications(request, siae_pk, template_name="apply/submit_step_check_prev_applications.html"):
+def step_check_prev_applications(
+    request, siae_pk, template_name="apply/submit_step_check_prev_applications.html"
+):  # pylint: disable=unused-argument
     """
     Check previous job applications to avoid duplicates.
     """
@@ -510,7 +514,9 @@ def step_application(request, siae_pk, template_name="apply/submit_step_applicat
 
 @login_required
 @valid_session_required
-def step_application_sent(request, siae_pk, template_name="apply/submit_step_application_sent.html"):
+def step_application_sent(
+    request, siae_pk, template_name="apply/submit_step_application_sent.html"
+):  # pylint: disable=unused-argument
     if request.user.is_siae_staff:
         dashboard_url = reverse("apply:list_for_siae")
         messages.success(request, "Candidature bien envoyée !")


### PR DESCRIPTION
### Quoi ?

Revoir la façon dont sont gérées les sessions.

### Pourquoi ?

Actuellement on a des conflits entre les données de sessions dans différents tabs et pour différentes SIAE potentiellement.

### Comment ?

En faisant une refonte assez profonde.

Cette PR est une réouverture de [cette dernière](https://github.com/betagouv/itou/pull/1307) cloturée par erreur sans espoir de réouverture (base branch deleted)