### PR TITLE
Import EA/EATT

### DIFF
--- a/itou/siaes/management/commands/import_ea_eatt.py
+++ b/itou/siaes/management/commands/import_ea_eatt.py
@@ -110,12 +110,6 @@ def get_ea_eatt_df():
 
     df["department"] = df.post_code.apply(department_from_postcode)
 
-    missing_emails_count = len(df[df.auth_email.isnull()])
-    assert missing_emails_count <= 20, f"Too many missing emails: {missing_emails_count}"
-
-    # Drop rows without auth_email.
-    df = df[~df.auth_email.isnull()]
-
     assert df.siret.is_unique
     assert len(df) >= 600, f"Export usually has 700+ EA/EATT structures (only {len(df)})."
 

--- a/itou/siaes/management/commands/import_ea_eatt.py
+++ b/itou/siaes/management/commands/import_ea_eatt.py
@@ -1,3 +1,5 @@
+import datetime
+
 import numpy as np
 import pandas as pd
 from django.core.management.base import BaseCommand
@@ -33,8 +35,17 @@ def get_ea_eatt_df():
     siret_field_name = "Siret_Signataire"
     post_code_field_name = "CODE_POST_Signataire"
     phone_field_name = "TEL_CONT_Signataire"
+    convention_end_date_field_name = "Date_Fin_App_Etab_Membre"
 
-    df = pd.read_excel(filename, converters={siret_field_name: str, post_code_field_name: str, phone_field_name: str})
+    df = pd.read_excel(
+        filename,
+        converters={
+            siret_field_name: str,
+            post_code_field_name: str,
+            phone_field_name: str,
+            convention_end_date_field_name: datetime.date.fromisoformat,
+        },
+    )
 
     column_mapping = {
         "Denomination_Sociale_Signataire": "name",
@@ -48,6 +59,7 @@ def get_ea_eatt_df():
         siret_field_name: "siret",
         "CRL_CONT_Signataire": "auth_email",
         phone_field_name: "phone",
+        convention_end_date_field_name: "convention_end_date",
     }
     df = remap_columns(df, column_mapping=column_mapping)
 
@@ -64,6 +76,9 @@ def get_ea_eatt_df():
         keep="first",
         inplace=True,
     )
+
+    # Drop the rows with an expired convention
+    df = df[df["convention_end_date"] > datetime.date.today()]
 
     df["address_line_1"] = ""
 


### PR DESCRIPTION
### Quoi ?

1. Ignorer les EA/EATT ayant une convention qui a expirée.
2. Meilleure gestion des emails manquants.
3. Affichage de quelques informations à propos des lignes contenues dans le fichier.

### Pourquoi ?

1. Ne pas se préoccuper d'informations désormais inutiles.
2. Que le script fasse ce qu'il doit faire même si ils nous manquent des informations.
3. Avoir une meilleure idée de semaine en semaine de l'évolution du contenu du fichier.

