### PR TITLE
Déconnexion de PE Connect via une redirection et non via le serveur

### DIFF
--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -1,4 +1,3 @@
-import httpx
 from allauth.account.views import LogoutView, PasswordChangeView
 from django.conf import settings
 from django.contrib import auth, messages
@@ -145,12 +144,9 @@ class ItouLogoutView(LogoutView):
             hp_url = self.request.build_absolute_uri("/")
             params = {"id_token_hint": peamu_id_token, "redirect_uri": hp_url}
             peamu_logout_url = f"{settings.PEAMU_AUTH_BASE_URL}/compte/deconnexion?{urlencode(params)}"
-            # Redirecting to PEAMU_AUTH_BASE_URL causes the user to end up there
-            # because the redirect_uri param doen't work anymore.
-            # As a temporary work around, perform a simple post to try to log out the user
-            # but stay on Itou.
-            httpx.post(peamu_logout_url)
-        return ajax_response
+            return HttpResponseRedirect(peamu_logout_url)
+        else:
+            return ajax_response
 
 
 logout = login_required(ItouLogoutView.as_view())


### PR DESCRIPTION
[Dans une PR précédente](https://github.com/betagouv/itou/pull/1364), je proposais de faire un appel HTTP à l'URL de déconnexion de Pôle emploi au lieu de la redirection. Pourquoi ? Car le paramètre `redirect_uri` n'étant plus reconnu par leur SI, l'utilisateur finit son parcours sur le site de PE au lieu d'être redirigé vers le nôtre.
Malheureusement, la technique proposée ne fonctionne pas. Je suppose que le _endpoint_ nettoie des données de session stockées dans le navigateur et qu'il faut, par conséquent, bel et bien que le navigateur charge la page. Ce n'est qu'une supposition.
En attendant, revenons à ce qui fonctionne : la redirection !