### PR TITLE
Lien vers "questions à la communauté" dans le footer

### DIFF
--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -27,7 +27,7 @@
                         <i class="ri-external-link-line ml-1 font-weight-bold"></i>
                     </li>
                     <li>
-                        <a href="{{ ITOU_COMMUNITY_URL }}/c/retours-sur-le-site/2" rel="noopener" target="_blank" title="Questions à la communauté (ouverture dans un nouvel onglet)">
+                        <a href="{{ ITOU_COMMUNITY_URL }}/communautes/difficultes-ou-interrogations/forum/difficultes-ou-interrogations/" rel="noopener" target="_blank" title="Questions à la communauté (ouverture dans un nouvel onglet)">
                             Questions à la communauté
                         </a>
                         <i class="ri-external-link-line ml-1 font-weight-bold"></i>


### PR DESCRIPTION
### Quoi ?

Mise à jour du lien du footer "Questions à la communauté"

### Pourquoi ?

Le lien redirige vers une page 404 (du C3)

### Comment ?

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran (optionnel)

Mise à jour de l'url dans le template