### PR TITLE
Déblocage des employeurs et des prescripteurs à l’étape de saisie du mail du candidat

### DIFF
--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -11,7 +11,7 @@
 
                 {% csrf_token %}
 
-                {% bootstrap_form_errors form type="non_field_errors" %}
+                {% bootstrap_form_errors form type="all" %}
 
                 {% bootstrap_form form %}
 

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -40,7 +40,7 @@
                         </div>
                         <div class="col-6 col-lg-auto">
                             {# Reload this page and show a modal containing more information about the job seeker. #}
-                            <button type="submit" name="preview" class="btn btn-primary">Suivant</button>
+                            <button type="submit" name="preview" value="1" class="btn btn-primary">Suivant</button>
                         </div>
                     </div>
                 {% endbuttons %}

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -159,7 +159,7 @@ def step_check_job_seeker_nir(request, siae_pk, template_name="apply/submit_step
     preview_mode = False
 
     # Clean nir in session, especially in case of using back button
-    if "nir" in session_data:
+    if request.method == "GET" and "nir" in session_data:
         session_data["nir"] = None
         request.session.modified = True
 


### PR DESCRIPTION
### Quoi ?

Des employeurs et des prescripteurs ne peuvent pas passer l’étape de saisie du mail du candidat.

### Pourquoi ?

Le bouton suivant ne semble pas fonctionner sur certains navigateurs.

### Comment ?

Correction sur le balise `button` en ajoutant l'attribut `value`.

### Autre

J'en profite pour remettre les messages d'erreur comme avant sur l'étape de saisie de NIR car il y a eu des remontées d'utilisateurs bloqués à cette étape. J'émets l'hypothèse qu'ils avaient une erreur non affichée. 

