### PR TITLE
Makefile: Ajout de la commande test_venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,9 @@ test:
 test-interactive:
 	docker exec -ti itou_django django-admin test --settings=config.settings.test --failfast $(TARGET)
 
+test_venv:
+	./manage.py test --settings=config.settings.test --verbosity 1 --force-color --timing $(TARGET)
+
 # Docker shell.
 # =============================================================================
 


### PR DESCRIPTION
So that you can also reset the test database easily.

### Quoi ?

Pour resetter la database, ou lancer des tests en ligne de commande si vous n'avez pas deja un script :)

### Pourquoi ?
Plus facile.

### Comment ?
Avec une commande.
