### PR TITLE
HOTFIX : Management command transfert du fichier de feedback pour les notifications ASP

### DIFF
--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -1,4 +1,3 @@
-import logging
 from io import BytesIO
 from os import path
 

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -649,6 +649,9 @@ class EmployeeRecordUpdateNotificationQuerySet(QuerySet):
     def rejected(self):
         return self.filter(status=NotificationStatus.REJECTED)
 
+    def find_by_batch(self, filename, line_number):
+        return self.filter(asp_batch_file=filename, asp_batch_line_number=line_number)
+
 
 class EmployeeRecordUpdateNotification(models.Model):
     """


### PR DESCRIPTION
### Quoi ?

Modification de l'import des notifications.

### Pourquoi ?

Apparemment, une méthode du queryset à du sauter lors d'un rebase entre les tests ASP et la MEP

### Comment ?

Remettre en place la méthode de queryset `find_by_batch` pour les notifications.