### PR TITLE
Affichage de l'identifiant obfusqué dans l'administration

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -183,7 +183,7 @@ class ItouUserAdmin(UserAdmin):
         "pk",
         "nir",
     )
-    readonly_fields = ("pk",)
+    readonly_fields = ("pk", "jobseeker_hash_id")
 
     fieldsets = UserAdmin.fieldsets + (
         (
@@ -191,6 +191,7 @@ class ItouUserAdmin(UserAdmin):
             {
                 "fields": (
                     "pk",
+                    "jobseeker_hash_id",
                     "title",
                     "birthdate",
                     "birth_place",
@@ -240,6 +241,10 @@ class ItouUserAdmin(UserAdmin):
     is_peamu.boolean = True
     is_peamu.admin_order_field = "_is_peamu"
     is_peamu.short_description = "pe connect"
+
+    @admin.display(description="id ITOU obfusqué")
+    def jobseeker_hash_id(self, obj):
+        return obj.jobseeker_hash_id
 
     def get_queryset(self, request):
         """


### PR DESCRIPTION
### Quoi ?

Affichage de l'identifiant obfusqué dans l'édition d'un utilisateur.

### Pourquoi ?

Pour pouvoir mener des analyses sur des exports où l'identifiant a été obfusqué.

### Comment ?

Affichage dans l'administration
