### PR TITLE
Candidats sans solution à 30 jours

### DIFF
--- a/itou/metabase/management/commands/sql/023_candidats_sans_solution.sql
+++ b/itou/metabase/management/commands/sql/023_candidats_sans_solution.sql
@@ -1,0 +1,93 @@
+/*
+ 
+L'objectif est de suivre le nombre de candidats sans solution à 30 jours et pourcentage de ces candidats dans la totalité des candidats:
+    - nb candidats qui 30 jours après leur inscription restent sans candidatures 
+ou 
+    - avec candidatures dont l’état est différent de “acceptée”
+
+*/
+
+with candidature as ( 
+    select  
+        distinct (id_candidat_anonymisé) identifiant_candidat, 
+	    date_candidature,
+	    count(distinct (Candidatures.id_anonymisé)) nombre_candidature,
+	    état, 
+	    date_inscription
+   from 
+       Candidatures 
+   left join 
+       Candidats on id_candidat_anonymisé =  public.Candidats.id_anonymisé 
+   where 
+       date_candidature <= date_trunc('month', date_inscription) + interval '1 month'
+       and date_candidature >= date_inscription 
+       and Candidatures.injection_ai = 0 
+       and Candidats.injection_ai = 0
+    group by 
+        identifiant_candidat,
+        date_candidature,
+        date_inscription,
+        état
+order by 
+        identifiant_candidat ),
+/* Nb candidats qui 30 jours après leur inscription restent sans candidatures */
+candidats_0_candidatures as (
+    select 
+        distinct(identifiant_candidat ),
+        date_inscription
+    from 
+        candidature
+    where 
+        nombre_candidature = 0 ),
+/* Nb candidats qui 30 jours après leur inscription ont candidaté mais dont l’état est différent de “acceptée” */
+candidats_avc_candidature_acceptee as (
+    select 
+        identifiant_candidat,
+        sum( 
+            case
+                when état = 'Candidature acceptée' then 1 
+                else 0 
+            end ) as nb_candidature_acceptee, 
+        date_inscription
+    from 
+        candidature 
+    group by 
+        identifiant_candidat,
+        date_inscription
+    order by 
+        identifiant_candidat ),
+
+union_table as ( 
+    select 
+        * 
+    from 
+        candidats_0_candidatures 
+    union (
+        select 
+            identifiant_candidat,
+            date_inscription  
+        from 
+            candidats_avc_candidature_acceptee 
+        where 
+            nb_candidature_acceptee=0 ) )
+select 
+    a.nombre_candidats_ss_solution, 
+    a.date_inscription, 
+    b.nombre_candidats
+from (
+    select 
+        count(distinct (identifiant_candidat) )  as nombre_candidats_ss_solution,
+        date_inscription
+    from 
+        sa_union_table
+    group by 
+        date_inscription ) as a 
+left join (
+    select 
+        count(distinct(id_anonymisé)) as nombre_candidats,
+        date_inscription
+    from Candidats 
+    where Candidats.injection_ai = 0
+    group by date_inscription 
+    ) as b 
+    on a.date_inscription = b.date_inscription

--- a/itou/metabase/management/commands/sql/023_candidats_sans_solution.sql
+++ b/itou/metabase/management/commands/sql/023_candidats_sans_solution.sql
@@ -6,23 +6,22 @@ ou
     - avec candidatures dont l’état est différent de “acceptée”
 
 */
-
 with candidature as ( 
     select  
         distinct (id_candidat_anonymisé) identifiant_candidat, 
 	    date_candidature,
-	    count(distinct (Candidatures.id_anonymisé)) nombre_candidature,
+	    count(distinct (candidatures.id_anonymisé)) nombre_candidature,
 	    état, 
 	    date_inscription
    from 
-       Candidatures 
+       candidatures 
    left join 
-       Candidats on id_candidat_anonymisé =  public.Candidats.id_anonymisé 
+       Candidats on id_candidat_anonymisé =  public.candidats.id_anonymisé 
    where 
        date_candidature <= date_trunc('month', date_inscription) + interval '1 month'
        and date_candidature >= date_inscription 
-       and Candidatures.injection_ai = 0 
-       and Candidats.injection_ai = 0
+       and candidatures.injection_ai = 0 
+       and candidats.injection_ai = 0
     group by 
         identifiant_candidat,
         date_candidature,
@@ -31,9 +30,9 @@ with candidature as (
 order by 
         identifiant_candidat ),
 /* Nb candidats qui 30 jours après leur inscription restent sans candidatures */
-candidats_0_candidatures as (
+candidats_sans_candidatures as (
     select 
-        distinct(identifiant_candidat ),
+        distinct(identifiant_candidat),
         date_inscription
     from 
         candidature
@@ -61,7 +60,7 @@ union_table as (
     select 
         * 
     from 
-        candidats_0_candidatures 
+        candidats_sans_candidatures 
     union (
         select 
             identifiant_candidat,
@@ -79,15 +78,15 @@ from (
         count(distinct (identifiant_candidat) )  as nombre_candidats_ss_solution,
         date_inscription
     from 
-        sa_union_table
+        union_table
     group by 
         date_inscription ) as a 
 left join (
     select 
         count(distinct(id_anonymisé)) as nombre_candidats,
         date_inscription
-    from Candidats 
-    where Candidats.injection_ai = 0
+    from candidats 
+    where candidats.injection_ai = 0
     group by date_inscription 
     ) as b 
     on a.date_inscription = b.date_inscription


### PR DESCRIPTION
### Quoi ?

Suivi du nombre de candidats sans solution à 30 jours

### Pourquoi ?

Statistiques d'impact des emplois de l'inclusion