### PR TITLE
Boost PEConnect

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -391,6 +391,9 @@ API_ESD = {
 # - PEAM "Utilisateur", PEAM-U or PEAMU for short.
 # To avoid confusion between the two when contacting ESD support,
 # we get the habit to always explicitely state that we are using PEAM*U*.
+# PE Connect is enabled by default, but a feature flag allows to deactivate it.
+# Disabled in the DEMO environment.
+PEAMU_ENABLED = os.environ.get("PEAMU_ENABLED", "True") == "True"
 PEAMU_AUTH_BASE_URL = "https://authentification-candidat.pole-emploi.fr"
 SOCIALACCOUNT_PROVIDERS = {
     "peamu": {

--- a/itou/allauth_adapters/peamu/tasks.py
+++ b/itou/allauth_adapters/peamu/tasks.py
@@ -1,0 +1,11 @@
+import httpx
+from django.conf import settings
+from django.utils.http import urlencode
+from huey.contrib.djhuey import task
+
+
+@task()
+def huey_logout_from_pe_connect(peamu_id_token, hp_url):
+    params = {"id_token_hint": peamu_id_token, "redirect_uri": hp_url}
+    peamu_logout_url = f"{settings.PEAMU_AUTH_BASE_URL}/compte/deconnexion?{urlencode(params)}"
+    return httpx.get(peamu_logout_url)

--- a/itou/allauth_adapters/peamu/urls.py
+++ b/itou/allauth_adapters/peamu/urls.py
@@ -1,16 +1,19 @@
 from django.urls import include, re_path
 
+from itou.allauth_adapters.peamu import views as peamu_views
 from itou.allauth_adapters.peamu.provider import PEAMUProvider
-from itou.allauth_adapters.peamu.views import oauth2_callback as callback_view, oauth2_login as login_view
 
 
 def default_urlpatterns(provider):
     urlpatterns = [
-        re_path(r"^login/$", login_view, name=provider.id + "_login"),
-        re_path(r"^login/callback/$", callback_view, name=provider.id + "_callback"),
+        re_path(r"^login/$", peamu_views.oauth2_login, name=provider.id + "_login"),
+        re_path(r"^login/callback/$", peamu_views.oauth2_callback, name=provider.id + "_callback"),
     ]
 
-    return [re_path(r"^" + provider.get_slug() + r"/", include(urlpatterns))]
+    return [
+        re_path(r"^profile/$", peamu_views.redirect_to_dashboard_view),
+        re_path(r"^" + provider.get_slug() + r"/", include(urlpatterns)),
+    ]
 
 
 urlpatterns = default_urlpatterns(PEAMUProvider)

--- a/itou/allauth_adapters/peamu/views.py
+++ b/itou/allauth_adapters/peamu/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from allauth.account.adapter import get_adapter
 from allauth.socialaccount.helpers import complete_social_login, render_authentication_error
 from allauth.socialaccount.models import SocialLogin
 from allauth.socialaccount.providers.base import AuthError, ProviderException
@@ -7,6 +8,7 @@ from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from allauth.socialaccount.providers.oauth2.views import OAuth2CallbackView, OAuth2LoginView
 from allauth.utils import get_request_param
 from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
 from requests import RequestException
 
 from itou.allauth_adapters.peamu.adapter import PEAMUOAuth2Adapter
@@ -82,6 +84,11 @@ class PEAMUOAuth2CallbackView(OAuth2CallbackView):
         except (PermissionDenied, OAuth2Error, RequestException, ProviderException) as e:
             logger.error("Unknown error in PEAMU dispatch with exception '%s'.", e)
             return render_authentication_error(request, self.adapter.provider_id, exception=e)
+
+
+def redirect_to_dashboard_view(request):
+    redirect_url = get_adapter().get_login_redirect_url(request)
+    return HttpResponseRedirect(redirect_url)
 
 
 oauth2_login = OAuth2LoginView.adapter_view(PEAMUOAuth2Adapter)

--- a/itou/templates/account/login_job_seeker.html
+++ b/itou/templates/account/login_job_seeker.html
@@ -19,13 +19,19 @@
                     <b>Ou</b>
                 </p>
             </div>
+        {% else %}
+            <p class="font-italic text-center mt-3">FranceConnect est désactivé.</p>
         {% endif %}
 
-        <div class="row mt-3">
-            <div class="col-sm">
-                <p class="text-center">{% include "signup/includes/peamu_button.html" %}</p>
+        {% if show_peamu %}
+            <div class="row mt-3">
+                <div class="col-sm">
+                    <p class="text-center">{% include "signup/includes/peamu_button.html" %}</p>
+                </div>
             </div>
-        </div>
+        {% else %}
+            <p class="font-italic text-center">Pôle emploi Connect est désactivé.</p>
+        {% endif %}
         <div class="mt-4 mb-3">
             <b>Ou utilisez votre adresse e-mail</b>
         </div>

--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -21,13 +21,20 @@
                     <b>Ou</b>
                 </p>
             </div>
+        {% else %}
+            <p class="font-italic text-center mt-3">FranceConnect est désactivé.</p>
         {% endif %}
 
-        <div class="row mt-3">
-            <div class="col-sm">
-                <p class="text-center">{% include "signup/includes/peamu_button.html" %}</p>
+        {% if show_peamu %}
+            <div class="row mt-3">
+                <div class="col-sm">
+                    <p class="text-center">{% include "signup/includes/peamu_button.html" %}</p>
+                </div>
             </div>
-        </div>
+        {% else %}
+            <p class="font-italic text-center">Pôle emploi Connect est désactivé.</p>
+        {% endif %}
+
         <div class="mt-4 mb-3">
             <b>Ou utilisez votre adresse e-mail</b>
         </div>

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -1,4 +1,3 @@
-import httpx
 from allauth.account.views import LogoutView, PasswordChangeView
 from django.conf import settings
 from django.contrib import auth, messages
@@ -11,6 +10,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils.http import urlencode
 from django.views.decorators.http import require_POST
 
+from itou.allauth_adapters.peamu.tasks import huey_logout_from_pe_connect
 from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
 from itou.institutions.models import Institution
@@ -143,13 +143,12 @@ class ItouLogoutView(LogoutView):
             return HttpResponseRedirect(fc_logout_url)
         if peamu_id_token:
             hp_url = self.request.build_absolute_uri("/")
-            params = {"id_token_hint": peamu_id_token, "redirect_uri": hp_url}
-            peamu_logout_url = f"{settings.PEAMU_AUTH_BASE_URL}/compte/deconnexion?{urlencode(params)}"
-            # Redirecting to PEAMU_AUTH_BASE_URL causes the user to end up there
-            # because the redirect_uri param doen't work anymore.
-            # As a temporary work around, perform a simple post to try to log out the user
-            # but stay on Itou.
-            httpx.post(peamu_logout_url)
+            # Redirecting to PEAMU_AUTH_BASE_URL causes the user to stay on Pôle emploi's website
+            # because the redirect_uri param doesn't work anymore.
+            # As a temporary work around, perform a fire and forget HTTP request
+            # to try to log out the user while staying on Itou.
+            huey_logout_from_pe_connect(peamu_id_token=peamu_id_token, hp_url=hp_url)
+
         return ajax_response
 
 

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -1,3 +1,4 @@
+import httpx
 from allauth.account.views import LogoutView, PasswordChangeView
 from django.conf import settings
 from django.contrib import auth, messages
@@ -144,9 +145,12 @@ class ItouLogoutView(LogoutView):
             hp_url = self.request.build_absolute_uri("/")
             params = {"id_token_hint": peamu_id_token, "redirect_uri": hp_url}
             peamu_logout_url = f"{settings.PEAMU_AUTH_BASE_URL}/compte/deconnexion?{urlencode(params)}"
-            return HttpResponseRedirect(peamu_logout_url)
-        else:
-            return ajax_response
+            # Redirecting to PEAMU_AUTH_BASE_URL causes the user to end up there
+            # because the redirect_uri param doen't work anymore.
+            # As a temporary work around, perform a simple post to try to log out the user
+            # but stay on Itou.
+            httpx.post(peamu_logout_url)
+        return ajax_response
 
 
 logout = login_required(ItouLogoutView.as_view())

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -114,7 +114,9 @@ class JobSeekerLoginView(ItouLoginView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         show_france_connect = settings.FRANCE_CONNECT_ENABLED
+        show_peamu = settings.PEAMU_ENABLED
         extra_context = {
             "show_france_connect": show_france_connect,
+            "show_peamu": show_peamu,
         }
         return context | extra_context

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -68,7 +68,7 @@ class JobSeekerSignupView(SignupView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["show_france_connect"] = settings.FRANCE_CONNECT_ENABLED
-        context["show_peamu"] = True
+        context["show_peamu"] = settings.PEAMU_ENABLED
         return context
 
     def get_form_kwargs(self):


### PR DESCRIPTION
### Quoi ?

- Corrections de bugs relatifs à PE Connect.
- Ajout d'un interrupteur dans les settings pour désactiver PE Connect rapidement.
- Ajout d'un message dans l'interface (inscription et connexion) si PE Connect ou FranceConnect sont désactivés.

### Pourquoi ?

Quand un utilisateur venait de se créer un compte avec PE Connect, il était redirigé vers Itou mais voyait une 404.
Cela vient du fait que Allauth ne prend pas en compte l'adaptateur que nous utilisons à la place de `settings.LOGIN_REDIRECT_URL`. Il continuait de rediriger l'utilisateur vers la valeur par défaut, `/accounts/profile`.
Je propose une redirection de cette URL vers le tableau de bord. Ce n'est pas terrible, j'en conviens, mais c'est rapide et efficace.

À sa déconnexion, l'utilisateur était redirigé vers le site de Pôle emploi et y restait car le pramètre `redirect_uri` ne semble plus être pris en compte.
Je propose que le serveur effectue un `POST` au lieu de la redirection.

### Captures d'écran

![image](https://user-images.githubusercontent.com/6150920/174980073-fa60daee-2340-4866-b365-556b49893359.png)
