### PR TITLE
Amélioration de la performance du cron Metabase quotidien.

### DIFF
--- a/.github/workflows/populate-metabase-itou.yml
+++ b/.github/workflows/populate-metabase-itou.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: # allows us to run this action manually
   schedule:
     # Run this workflow every night.
-    # 19:00 here means 22:00 or 23:00 in France depending on winter/summer time.
+    # 19:00 here means 21:00 or 22:00 in France depending on winter/summer time.
     - cron: '0 19 * * *'
 
 # How to run this:
@@ -36,14 +36,18 @@ jobs:
   populate_metabase_itou:
     runs-on: ubuntu-latest
 
-    # Default github action workflow timeout is 6 hours (360 minutes). If the script lasts longer than this for any reason,
-    # the github action will be killed but the clever instance will keep running forever as the last job supposed to
-    # delete it was never runned. This is why we set a very large timer here (24 hours == 1440 minutes) because
-    # clever instances are expensive but github actions are not. Cutting financial costs is the reponsibility of the
-    # last job, not of github.
-    # Unfortunately this does not work, the new timeout value is silently ignored and github keeps killing the job
-    # after the default 6 hours. This will need to be investigated further.
-    timeout-minutes: 1440
+    # Default github action workflow timeout is 6 hours (360 minutes). If the script lasts longer than this for any
+    # reason, the github action will be killed but the clever instance will keep running forever as the last job
+    # supposed to delete it was never runned. This is why we want a very large timer here because clever instances
+    # are expensive but github actions are not.
+    # Unfortunately this does not work as any new timeout value above 6 hours is silently ignored and github keeps
+    # killing the job after the default 6 hours. This is due to the fact that there is also a maximum job execution
+    # time limit of 6 hours for Github-hosted runners. Thus we cannot push through 6 hours unless we one day use
+    # self-hoster runners. ¯\_(ツ)_/¯
+    # Another possible solution would be, as recommended by Clever support, to end the github action immediately
+    # after launching the clever instance with its worker, and add a "harakiri" script at the end of
+    # `CC_WORKER_COMMAND` to make the clever instance connect by itself to the clever API, and order its own deletion.
+    timeout-minutes: 360
 
     steps:
     - name: 📥 Checkout to the latest version on $DEPLOY_BRANCH
@@ -98,11 +102,11 @@ jobs:
     - name: 🚀 Deploy app to Clever Cloud
       run: $CLEVER_CLI deploy --alias $CRON_TASK_APP_NAME --branch $DEPLOY_BRANCH --force
 
-    # This script was taking less than 3h (10800s) until https://github.com/betagouv/itou/pull/1154 introduced
-    # significant performance degradation due to several additional joins. The script now takes 5h instead of 3h
-    # even after some optimization. We set the timeout at 5h45 (20700s), just below 6h, because there is
-    # an unresolved issue with a different timeout system, see `timeout-minutes` above.
-    - name: 🕒 Wait a reasonable amount of time for the script to complete
+    # Here we should wait an amount of time after which we are sure the script has completed.
+    # This waiting time should never be increased above 5h45 (20700s), just below 6h, because otherwise
+    # the github action will be killed at 6 hours but the clever instance will keep running forever,
+    # see `timeout-minutes` above for more details.
+    - name: 🕒 Wait a reasonable amount of time after which we are sure the script has completed
       run: sleep 20700
 
     - name: 🔪 Delete the app once the work is done

--- a/itou/metabase/management/commands/_approvals.py
+++ b/itou/metabase/management/commands/_approvals.py
@@ -3,7 +3,11 @@ from datetime import datetime
 from django.conf import settings
 
 from itou.approvals.models import Approval, PoleEmploiApproval
-from itou.metabase.management.commands._utils import get_department_and_region_columns, get_hiring_siae
+from itou.metabase.management.commands._utils import (
+    AI_STOCK_APPROVAL_PKS,
+    get_department_and_region_columns,
+    get_hiring_siae,
+)
 from itou.prescribers.models import PrescriberOrganization
 
 
@@ -101,6 +105,6 @@ TABLE_COLUMNS += [
         "name": "injection_ai",
         "type": "boolean",
         "comment": "Provient des injections AI",
-        "fn": lambda o: o.is_from_ai_stock if isinstance(o, Approval) else False,
+        "fn": lambda o: o.pk in AI_STOCK_APPROVAL_PKS if isinstance(o, Approval) else False,
     },
 ]

--- a/itou/metabase/management/commands/_approvals.py
+++ b/itou/metabase/management/commands/_approvals.py
@@ -4,7 +4,7 @@ from django.conf import settings
 
 from itou.approvals.models import Approval, PoleEmploiApproval
 from itou.metabase.management.commands._utils import (
-    AI_STOCK_APPROVAL_PKS,
+    get_ai_stock_approval_pks,
     get_department_and_region_columns,
     get_hiring_siae,
 )
@@ -105,6 +105,6 @@ TABLE_COLUMNS += [
         "name": "injection_ai",
         "type": "boolean",
         "comment": "Provient des injections AI",
-        "fn": lambda o: o.pk in AI_STOCK_APPROVAL_PKS if isinstance(o, Approval) else False,
+        "fn": lambda o: o.pk in get_ai_stock_approval_pks() if isinstance(o, Approval) else False,
     },
 ]

--- a/itou/metabase/management/commands/_job_applications.py
+++ b/itou/metabase/management/commands/_job_applications.py
@@ -1,7 +1,7 @@
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.metabase.management.commands._utils import (
-    AI_STOCK_APPROVAL_PKS,
     anonymize,
+    get_ai_stock_approval_pks,
     get_choice,
     get_department_and_region_columns,
 )
@@ -227,6 +227,6 @@ TABLE_COLUMNS += [
         "name": "injection_ai",
         "type": "boolean",
         "comment": "Provient des injections AI",
-        "fn": lambda o: o.approval.pk in AI_STOCK_APPROVAL_PKS if o.approval else False,
+        "fn": lambda o: o.approval.pk in get_ai_stock_approval_pks() if o.approval else False,
     },
 ]

--- a/itou/metabase/management/commands/_job_applications.py
+++ b/itou/metabase/management/commands/_job_applications.py
@@ -1,5 +1,10 @@
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
-from itou.metabase.management.commands._utils import anonymize, get_choice, get_department_and_region_columns
+from itou.metabase.management.commands._utils import (
+    AI_STOCK_APPROVAL_PKS,
+    anonymize,
+    get_choice,
+    get_department_and_region_columns,
+)
 
 
 JOB_APPLICATION_PK_ANONYMIZATION_SALT = "job_application.id"
@@ -222,6 +227,6 @@ TABLE_COLUMNS += [
         "name": "injection_ai",
         "type": "boolean",
         "comment": "Provient des injections AI",
-        "fn": lambda o: o.approval.is_from_ai_stock if o.approval else False,
+        "fn": lambda o: o.approval.pk in AI_STOCK_APPROVAL_PKS if o.approval else False,
     },
 ]

--- a/itou/metabase/management/commands/_job_seekers.py
+++ b/itou/metabase/management/commands/_job_seekers.py
@@ -7,8 +7,8 @@ from django.utils import timezone
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.metabase.management.commands._utils import (
-    AI_STOCK_JOB_SEEKER_PKS,
     anonymize,
+    get_ai_stock_job_seeker_pks,
     get_choice,
     get_department_and_region_columns,
     get_hiring_siae,
@@ -283,6 +283,6 @@ TABLE_COLUMNS += [
         # but the performance becomes terrible (e.g. 120 minutes vs 30 minutes), is not easy to fix due to how
         # `approvals_wrapper.latest_approval` is implemented and gives the exact same end result anyway (71205 users),
         # most likely since most if not all of these users only have a single approval anyway.
-        "fn": lambda o: o.pk in AI_STOCK_JOB_SEEKER_PKS,
+        "fn": lambda o: o.pk in get_ai_stock_job_seeker_pks(),
     },
 ]

--- a/itou/metabase/management/commands/_utils.py
+++ b/itou/metabase/management/commands/_utils.py
@@ -180,8 +180,8 @@ def _get_ai_stock_approvals():
 # As of June 2022 we have exactly 71205 approvals from the AI stock and exactly the same number of job seekers.
 # This number is supposed to stay constant over time, there is no reason for it to grow.
 # We load all 71k pks once and for all in memory for performance reasons.
-AI_STOCK_APPROVAL_PKS = set(_get_ai_stock_approvals().values_list("pk", flat=True))
-AI_STOCK_JOB_SEEKER_PKS = set(_get_ai_stock_approvals().values_list("user_id", flat=True))
+AI_STOCK_APPROVAL_PKS = _get_ai_stock_approvals().values_list("pk", flat=True).distinct()
+AI_STOCK_JOB_SEEKER_PKS = _get_ai_stock_approvals().values_list("user_id", flat=True).distinct()
 
 
 def chunked_queryset(queryset, chunk_size=10000):

--- a/itou/metabase/management/commands/_utils.py
+++ b/itou/metabase/management/commands/_utils.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 from operator import attrgetter
 
 from django.conf import settings
@@ -177,11 +178,19 @@ def _get_ai_stock_approvals():
     )
 
 
-# As of June 2022 we have exactly 71205 approvals from the AI stock and exactly the same number of job seekers.
-# This number is supposed to stay constant over time, there is no reason for it to grow.
-# We load all 71k pks once and for all in memory for performance reasons.
-AI_STOCK_APPROVAL_PKS = _get_ai_stock_approvals().values_list("pk", flat=True).distinct()
-AI_STOCK_JOB_SEEKER_PKS = _get_ai_stock_approvals().values_list("user_id", flat=True).distinct()
+@lru_cache(maxsize=1)
+def get_ai_stock_approval_pks():
+    """
+    As of June 2022 we have exactly 71205 approvals from the AI stock and exactly the same number of job seekers.
+    This number is supposed to stay constant over time, there is no reason for it to grow.
+    We load all 71k pks once and for all in memory for performance reasons.
+    """
+    return _get_ai_stock_approvals().values_list("pk", flat=True).distinct()
+
+
+@lru_cache(maxsize=1)
+def get_ai_stock_job_seeker_pks():
+    return _get_ai_stock_approvals().values_list("user_id", flat=True).distinct()
 
 
 def chunked_queryset(queryset, chunk_size=10000):

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -223,6 +223,8 @@ class Command(BaseCommand):
                     # Insert rows by batch of settings.METABASE_INSERT_BATCH_SIZE.
                     for chunk_qs in chunked_queryset(queryset, chunk_size=settings.METABASE_INSERT_BATCH_SIZE):
                         injections_left = total_injections - injections
+                        if injections_left == 0:
+                            break  # During a dry run stop as soon as we have injected enough rows.
                         if chunk_qs.count() > injections_left:
                             chunk_qs = chunk_qs[:injections_left]
                         self.inject_chunk(table_columns=table_columns, chunk=chunk_qs, new_table_name=new_table_name)


### PR DESCRIPTION
### Quoi ?

Amélioration de la performance du cron Metabase quotidien :
- refactoring significatif autour de `is_from_ai_stock`.
- `populate_job_seekers` tombe de 120 minutes à 30 minutes (!) en local dev.
- `populate_job_applications` passe de 50 minutes à 40 minutes en local dev.
- `populate_approvals` passe de 35 minutes à 15 minutes en local dev.
- le cron dans son ensemble tombe de 6h+ à seulement 2h20 en condition réelle (fast-machine).
- amélioration de la documentation autour du timeout infranchissable de 6 heures des github actions.

### Pourquoi ?

- depuis 2-3 semaines ce cron échoue chaque nuit car dépasse le timeout github action de 6 heures. En dépannant je le lancais chaque samedi depuis mon local dev (qui, ironiquement, ne prend que 4 heures, comme quoi le réseau n'est pas à blamer), puisque le local dev contourne github action.
