### PR TITLE
Bloquer la création d’antennes pour les EA / EATT / GEIQ

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -396,7 +396,8 @@ class User(AbstractUser, AddressMixin):
         in that case we must absolutely not allow any antenna to be created.
 
         For non SIAE structures (GEIQ, EA...) the convention logic is not implemented thus no convention ever exists.
-        Antennas can be freely created and technically are not rigorously linked to the parent structure.
+        Antennas cannot be freely created by the user as the EA system authorities do not allow any non official SIRET
+        to be used.
 
         Finally, for OPCS it has been decided for now to disallow it; those structures are strongly attached to
         a given territory and thus would not need to join others.
@@ -405,8 +406,8 @@ class User(AbstractUser, AddressMixin):
             self.is_siae_staff
             and parent_siae.is_active
             and parent_siae.has_admin(self)
-            and not parent_siae.is_opcs
-            and (parent_siae.convention is not None or not parent_siae.is_asp_managed)
+            and parent_siae.is_asp_managed
+            and parent_siae.convention is not None
         )
 
     def can_view_stats_dashboard_widget(self, current_org):

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -437,7 +437,7 @@ class ModelTest(TestCase):
         self.assertTrue(user.has_verified_email)
 
     def test_siae_admin_can_create_siae_antenna(self):
-        siae = SiaeWithMembershipFactory()
+        siae = SiaeWithMembershipFactory(membership__is_admin=True)
         user = siae.members.get()
         self.assertTrue(user.can_create_siae_antenna(siae))
 
@@ -451,17 +451,12 @@ class ModelTest(TestCase):
         user = siae.members.get()
         self.assertFalse(user.can_create_siae_antenna(siae))
 
-    def test_geiq_admin_can_create_siae_antenna(self):
-        # A GEIQ never has a convention.
-        siae = SiaeWithMembershipFactory(kind=SiaeKind.GEIQ, convention=None)
-        user = siae.members.get()
-        self.assertTrue(user.can_create_siae_antenna(siae))
-
-    def test_ea_admin_can_create_siae_antenna(self):
-        # An EA never has a convention.
-        siae = SiaeWithMembershipFactory(kind=SiaeKind.EA, convention=None)
-        user = siae.members.get()
-        self.assertTrue(user.can_create_siae_antenna(siae))
+    def test_admin_ability_to_create_siae_antenna(self):
+        for kind in SiaeKind:
+            with self.subTest(kind=kind):
+                siae = SiaeWithMembershipFactory(kind=kind, membership__is_admin=True)
+                user = siae.members.get()
+                self.assertEqual(user.can_create_siae_antenna(siae), siae.is_asp_managed)
 
     def test_can_view_stats_siae_hiring(self):
         # An employer can only view hiring stats of their own SIAE.


### PR DESCRIPTION
### Quoi ?

Dans le tableau de bord employeur EA+GEIQ+ EATT :  Supprimer  le lien “créer/rejoindre une nouvelle structure”
En plus des OPCS et des ACIPH

### Pourquoi ?

La fonctionnalité “antennes” pour les SIAE du C1 n'est pas pertinente pour les EA, car les “antennes” potentielles d’EA dans le fichier EA existent déjà dans le fichier EA et donc existent en tant que structures mères sur le C1. La METH est très vigilante a ce qu’aucune EA ne puisse se créer un établissement sans SIRET.

### Comment ?

- Modification de la méthode `can_create_siae_antenna`, exclusion des types d'entreprises non gérées par l'ASP, même si une convention existe.
