### PR TITLE
Utilisation de `factory.Trait` pour `SiaeFactory()`

### DIFF
--- a/itou/api/employee_record_api/tests/tests_throttling.py
+++ b/itou/api/employee_record_api/tests/tests_throttling.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient, APITestCase
 
 from itou.api.employee_record_api.viewsets import EmployeeRecordRateThrottle
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import DEFAULT_PASSWORD
 
 
@@ -20,7 +20,7 @@ class EmployeeRecordThrottleTest(APITestCase):
 
     def test_basic_ko_throttling(self):
         client = APIClient()
-        user = SiaeWithMembershipFactory().members.first()
+        user = SiaeFactory(with_membership=True).members.first()
 
         client.login(username=user.username, password=DEFAULT_PASSWORD)
 
@@ -35,7 +35,7 @@ class EmployeeRecordThrottleTest(APITestCase):
 
     def test_basic_ok_throttling(self):
         client = APIClient()
-        user = SiaeWithMembershipFactory().members.first()
+        user = SiaeFactory(with_membership=True).members.first()
 
         client.login(username=user.username, password=DEFAULT_PASSWORD)
 

--- a/itou/api/siae_api/tests.py
+++ b/itou/api/siae_api/tests.py
@@ -5,7 +5,7 @@ from rest_framework.test import APIClient, APITestCase
 
 from itou.cities.factories import create_city_guerande, create_city_saint_andre
 from itou.siaes.enums import SiaeKind
-from itou.siaes.factories import SiaeFactory, SiaeWithJobsFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import SiaeStaffFactory
 
 
@@ -21,8 +21,8 @@ class SiaeAPIFetchListTest(APITestCase):
         self.saint_andre = create_city_saint_andre()
         self.guerande = create_city_guerande()
         self.siae_a = SiaeFactory(kind=SiaeKind.EI, department="44", coords=self.saint_andre.coords)
-        self.siae_b = SiaeWithJobsFactory(
-            romes=("N1101", "N1105", "N1103", "N4105"), department="44", coords=self.saint_andre.coords
+        self.siae_b = SiaeFactory(
+            with_jobs=True, romes=("N1101", "N1105", "N1103", "N4105"), department="44", coords=self.saint_andre.coords
         )
 
     def test_fetch_siae_list_without_params(self):

--- a/itou/approvals/factories.py
+++ b/itou/approvals/factories.py
@@ -8,7 +8,7 @@ from faker import Faker
 
 from itou.approvals.models import Approval, PoleEmploiApproval, Prolongation, Suspension
 from itou.prescribers.factories import AuthorizedPrescriberOrganizationWithMembershipFactory
-from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import JobSeekerFactory
 
 
@@ -51,7 +51,7 @@ class ProlongationFactory(factory.django.DjangoModelFactory):
     reason = Prolongation.Reason.COMPLETE_TRAINING.value
     reason_explanation = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     declared_by = factory.LazyAttribute(lambda obj: obj.declared_by_siae.members.first())
-    declared_by_siae = factory.SubFactory(SiaeWithMembershipFactory)
+    declared_by_siae = factory.SubFactory(SiaeFactory, with_membership=True)
     created_by = factory.LazyAttribute(lambda obj: obj.declared_by)
 
     @factory.post_generation

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -31,7 +31,7 @@ from itou.job_applications.factories import (
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.prescribers.factories import AuthorizedPrescriberOrganizationFactory, PrescriberOrganizationFactory
 from itou.siaes.enums import SiaeKind
-from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import Siae
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, UserFactory
 
@@ -1442,7 +1442,7 @@ class ProlongationModelTest(TestCase):
         """
 
         approval = ApprovalFactory()
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
 
         start_at = approval.end_at - relativedelta(days=2)
         end_at = start_at + relativedelta(months=1)

--- a/itou/common_apps/notifications/tests.py
+++ b/itou/common_apps/notifications/tests.py
@@ -3,14 +3,14 @@ from django.test import TestCase
 
 from itou.job_applications.factories import JobApplicationFactory
 from itou.job_applications.notifications import NewSpontaneousJobAppEmployersNotification
-from itou.siaes.factories import SiaeMembershipFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory, SiaeMembershipFactory
 
 
 class NotificationsBaseClassTest(TestCase):
     # Use a child class to test parent class. Maybe refactor that later.
 
     def setUp(self):
-        self.siae = SiaeWithMembershipFactory()
+        self.siae = SiaeFactory(with_membership=True)
         self.job_application = JobApplicationFactory(to_siae=self.siae)
         self.notification = NewSpontaneousJobAppEmployersNotification(job_application=self.job_application)
 
@@ -84,7 +84,7 @@ class NotificationsBaseClassTest(TestCase):
 
 class NewSpontaneousJobAppEmployersNotificationTest(TestCase):
     def test_mail_content_when_subject_to_eligibility_rules(self):
-        siae = SiaeWithMembershipFactory(subject_to_eligibility=True)
+        siae = SiaeFactory(subject_to_eligibility=True, with_membership=True)
         notification = NewSpontaneousJobAppEmployersNotification(
             job_application=JobApplicationFactory(to_siae=siae),
         )
@@ -92,7 +92,7 @@ class NewSpontaneousJobAppEmployersNotificationTest(TestCase):
         self.assertIn("PASS IAE", notification.email.body)
 
     def test_mail_content_when_not_subject_to_eligibility_rules(self):
-        siae = SiaeWithMembershipFactory(not_subject_to_eligibility=True)
+        siae = SiaeFactory(not_subject_to_eligibility=True, with_membership=True)
         notification = NewSpontaneousJobAppEmployersNotification(
             job_application=JobApplicationFactory(to_siae=siae),
         )

--- a/itou/eligibility/factories.py
+++ b/itou/eligibility/factories.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 
 from itou.eligibility import models
 from itou.prescribers.factories import AuthorizedPrescriberOrganizationWithMembershipFactory
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import JobSeekerFactory
 
 
@@ -27,7 +27,7 @@ class EligibilityDiagnosisMadeBySiaeFactory(factory.django.DjangoModelFactory):
 
     author = factory.LazyAttribute(lambda obj: obj.author_siae.members.first())
     author_kind = models.EligibilityDiagnosis.AUTHOR_KIND_SIAE_STAFF
-    author_siae = factory.SubFactory(SiaeWithMembershipFactory)
+    author_siae = factory.SubFactory(SiaeFactory, with_membership=True)
     job_seeker = factory.SubFactory(JobSeekerFactory)
 
 

--- a/itou/eligibility/tests.py
+++ b/itou/eligibility/tests.py
@@ -14,7 +14,7 @@ from itou.eligibility.factories import (
 from itou.eligibility.models import AdministrativeCriteria, AdministrativeCriteriaQuerySet, EligibilityDiagnosis
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.prescribers.factories import AuthorizedPrescriberOrganizationWithMembershipFactory
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import JobSeekerFactory
 from itou.utils.perms.user import KIND_PRESCRIBER, KIND_SIAE_STAFF, UserInfo
 
@@ -131,8 +131,8 @@ class EligibilityDiagnosisManagerTest(TestCase):
         self.assertIsNone(last_expired)
 
         # Has Itou diagnosis made by an SIAE.
-        siae1 = SiaeWithMembershipFactory()
-        siae2 = SiaeWithMembershipFactory()
+        siae1 = SiaeFactory(with_membership=True)
+        siae2 = SiaeFactory(with_membership=True)
         diagnosis = EligibilityDiagnosisMadeBySiaeFactory(author_siae=siae1)
         # From `siae1` perspective.
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
@@ -158,7 +158,7 @@ class EligibilityDiagnosisManagerTest(TestCase):
         self.assertIsNone(last_expired)
 
         # Has Itou diagnosis made by a prescriber.
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         prescriber_diagnosis = EligibilityDiagnosisFactory()
         # From siae perspective.
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
@@ -176,7 +176,7 @@ class EligibilityDiagnosisManagerTest(TestCase):
 
         # Has 2 Itou diagnoses: 1 made by an SIAE prior to another one by a prescriber.
         job_seeker = JobSeekerFactory()
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         prescriber_diagnosis = EligibilityDiagnosisFactory(job_seeker=job_seeker)
         # From `siae` perspective.
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(job_seeker=job_seeker, for_siae=siae)
@@ -191,8 +191,8 @@ class EligibilityDiagnosisManagerTest(TestCase):
 
         # Has an expired Itou diagnoses made by another SIAE.
         job_seeker = JobSeekerFactory()
-        siae1 = SiaeWithMembershipFactory()
-        siae2 = SiaeWithMembershipFactory()
+        siae1 = SiaeFactory(with_membership=True)
+        siae2 = SiaeFactory(with_membership=True)
         expired_diagnosis = ExpiredEligibilityDiagnosisMadeBySiaeFactory(job_seeker=job_seeker, author_siae=siae1)
 
         # From `siae` perspective.
@@ -232,7 +232,7 @@ class EligibilityDiagnosisManagerTest(TestCase):
 class EligibilityDiagnosisModelTest(TestCase):
     def test_create_diagnosis(self):
         job_seeker = JobSeekerFactory()
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         user_info = UserInfo(
             user=user, kind=KIND_SIAE_STAFF, prescriber_organization=None, is_authorized_prescriber=False, siae=siae
@@ -321,7 +321,7 @@ class AdministrativeCriteriaModelTest(TestCase):
         self.assertNotIn(level1_criterion, qs)
 
     def test_for_job_application(self):
-        siae = SiaeWithMembershipFactory(department="14")
+        siae = SiaeFactory(department="14", with_membership=True)
 
         job_seeker = JobSeekerFactory()
         user = siae.members.first()

--- a/itou/invitations/factories.py
+++ b/itou/invitations/factories.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 from itou.invitations import models
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import UserFactory
 
 
@@ -17,7 +17,7 @@ class SiaeStaffInvitationFactory(factory.django.DjangoModelFactory):
     first_name = factory.Sequence("first_name{0}".format)
     last_name = factory.Sequence("last_name{0}".format)
     sender = factory.SubFactory(UserFactory)
-    siae = factory.SubFactory(SiaeWithMembershipFactory)
+    siae = factory.SubFactory(SiaeFactory, with_membership=True)
 
 
 class SentSiaeStaffInvitationFactory(SiaeStaffInvitationFactory):

--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -11,7 +11,7 @@ from itou.prescribers.factories import (
     AuthorizedPrescriberOrganizationWithMembershipFactory,
     PrescriberOrganizationWithMembershipFactory,
 )
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import SiaeJobDescription
 from itou.users.factories import (
     JobSeekerFactory,
@@ -29,7 +29,7 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
         model = models.JobApplication
 
     job_seeker = factory.SubFactory(JobSeekerFactory)
-    to_siae = factory.SubFactory(SiaeWithMembershipFactory)
+    to_siae = factory.SubFactory(SiaeFactory, with_membership=True)
     message = factory.Faker("sentence", nb_words=40)
     answer = factory.Faker("sentence", nb_words=40)
     hiring_start_at = timezone.localdate()

--- a/itou/job_applications/tests/tests_transfer.py
+++ b/itou/job_applications/tests/tests_transfer.py
@@ -12,7 +12,7 @@ from itou.job_applications.factories import (
     JobApplicationWithEligibilityDiagnosis,
 )
 from itou.job_applications.models import JobApplicationWorkflow
-from itou.siaes.factories import SiaeWith2MembershipsFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory, SiaeWith2MembershipsFactory
 from itou.users.factories import UserFactory
 
 
@@ -43,8 +43,8 @@ class JobApplicationTransferModelTest(TestCase):
         # Only users in both origin and target SIAE
         # can transfer a job_application
         # (provided it is in correct state)
-        origin_siae = SiaeWithMembershipFactory()
-        target_siae = SiaeWithMembershipFactory()
+        origin_siae = SiaeFactory(with_membership=True)
+        target_siae = SiaeFactory(with_membership=True)
 
         origin_user = origin_siae.members.first()
         target_user = target_siae.members.first()
@@ -70,8 +70,8 @@ class JobApplicationTransferModelTest(TestCase):
         # After transfer:
         # - job application is not linked to origin SIAE anymore (only to target SIAE)
         # - eligibility diagnosis is deleted if not created by an authorized prescriber
-        origin_siae = SiaeWithMembershipFactory()
-        target_siae = SiaeWithMembershipFactory()
+        origin_siae = SiaeFactory(with_membership=True)
+        target_siae = SiaeFactory(with_membership=True)
 
         origin_user = origin_siae.members.first()
         target_user = target_siae.members.first()
@@ -116,8 +116,8 @@ class JobApplicationTransferModelTest(TestCase):
 
     def test_model_fields(self):
         # Check new fields in model
-        origin_siae = SiaeWithMembershipFactory()
-        target_siae = SiaeWithMembershipFactory()
+        origin_siae = SiaeFactory(with_membership=True)
+        target_siae = SiaeFactory(with_membership=True)
 
         origin_user = origin_siae.members.first()
         target_user = target_siae.members.first()
@@ -161,8 +161,8 @@ class JobApplicationTransferModelTest(TestCase):
         # - origin SIAE
         # - job seeker
         # - Prescriber (if any linked eligibility diagnosis was not sent by a SIAE)
-        origin_siae = SiaeWithMembershipFactory()
-        target_siae = SiaeWithMembershipFactory()
+        origin_siae = SiaeFactory(with_membership=True)
+        target_siae = SiaeFactory(with_membership=True)
 
         origin_user = origin_siae.members.first()
         target_siae.members.add(origin_user)
@@ -195,8 +195,8 @@ class JobApplicationTransferModelTest(TestCase):
     def test_transfer_must_notify_prescriber(self):
         # Same test and conditions as above, but this time prescriber
         # at the origin of the eligibility disgnosis must be notified
-        origin_siae = SiaeWithMembershipFactory()
-        target_siae = SiaeWithMembershipFactory()
+        origin_siae = SiaeFactory(with_membership=True)
+        target_siae = SiaeFactory(with_membership=True)
 
         origin_user = origin_siae.members.first()
         target_siae.members.add(origin_user)
@@ -227,7 +227,7 @@ class JobApplicationTransferModelTest(TestCase):
         # Same as test_transfer_must_notify_siae_and_job_seeker
         # but with to recipients for SIAE transfer notification
         origin_siae = SiaeWith2MembershipsFactory()
-        target_siae = SiaeWithMembershipFactory()
+        target_siae = SiaeFactory(with_membership=True)
 
         origin_user_1 = origin_siae.members.all()[0]
         origin_user_2 = origin_siae.members.all()[1]

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -31,7 +31,7 @@ from itou.siae_evaluations.models import (
     validate_institution,
 )
 from itou.siaes.enums import SiaeKind
-from itou.siaes.factories import SiaeFactory, SiaeWith2MembershipsFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory, SiaeWith2MembershipsFactory
 from itou.users.factories import JobSeekerFactory
 from itou.utils.perms.user import KIND_SIAE_STAFF, UserInfo
 
@@ -411,7 +411,7 @@ class EvaluationCampaignManagerTest(TestCase):
     def test_populate(self):
         # integration tests
         evaluation_campaign = EvaluationCampaignFactory()
-        siae = SiaeWithMembershipFactory(department=evaluation_campaign.institution.department)
+        siae = SiaeFactory(department=evaluation_campaign.institution.department, with_membership=True)
         job_seeker = JobSeekerFactory()
         user = siae.members.first()
         user_info = UserInfo(

--- a/itou/siaes/factories.py
+++ b/itou/siaes/factories.py
@@ -142,29 +142,7 @@ class SiaeWith4MembershipsFactory(SiaeFactory):
     membership4 = factory.RelatedFactory(SiaeMembershipFactory, "siae", is_admin=False, user__is_active=False)
 
 
-class SiaeWithJobsFactory(SiaeFactory):
-    """
-    Generates an Siae() object with random jobs (based on given ROME codes) for unit tests.
-    https://factoryboy.readthedocs.io/en/latest/recipes.html#simple-many-to-many-relationship
-
-    Usage:
-        SiaeWithJobsFactory(romes=("N1101", "N1105", "N1103", "N4105"))
-    """
-
-    @factory.post_generation
-    def romes(self, create, extracted, **kwargs):
-        if not create:
-            # Simple build, do nothing.
-            return
-
-        romes = extracted or ("N1101", "N1105", "N1103", "N4105")
-        create_test_romes_and_appellations(romes)
-        # Pick random results.
-        appellations = Appellation.objects.order_by("?")[: len(romes)]
-        self.jobs.add(*appellations)
-
-
-SiaeWithMembershipAndJobsFactory = functools.partial(SiaeWithJobsFactory, with_membership=True)
+SiaeWithMembershipAndJobsFactory = functools.partial(SiaeFactory, with_membership=True, with_jobs=True)
 
 
 class SiaeConventionPendingGracePeriodFactory(SiaeConventionFactory):

--- a/itou/siaes/factories.py
+++ b/itou/siaes/factories.py
@@ -1,3 +1,4 @@
+import functools
 import string
 
 import factory.fuzzy
@@ -101,15 +102,6 @@ class SiaeMembershipFactory(factory.django.DjangoModelFactory):
     is_admin = True
 
 
-class SiaeWithMembershipFactory(SiaeFactory):
-    """
-    Generates an Siae() object with a member for unit tests.
-    https://factoryboy.readthedocs.io/en/latest/recipes.html#many-to-many-relation-with-a-through
-    """
-
-    membership = factory.RelatedFactory(SiaeMembershipFactory, "siae")
-
-
 class SiaeWith2MembershipsFactory(SiaeFactory):
     """
     Generates an Siae() object with 2 members for unit tests.
@@ -158,14 +150,7 @@ class SiaeWithJobsFactory(SiaeFactory):
         self.jobs.add(*appellations)
 
 
-class SiaeWithMembershipAndJobsFactory(SiaeWithMembershipFactory, SiaeWithJobsFactory):
-    """
-    Generates an Siae() object with a member and random jobs (based on given ROME codes) for unit tests.
-    https://factoryboy.readthedocs.io/en/latest/recipes.html#simple-many-to-many-relationship
-
-    Usage:
-        SiaeWithMembershipAndJobsFactory(romes=("N1101", "N1105", "N1103", "N4105"))
-    """
+SiaeWithMembershipAndJobsFactory = functools.partial(SiaeWithJobsFactory, with_membership=True)
 
 
 class SiaeConventionPendingGracePeriodFactory(SiaeConventionFactory):

--- a/itou/siaes/factories.py
+++ b/itou/siaes/factories.py
@@ -47,7 +47,13 @@ class SiaeConventionFactory(factory.django.DjangoModelFactory):
 
 
 class SiaeFactory(factory.django.DjangoModelFactory):
-    """Generate an Siae() object for unit tests."""
+    """Generate a Siae() object for unit tests.
+
+    Usage:
+        SiaeFactory(subject_to_eligibility=True, ...)
+        SiaeFactory(not_subject_to_eligibility=True, ...)
+        SiaeFactory(with_membership=True, ...)
+    """
 
     class Meta:
         model = models.Siae
@@ -60,6 +66,9 @@ class SiaeFactory(factory.django.DjangoModelFactory):
             kind=factory.fuzzy.FuzzyChoice(
                 [kind for kind, _ in SiaeKind.choices if kind not in models.Siae.ELIGIBILITY_REQUIRED_KINDS]
             ),
+        )
+        with_membership = factory.Trait(
+            membership=factory.RelatedFactory("itou.siaes.factories.SiaeMembershipFactory", "siae"),
         )
 
     # Don't start a SIRET with 0.

--- a/itou/siaes/tests/tests_models.py
+++ b/itou/siaes/tests/tests_models.py
@@ -17,14 +17,13 @@ from itou.siaes.factories import (
     SiaeWith4MembershipsFactory,
     SiaeWithJobsFactory,
     SiaeWithMembershipAndJobsFactory,
-    SiaeWithMembershipFactory,
 )
 from itou.siaes.models import Siae, SiaeJobDescription
 
 
 class SiaeFactoriesTest(TestCase):
     def test_siae_with_membership_factory(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         self.assertEqual(siae.members.count(), 1)
         user = siae.members.get()
         self.assertTrue(siae.has_admin(user))
@@ -95,14 +94,14 @@ class SiaeModelTest(TestCase):
 
     def test_has_members(self):
         siae1 = SiaeFactory()
-        siae2 = SiaeWithMembershipFactory()
+        siae2 = SiaeFactory(with_membership=True)
 
         self.assertFalse(siae1.has_members)
         self.assertTrue(siae2.has_members)
 
     def test_has_member(self):
-        siae1 = SiaeWithMembershipFactory()
-        siae2 = SiaeWithMembershipFactory()
+        siae1 = SiaeFactory(with_membership=True)
+        siae2 = SiaeFactory(with_membership=True)
 
         user1 = siae1.members.get()
         user2 = siae2.members.get()
@@ -132,9 +131,9 @@ class SiaeModelTest(TestCase):
         Test that if a user is admin of siae_1 and regular user
         of siae_2 he is not considered as admin of siae_2.
         """
-        siae_1 = SiaeWithMembershipFactory()
+        siae_1 = SiaeFactory(with_membership=True)
         siae_1_admin_user = siae_1.members.first()
-        siae_2 = SiaeWithMembershipFactory()
+        siae_2 = SiaeFactory(with_membership=True)
         siae_2.members.add(siae_1_admin_user)
 
         self.assertIn(siae_1_admin_user, siae_1.active_admin_members)
@@ -157,7 +156,7 @@ class SiaeModelTest(TestCase):
 
     def test_new_signup_activation_email_to_official_contact(self):
 
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         token = siae.get_token()
         with mock.patch("itou.utils.tokens.SiaeSignupTokenGenerator.make_token", return_value=token):
 
@@ -297,7 +296,7 @@ class SiaeQuerySetTest(TestCase):
         self.assertEqual(1, result.count_active_job_descriptions)
 
     def test_with_has_active_members(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         result = Siae.objects.with_has_active_members().get(pk=siae.pk)
         self.assertTrue(result.has_active_members)
 

--- a/itou/siaes/tests/tests_models.py
+++ b/itou/siaes/tests/tests_models.py
@@ -15,7 +15,6 @@ from itou.siaes.factories import (
     SiaePendingGracePeriodFactory,
     SiaeWith2MembershipsFactory,
     SiaeWith4MembershipsFactory,
-    SiaeWithJobsFactory,
     SiaeWithMembershipAndJobsFactory,
 )
 from itou.siaes.models import Siae, SiaeJobDescription
@@ -225,7 +224,7 @@ class SiaeModelTest(TestCase):
 
 class SiaeQuerySetTest(TestCase):
     def test_prefetch_job_description_through(self):
-        siae = SiaeWithJobsFactory()
+        siae = SiaeFactory(with_jobs=True)
 
         siae_result = Siae.objects.prefetch_job_description_through().get(pk=siae.pk)
         self.assertTrue(hasattr(siae_result, "job_description_through"))
@@ -257,7 +256,7 @@ class SiaeQuerySetTest(TestCase):
         self.assertEqual(expected, result.count_recent_received_job_apps)
 
     def test_with_job_app_score(self):
-        siae = SiaeWithJobsFactory(romes=("N1101", "N1105", "N1103", "N4105"))
+        siae = SiaeFactory(with_jobs=True, romes=("N1101", "N1105", "N1103", "N4105"))
         siae.job_description_through.first()
         JobApplicationFactory(to_siae=siae)
         JobApplicationFactory(to_siae=siae)
@@ -286,7 +285,7 @@ class SiaeQuerySetTest(TestCase):
         self.assertEqual(expected_score, result.job_app_score)
 
     def test_with_count_active_job_descriptions(self):
-        siae = SiaeWithJobsFactory(romes=("N1101", "N1105", "N1103", "N4105"))
+        siae = SiaeFactory(with_jobs=True, romes=("N1101", "N1105", "N1103", "N4105"))
         job_descriptions = siae.job_description_through.all()[:3]
         for job_description in job_descriptions:
             job_description.is_active = False
@@ -313,7 +312,7 @@ class SiaeQuerySetTest(TestCase):
 
 class SiaeJobDescriptionQuerySetTest(TestCase):
     def setUp(self):
-        self.siae = SiaeWithJobsFactory()
+        self.siae = SiaeFactory(with_jobs=True)
 
     def test_with_annotation_is_popular(self):
         siae_job_descriptions = self.siae.job_description_through.all()

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -24,7 +24,7 @@ from itou.job_applications.factories import (
 )
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.enums import SiaeKind
-from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import JobSeekerFactory, PrescriberFactory, UserFactory
 from itou.users.management.commands.import_ai_employees import (
     APPROVAL_COL,
@@ -559,7 +559,7 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
 
         # PASS created after November 30th with a job application:
         # the employer tried to get a PASS IAE quicker.
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         previous_approval = ApprovalFactory(user__nir=getattr(CleanedAiCsvFileMock(), NIR_COL))
         job_seeker = previous_approval.user
         job_application = JobApplicationSentBySiaeFactory(
@@ -583,7 +583,7 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
         job_seeker.delete()
 
         # PASS created after November 30th with a job application but not sent by this employer.
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         previous_approval = ApprovalFactory(user__nir=getattr(CleanedAiCsvFileMock(), NIR_COL))
         job_seeker = previous_approval.user
         job_application = JobApplicationSentBySiaeFactory(
@@ -606,7 +606,7 @@ class ImportAiEmployeesManagementCommandTest(TestCase):
         job_seeker.delete()
 
         # Multiple accepted job applications linked to this approval. Raise an error if dry run is not set.
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         previous_approval = ApprovalFactory(user__nir=getattr(CleanedAiCsvFileMock(), NIR_COL))
         job_seeker = previous_approval.user
         job_application = JobApplicationSentBySiaeFactory(

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -24,7 +24,7 @@ from itou.prescribers.factories import (
 )
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.enums import SiaeKind
-from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.enums import IdentityProvider, Title
 from itou.users.factories import JobSeekerFactory, JobSeekerProfileFactory, PrescriberFactory, UserFactory
 from itou.users.models import User
@@ -400,7 +400,7 @@ class ModelTest(TestCase):
         self.assertFalse(user.can_edit_email(job_seeker))
 
     def test_can_add_nir(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         siae_staff = siae.members.first()
         prescriber_org = AuthorizedPrescriberOrganizationWithMembershipFactory()
         authorized_prescriber = prescriber_org.members.first()
@@ -437,31 +437,31 @@ class ModelTest(TestCase):
         self.assertTrue(user.has_verified_email)
 
     def test_siae_admin_can_create_siae_antenna(self):
-        siae = SiaeWithMembershipFactory(membership__is_admin=True)
+        siae = SiaeFactory(with_membership=True, membership__is_admin=True)
         user = siae.members.get()
         self.assertTrue(user.can_create_siae_antenna(siae))
 
     def test_siae_normal_member_cannot_create_siae_antenna(self):
-        siae = SiaeWithMembershipFactory(membership__is_admin=False)
+        siae = SiaeFactory(with_membership=True, membership__is_admin=False)
         user = siae.members.get()
         self.assertFalse(user.can_create_siae_antenna(siae))
 
     def test_siae_admin_without_convention_cannot_create_siae_antenna(self):
-        siae = SiaeWithMembershipFactory(convention=None)
+        siae = SiaeFactory(with_membership=True, convention=None)
         user = siae.members.get()
         self.assertFalse(user.can_create_siae_antenna(siae))
 
     def test_admin_ability_to_create_siae_antenna(self):
         for kind in SiaeKind:
             with self.subTest(kind=kind):
-                siae = SiaeWithMembershipFactory(kind=kind, membership__is_admin=True)
+                siae = SiaeFactory(kind=kind, with_membership=True, membership__is_admin=True)
                 user = siae.members.get()
                 self.assertEqual(user.can_create_siae_antenna(siae), siae.is_asp_managed)
 
     def test_can_view_stats_siae_hiring(self):
         # An employer can only view hiring stats of their own SIAE.
         deployed_department = settings.STATS_SIAE_DEPARTMENT_WHITELIST[0]
-        siae1 = SiaeWithMembershipFactory(department=deployed_department)
+        siae1 = SiaeFactory(with_membership=True, department=deployed_department)
         user1 = siae1.members.get()
         siae2 = SiaeFactory(department=deployed_department)
 
@@ -471,14 +471,14 @@ class ModelTest(TestCase):
         self.assertFalse(user1.can_view_stats_siae_hiring(current_org=siae2))
 
         # Even non admin members can view their SIAE stats.
-        siae3 = SiaeWithMembershipFactory(department=deployed_department, membership__is_admin=False)
+        siae3 = SiaeFactory(department=deployed_department, with_membership=True, membership__is_admin=False)
         user3 = siae3.members.get()
         self.assertTrue(user3.can_view_stats_siae_hiring(current_org=siae3))
 
         # Non deployed department cannot be accessed.
         non_deployed_departments = [dpt for dpt in DEPARTMENTS if dpt not in settings.STATS_SIAE_DEPARTMENT_WHITELIST]
         non_deployed_department = non_deployed_departments[0]
-        siae4 = SiaeWithMembershipFactory(department=non_deployed_department)
+        siae4 = SiaeFactory(department=non_deployed_department, with_membership=True)
         user4 = siae4.members.get()
         self.assertFalse(user4.can_view_stats_siae_hiring(current_org=siae4))
 

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -31,7 +31,7 @@ from itou.institutions.factories import InstitutionFactory, InstitutionWithMembe
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
-from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import Siae, SiaeMembership
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory, UserFactory
 from itou.users.models import User
@@ -110,7 +110,7 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
         return request
 
     def test_siae_one_membership(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         self.assertTrue(siae.has_admin(user))
 
@@ -132,7 +132,7 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
 
     def test_siae_multiple_memberships(self):
         # Specify name to ensure alphabetical sorting order.
-        siae1 = SiaeWithMembershipFactory(name="1")
+        siae1 = SiaeFactory(name="1", with_membership=True)
         user = siae1.members.first()
         self.assertTrue(siae1.has_admin(user))
 
@@ -481,7 +481,7 @@ class UtilsTemplateTagsTestCase(TestCase):
 
     def test_call_method(self):
         """Test `call_method` template tag."""
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         context = {"siae": siae, "user": user}
         template = Template("{% load call_method %}{% call_method siae 'has_member' user %}")
@@ -577,7 +577,7 @@ class UtilsEmailsTestCase(TestCase):
 
 class PermsUserTest(TestCase):
     def test_get_user_info_for_siae_staff(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
         factory = RequestFactory()

--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -19,7 +19,7 @@ from itou.prescribers.factories import (
     PrescriberMembershipFactory,
     PrescriberOrganizationWithMembershipFactory,
 )
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import DEFAULT_PASSWORD
 from itou.utils.widgets import DuetDatePickerWidget
 
@@ -58,7 +58,7 @@ class ProcessListTest(TestCase):
         audrey_envol = l_envol.members.get(first_name="Audrey")
 
         # Hit Pit
-        hit_pit = SiaeWithMembershipFactory(name="Hit Pit", membership__user__first_name="Eddie")
+        hit_pit = SiaeFactory(name="Hit Pit", with_membership=True, membership__user__first_name="Eddie")
         eddie_hit_pit = hit_pit.members.get(first_name="Eddie")
 
         # Now send applications

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -22,7 +22,7 @@ from itou.job_applications.factories import (
 )
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.enums import SiaeKind
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerWithAddressFactory
 from itou.users.models import User
 from itou.utils.widgets import DuetDatePickerWidget
@@ -198,7 +198,7 @@ class ProcessViewsTest(TestCase):
             "city": city.name,
             "city_slug": city.slug,
         }
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         siae_user = siae.members.first()
 
         hiring_end_dates = [
@@ -332,7 +332,7 @@ class ProcessViewsTest(TestCase):
         )
 
         # Now, another Siae wants to hire the job seeker
-        other_siae = SiaeWithMembershipFactory()
+        other_siae = SiaeFactory(with_membership=True)
         job_application = JobApplicationSentByJobSeekerFactory(
             approval=approval_job_seeker,
             state=JobApplicationWorkflow.STATE_PROCESSING,
@@ -541,7 +541,7 @@ class ProcessViewsTest(TestCase):
         create_test_cities(["54"], num_per_department=1)
         city = City.objects.first()
 
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         job_seeker = JobSeekerWithAddressFactory(city=city.name)
         job_application = JobApplicationSentByJobSeekerFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING, job_seeker=job_seeker, to_siae=siae
@@ -655,7 +655,7 @@ class ProcessViewsTest(TestCase):
     def test_eligibility_state_for_job_application(self, *args, **kwargs):
         """The eligibility diagnosis page must only be accessible
         in JobApplicationWorkflow.CAN_BE_ACCEPTED_STATES states."""
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         siae_user = siae.members.first()
         job_application = JobApplicationSentByJobSeekerFactory(to_siae=siae)
 
@@ -960,7 +960,7 @@ class ProcessTransferJobApplicationTest(TestCase):
     def test_job_application_transfer_disabled_for_lone_users(self):
         # A user member of only one SIAE
         # must not be able to transfer a job application to another SIAE
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(
             to_siae=siae, state=JobApplicationWorkflow.STATE_PROCESSING
@@ -976,7 +976,7 @@ class ProcessTransferJobApplicationTest(TestCase):
     def test_job_application_transfer_disabled_for_bad_state(self):
         # A user member of only one SIAE must not be able to transfert
         # to another SIAE
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         job_application_1 = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(
             to_siae=siae, state=JobApplicationWorkflow.STATE_NEW
@@ -999,8 +999,8 @@ class ProcessTransferJobApplicationTest(TestCase):
 
     def test_job_application_transfer_enabled(self):
         # A user member of several SIAE can transfer a job application
-        siae = SiaeWithMembershipFactory()
-        other_siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
+        other_siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         other_siae.members.add(user)
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(
@@ -1019,8 +1019,8 @@ class ProcessTransferJobApplicationTest(TestCase):
         # After transfering a job application,
         # user must be redirected to job application list
         # with a nice message
-        siae = SiaeWithMembershipFactory()
-        other_siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
+        other_siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         other_siae.members.add(user)
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory(

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -16,7 +16,7 @@ from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.models import JobApplication
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.enums import SiaeKind
-from itou.siaes.factories import SiaeWithMembershipAndJobsFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory, SiaeWithMembershipAndJobsFactory
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory
 from itou.users.models import User
 from itou.utils.storage.s3 import S3Upload
@@ -976,8 +976,8 @@ class ApplyAsSiaeTest(TestCase):
 
     def test_perms_for_siae(self):
         """An SIAE can postulate only for itself."""
-        siae1 = SiaeWithMembershipFactory()
-        siae2 = SiaeWithMembershipFactory()
+        siae1 = SiaeFactory(with_membership=True)
+        siae2 = SiaeFactory(with_membership=True)
 
         user = siae1.members.first()
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)

--- a/itou/www/approvals_views/tests/test_pe_approval.py
+++ b/itou/www/approvals_views/tests/test_pe_approval.py
@@ -8,7 +8,7 @@ from itou.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
 from itou.approvals.models import Approval
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplicationWorkflow
-from itou.siaes.factories import SiaeMembershipFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory, SiaeMembershipFactory
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
 from itou.users.models import User
 
@@ -21,7 +21,7 @@ class PoleEmploiApprovalSearchTest(TestCase):
         # pylint: disable=attribute-defined-outside-init
         self.pe_approval = PoleEmploiApprovalFactory()
 
-        self.siae = SiaeWithMembershipFactory()
+        self.siae = SiaeFactory(with_membership=True)
         self.siae_user = self.siae.members.first()
         if with_job_application:
             self.job_application = JobApplicationWithApprovalFactory(

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -25,7 +25,6 @@ from itou.siaes.factories import (
     SiaeFactory,
     SiaePendingGracePeriodFactory,
     SiaeWithMembershipAndJobsFactory,
-    SiaeWithMembershipFactory,
 )
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory, SiaeStaffFactory
 from itou.users.models import User
@@ -34,7 +33,7 @@ from itou.www.dashboard.forms import EditUserEmailForm
 
 class DashboardViewTest(TestCase):
     def test_dashboard(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
 
@@ -68,7 +67,7 @@ class DashboardViewTest(TestCase):
         self.assertContains(response, expected_message)
 
     def test_dashboard_eiti(self):
-        siae = SiaeWithMembershipFactory(kind=SiaeKind.EITI)
+        siae = SiaeFactory(kind=SiaeKind.EITI, with_membership=True)
         user = siae.members.first()
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
 
@@ -77,9 +76,9 @@ class DashboardViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_dashboard_displays_asp_badge(self):
-        siae = SiaeWithMembershipFactory(kind=SiaeKind.EI)
-        other_siae = SiaeWithMembershipFactory(kind=SiaeKind.ETTI)
-        last_siae = SiaeWithMembershipFactory(kind=SiaeKind.ETTI)
+        siae = SiaeFactory(kind=SiaeKind.EI, with_membership=True)
+        other_siae = SiaeFactory(kind=SiaeKind.ETTI, with_membership=True)
+        last_siae = SiaeFactory(kind=SiaeKind.ETTI, with_membership=True)
 
         user = siae.members.first()
         user.siae_set.add(other_siae)
@@ -137,7 +136,7 @@ class DashboardViewTest(TestCase):
             SiaeKind.ACIPHC,
         ]:
             with self.subTest(f"should display when siae_kind={kind}"):
-                siae = SiaeWithMembershipFactory(kind=kind)
+                siae = SiaeFactory(kind=kind, with_membership=True)
                 user = siae.members.first()
                 self.client.login(username=user.email, password=DEFAULT_PASSWORD)
 
@@ -147,7 +146,7 @@ class DashboardViewTest(TestCase):
 
         for kind in [SiaeKind.EA, SiaeKind.EATT, SiaeKind.GEIQ, SiaeKind.OPCS]:
             with self.subTest(f"should not display when siae_kind={kind}"):
-                siae = SiaeWithMembershipFactory(kind=kind)
+                siae = SiaeFactory(kind=kind, with_membership=True)
                 user = siae.members.first()
                 self.client.login(username=user.email, password=DEFAULT_PASSWORD)
 
@@ -158,7 +157,7 @@ class DashboardViewTest(TestCase):
     def test_dashboard_can_create_siae_antenna(self):
         for kind in SiaeKind:
             with self.subTest(kind=kind):
-                siae = SiaeWithMembershipFactory(kind=kind, membership__is_admin=True)
+                siae = SiaeFactory(kind=kind, with_membership=True, membership__is_admin=True)
                 user = siae.members.get()
 
                 self.client.login(username=user.email, password=DEFAULT_PASSWORD)
@@ -197,7 +196,7 @@ class DashboardViewTest(TestCase):
 
     def test_dashboard_siae_evaluations_siae_access(self):
         # preset for incoming new pages
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
 
@@ -335,7 +334,7 @@ class EditJobSeekerInfo(TestCase):
         The SIAE can edit the email of a jobseeker it works with, provided he did not confirm its email.
         """
         new_email = "bidou@yopmail.com"
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         job_application = JobApplicationSentByPrescriberFactory(to_siae=siae, job_seeker__created_by=user)
 
@@ -499,7 +498,7 @@ class EditUserEmailFormTest(TestCase):
 
 class SwitchSiaeTest(TestCase):
     def test_switch_siae(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
 
@@ -543,7 +542,7 @@ class SwitchSiaeTest(TestCase):
         self.assertEqual(response.context["current_siae"], related_siae)
 
     def test_can_still_switch_to_inactive_siae_during_grace_period(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
 
@@ -566,7 +565,7 @@ class SwitchSiaeTest(TestCase):
         self.assertEqual(response.context["current_siae"], related_siae)
 
     def test_cannot_switch_to_inactive_siae_after_grace_period(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
 
@@ -593,7 +592,7 @@ class SwitchSiaeTest(TestCase):
 
 class EditUserPreferencesTest(TestCase):
     def test_employer_opt_in_siae_no_job_description(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         recipient = user.siaemembership_set.get(siae=siae)
         form_name = "new_job_app_notification_form"
@@ -652,7 +651,7 @@ class EditUserPreferencesTest(TestCase):
             )
 
     def test_employer_opt_out_siae_no_job_descriptions(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         recipient = user.siaemembership_set.get(siae=siae)
         form_name = "new_job_app_notification_form"

--- a/itou/www/eligibility_views/tests.py
+++ b/itou/www/eligibility_views/tests.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.siaes.enums import SiaeKind
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import JobSeekerFactory, PrescriberFactory
 from itou.utils.perms.user import KIND_SIAE_STAFF, UserInfo
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm, AdministrativeCriteriaOfJobApplicationForm
@@ -26,7 +26,7 @@ class AdministrativeCriteriaFormTest(TestCase):
         self.assertEqual(form.cleaned_data, expected_cleaned_data)
 
     def test_valid_for_siae(self):
-        siae = SiaeWithMembershipFactory(kind=SiaeKind.ACI)
+        siae = SiaeFactory(kind=SiaeKind.ACI, with_membership=True)
         user = siae.members.first()
 
         criterion1 = AdministrativeCriteria.objects.get(pk=1)
@@ -53,7 +53,7 @@ class AdministrativeCriteriaFormTest(TestCase):
         self.assertEqual(form.cleaned_data, expected_cleaned_data)
 
     def test_criteria_fields(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
         form = AdministrativeCriteriaForm(user, siae)
@@ -63,7 +63,7 @@ class AdministrativeCriteriaFormTest(TestCase):
         """
         Test errors for SIAEs.
         """
-        siae = SiaeWithMembershipFactory(kind=SiaeKind.ACI)
+        siae = SiaeFactory(kind=SiaeKind.ACI, with_membership=True)
         user = siae.members.first()
 
         criterion1 = AdministrativeCriteria.objects.get(pk=1)
@@ -84,7 +84,7 @@ class AdministrativeCriteriaFormTest(TestCase):
         self.assertIn(form.ERROR_CRITERIA_NUMBER, form.errors["__all__"])
 
     def test_valid_for_siae_of_kind_etti(self):
-        siae = SiaeWithMembershipFactory(kind=SiaeKind.ETTI)
+        siae = SiaeFactory(kind=SiaeKind.ETTI, with_membership=True)
         user = siae.members.first()
 
         criterion1 = AdministrativeCriteria.objects.get(pk=1)
@@ -112,7 +112,7 @@ class AdministrativeCriteriaFormTest(TestCase):
         """
         Test errors for SIAEs of kind ETTI.
         """
-        siae = SiaeWithMembershipFactory(kind=SiaeKind.ETTI)
+        siae = SiaeFactory(kind=SiaeKind.ETTI, with_membership=True)
         user = siae.members.first()
 
         criterion1 = AdministrativeCriteria.objects.get(pk=1)
@@ -169,7 +169,7 @@ class AdministrativeCriteriaFormTest(TestCase):
 
 class AdministrativeCriteriaOfJobApplicationFormTest(TestCase):
     def test_job_application(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
         job_seeker = JobSeekerFactory()
@@ -208,7 +208,7 @@ class AdministrativeCriteriaOfJobApplicationFormTest(TestCase):
     def test_num_level2_admin_criteria(self):
         for kind, _ in SiaeKind.choices:
             with self.subTest(kind):
-                siae = SiaeWithMembershipFactory(kind=kind)
+                siae = SiaeFactory(kind=kind, with_membership=True)
                 user = siae.members.first()
 
                 job_application = JobApplicationWithApprovalFactory(

--- a/itou/www/invitations_views/tests/tests_prescriber_organization.py
+++ b/itou/www/invitations_views/tests/tests_prescriber_organization.py
@@ -11,7 +11,7 @@ from itou.invitations.factories import PrescriberWithOrgSentInvitationFactory
 from itou.invitations.models import PrescriberWithOrgInvitation
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory, PrescriberPoleEmploiFactory
 from itou.prescribers.models import PrescriberOrganization
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory, UserFactory
 from itou.users.models import User
 from itou.utils.perms.prescriber import get_current_org_or_404
@@ -106,7 +106,7 @@ class TestSendPrescriberWithOrgInvitationExceptions(TestCase):
         self.assertFalse(PrescriberWithOrgInvitation.objects.exists())
 
     def test_invite_existing_user_is_employer(self):
-        guest = SiaeWithMembershipFactory().members.first()
+        guest = SiaeFactory(with_membership=True).members.first()
         self.client.login(email=self.sender.email, password=DEFAULT_PASSWORD)
         self.post_data.update(
             {"form-0-first_name": guest.first_name, "form-0-last_name": guest.last_name, "form-0-email": guest.email}
@@ -279,7 +279,7 @@ class TestAcceptPrescriberWithOrgInvitationExceptions(TestCase):
         self.sender = self.organization.members.first()
 
     def test_existing_user_is_not_prescriber(self):
-        user = SiaeWithMembershipFactory().members.first()
+        user = SiaeFactory(with_membership=True).members.first()
         invitation = PrescriberWithOrgSentInvitationFactory(
             sender=self.sender,
             organization=self.organization,

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -7,7 +7,7 @@ from django.utils.html import escape
 
 from itou.invitations.factories import ExpiredSiaeStaffInvitationFactory, SentSiaeStaffInvitationFactory
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
-from itou.siaes.factories import SiaeFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import DEFAULT_PASSWORD, SiaeStaffFactory, UserFactory
 from itou.users.models import User
 from itou.utils.perms.siae import get_current_siae_or_404
@@ -136,9 +136,9 @@ class TestAcceptInvitation(TestCase):
         can only be ressucitated by being invited to a new SIAE.
         We test here that this is indeed possible.
         """
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         sender = siae.members.first()
-        user = SiaeWithMembershipFactory(convention__is_active=False).members.first()
+        user = SiaeFactory(convention__is_active=False, with_membership=True).members.first()
         invitation = SentSiaeStaffInvitationFactory(
             sender=sender,
             siae=siae,
@@ -155,7 +155,7 @@ class TestAcceptInvitation(TestCase):
         self.assert_accepted_invitation(invitation, user)
 
     def test_accept_new_user_to_inactive_siae(self):
-        siae = SiaeWithMembershipFactory(convention__is_active=False)
+        siae = SiaeFactory(convention__is_active=False, with_membership=True)
         sender = siae.members.first()
         invitation = SentSiaeStaffInvitationFactory(
             sender=sender,

--- a/itou/www/invitations_views/tests/tests_siae_send.py
+++ b/itou/www/invitations_views/tests/tests_siae_send.py
@@ -6,7 +6,7 @@ from django.utils.html import escape
 
 from itou.invitations.models import SiaeStaffInvitation
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
-from itou.siaes.factories import SiaeMembershipFactory, SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory, SiaeMembershipFactory
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, UserFactory
 from itou.www.invitations_views.forms import SiaeStaffInvitationForm
 
@@ -16,7 +16,7 @@ INVITATION_URL = reverse("invitations_views:invite_siae_staff")
 
 class TestSendSingleSiaeInvitation(TestCase):
     def setUp(self):
-        self.siae = SiaeWithMembershipFactory()
+        self.siae = SiaeFactory(with_membership=True)
         # The sender is a member of the SIAE
         self.sender = self.siae.members.first()
         self.guest_data = {"first_name": "Léonie", "last_name": "Bathiat", "email": "leonie@example.com"}
@@ -102,7 +102,7 @@ class TestSendSingleSiaeInvitation(TestCase):
         self.assertEqual(SiaeStaffInvitation.objects.count(), 1)
 
         # SIAE 2 invites guest as well.
-        siae_2 = SiaeWithMembershipFactory()
+        siae_2 = SiaeFactory(with_membership=True)
         sender_2 = siae_2.members.first()
         self.client.login(email=sender_2.email, password=DEFAULT_PASSWORD)
         self.client.post(INVITATION_URL, data=self.post_data)
@@ -115,7 +115,7 @@ class TestSendSingleSiaeInvitation(TestCase):
 
 class TestSendMultipleSiaeInvitation(TestCase):
     def setUp(self):
-        self.siae = SiaeWithMembershipFactory()
+        self.siae = SiaeFactory(with_membership=True)
         # The sender is a member of the SIAE
         self.sender = self.siae.members.first()
         # Define instances not created in DB
@@ -168,7 +168,7 @@ class TestSendMultipleSiaeInvitation(TestCase):
 
 class TestSendInvitationToSpecialGuest(TestCase):
     def setUp(self):
-        self.sender_siae = SiaeWithMembershipFactory()
+        self.sender_siae = SiaeFactory(with_membership=True)
         self.sender = self.sender_siae.members.first()
         self.client.login(email=self.sender.email, password=DEFAULT_PASSWORD)
         self.post_data = {
@@ -184,7 +184,7 @@ class TestSendInvitationToSpecialGuest(TestCase):
         can only be ressucitated by being invited to a new SIAE.
         We test here that this is indeed possible.
         """
-        guest = SiaeWithMembershipFactory(convention__is_active=False).members.first()
+        guest = SiaeFactory(convention__is_active=False, with_membership=True).members.first()
         self.post_data.update(
             {
                 "form-0-first_name": guest.first_name,
@@ -201,7 +201,7 @@ class TestSendInvitationToSpecialGuest(TestCase):
         Admins can "deactivate" members of the organization (making the membership inactive).
         A deactivated member must be able to receive new invitations.
         """
-        guest = SiaeWithMembershipFactory().members.first()
+        guest = SiaeFactory(with_membership=True).members.first()
 
         # Deactivate user
         membership = guest.siaemembership_set.first()

--- a/itou/www/search/tests.py
+++ b/itou/www/search/tests.py
@@ -7,7 +7,7 @@ from itou.cities.models import City
 from itou.job_applications.factories import JobApplicationFactory
 from itou.prescribers.factories import AuthorizedPrescriberOrganizationFactory
 from itou.siaes.enums import SiaeKind
-from itou.siaes.factories import SiaeFactory, SiaeWithJobsFactory
+from itou.siaes.factories import SiaeFactory
 
 
 class SearchSiaeTest(TestCase):
@@ -96,16 +96,16 @@ class SearchSiaeTest(TestCase):
         created_siaes = []
 
         # Several job descriptions but no job application.
-        siae = SiaeWithJobsFactory(department="44", coords=guerande.coords, post_code="44350")
+        siae = SiaeFactory(with_jobs=True, department="44", coords=guerande.coords, post_code="44350")
         created_siaes.append(siae)
 
         # Many job descriptions and job applications.
-        siae = SiaeWithJobsFactory(department="44", coords=guerande.coords, post_code="44350")
+        siae = SiaeFactory(with_jobs=True, department="44", coords=guerande.coords, post_code="44350")
         JobApplicationFactory(to_siae=siae)
         created_siaes.append(siae)
 
         # Many job descriptions and more job applications than the first one.
-        siae = SiaeWithJobsFactory(department="44", coords=guerande.coords, post_code="44350")
+        siae = SiaeFactory(with_jobs=True, department="44", coords=guerande.coords, post_code="44350")
         JobApplicationFactory(to_siae=siae)
         JobApplicationFactory(to_siae=siae)
         created_siaes.append(siae)

--- a/itou/www/siaes_views/tests/tests_job_description_views.py
+++ b/itou/www/siaes_views/tests/tests_job_description_views.py
@@ -9,7 +9,7 @@ from itou.jobs.factories import create_test_romes_and_appellations
 from itou.jobs.models import Appellation
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.enums import ContractType, SiaeKind
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import SiaeJobDescription
 from itou.users.factories import DEFAULT_PASSWORD
 
@@ -21,10 +21,11 @@ class JobDescriptionAbstractTest(TestCase):
             name="Paris", slug=city_slug, department="75", post_codes=["75001"], coords=Point(5, 23)
         )
 
-        siae = SiaeWithMembershipFactory(
+        siae = SiaeFactory(
             department="75",
             coords=self.paris_city.coords,
             post_code="75001",
+            with_membership=True,
         )
         user = siae.members.first()
 
@@ -201,11 +202,12 @@ class EditJobDescriptionViewTest(JobDescriptionAbstractTest):
         self.assertEqual(self.siae.job_description_through.count(), 5)
 
     def test_edit_job_description_opcs(self):
-        opcs = SiaeWithMembershipFactory(
+        opcs = SiaeFactory(
             department="75",
             coords=self.paris_city.coords,
             post_code="75001",
             kind=SiaeKind.OPCS,
+            with_membership=True,
         )
         user_opcs = opcs.members.first()
         opcs.jobs.add(*self.appellations)

--- a/itou/www/siaes_views/tests/tests_views.py
+++ b/itou/www/siaes_views/tests/tests_views.py
@@ -15,7 +15,6 @@ from itou.siaes.factories import (
     SiaeFactory,
     SiaeWith2MembershipsFactory,
     SiaeWithMembershipAndJobsFactory,
-    SiaeWithMembershipFactory,
 )
 from itou.siaes.models import Siae
 from itou.users.factories import DEFAULT_PASSWORD
@@ -24,7 +23,7 @@ from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
 
 class CardViewTest(TestCase):
     def test_card(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         url = reverse("siaes_views:card", kwargs={"siae_id": siae.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -52,7 +51,7 @@ class JobDescriptionCardViewTest(TestCase):
 
 class ShowAndSelectFinancialAnnexTest(TestCase):
     def test_asp_source_siae_admin_can_see_but_cannot_select_af(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         self.assertTrue(siae.has_admin(user))
         self.assertTrue(siae.is_asp_managed)
@@ -70,8 +69,9 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_user_created_siae_admin_can_see_and_select_af(self):
-        siae = SiaeWithMembershipFactory(
+        siae = SiaeFactory(
             source=Siae.SOURCE_USER_CREATED,
+            with_membership=True,
         )
         user = siae.members.first()
         old_convention = siae.convention
@@ -107,7 +107,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertEqual(siae.convention, new_convention)
 
     def test_staff_created_siae_admin_cannot_see_nor_select_af(self):
-        siae = SiaeWithMembershipFactory(source=Siae.SOURCE_STAFF_CREATED)
+        siae = SiaeFactory(source=Siae.SOURCE_STAFF_CREATED, with_membership=True)
         user = siae.members.first()
         self.assertTrue(siae.has_admin(user))
         self.assertTrue(siae.is_asp_managed)
@@ -125,7 +125,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_asp_source_siae_non_admin_cannot_see_nor_select_af(self):
-        siae = SiaeWithMembershipFactory(membership__is_admin=False)
+        siae = SiaeFactory(membership__is_admin=False, with_membership=True)
         user = siae.members.first()
         self.assertFalse(siae.has_admin(user))
         self.assertTrue(siae.is_asp_managed)
@@ -143,7 +143,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_import_created_geiq_admin_cannot_see_nor_select_af(self):
-        siae = SiaeWithMembershipFactory(kind=SiaeKind.GEIQ, source=Siae.SOURCE_GEIQ)
+        siae = SiaeFactory(kind=SiaeKind.GEIQ, source=Siae.SOURCE_GEIQ, with_membership=True)
         user = siae.members.first()
         self.assertTrue(siae.has_admin(user))
         self.assertFalse(siae.is_asp_managed)
@@ -161,7 +161,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_user_created_geiq_admin_cannot_see_nor_select_af(self):
-        siae = SiaeWithMembershipFactory(kind=SiaeKind.GEIQ, source=Siae.SOURCE_USER_CREATED)
+        siae = SiaeFactory(kind=SiaeKind.GEIQ, source=Siae.SOURCE_USER_CREATED, with_membership=True)
         user = siae.members.first()
         self.assertTrue(siae.has_admin(user))
         self.assertFalse(siae.is_asp_managed)
@@ -182,7 +182,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
 class CreateSiaeViewTest(TestCase):
     def test_create_non_preexisting_siae_outside_of_siren_fails(self):
 
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
@@ -222,7 +222,7 @@ class CreateSiaeViewTest(TestCase):
 
     def test_create_preexisting_siae_outside_of_siren_fails(self):
 
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
@@ -262,7 +262,7 @@ class CreateSiaeViewTest(TestCase):
 
     def test_cannot_create_siae_with_same_siret_and_same_kind(self):
 
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
@@ -298,7 +298,7 @@ class CreateSiaeViewTest(TestCase):
 
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
     def test_cannot_create_siae_with_same_siret_and_different_kind(self, _mock_call_ban_geocoding_api):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         siae.kind = SiaeKind.ETTI
         siae.save()
         user = siae.members.first()
@@ -330,7 +330,7 @@ class CreateSiaeViewTest(TestCase):
 
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
     def test_cannot_create_siae_with_same_siren_and_different_kind(self, _mock_call_ban_geocoding_api):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         siae.kind = SiaeKind.ETTI
         siae.save()
         user = siae.members.first()
@@ -366,7 +366,7 @@ class CreateSiaeViewTest(TestCase):
 
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
     def test_create_siae_with_same_siren_and_same_kind(self, mock_call_ban_geocoding_api):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
@@ -429,7 +429,7 @@ class EditSiaeViewTest(TestCase):
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
     def test_edit(self, _unused_mock):
 
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
@@ -531,7 +531,7 @@ class EditSiaeViewTest(TestCase):
         self.assertEqual(siae.geocoding_score, 0.587663373207207)
 
     def test_permission(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
@@ -547,7 +547,7 @@ class EditSiaeViewTest(TestCase):
 
 class MembersTest(TestCase):
     def test_members(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
         self.client.login(username=user.email, password=DEFAULT_PASSWORD)
         url = reverse("siaes_views:members")
@@ -561,7 +561,7 @@ class UserMembershipDeactivationTest(TestCase):
         A user, even if admin, can't self-deactivate
         (must be done by another admin)
         """
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         admin = siae.members.filter(siaemembership__is_admin=True).first()
         memberships = admin.siaemembership_set.all()
         membership = memberships.first()
@@ -649,7 +649,7 @@ class UserMembershipDeactivationTest(TestCase):
         Check that a deactivated member can't access the structure
         from the dashboard selector
         """
-        siae2 = SiaeWithMembershipFactory()
+        siae2 = SiaeFactory(with_membership=True)
         guest = siae2.members.first()
 
         siae = SiaeWith2MembershipsFactory()

--- a/itou/www/welcoming_tour/tests.py
+++ b/itou/www/welcoming_tour/tests.py
@@ -5,7 +5,7 @@ from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
 
-from itou.siaes.factories import SiaeWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
 from itou.users.factories import JobSeekerFactory, PrescriberFactory, SiaeStaffFactory
 from itou.users.models import User
 
@@ -89,7 +89,7 @@ class WelcomingTourTest(TestCase):
 
     def test_new_employer_sees_welcoming_tour(self):
         employer = SiaeStaffFactory.build()
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
 
         url = reverse("signup:siae", kwargs={"encoded_siae_id": siae.get_encoded_siae_id(), "token": siae.get_token()})
         post_data = {
@@ -128,7 +128,7 @@ class WelcomingTourExceptions(TestCase):
         return response
 
     def test_new_job_seeker_is_redirected_after_welcoming_tour_test(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeFactory(with_membership=True)
         job_seeker = JobSeekerFactory.build()
 
         # First signup step: job seeker NIR.


### PR DESCRIPTION
### Quoi ?

Utilisation de [Traits](https://factoryboy.readthedocs.io/en/stable/reference.html#factory.Trait) en lieu et place de classe enfants.

### Pourquoi ?

Principalement pour ne pas devoir créer une classe (`Siae`, `SiaeWithMembership`, `SiaeWithJobsFactory`, `SiaeWithMembershipAndJobsFactory`, etc) pour chaque combinaison qui nous intéresse.

Répandre cette possibilité et avoir l'avis collégial [1] sur cette manière de faire !

[1] Alors, oui, j'ai déjà fait les commits pour supprimer certaines _factories_ mais on est pas obligé de les fusionner ;).
