### PR TITLE
Message d'information fiches salarié

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -101,11 +101,11 @@
         {% include "welcoming_tour/includes/message.html" %}
     {% endif %}
 
-    {# Message d'information temporaire pour les fiches salarié / annexes financières #}
+    {# Message d'information temporaire pour les fiches salarié #}
     {% if can_show_employee_records %}
         <div class="alert alert-info">
-            <p>La fin de validité des annexes financières de 2021 n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.</p>
-            <p class="mb-0">Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
+            <p>Pour des raisons de maintenance, le traitement des fiches salarié est temporairement suspendu <b>jusqu’au 31 mai 2022 inclus</b>.</p>
+            <p class="mb-0">Vous pouvez continuer à recruter et générer vos fiches, il n'y a pas de blocage, mais l'envoi et le traitement reprendront dés <b>le 1er juin</b> au matin.</p>
         </div>
     {% endif %}
 


### PR DESCRIPTION
### Quoi ?

Ajout d'un message d'information pour les structures utilisant les fiches salariés.

### Pourquoi ?

Coupure du transfert des fiches salarié les 30 et 31 mai 2022 : pour installation du service de MAJ des dates de PASS IAE et le temps d'une reprise de données par l'ASP.

### Comment ?

Petit message informatif sur le tableau de bord.
