### PR TITLE
Envoyer un email automatique lorsqu’une une nouvelle structure est détectée après l’import de nouvelle SIAE

### DIFF
--- a/itou/siaes/management/commands/import_siae.py
+++ b/itou/siaes/management/commands/import_siae.py
@@ -14,6 +14,7 @@ and thus we need a proper tool to manage columns by their
 name instead of hardcoding column numbers as in `field = row[42]`.
 
 """
+from django.core import mail
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
@@ -253,6 +254,10 @@ class Command(BaseCommand):
             self.stdout.write(f"{siae.siret};{siae.kind};{siae.department};{siae.name};{siae.address_on_one_line}")
             siae.save()
         self.stdout.write("--- end of CSV output of all creatable_siaes ---")
+
+        activate_your_account_emails = (siae.activate_your_account_email() for siae in creatable_siaes)
+        connection = mail.get_connection()
+        connection.send_messages(activate_your_account_emails)
 
         self.stdout.write(f"{len(creatable_siaes)} structures will be created")
         self.stdout.write(f"{len([s for s in creatable_siaes if s.coords])} structures will have geolocation")

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -374,6 +374,15 @@ class Siae(AddressMixin, OrganizationAbstract):
         body = "siaes/email/new_signup_activation_email_to_official_contact_body.txt"
         return get_email_message(to, context, subject, body)
 
+    def activate_your_account_email(self):
+        if self.has_members or not self.auth_email:
+            raise ValidationError("Siae cannot be signed up for, this should never happen.")
+        to = [self.auth_email]
+        context = {"siae": self, "signup_url": reverse("signup:siae_select")}
+        subject = "siaes/email/activate_your_account_subject.txt"
+        body = "siaes/email/activate_your_account_body.txt"
+        return get_email_message(to, context, subject, body)
+
     @property
     def grace_period_end_date(self):
         """

--- a/itou/templates/siaes/email/activate_your_account_body.txt
+++ b/itou/templates/siaes/email/activate_your_account_body.txt
@@ -1,0 +1,19 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% load format_filters %}
+{% block body %}
+Bonjour,
+
+Le compte de votre {{siae.kind}} SIRET {{siae.siret}} vient d’être créé sur les emplois de l’inclusion !
+
+Pour activer le compte de l’entreprise, pouvoir embaucher, obtenir des PASS IAE et créer vos fiches salarié, activez votre compte en cliquant ici {{ itou_protocol }}://{{ itou_fqdn }}{{ signup_url }}
+
+Vous avez déjà un compte employeur sur les emplois de l’inclusion ?
+- demandez à un de vos collègues qui n’en a pas encore d’activer le compte
+- vous recevrez l’e-mail d’authentification nécessaire à la première connexion
+- Votre collègue rejoindra le compte de la SIAE.
+- Elle pourra ensuite vous inviter à le rejoindre aussi via le bouton « gérer les collaborateurs de ma structure ».
+
+Pour en savoir plus, consultez notre mode d’emploi {{ itou_community_url }}/aide/emplois/mode-demploi-employeur-solidaire/
+
+Cordialement,
+{% endblock body%}

--- a/itou/templates/siaes/email/activate_your_account_subject.txt
+++ b/itou/templates/siaes/email/activate_your_account_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+Activez le compte de votre {{siae.kind}} {{siae.name}} sur les emplois de l'inclusion
+{% endblock %}


### PR DESCRIPTION
### Quoi ?

En tant que SIAE récemment intégrée dans la base de donnée, on m’informe que je peux désormais créer mon compte sur les emplois de l’inclusion.

### Pourquoi ?

A ce jour, un grand nombre de SIAE n’ont encore jamais activé leur compte sur les emplois de l’inclusion. Cela les empêche d’embaucher, obtenir des PASS IAE et envoyer leurs fiches a l’ASP. Souvent, ce sont des SIAE qui ont plusieurs structures, donc elles vont créer une antenne, au lieu de rejoindre la bonne structure mère. Ensuite, au moment de l’envoi des fiches salarié, elles envoient sur la mauvaise annexe fi, et contactent le support. Beaucoup de temps en régularisation

### Comment ?

Envoyer un email automatique lorsqu’une une nouvelle structure est détectée après l’import de nouvelle SIAE. 
Management Command `import_siae`

### Note 
Traiter les EA, les EATT et les GEIQ dans une seconde PR si besoin