### PR TITLE
Éviter l'arrêt du serveur en environnement de développement Docker

### DIFF
--- a/docker/dev/django/entrypoint.sh
+++ b/docker/dev/django/entrypoint.sh
@@ -16,6 +16,8 @@ django-admin migrate
 
 # --nopin disables for you the annoying PIN security prompt on the web
 # debugger. For local dev only of course!
-django-admin runserver_plus 0.0.0.0:8000 --nopin
+# --keep-meta-shutdown is set to avoid this issue : https://github.com/django-extensions/django-extensions/issues/1715
+# This option should be removed when the package Werkzeug is updated with the fix.
+django-admin runserver_plus --keep-meta-shutdown 0.0.0.0:8000 --nopin
 
 exec "$@"


### PR DESCRIPTION
### Quoi ?

Le serveur `werkzeug` s'arrête en développement (env Docker) depuis la dernière mise à jour du paquet.

### Pourquoi ?

https://github.com/django-extensions/django-extensions/issues/1715

### Comment ?

Soit il fallait downgrader le paquet `Werkzeug`.
Soit il fallait ajouter un argument à la commande `runserver_plus`.

Pour aller de l'avant, j'ai opté pour la deuxième option.
