### PR TITLE
Accélération de la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         make quality_venv
     - name: 🤹‍ Django tests
-      run: django-admin test --noinput --failfast --parallel=2
+      run: django-admin test --noinput --failfast --parallel
       env:
         DJANGO_DEBUG: True
     - name: 🚧 Check pending migrations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,9 @@ jobs:
     - name: ✨ Black, isort, flake8 & djhtml
       run: |
         make quality_venv
+    - name: 🚧 Check pending migrations
+      run: django-admin makemigrations --check --dry-run --noinput
     - name: 🤹‍ Django tests
       run: django-admin test --noinput --failfast --parallel
       env:
         DJANGO_DEBUG: True
-    - name: 🚧 Check pending migrations
-      run: django-admin makemigrations --check --dry-run --noinput


### PR DESCRIPTION
### Quoi ?

Tentative d'accélération de la CI, pas vraiment fulgurante car on passe de 13 minutes à 12, mais au moins les migrations échouent avant les tests.

### Pourquoi ?

- La CI est trop lente.
- C'est trop frustrant que la CI casse à cause d'une migration manquante après avoir attendu 10 minutes que les tests passent. 
