### PR TITLE
Mise à jour des scripts automatiques de transfert des fiches salariés 

### DIFF
--- a/clevercloud/download_employee_records.sh
+++ b/clevercloud/download_employee_records.sh
@@ -18,4 +18,9 @@ fi
 # $APP_HOME is set by default by clever cloud.
 cd $APP_HOME
 
+# Download employee records 
 django-admin transfer_employee_records --download
+
+# Download update notifications 
+django-admin transfer_employee_records_updates --download --wet-run
+

--- a/clevercloud/upload_employee_records.sh
+++ b/clevercloud/upload_employee_records.sh
@@ -18,4 +18,9 @@ fi
 # $APP_HOME is set by default by clever cloud.
 cd $APP_HOME
 
+# Upload employee records 
 django-admin transfer_employee_records --upload
+
+# Upload update notifications 
+django-admin transfer_employee_records_updates --upload --wet-run
+

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -141,7 +141,7 @@ class Command(EmployeeRecordTransferCommand):
         total_errors = 0
         files_to_delete = []
 
-        self.stdout.write("Starting DOWNLOAD")
+        self.stdout.write("Starting DOWNLOAD of employee record notifications")
 
         with conn.cd(settings.ASP_FS_REMOTE_DOWNLOAD_DIR):
             result_files = conn.listdir()
@@ -178,7 +178,7 @@ class Command(EmployeeRecordTransferCommand):
                 files_to_delete.append(result_file)
 
             for file in files_to_delete:
-                # All employee records processed, we can delete feedback file from server
+                # All employee record notifications processed , we can delete feedback file from server
                 if dry_run:
                     self.stdout.write(f"DRY-RUN: Deleting file '{file}'")
                     continue


### PR DESCRIPTION
### Quoi ?

Ajout des notifications de changement des PASS IAE dans les scripts automatiques de transfert vers l'ASP.

### Pourquoi ?

Fin des vérifications manuelles des transferts de notifications, le processus peut devenir automatique.

### Comment ?

Ajout des lancements de la management command spécifique aux notifications aux scripts automatisés déjà existant.

### Autre (optionnel)

Les notifications de changement de PASS IAE étaient la dernière partie du cahier des charges "Interopérabilité" de l'ASP.
C'est la fin des travaux d'échanges d'informations avec l'ASP :)

Ne s'en suivront que des modifications coté plateforme pour améliorer l'expérience utilisateur.
