### PR TITLE
Supprimer la suspension si la date de début de contrat est égale à la date de début de suspension du pass

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -338,12 +338,16 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     def unsuspend(self, hiring_start_at):
         """
         When a job application is accepted, the approval is "unsuspended":
-        we do it by setting its end_date to JobApplication.hiring_start_at - 1 day.
+        we do it by setting its end_date to JobApplication.hiring_start_at - 1 day,
+        or deleting if JobApplication.hiring starts the day suspension starts.
         """
         active_suspension = self.last_in_progress_suspension
         if active_suspension and self.can_be_unsuspended:
-            active_suspension.end_at = hiring_start_at - relativedelta(days=1)
-            active_suspension.save()
+            if active_suspension.start_at == hiring_start_at:
+                active_suspension.delete()
+            else:
+                active_suspension.end_at = hiring_start_at - relativedelta(days=1)
+                active_suspension.save()
 
     # Postpone start date.
 


### PR DESCRIPTION
### Quoi ?

cf titre

### Pourquoi ?

Cas nominal : Le Pass d’un candidat est suspendu. Le candidat est embauché plus tard. La date de fin de suspension du Pass est mise à jour à la veille de la date de début du nouveau contrat.

Règles métier :

- pas d'embauche dans le passé (la date de début de contrat est au minimum aujourd’hui)
- pas de suspension dans le futur (la date de début de suspension est au maximum aujourd’hui)

Cas en erreur :  Le Pass d’un candidat est suspendu au jour J. Le candidat est embauché *le même jour J*. La plateforme tente de mettre à jour la date de fin de suspension à J-1.

⇒ date de fin de suspension (J-1) est inférieur la date de début de suspension (J) … KO

### Comment ?

Mise à jour de la méthode `unsuspend` de la class `Approval`. Test de l'équivalence entre la date de début de suspension et la date d'embauche.