### PR TITLE
Améliorer l'UX de l'étape de renseignement du NIR du candidat dans le parcours de prescription

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -19,7 +19,7 @@
 /* Spacing.
 --------------------------------------------------------------------------- */
 
-.s-main > section {
+.s-main>section {
     padding-top: 2rem;
     padding-bottom: 3rem;
 }
@@ -30,7 +30,7 @@
 }
 
 @media (min-width: 992px) {
-    .s-main > section {
+    .s-main>section {
         padding-top: 3rem;
         padding-bottom: 4rem;
     }
@@ -48,19 +48,19 @@
     justify-content: space-between;
 }
 
-.card-deck-itou > .card {
+.card-deck-itou>.card {
     /* flex: 0 0 26%; */
     position: relative;
     padding: 1.5rem;
 }
 
-.card-deck-itou > .card > .card-body {
+.card-deck-itou>.card>.card-body {
     align-items: center;
     justify-content: center;
     display: flex;
 }
 
-.card-deck-itou > .card > .card-footer {
+.card-deck-itou>.card>.card-footer {
     background: transparent;
 }
 
@@ -85,7 +85,7 @@ body:after {
 /* Forms.
 --------------------------------------------------------------------------- */
 
-.form-group-required > label:first-of-type:after {
+.form-group-required>label:first-of-type:after {
     content: " *";
     color: #d63626;
 }
@@ -104,7 +104,7 @@ See also `duet_date_picker.html`.
 https://getbootstrap.com/docs/4.6/components/forms/#server-side
 */
 
-duet-date-picker.is-invalid ~ .invalid-feedback {
+duet-date-picker.is-invalid~.invalid-feedback {
     display: block;
 }
 
@@ -131,19 +131,24 @@ Credits go to https://stackoverflow.com/a/19229738
         bottom: 0;
         z-index: 1030;
     }
+
     /* Set width depending on a breaking point. */
     .w-sm-25 {
         width: 25% !important;
     }
+
     .w-sm-33 {
         width: 33% !important;
     }
+
     .w-sm-50 {
         width: 50% !important;
     }
+
     .w-sm-75 {
         width: 75% !important;
     }
+
     /* Reset width */
     /* To be used with, for example, w-100 to have a with: 100%; only on mobile. */
     .w-sm-auto {
@@ -211,13 +216,13 @@ Usage:
     </ul>
 --------------------------------------------------------------------------- */
 
-.multi-steps > li.is-active:before,
-.multi-steps > li.is-active ~ li:before {
+.multi-steps>li.is-active:before,
+.multi-steps>li.is-active~li:before {
     content: counter(stepNum);
 }
 
-.multi-steps > li.is-active:after,
-.multi-steps > li.is-active ~ li:after {
+.multi-steps>li.is-active:after,
+.multi-steps>li.is-active~li:after {
     background-color: #ededed;
 }
 
@@ -227,7 +232,7 @@ Usage:
     width: 100%;
 }
 
-.multi-steps > li {
+.multi-steps>li {
     counter-increment: stepNum;
     text-align: center;
     display: table-cell;
@@ -236,7 +241,7 @@ Usage:
     z-index: 1;
 }
 
-.multi-steps > li:before {
+.multi-steps>li:before {
     content: "\2713";
     /* Check mark symbol. */
     display: block;
@@ -251,7 +256,7 @@ Usage:
     border-radius: 50%;
 }
 
-.multi-steps > li:after {
+.multi-steps>li:after {
     content: "";
     height: 2px;
     width: 100%;
@@ -262,20 +267,20 @@ Usage:
     z-index: -1;
 }
 
-.multi-steps > li:last-child:after {
+.multi-steps>li:last-child:after {
     display: none;
 }
 
-.multi-steps > li.is-active:before {
+.multi-steps>li.is-active:before {
     background-color: #fff;
     border-color: #28a745;
 }
 
-.multi-steps > li.is-active ~ li {
+.multi-steps>li.is-active~li {
     color: #808080;
 }
 
-.multi-steps > li.is-active ~ li:before {
+.multi-steps>li.is-active~li:before {
     background-color: #ededed;
     border-color: #ededed;
 }
@@ -332,20 +337,21 @@ Usage:
     position: relative;
     text-decoration: none !important;
 }
-.collapse-caret > *::after {
-  content: '\ea4e';
-  font-family: remixicon !important;
-  font-style: normal;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  line-height: 1;
-  vertical-align: text-bottom;
-  font-size: 1.25rem;
-  font-weight: 700;
-  margin-left: 0.5rem;
+
+.collapse-caret>*::after {
+    content: '\ea4e';
+    font-family: remixicon !important;
+    font-style: normal;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    line-height: 1;
+    vertical-align: text-bottom;
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin-left: 0.5rem;
 }
 
-.collapse-caret[aria-expanded=true] > *::after {
+.collapse-caret[aria-expanded=true]>*::after {
     content: '\ea78';
 }
 
@@ -390,7 +396,7 @@ Usage:
 }
 
 @media (min-width: 992px) {
-    .s-section-twocolumns {
+    .s-section-twocolumns-with-bg {
         background-color: #fff;
         background: linear-gradient(to left, #fbfbfb 50%, #f2f8fd 50%);
     }
@@ -421,9 +427,9 @@ Usage:
 }
 
 #welcoming_tour .carousel-indicators li {
-  background-color: #3F3E62;
+    background-color: #3F3E62;
 }
 
 #welcoming_tour .carousel-indicators li.active {
-  background-color: #000638;
+    background-color: #000638;
 }

--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -396,7 +396,7 @@ Usage:
 }
 
 @media (min-width: 992px) {
-    .s-section-twocolumns-with-bg {
+    .s-section-lg-with-background {
         background-color: #fff;
         background: linear-gradient(to left, #fbfbfb 50%, #f2f8fd 50%);
     }

--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -6,6 +6,8 @@
 
 {% block title %}Connexion{{ block.super }}{% endblock %}
 
+{% block content_container_css_classes %}s-section-twocolumns-with-bg{% endblock %}
+
 {% block right_content %}
     <div class="py-5 py-lg-7">
         <h1 class="h1-hero-c1">Connexion</h1>

--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -6,7 +6,7 @@
 
 {% block title %}Connexion{{ block.super }}{% endblock %}
 
-{% block content_container_css_classes %}s-section-twocolumns-with-bg{% endblock %}
+{% block content_container_css_classes %}s-section-lg-with-background{% endblock %}
 
 {% block right_content %}
     <div class="py-5 py-lg-7">

--- a/itou/templates/account/login_job_seeker.html
+++ b/itou/templates/account/login_job_seeker.html
@@ -6,6 +6,8 @@
 
 {% block title %}Connexion candidat{{ block.super }}{% endblock %}
 
+{% block content_container_css_classes %}s-section-twocolumns-with-bg{% endblock %}
+
 {% block right_content %}
     <div class="py-5 py-lg-7">
         <h1 class="h1-hero-c1">Connexion</h1>

--- a/itou/templates/account/login_job_seeker.html
+++ b/itou/templates/account/login_job_seeker.html
@@ -6,7 +6,7 @@
 
 {% block title %}Connexion candidat{{ block.super }}{% endblock %}
 
-{% block content_container_css_classes %}s-section-twocolumns-with-bg{% endblock %}
+{% block content_container_css_classes %}s-section-lg-with-background{% endblock %}
 
 {% block right_content %}
     <div class="py-5 py-lg-7">

--- a/itou/templates/apply/submit_base_two_columns.html
+++ b/itou/templates/apply/submit_base_two_columns.html
@@ -1,46 +1,63 @@
-{# The application process step is sometimes split in two columns. #}
-{# This should not last but, in the meantime, two base templates exist. #}
-
-{% extends "layout/content_two_columns.html" %}
+{% extends "layout/base.html" %}
+{% load static %}
 
 {% block title %}Postuler{{ block.super }}{% endblock %}
 
-{% block right_content %}
-    {{ block.super }}
-    <div>
-        <!-- SAME AS submit_base.html. -->
-        <!-- Not possible to extend from it as we need a full layout (layout/base.html) -->
-        <!-- instead of the tiny layout/content_small.html. -->
-        <h1 class="h1-hero-c1">
-            {% if request.user.is_siae_staff %}
-                Déclarer une embauche
-            {% else %}
-                Postuler chez <span class="text-muted">{{ siae.display_name }}</span>
-            {% endif %}
-        </h1>
-        {% if request.user.is_siae_staff and job_seeker %}
-            <h2 class="h1">{{ job_seeker.get_full_name|title }}</h2>
-        {% endif %}
+{% block content_full_viewport %}
 
-        {% if approvals_wrapper.latest_approval %}
-            {# Approval status. #}
-            <div class="card my-3">
-                <div class="card-body">
-                    <div class="card-text">
-                        {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
+    {% block pre_content %}{% endblock %}
+
+    <section class="s-section-twocolumns {% block content_container_css_classes %}{% endblock %}">
+        <div class="container">
+            <div class="row">
+                <div class="col-12 col-lg-6 order-md-1 pr-lg-5 mt-4">
+                    <h1 class="h1-hero-c1">
+                        {% if request.user.is_siae_staff %}
+                            Déclarer une embauche
+                        {% else %}
+                            Postuler</span>
+                        {% endif %}
+                    </h1>
+                    {% if request.user.is_siae_staff and job_seeker %}
+                        <h2 class="h1">{{ job_seeker.get_full_name|title }}</h2>
+                    {% endif %}
+
+                    {% if approvals_wrapper.latest_approval %}
+                        {# Approval status. #}
+                        <div class="card my-3">
+                            <div class="card-body">
+                                <div class="card-text">
+                                    {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
+
+                    <div class="card c-card c-card--emploi mb-3 mb-lg-5">
+                        <div class="card-body">
+                            <p><i class="ri-home-7-line ri-xl mr-2"></i>{{ siae.kind }} - {{ siae.display_kind }} </p>
+                            <hr>
+                            <p class="h2">
+                                <a href="{% url 'siaes_views:card' siae_id=siae.pk %}{% if back_url %}?back_url={{ back_url }}{% endif %}">
+                                    {{ siae.display_name }}
+                                </a>
+                            </p>
+                            {# Display non-user-edited name too. #}
+                            <adresse class="card-subtitle fs-lg font-weight-bold text-secondary">{{ siae.address_on_one_line }}</adresse>
+                        </div>
                     </div>
                 </div>
             </div>
-        {% endif %}
-        <!-- End of duplicated code. -->
-
-        {% block right_column %}{% endblock %}
-    </div>
-{% endblock %}
-
-{% block left_content %}
-    {{ block.super }}
-    <div class="text-center">
-        {% block left_column %}{% endblock %}
-    </div>
+            <div class="row">
+                <div class="col-12 col-lg-6 order-md-2 pl-lg-5 d-none d-lg-block d-xl-block">
+                    <h2 class="h1 ff-extra-01">Où trouver {% if request.user.is_job_seeker %}mon{% else %}le{% endif %} numéro de sécurité sociale ?</h2>
+                    <img class="mt-5 img-fluid" src="{% static 'img/carte_vitale.png' %}" alt="Spécimen de carte vitale">
+                    <p class="ff-extra-01 mt-0">Il est présent à cet endroit sur {% if request.user.is_job_seeker %}votre{% else %}la{% endif %} carte Vitale.</p>
+                </div>
+                <div class="col-12 col-lg-6 order-md-1 pr-lg-5">
+                    {% block left_column %}{% endblock %}
+                </div>
+            </div>
+        </div>
+    </section>
 {% endblock %}

--- a/itou/templates/apply/submit_base_two_columns.html
+++ b/itou/templates/apply/submit_base_two_columns.html
@@ -49,7 +49,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-12 col-lg-6 order-md-2 pl-lg-5 d-none d-lg-block d-xl-block">
+                <div class="col-12 col-lg-6 order-md-2 pl-lg-5 d-none d-lg-block mb-6">
                     <h2 class="h1 ff-extra-01">Où trouver {% if request.user.is_job_seeker %}mon{% else %}le{% endif %} numéro de sécurité sociale ?</h2>
                     <img class="mt-5 img-fluid" src="{% static 'img/carte_vitale.png' %}" alt="Spécimen de carte vitale">
                     <p class="ff-extra-01 mt-0">Il est présent à cet endroit sur {% if request.user.is_job_seeker %}votre{% else %}la{% endif %} carte Vitale.</p>

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -64,7 +64,7 @@
                             <a class="btn btn-link" title="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
                         </div>
                         <div class="col-6 col-lg-auto">
-                            <button type="submit" name="preview" value="1" class="btn float-right btn-primary">Suivant</button>
+                            <button type="submit" name="preview" value="1" class="btn btn-primary">Suivant</button>
                         </div>
                     </div>
                 {% endbuttons %}

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -6,7 +6,7 @@
 
 {% block left_column %}
     <form method="post" action="{% url 'apply:step_check_job_seeker_nir' siae_pk=siae.pk %}" class="js-prevent-multiple-submit js-format-nir">
-        <div class="card c-card mb-3 mb-lg-5">
+        <div class="card c-card mb-3 mb-lg-5 p-3">
             <div class="card-body">
 
                 {% csrf_token %}
@@ -55,13 +55,18 @@
                         </div>
                     </div>
                 {% endif %}
-            </div>
-            <div class="card-footer">
                 {% buttons %}
                     {# Reload this page and show a modal containing more information about the job seeker. #}
-                    <button type="submit" name="preview" value="1" class="btn btn-primary">
-                        Continuer
-                    </button>
+                    <hr class="my-3 my-lg-5">
+
+                    <div class="row mt-3 mt-lg-5 justify-content-end">
+                        <div class="col-6 col-lg-auto">
+                            <a class="btn btn-link" title="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
+                        </div>
+                        <div class="col-6 col-lg-auto">
+                            <button type="submit" name="preview" value="1" class="btn float-right btn-primary">Suivant</button>
+                        </div>
+                    </div>
                 {% endbuttons %}
             </div>
         </div>

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -11,7 +11,7 @@
 
                 {% csrf_token %}
 
-                {% bootstrap_form_errors form type="all" %}
+                {% bootstrap_form_errors form type="non_field_errors" %}
 
                 {% bootstrap_form form %}
 

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -4,40 +4,67 @@
 {% load redirection_fields %}
 {% load static %}
 
-{% block title %}{{ block.super }}{% endblock %}
-
-{% block right_column %}
+{% block left_column %}
     <form method="post" action="{% url 'apply:step_check_job_seeker_nir' siae_pk=siae.pk %}" class="js-prevent-multiple-submit js-format-nir">
+        <div class="card c-card mb-3 mb-lg-5">
+            <div class="card-body">
 
-        {% csrf_token %}
+                {% csrf_token %}
 
-        {% bootstrap_form_errors form type="all" %}
+                {% bootstrap_form_errors form type="all" %}
 
-        {% bootstrap_form form %}
+                {% bootstrap_form form %}
 
-        {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
+                {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
 
-        {% if form.errors %}
-            <div class="alert alert-info">
-                Vous possédez un numéro de sécurité sociale temporaire ?
-                <button
-                    type="submit" name="skip" value="1"
-                    class="btn btn-link p-0 matomo-event"
-                    data-matomo-category="nir-temporaire"
-                    data-matomo-action="etape-suivante"
-                    data-matomo-option="candidature">
-                    Cliquez ici pour accéder à l'étape suivante.
-                </button>
+                {% if form.errors %}
+                    <div class="alert alert-info">
+                        <div class="row">
+                            <div class="col-auto pr-0">
+                                <i class="ri-information-line ri-xl text-info"></i>
+                            </div>
+                            <div class="col">
+                                <p class="mb-0">
+                                    Vous possédez un numéro de sécurité sociale temporaire ?
+                                    <button
+                                        type="submit" name="skip" value="1"
+                                        class="btn btn-link p-0 matomo-event"
+                                        data-matomo-category="nir-temporaire"
+                                        data-matomo-action="etape-suivante"
+                                        data-matomo-option="candidature">
+                                        Cliquez ici pour accéder à l'étape suivante.
+                                    </button>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                {% else %}
+                    <div class="alert alert-info">
+                        <div class="row">
+                            <div class="col-auto pr-0">
+                                <i class="ri-information-line ri-xl text-info"></i>
+                            </div>
+                            <div class="col">
+                                <p class="mb-0">{% if request.user.is_job_seeker %}
+                                    Vous n'avez pas de numéro de sécurité sociale ?<br>
+                                {% else %}
+                                    Le candidat n'a pas de numéro de sécurité sociale ?<br>
+                                {% endif %}
+                                    <a href="https://www.ameli.fr/assure/droits-demarches/principes/numero-securite-sociale" title="ameli.fr, article concernant le numéro de sécurité sociale (ouverture dans un nouvel onglet)" rel="noopener" target="_blank">ameli.fr</a><i class="ri-external-link-line ml-1"></i>, le site de l'assurance maladie, vous explique comment l'obtenir.</p>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
-        {% endif %}
-
-        {% buttons %}
-            {# Reload this page and show a modal containing more information about the job seeker. #}
-            <button type="submit" name="preview" value="1" class="btn btn-primary">
-                Continuer
-            </button>
-        {% endbuttons %}
-
+            <div class="card-footer">
+                {% buttons %}
+                    {# Reload this page and show a modal containing more information about the job seeker. #}
+                    <button type="submit" name="preview" value="1" class="btn btn-primary">
+                        Continuer
+                    </button>
+                {% endbuttons %}
+            </div>
+        </div>
         {% if preview_mode %}
             <!-- Modal -->
             <div class="modal" id="nir-confirmation-modal" tabindex="-1" role="dialog" aria-labelledby="nir-confirmation-label" aria-modal="true">
@@ -71,22 +98,7 @@
                 </div>
             </div>
         {% endif %}
-
     </form>
-    <p class="mt-5">
-        {% if request.user.is_job_seeker %}
-            Vous n'avez pas de numéro de sécurité sociale ?<br>
-        {% else %}
-            Le candidat n'a pas de numéro de sécurité sociale ?<br>
-        {% endif %}
-        <a href="https://www.ameli.fr/assure/droits-demarches/principes/numero-securite-sociale" title="ameli.fr, article concernant le numéro de sécurité sociale (ouverture dans un nouvel onglet)" rel="noopener" target="_blank">ameli.fr</a><i class="ri-external-link-line ml-1"></i>, le site de l'assurance maladie, vous explique comment l'obtenir.
-    </p>
-{% endblock %}
-
-{% block left_column %}
-    <h2 class="h1 ff-extra-01">Où trouver {% if request.user.is_job_seeker %}mon{% else %}le{% endif %} numéro de sécurité sociale ?</h2>
-    <img class="mt-5 img-fluid" src="{% static 'img/carte_vitale.png' %}" alt="Spécimen de carte vitale">
-    <p class="ff-extra-01 mt-0">Il est présent à cet endroit sur {% if request.user.is_job_seeker %}votre{% else %}la{% endif %} carte Vitale.</p>
 {% endblock %}
 
 {% block script %}

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -4,7 +4,7 @@
 
 {% block left_column %}
     <form method="post" action="" class="js-prevent-multiple-submit">
-        <div class="card c-card mb-3 mb-lg-5">
+        <div class="card c-card mb-3 mb-lg-5 p-3">
             <div class="card-body">
                 {% if nir %}
                     <div class="form-group form-group-required">
@@ -20,7 +20,7 @@
                         </div>
                         <div class="col">
                             <p class="mb-2"><strong>Créer un compte pour votre candidat</strong></p>
-                            <p class="mb-0">Aucun utilisateur n'est inscrit avec ce numéro de sécurité sociale. Merci de rensigner l'adresse e-mail de votre candidat pour l'inscrire.</p>
+                            <p class="mb-0">Aucun utilisateur n'est inscrit avec ce numéro de sécurité sociale. Merci de renseigner l'adresse e-mail de votre candidat pour l'inscrire.</p>
                         </div>
                     </div>
                 </div>
@@ -31,17 +31,19 @@
 
                 <p>{% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}</p>
 
-                <div class="card-footer">
-                    {% buttons %}
-                        {# Reload this page and show a modal containing more information about the job seeker. #}
-                        <a href="{% url 'apply:step_check_job_seeker_nir' siae_pk=siae.pk %}" class="btn btn-outline-primary">
-                            Retour
-                        </a>
-                        <button type="submit" name="preview" value="1" class="btn btn-primary">
-                            Continuer
-                        </button>
-                    {% endbuttons %}
-                </div>
+                {% buttons %}
+                    <hr class="my-3 my-lg-5">
+
+                    <div class="row mt-3 mt-lg-5 justify-content-end">
+                        <div class="col-6 col-lg-auto">
+                            <a href="{% url 'apply:step_check_job_seeker_nir' siae_pk=siae.pk %}" class="btn btn-link">Retour</a>
+                        </div>
+                        <div class="col-6 col-lg-auto">
+                            {# Reload this page and show a modal containing more information about the job seeker. #}
+                            <button type="submit" name="preview" class="btn float-right btn-primary">Suivant</button>
+                        </div>
+                    </div>
+                {% endbuttons %}
             </div>
         </div>
         {% if preview_mode %}

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -9,7 +9,7 @@
                 {% if nir %}
                     <div class="form-group form-group-required">
                         <label for="id_nir">Numéro de sécurité sociale du candidat</label>
-                        <input type="nir" name="nir" class="form-control" title="" required="" id="id_nir" disabled value="{{ nir }}">
+                        <input type="nir" name="nir" class="form-control" title="" required="" id="id_nir" disabled value="{{ nir|format_nir }}">
                     </div>
                 {% endif %}
 

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -1,38 +1,49 @@
-{% extends "apply/submit_base.html" %}
+{% extends "apply/submit_base_two_columns.html" %}
 {% load bootstrap4 %}
 {% load format_filters %}
 
-{% block content %}
-
-    {{ block.super }}
-
-    <div class="alert alert-info">
-        <p class="mb-0">
-            Aucun utilisateur n'est incrit avec ce numéro de sécurité sociale.
-        </p>
-        <p class="mb-0">
-            Merci de renseigner l'adresse e-mail de votre candidat.
-        </p>
-    </div>
-
+{% block left_column %}
     <form method="post" action="" class="js-prevent-multiple-submit">
+        <div class="card c-card mb-3 mb-lg-5">
+            <div class="card-body">
+                {% if nir %}
+                    <div class="form-group form-group-required">
+                        <label for="id_nir">Numéro de sécurité sociale du candidat</label>
+                        <input type="nir" name="nir" class="form-control" title="" required="" id="id_nir" disabled value="{{ nir }}">
+                    </div>
+                {% endif %}
 
-        {% csrf_token %}
+                <div class="alert alert-info mt-4 mb-4">
+                    <div class="row">
+                        <div class="col-auto pr-0">
+                            <i class="ri-information-line ri-xl"></i>
+                        </div>
+                        <div class="col">
+                            <p class="mb-2"><strong>Créer un compte pour votre candidat</strong></p>
+                            <p class="mb-0">Aucun utilisateur n'est inscrit avec ce numéro de sécurité sociale. Merci de rensigner l'adresse e-mail de votre candidat pour l'inscrire.</p>
+                        </div>
+                    </div>
+                </div>
 
-        {% bootstrap_form form alert_error_type="all" %}
+                {% csrf_token %}
 
-        <p>{% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}</p>
+                {% bootstrap_form form alert_error_type="all" %}
 
-        {% buttons %}
-            {# Reload this page and show a modal containing more information about the job seeker. #}
-            <a href="{% url 'apply:step_check_job_seeker_nir' siae_pk=siae.pk %}" class="btn btn-outline-primary">
-                Retour
-            </a>
-            <button type="submit" name="preview" value="1" class="btn btn-primary">
-                Continuer
-            </button>
-        {% endbuttons %}
+                <p>{% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}</p>
 
+                <div class="card-footer">
+                    {% buttons %}
+                        {# Reload this page and show a modal containing more information about the job seeker. #}
+                        <a href="{% url 'apply:step_check_job_seeker_nir' siae_pk=siae.pk %}" class="btn btn-outline-primary">
+                            Retour
+                        </a>
+                        <button type="submit" name="preview" value="1" class="btn btn-primary">
+                            Continuer
+                        </button>
+                    {% endbuttons %}
+                </div>
+            </div>
+        </div>
         {% if preview_mode %}
             <!-- Modal -->
             <div class="modal" id="email-confirmation-modal" tabindex="-1" role="dialog" aria-labelledby="email-confirmation-label" aria-modal="true">
@@ -73,7 +84,6 @@
             </div>
         {% endif %}
     </form>
-
 {% endblock %}
 
 {% block script %}

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -40,7 +40,7 @@
                         </div>
                         <div class="col-6 col-lg-auto">
                             {# Reload this page and show a modal containing more information about the job seeker. #}
-                            <button type="submit" name="preview" class="btn float-right btn-primary">Suivant</button>
+                            <button type="submit" name="preview" class="btn btn-primary">Suivant</button>
                         </div>
                     </div>
                 {% endbuttons %}

--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -5,6 +5,8 @@
 
 {% block title %}Demandeur d'emploi - Inscription{{ block.super }}{% endblock %}
 
+{% block content_container_css_classes %}s-section-twocolumns-with-bg{% endblock %}
+
 {% block right_content %}
     <div class="py-5 py-lg-7">
         <h1 class="h1-hero-c1">

--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -5,7 +5,7 @@
 
 {% block title %}Demandeur d'emploi - Inscription{{ block.super }}{% endblock %}
 
-{% block content_container_css_classes %}s-section-twocolumns-with-bg{% endblock %}
+{% block content_container_css_classes %}s-section-lg-with-background{% endblock %}
 
 {% block right_content %}
     <div class="py-5 py-lg-7">

--- a/itou/templates/signup/job_seeker_situation.html
+++ b/itou/templates/signup/job_seeker_situation.html
@@ -5,7 +5,7 @@
 
 {% block title %}Inscription candidat{{ block.super }}{% endblock %}
 
-{% block content_container_css_classes %}s-section-twocolumns-with-bg{% endblock %}
+{% block content_container_css_classes %}s-section-lg-with-background{% endblock %}
 
 {% block right_content %}
     <div class="py-5 py-lg-7">

--- a/itou/templates/signup/job_seeker_situation.html
+++ b/itou/templates/signup/job_seeker_situation.html
@@ -5,6 +5,8 @@
 
 {% block title %}Inscription candidat{{ block.super }}{% endblock %}
 
+{% block content_container_css_classes %}s-section-twocolumns-with-bg{% endblock %}
+
 {% block right_content %}
     <div class="py-5 py-lg-7">
         <h1 class="h1-hero-c1">

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -62,6 +62,10 @@ class CheckJobSeekerNirForm(forms.Form):
     def __init__(self, *args, job_seeker=None, **kwargs):
         self.job_seeker = job_seeker
         super().__init__(*args, **kwargs)
+        if self.job_seeker:
+            self.fields["nir"].label = "Votre numéro de sécurité sociale"
+        else:
+            self.fields["nir"].label = "Numéro de sécurité sociale du candidat"
 
     def clean_nir(self):
         nir = self.cleaned_data["nir"]

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -158,6 +158,11 @@ def step_check_job_seeker_nir(request, siae_pk, template_name="apply/submit_step
     form = CheckJobSeekerNirForm(job_seeker=job_seeker, data=request.POST or None)
     preview_mode = False
 
+    # Clean nir in session, especially in case of using back button
+    if "nir" in session_data:
+        session_data["nir"] = None
+        request.session.modified = True
+
     if request.method == "POST" and form.is_valid():
         nir = form.cleaned_data["nir"]
 


### PR DESCRIPTION
### Quoi ?

Améliorer l'UX de l'étape de renseignement du NIR du candidat dans le parcours de prescription.

### Pourquoi ?

Pour assurer la continuité dans le parcours d'inscription et éviter les confusions sur le NIR à renseigner.

### Comment ?

• En étant plus guidant dans les étapes
• Laisser le NIR visible à l'écran à l'étape de création du compte candidat
• Rappeler la structure sur laquelle il postule

### Captures d'écran

Déclaration d'une embauche
![Déclaration d'une embauche](https://user-images.githubusercontent.com/17601807/174086457-3c904383-0b04-436a-b0d3-fad1c9dd8079.png)

Un candidat postule
![Un candidat postule](https://user-images.githubusercontent.com/17601807/174086491-67deb777-d824-4dec-9e37-fa44d8ee8b69.png)

Erreur dans la saisie du NIR
![Erreur dans la saisie du NIR](https://user-images.githubusercontent.com/17601807/174086519-9c8241ed-5d19-406b-9d10-02a0be9afc3a.png)

Étape de création du compte candidat
![Étape de création du compte candidat](https://user-images.githubusercontent.com/17601807/174087497-4b448c6d-41c4-4920-8b09-ede3110e6ee2.png)
