### PR TITLE
Evolution des stats employeur : "Ensemblier" des structures

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -540,7 +540,7 @@ METABASE_DASHBOARD_IDS = {
     "stats_public": 119,
     # Employer stats.
     "stats_siae_etp": 128,
-    "stats_siae_hiring": 165,
+    "stats_siae_hiring": 185,
     # Prescriber stats.
     "stats_cd": 118,
     "stats_pe_delay_main": 168,

--- a/itou/metabase/management/commands/_siaes.py
+++ b/itou/metabase/management/commands/_siaes.py
@@ -52,6 +52,12 @@ TABLE_COLUMNS = [
     },
     {"name": "nom", "type": "varchar", "comment": "Nom de la structure", "fn": lambda o: o.display_name},
     {
+        "name": "nom_complet",
+        "type": "varchar",
+        "comment": "Nom complet de la structure avec type et ID",
+        "fn": lambda o: f"{o.kind} - ID {o.id} - {o.display_name}",
+    },
+    {
         "name": "description",
         "type": "varchar",
         "comment": "Description de la structure",

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -3,7 +3,7 @@ Populate metabase with fluxIAE data and some custom tables for our needs.
 
 For itou data, see the other script `populate_metabase_itou.py`.
 
-At this time this script is only supposed to run manually on your local dev, not in production.
+This script is launched manually every week by Supportix on a fast machine, not production.
 
 It manipulates large dataframes in memory (~10M rows) and thus is not optimized for production low memory environment.
 

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -113,9 +113,10 @@ class Command(BaseCommand):
             self.stdout.write("Populating metabase is not allowed in this environment.")
             return
 
-        send_slack_message(
-            ":rocket: Début de la mise à jour hebdomadaire de Metabase avec les dernières données FluxIAE :rocket:"
-        )
+        if not self.dry_run:
+            send_slack_message(
+                ":rocket: Début de la mise à jour hebdomadaire de Metabase avec les dernières données FluxIAE :rocket:"
+            )
 
         self.populate_fluxiae_referentials()
 
@@ -135,10 +136,11 @@ class Command(BaseCommand):
         # Build custom tables by running raw SQL queries on existing tables.
         build_final_tables(dry_run=self.dry_run)
 
-        send_slack_message(
-            ":white_check_mark: Fin de la mise à jour hebdomadaire de Metabase avec les"
-            " dernières données FluxIAE :white_check_mark:"
-        )
+        if not self.dry_run:
+            send_slack_message(
+                ":white_check_mark: Fin de la mise à jour hebdomadaire de Metabase avec les"
+                " dernières données FluxIAE :white_check_mark:"
+            )
 
     def handle(self, dry_run=False, **options):
         self.dry_run = dry_run

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -462,9 +462,10 @@ class Command(BaseCommand):
             self.stdout.write("Populating metabase is not allowed in this environment.")
             return
 
-        send_slack_message(
-            ":rocket: Début de la mise à jour quotidienne de Metabase avec les dernières données C1 :rocket:"
-        )
+        if not self.dry_run:
+            send_slack_message(
+                ":rocket: Début de la mise à jour quotidienne de Metabase avec les dernières données C1 :rocket:"
+            )
 
         # Load once and for all the list of all active siae pks in memory and reuse them multiple times in various
         # queries to avoid additional joins of the SiaeConvention model and the non trivial use of the
@@ -495,10 +496,11 @@ class Command(BaseCommand):
             if VERBOSE_SLACK_MESSAGES:
                 send_slack_message(f"Fin de l'étape {update.__name__} :white_check_mark:")
 
-        send_slack_message(
-            ":white_check_mark: Fin de la mise à jour quotidienne de Metabase avec les"
-            " dernières données C1 :white_check_mark:"
-        )
+        if not self.dry_run:
+            send_slack_message(
+                ":white_check_mark: Fin de la mise à jour quotidienne de Metabase avec les"
+                " dernières données C1 :white_check_mark:"
+            )
 
     @timeit
     def handle(self, dry_run=False, **options):

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -3,7 +3,7 @@ Populate metabase database with transformed data from itou database.
 
 For fluxIAE data, see the other script `populate_metabase_fluxiae.py`.
 
-This script runs every night in production via a cronjob, but can also be run from your local dev.
+This script is launched by a github action every night on a fast machine, not production.
 
 This script reads data from the itou production database,
 transforms it for the convenience of our metabase non tech-savvy,

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -67,10 +67,6 @@ from itou.users.models import User
 from itou.utils.slack import send_slack_message
 
 
-# Emit more verbose slack messages about every step, not just the beginning and the ending of the command.
-VERBOSE_SLACK_MESSAGES = False
-
-
 if settings.METABASE_SHOW_SQL_REQUESTS:
     # Unfortunately each SQL query log appears twice ¬_¬
     mylogger = logging.getLogger("django.db.backends")
@@ -474,27 +470,18 @@ class Command(BaseCommand):
         # and better performance.
         self.active_siae_pks = [siae_pk for siae_pk in Siae.objects.active().values_list("pk", flat=True)]
 
-        updates = [
-            self.populate_siaes,
-            self.populate_job_descriptions,
-            self.populate_organizations,
-            self.populate_job_seekers,
-            self.populate_job_applications,
-            self.populate_selected_jobs,
-            self.populate_approvals,
-            self.populate_rome_codes,
-            self.populate_insee_codes,
-            self.populate_departments,
-            self.build_final_tables,
-            self.report_data_inconsistencies,
-        ]
-
-        for update in updates:
-            if VERBOSE_SLACK_MESSAGES:
-                send_slack_message(f"Début de l'étape {update.__name__} :rocket:")
-            update()
-            if VERBOSE_SLACK_MESSAGES:
-                send_slack_message(f"Fin de l'étape {update.__name__} :white_check_mark:")
+        self.populate_siaes()
+        self.populate_job_descriptions()
+        self.populate_organizations()
+        self.populate_job_seekers()
+        self.populate_job_applications()
+        self.populate_selected_jobs()
+        self.populate_approvals()
+        self.populate_rome_codes()
+        self.populate_insee_codes()
+        self.populate_departments()
+        self.build_final_tables()
+        self.report_data_inconsistencies()
 
         if not self.dry_run:
             send_slack_message(

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -487,7 +487,7 @@
                         {% if can_view_stats_siae_hiring %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_siae_hiring' %}">Voir les données de recrutement de ma structure (Plateforme de l'inclusion)</a>
+                                <a href="{% url 'stats:stats_siae_hiring' %}">Voir les données de recrutement de mes structures (Plateforme de l'inclusion)</a>
                                 <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
                         {% endif %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -500,7 +500,7 @@
                         {% if can_view_stats_pe %}
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_pe_delay_main' %}">Voir les données d’entrée en IAE</a>
+                                <a href="{% url 'stats:stats_pe_delay_main' %}">Voir les données du délai d'entrée en IAE</a>
                                 <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
                             <li class="card-text mb-3">

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -27,16 +27,7 @@ def get_current_organization_and_perms(request):
         # SIAE ?
         siae_pk = request.session.get(settings.ITOU_SESSION_CURRENT_SIAE_KEY)
         if siae_pk:
-            # Sorry I could not find an elegant DNRY one-query solution ¯\_(ツ)_/¯
-            user_siae_set_pks = request.user.siae_set.active_or_in_grace_period().values_list("pk", flat=True)
-            # SIAE members can be deactivated, hence filtering on `membership.is_active`
-            memberships = (
-                request.user.siaemembership_set.active()
-                .select_related("siae")
-                .filter(siae__pk__in=user_siae_set_pks)
-                .order_by("created_at")
-                .all()
-            )
+            memberships = request.user.active_or_in_grace_period_siae_memberships()
             user_siaes = [membership.siae for membership in memberships]
 
             for membership in memberships:

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -166,19 +166,23 @@ def stats_siae_etp(request):
 @login_required
 def stats_siae_hiring(request):
     """
-    SIAE stats shown to their own members.
-    They can only view data for their own SIAE.
+    SIAE stats shown only to their own members.
+    Employers can see stats for all their SIAEs at once, not just the one currently being worked on.
     These stats are about hiring and are built directly from C1 data.
     """
     current_org = get_stats_siae_hiring_current_org(request)
     context = {
-        "page_title": "Données de recrutement de ma structure (Plateforme de l'inclusion)",
+        "page_title": "Données de recrutement de mes structures (Plateforme de l'inclusion)",
         "matomo_custom_url_suffix": format_region_and_department_for_matomo(current_org.department),
     }
     return render_stats(
         request=request,
         context=context,
-        params={C1_SIAE_FILTER_KEY: str(current_org.id)},
+        params={
+            C1_SIAE_FILTER_KEY: [
+                str(membership.siae_id) for membership in request.user.active_or_in_grace_period_siae_memberships()
+            ]
+        },
     )
 
 


### PR DESCRIPTION
### Quoi ?

- Evolution des stats employeur : "Ensemblier" des structures. Pour la première fois on montre les stats aggrégées de toutes les structures C1 dont l'employeur est membre, pas seulement la structure C1 actuellement sélectionnée.
- Refactorisation de code commun pour récupérer la liste des structures C1 de l'employeur.
- Ajout d'une colonne `structures.nom_complet` (e.g. `ACI - ID 1058 - Emmaüs Alternatives`) dans Metabase qui sera utilisée dans le TDB employeur pour identifier clairement les différentes structures C1 de l'employeur.
- Améliorations mineures des scripts Metabase en passant.

### Pourquoi ?

En webinaire employeur en parlant de ce TDB employeur on a eu de nombreux retours comme quoi les employeurs souhaitaient voir les données de toutes leurs structures C1 simultanément.
