### PR TITLE
Active l'authentification par token pour le endpoint data.inclusion

### DIFF
--- a/itou/api/data_inclusion_api/tests.py
+++ b/itou/api/data_inclusion_api/tests.py
@@ -19,7 +19,7 @@ class DataInclusionStructureTest(APITestCase):
 
     def test_list_structures_unauthenticated(self):
         response = self.client.get(self.url, format="json")
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
 
     def test_list_structures(self):
         def _str_with_tz(dt):

--- a/itou/api/data_inclusion_api/views.py
+++ b/itou/api/data_inclusion_api/views.py
@@ -1,4 +1,4 @@
-from rest_framework import generics
+from rest_framework import authentication, generics
 
 from itou.api.data_inclusion_api import serializers
 from itou.siaes.models import Siae
@@ -15,3 +15,7 @@ class DataInclusionStructureView(generics.ListAPIView):
 
     queryset = Siae.objects.active().order_by("created_at").select_related("convention")
     serializer_class = serializers.DataInclusionStructureSerializer
+    authentication_classes = [
+        authentication.TokenAuthentication,
+        authentication.SessionAuthentication,
+    ]


### PR DESCRIPTION
### Quoi ?

Active l'authentification par token pour le endpoint data.inclusion

### Pourquoi ?

Accès programmatique

