### PR TITLE
Désactivation des scripts CRON concernant les fiches salarié

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,6 +1,3 @@
 [
   "1 0 * * * $ROOT/clevercloud/update-prescriber-organization-with-api-entreprise.sh",
-  "25 8,10,12,14,16,18 * * 1,2,3,4,5 $ROOT/clevercloud/download_employee_records.sh",
-  "55 8,10,12,14,16,18 * * 1,2,3,4,5 $ROOT/clevercloud/upload_employee_records.sh",
-  "5 23 * * 1,2,3,4,5 $ROOT/clevercloud/archive_employee_records.sh"
 ]


### PR DESCRIPTION
### Quoi ?

Désactivation des scripts de transfert des fiches salarié sur la période du 30-31.05.2022.

### Pourquoi ?

A ces dates une reprise des données de l'ASP sera en cours (pour procéder à la mise en place des notifications de changement sur les PASS IAE).
Une autre PR est à suivre pour la réactivation des scripts CRON.

### Comment ?

Suppression du lancement des scripts concernés dans le fichier CRON de clevercloud.