### PR TITLE
Controle a posteriori : patch urgent en phase contradictoire pour prevenir des incoherences de données

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -11,6 +11,13 @@ class EvaluatedSiaesInline(admin.TabularInline):
     readonly_fields = ("id_link", "reviewed_at", "state")
     extra = 0
 
+    def get_queryset(self, request):
+        queryset = super(EvaluatedSiaesInline, self).get_queryset(request)
+        queryset = queryset.prefetch_related(
+            "evaluated_job_applications", "evaluated_job_applications__evaluated_administrative_criteria"
+        )
+        return queryset
+
     def state(self, obj):
         return obj.state
 
@@ -28,6 +35,11 @@ class EvaluatedJobApplicationsInline(admin.TabularInline):
     fields = ("id_link", "approval", "job_seeker", "state")
     readonly_fields = ("id_link", "approval", "job_seeker", "state")
     extra = 0
+
+    def get_queryset(self, request):
+        queryset = super(EvaluatedJobApplicationsInline, self).get_queryset(request)
+        queryset = queryset.prefetch_related("evaluated_administrative_criteria")
+        return queryset
 
     def state(self, obj):
         return obj.state
@@ -137,6 +149,13 @@ class EvaluatedSiae(admin.ModelAdmin):
         EvaluatedJobApplicationsInline,
     ]
 
+    def get_queryset(self, request):
+        queryset = super(EvaluatedSiae, self).get_queryset(request)
+        queryset = queryset.prefetch_related(
+            "evaluated_job_applications", "evaluated_job_applications__evaluated_administrative_criteria"
+        )
+        return queryset
+
     def state(self, obj):
         return obj.state
 
@@ -145,10 +164,18 @@ class EvaluatedSiae(admin.ModelAdmin):
 class EvaluatedJobApplication(admin.ModelAdmin):
     list_display = ("evaluated_siae", "job_application", "approval", "job_seeker")
     list_display_links = ("job_application",)
-    readonly_fields = ("evaluated_siae", "job_application", "approval", "job_seeker")
+    readonly_fields = ("evaluated_siae", "job_application", "approval", "job_seeker", "state")
     inlines = [
         EvaluatedAdministrativeCriteriaInline,
     ]
+
+    def get_queryset(self, request):
+        queryset = super(EvaluatedJobApplication, self).get_queryset(request)
+        queryset = queryset.prefetch_related("evaluated_administrative_criteria")
+        return queryset
+
+    def state(self, obj):
+        return obj.state
 
     def approval(self, obj):
         if obj.job_application.approval:

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -417,8 +417,11 @@ class EvaluatedSiae(models.Model):
         ):
             return evaluation_enums.EvaluatedSiaeState.SUBMITTABLE
 
+        # PENDING and reviewed_at is none !!
+        # OR PENDING with uploaded_at > reviewed_at
         if any(
             eval_admin_crit.review_state == evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING
+            and (not self.reviewed_at or (eval_admin_crit.submitted_at > self.reviewed_at))
             for eval_job_app in self.evaluated_job_applications.all()
             for eval_admin_crit in eval_job_app.evaluated_administrative_criteria.all()
         ):

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -386,6 +386,7 @@ class EvaluatedSiae(models.Model):
         body = "siae_evaluations/email/to_institution_submitted_by_siae_body.txt"
         return get_email_message(to, context, subject, body)
 
+    # fixme vincentporte : rsebille suggests to replace cached_property with prefetch_related
     @cached_property
     def state(self):
 
@@ -479,6 +480,7 @@ class EvaluatedJobApplication(models.Model):
     def __str__(self):
         return f"{self.job_application}"
 
+    # fixme vincentporte : rsebille suggests to replace cached_property with prefetch_related
     @cached_property
     def state(self):
 

--- a/itou/templates/siae_evaluations/includes/criterion_infos.html
+++ b/itou/templates/siae_evaluations/includes/criterion_infos.html
@@ -5,7 +5,9 @@
         </h3>
     </div>
     <div class="col-md-3 mt-1 text-right">
-        {%if review_state == "ACCEPTED" %}
+        {% if review_state == "PENDING" %}
+            <p class="text-success"><i class="ri-checkbox-circle-line"></i>En attente</p>
+        {% elif review_state == "ACCEPTED" %}
             <p class="text-success"><i class="ri-checkbox-circle-line"></i> Validé</p>
         {% elif review_state == "REFUSED" or review_state == "REFUSED_2" %}
             <p class="text-danger"><i class="ri-indeterminate-circle-line"></i> Refusé</p>


### PR DESCRIPTION
### Quoi ?

Pendant la phase contradictoire, les `review_state` peuvent être mis à jour par la SIAE et par la DDETS en même temps. Ce qui crée des incohérences de données dans le calcul de l'état de `EvaluatedSiae`

### Pourquoi ?

1. Test dans la méthode `state` de `EvaluatedSiae` insuffisant
2. plus un ajout de champ de l'admin et d'un label dans le front pour mieux suivre les états.


### Comment ?

mise du calcul de la méthode `state` dans le modèle `EvaluatedSiae`

### NOTE POST MEP
- Rechercher les cas de `EvaluatedAdministrativeCriteria` avec un `review_state` à `REFUSED_2` mais dont la date `submitted_at` est inférieure à la date `reviewed_at`de la `EvaluatedSiae` mère 
- Mettre à jour ces cas à `REFUSED`