### PR TITLE
Contrôle a posteriori : laisser le formulaire de saisie du commentaire modifiable après la revue par les DDETS

### DIFF
--- a/itou/templates/siae_evaluations/institution_evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_job_application.html
@@ -28,11 +28,7 @@
                                         <button
                                             type="submit"
                                             class="btn {% if evaluated_job_application.state == 'ACCEPTED' or evaluated_job_application.state == 'REFUSED' %}btn-primary {%else%}btn-outline-primary {% endif%}float-right">
-                                            {% if evaluated_siae.state == 'SUBMITTED' or evaluated_siae.state == 'ACCEPTED' or evaluated_siae.state == 'REFUSED' %}
-                                                Enregistrer le commentaire et retourner à la liste des auto-prescriptions
-                                            {%else%}
-                                                Retourner à la liste des auto-prescriptions
-                                            {%endif%}
+                                            Enregistrer le commentaire et retourner à la liste des auto-prescriptions
                                         </button>
                                     </form>
                                 </div>

--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -58,13 +58,3 @@ class LaborExplanationForm(forms.ModelForm):
             )
         }
         labels = {"labor_inspector_explanation": "Raison d'une auto-prescription refusée"}
-
-    def __init__(self, *args, **kwargs):
-        super(LaborExplanationForm, self).__init__(*args, **kwargs)
-        instance = getattr(self, "instance", None)
-
-        if instance.evaluated_siae.state in [
-            evaluation_enums.EvaluatedSiaeState.REVIEWED,
-            evaluation_enums.EvaluatedSiaeState.ADVERSARIAL_STAGE,
-        ]:
-            self.fields["labor_inspector_explanation"].widget.attrs["disabled"] = "disabled"


### PR DESCRIPTION
### Quoi ?

Retirer la bascule du champ du formulaire en readonly après la revue par les DDETS.

### Pourquoi ?

Des pièces ont été refusées avant la mise en production du formulaire. Des DDETS voudraient en profiter pour ajouter un commentaire a posteriori. Le passage en readonly crée un effet de bord génant pour le rattrapage.
À repenser pour les prochaines campagnes.

### Comment ?

- suppression de la méthode `init` de `LaborExplanationForm` (non testée :| )
- retrait de la décoration du template pour modifier le bouton