### PR TITLE
Mise à jour des Github Actions et des paquets Python de dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: 🌍 Install spatial libraries
       run: sudo apt-get update && sudo apt-get install binutils build-essential libproj-dev gdal-bin
     - name: 💾 Create a database to check migrations
@@ -48,7 +48,7 @@ jobs:
             CREATE DATABASE itou;
         SQL
     - name: 💂 Install Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: 📥 Install dependencies

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,5 +1,5 @@
 -r ./base.txt
 
 uwsgi==2.0.20  # https://github.com/unbit/uwsgi
-sentry-sdk==1.5.3  # https://github.com/getsentry/sentry-python
-elastic-apm==6.7.2  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html
+sentry-sdk==1.5.12  # https://github.com/getsentry/sentry-python
+elastic-apm==6.9.1  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,7 @@ ipdb==0.13.9  # https://github.com/gotcha/ipdb
 tblib==1.7.0  # https://github.com/ionelmc/python-tblib
 
 # Werkzeug is required to use django-extensions's runserver_plus.
-Werkzeug==2.0.2 # https://github.com/pallets/werkzeug
+Werkzeug==2.1.2 # https://github.com/pallets/werkzeug
 
 # Last jedi release (0.18.0) is incompatible with ipython
 # https://github.com/ipython/ipython/issues/12740
@@ -17,26 +17,26 @@ jedi==0.17.2
 # Code quality
 # ------------------------------------------------------------------------------
 black==22.3.0  # https://github.com/psf/black
-flake8==3.9.2  # https://github.com/PyCQA/flake8
-isort==5.9.3  # https://github.com/timothycrosley/isort
-pylint==2.12.2  # https://github.com/PyCQA/pylint
-pylint-django==2.4.3  # https://github.com/PyCQA/pylint-django
-pre-commit==2.16.0  # https://github.com/pre-commit/pre-commit
-coverage==6.2  # https://github.com/nedbat/coveragepy
+flake8==4.0.1  # https://github.com/PyCQA/flake8
+isort==5.10.1  # https://github.com/timothycrosley/isort
+pylint==2.14.1  # https://github.com/PyCQA/pylint
+pylint-django==2.5.3  # https://github.com/PyCQA/pylint-django
+pre-commit==2.19.0  # https://github.com/pre-commit/pre-commit
+coverage==6.4.1  # https://github.com/nedbat/coveragepy
 djhtml==1.5.0  # https://github.com/rtts/djhtml
 
 # Django
 # ------------------------------------------------------------------------------
 factory-boy==3.2.1  # https://github.com/FactoryBoy/factory_boy
 
-django-debug-toolbar==3.2.2  # https://github.com/jazzband/django-debug-toolbar
+django-debug-toolbar==3.4  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.1.5  # https://github.com/django-extensions/django-extensions
 django-admin-logs==1.0.2  # https://pypi.org/project/django-admin-logs/
 
 # Test & Mock
 # ------------------------------------------------------------------------------
 requests-mock==1.9.3  # https://github.com/jamielennox/requests-mock
-respx==0.19.0  # https://lundberg.github.io/respx/
+respx==0.19.2  # https://lundberg.github.io/respx/
 pytest==7.1.2  # https://github.com/pytest-dev/pytest
 pytest-django== 4.5.2 # https://github.com/pytest-dev/pytest-django/
 


### PR DESCRIPTION
### Quoi ?

Mise à jour des Github Actions `setup` / `checkout` et des paquets Python de dev (essentiellement pour la qualité du code)

### Pourquoi ?

Pour profiter des évolutions et éviter les erreurs liées à obsolescence des dépendances.

### Comment ?

Passage des Github actions en v3.
Passage des paquets Python à la dernière version à date.
