### PR TITLE
Commandes `_venv` du Makefile et logs SQL en double

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements/dev.txt
     - name: ✨ Black, isort, flake8 & djhtml
-      run: |
-        make quality_venv
+      run: USE_VENV=1 make quality
     - name: 🚧 Check pending migrations
       run: django-admin makemigrations --check --dry-run --noinput
     - name: 🤹‍ Django tests

--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ Une fois votre serveur de développement lancé, vous pouvez accéder au fronten
 l'adresse http://localhost:8080/.
 
 Dans un Virtualenv, vous pouvez utiliser les commandes Django habituelles
-(`./manage.py`), des commandes spécifiques au Virtualenv sont disponibles dans
-le Makefile. Elles sont suffixées par `_venv`.
+(`./manage.py`) mais également certaines recettes du Makefile, celles-ci 
+seront lancées directement dans votre venv si `USE_VENV=1` est utilisé.
+Cette variable devrait _normalement_ pouvoir être définie en global dans
+votre environnement shell (`export`, `.env`, ...). 
 
 ### Peupler la base de données
 

--- a/config/settings/dev.py.template
+++ b/config/settings/dev.py.template
@@ -69,10 +69,8 @@ ALLOW_POPULATING_METABASE = True
 
 # Log raw SQL to the console in Django.
 # https://www.neilwithdata.com/django-sql-logging
-LOGGING.setdefault("filters", {}).setdefault("require_debug_true", {})["()"] = "django.utils.log.RequireDebugTrue"
-LOGGING.setdefault("loggers", {})["django.db.backends"] = {
+LOGGING["loggers"]["django.db.backends"] = {
     "level": os.getenv("SQL_LOG_LEVEL", "DEBUG"),
-    "handlers": ["console"],
 }
 
 # ITOU.


### PR DESCRIPTION
### Quoi ?

- Correction du template pour `settings/dev.py` afin de ne plus logguer les requêtes SQL en double.
- Suppression des recettes du Makefile avec un suffixe `_venv` pour un flag.
L'idée est que tout le monde utilise la même interface (_ie._ nom des recettes) et qu'on s'adapte ensuite dans le Makefile, ça permet notamment d'éviter la duplication des commandes qui n'avais parfois pas tout à fait les mêmes options sans trop de raison.
