### PR TITLE
tests: Corriger les erreurs pickle.

### DIFF
--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -448,7 +448,7 @@ class EvaluationCampaignManagerTest(TestCase):
         # check links between EvaluatedSiae and EvaluatedJobApplication
         evaluated_siae = EvaluatedSiae.objects.first()
         for evaluated_job_application in EvaluatedJobApplication.objects.all():
-            with self.subTest(evaluated_job_application=evaluated_job_application):
+            with self.subTest(evaluated_job_application_pk=evaluated_job_application.pk):
                 self.assertEqual(evaluated_siae, evaluated_job_application.evaluated_siae)
 
         # retry on populated campaign
@@ -823,8 +823,8 @@ class EvaluatedJobApplicationModelTest(TestCase):
         ]
 
         for state in editable_status:
-            with mock.patch.object(EvaluatedJobApplication, "state", state):
-                with self.subTest(state=state):
+            with self.subTest(state=state):
+                with mock.patch.object(EvaluatedJobApplication, "state", state):
                     self.assertEqual(
                         evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.EDITABLE,
                         evaluated_job_application.should_select_criteria,
@@ -838,8 +838,8 @@ class EvaluatedJobApplicationModelTest(TestCase):
         ]
 
         for state in not_editable_status:
-            with mock.patch.object(EvaluatedJobApplication, "state", state):
-                with self.subTest(state=state):
+            with self.subTest(state=state):
+                with mock.patch.object(EvaluatedJobApplication, "state", state):
                     self.assertEqual(
                         evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.NOTEDITABLE,
                         evaluated_job_application.should_select_criteria,
@@ -863,8 +863,8 @@ class EvaluatedJobApplicationModelTest(TestCase):
             for state in evaluation_enums.EvaluatedJobApplicationsState.choices
             if state != evaluation_enums.EvaluatedJobApplicationsState.PENDING
         ]:
-            with mock.patch.object(EvaluatedJobApplication, "state", state):
-                with self.subTest(state=state):
+            with self.subTest(state=state):
+                with mock.patch.object(EvaluatedJobApplication, "state", state):
                     self.assertEqual(
                         evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.NOTEDITABLE,
                         evaluated_job_application.should_select_criteria,

--- a/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
@@ -436,11 +436,11 @@ class SiaeUploadDocsViewTest(TestCase):
         self.assertEqual(evaluated_administrative_criteria, response.context["evaluated_administrative_criteria"])
 
         for k, v in s3_form_values.items():
-            with self.subTest(k=k, v=v):
+            with self.subTest("s3_form_values", k=k):
                 self.assertEqual(v, response.context["s3_form_values"][k])
 
         for k, v in s3_upload_config.items():
-            with self.subTest(k=k, v=v):
+            with self.subTest("s3_upload_config", k=k):
                 self.assertEqual(v, response.context["s3_upload_config"][k])
 
     def test_post(self):


### PR DESCRIPTION
We have to pay attention to subTests.

During parallel runs, the tests fail (in very verbose mode, after many
many attempts) with this error message:

    subtest: test_access (itou.www.siae_evaluations_views.tests.tests_siaes_views.SiaeUploadDocsViewTest) (
        k='fields',
        v={'x-amz-algorithm': 'AWS4-HMAC-SHA256', 'x-amz-credential': [...] }
    )

    Unfortunately, the subtest that failed cannot be pickled, so the parallel
    test runner cannot handle it cleanly. Here is the pickling error:
    > Can't pickle local object 'convert_exception_to_response.<locals>.inner'

My understanding is that:

- subTests might be serialized by the test runner, waiting for a worker
  to pick it up if the parallel testing is activated. All subTests must
  be picklable.
- in its current form, the subTest that systematically crashes can't
  realistically "fail" (it's a trivial assertEqual, don't see how it
  could be flaky)
- the params that we pass to it though, are a little complex for no good
  reason, so I tried only simplifing those. There is no reason why a
  dict couldn't be pickled, but anyway. Doesn't hurt and is more
  readable.
- then I went looking for other instances of subTest and noticed that
  there are some times where we did register a mock outside of the
  subTest, meaning that it may not be accessible anymore when the
  subTest is deserialized. So I exchanged their order.

I ran the whole tests in full parallel 10000 times after that and never
saw any pickling errors again.

Conclusion: pay attention to the subTests.
