### PR TITLE
Mise a jour de la zone de contenu d'aide sur les pages "Stats" 

### DIFF
--- a/itou/templates/layout/content.html
+++ b/itou/templates/layout/content.html
@@ -10,4 +10,6 @@
         </div>
     </section>
 
+    {% block post_content %}{% endblock %}
+
 {% endblock %}

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -26,39 +26,6 @@
     <iframe src="{{ iframeurl }}" width="100%" onload="iFrameResize({}, this)" frameborder="0">
     </iframe>
 
-
-    <div class="mt-5 mb-3 mb-lg-5">
-        <h3 class="h2">Aide à la lecture et à l'utilisation de ces indicateurs/graphiques</h3>
-
-        <h4 class="h5">Comment obtenir le nombre (ou la répartition) exacte correspondant à un élément de réponse ?</h4>
-        <p>En survolant la couleur attribuée à cet élément de réponse sur le graphique, vous trouverez le nombre (ou la part) de cet élément dans une infobulle.</p>
-
-        <h4 class="h5">Comment obtenir la définition d'un chiffre ou d'un indicateur/graphique ?</h4>
-        <p>En cliquant dessus, notre dictionnaire des indicateurs s’ouvrira (directement au niveau de celui demandé).</p>
-
-        <h4 class="h5">Vous n’êtes pas sûr(e) de comprendre les termes/sigles utilisés ?</h4>
-        <p>
-            L'ensemble des termes/sigles utilisés ici est défini dans le
-            <a href="{{ ITOU_COMMUNITY_URL }}/doc/communaute/glossaire-de-linclusion/" rel="noopener" target="_blank" title="Le glossaire de l’inclusion (ouverture dans un nouvel onglet)">
-                glossaire de l’inclusion
-            </a>.
-        </p>
-
-        <h4 class="h5">Est-il possible de sélectionner seulement certaines données pour générer ces indicateurs/graphiques ?</h4>
-        <p>
-            Oui, vous pouvez sélectionner les données que vous souhaitez en utilisant les filtres en haut de l’écran, voici un exemple :
-            <br>
-            <img class="mt-5 img-fluid" src="{% static 'img/stats/metabase-department-filter.png' %}">
-        </p>
-
-        <h4 class="h5">Comment télécharger les données d'un indicateur/graphique ?</h4>
-        <p>
-            En cliquant sur cette icône qui apparaît en haut à droite d’un graphique au survol de la souris :
-            <br>
-            <img class="mt-5 img-fluid" src="{% static 'img/stats/metabase-download-icon.png' %}">
-        </p>
-    </div>
-
     {% if back_url %}
         <p class="mt-4">
             <a href="{{ back_url }}">Retour</a>
@@ -66,4 +33,61 @@
     {% endif %}
 
 
+{% endblock %}
+
+{% block post_content %}
+    <section class="s-section mt-0 pt-0">
+        <div class="s-section__container container">
+            <div class="s-section__row row row-cols-1 row-cols-md-2 row-cols-lg-3">
+                <div class="col mb-3 mb-md-5">
+                    <div class="card c-card c-card--communaute c-card--hovershadow h-100 w-100">
+                        <div class="card-header">
+                            <h2 class="h2 m-0">Guide d’utilisation</h2>
+                        </div>
+                        <div class="card-body">
+                            <p>Aide à la lecture et à l'utilisation des tableaux de bord</p>
+                        </div>
+                        <div class="card-footer text-right">
+                            <a href="https://communaute.inclusion.beta.gouv.fr/doc/pilotage/guide-d-utilisation/" target="_blank" class="btn btn-sm btn-ico btn-link stretched-link">
+                                <span>Accéder au guide d’utilisation</span>
+                                <i class="ri-external-link-line ri-lg"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="col mb-3 mb-md-5">
+                    <div class="card c-card c-card--communaute c-card--hovershadow h-100 w-100">
+                        <div class="card-header">
+                            <h2 class="h2 m-0">Dictionnaire des indicateurs</h2>
+                        </div>
+                        <div class="card-body">
+                            <p>Liste de tous les indicateurs présentant leurs définitions, formules et sources de données.</p>
+                        </div>
+                        <div class="card-footer text-right">
+                            <a href="https://communaute.inclusion.beta.gouv.fr/doc/pilotage/dictionnaire-des-indicateurs/" target="_blank" class="btn btn-sm btn-ico btn-link stretched-link">
+                                <span>Accéder au dictionnaire</span>
+                                <i class="ri-external-link-line ri-lg"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="col mb-3 mb-md-5">
+                    <div class="card c-card c-card--communaute c-card--hovershadow h-100 w-100">
+                        <div class="card-header">
+                            <h2 class="h2 m-0">Glossaire</h2>
+                        </div>
+                        <div class="card-body">
+                            <p>Comprenez les sigles utilisés dans nos tableaux</p>
+                        </div>
+                        <div class="card-footer text-right">
+                            <a href="https://communaute.inclusion.beta.gouv.fr/doc/communaute/glossaire-de-linclusion/" target="_blank" class="btn btn-sm btn-ico btn-link stretched-link">
+                                <span>Accéder au glossaire</span>
+                                <i class="ri-external-link-line ri-lg"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
 {% endblock %}


### PR DESCRIPTION
### Quoi ?

Mise a jour de la zone de contenu d'aide sur les pages "Stats".
Voir la carte notion pour plus d'infos https://www.notion.so/Modifier-page-des-tableaux-de-bord-529fc3f33cbe42958a3cc88705fee2ee

### Pourquoi ?

Pour fournir une aide à la prise en main des Tableaux de bord

### Comment ?

En remplacant le bloc de texte “Aide à la lecture et à l'utilisation de ces indicateurs/graphiques” par des `.cards` avec redirection vers la documentation

### Ou

Ces textes sont présent sur toutes les pages du C1 avec des tableaux de bord
Elles sont toutes derrière l’URL https://c1-review-deloo-update-stats-help-content.cleverapps.io/stats et ayant pour construction [https://c1-review-deloo-update-stats-help-content.cleverapps.io/stats/[rôle]/[nom_du_tebleau_de_bord]](https://c1-review-deloo-update-stats-help-content.cleverapps.io/stats/%5Br%C3%B4le%5D/%5Bnom_du_tebleau_de_bord%5D)
Exemple  : https://emplois.inclusion.beta.gouv.fr/stats/ddets/hiring/