### PR TITLE
Contrôle a posteriori : desambiguation des labels pour les DDETS pendant la phase contradictoire

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -490,6 +490,20 @@ class EvaluatedJobApplication(models.Model):
         if len(self.evaluated_administrative_criteria.all()) == 0:
             return evaluation_enums.EvaluatedJobApplicationsState.PENDING
 
+        if any(eval_admin_crit.proof_url == "" for eval_admin_crit in self.evaluated_administrative_criteria.all()):
+            return evaluation_enums.EvaluatedJobApplicationsState.PROCESSING
+
+        if any(
+            eval_admin_crit.submitted_at is None for eval_admin_crit in self.evaluated_administrative_criteria.all()
+        ):
+            return evaluation_enums.EvaluatedJobApplicationsState.UPLOADED
+
+        if any(
+            eval_admin_crit.review_state == evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING
+            for eval_admin_crit in self.evaluated_administrative_criteria.all()
+        ):
+            return evaluation_enums.EvaluatedJobApplicationsState.SUBMITTED
+
         if any(
             eval_admin_crit.review_state == evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2
             for eval_admin_crit in self.evaluated_administrative_criteria.all()
@@ -507,20 +521,6 @@ class EvaluatedJobApplication(models.Model):
             for eval_admin_crit in self.evaluated_administrative_criteria.all()
         ):
             return evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
-
-        if any(eval_admin_crit.proof_url == "" for eval_admin_crit in self.evaluated_administrative_criteria.all()):
-            return evaluation_enums.EvaluatedJobApplicationsState.PROCESSING
-
-        if any(
-            eval_admin_crit.submitted_at is None for eval_admin_crit in self.evaluated_administrative_criteria.all()
-        ):
-            return evaluation_enums.EvaluatedJobApplicationsState.UPLOADED
-
-        if any(
-            eval_admin_crit.review_state == evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING
-            for eval_admin_crit in self.evaluated_administrative_criteria.all()
-        ):
-            return evaluation_enums.EvaluatedJobApplicationsState.SUBMITTED
 
     @cached_property
     def should_select_criteria(self):

--- a/itou/templates/siae_evaluations/includes/criterion_infos.html
+++ b/itou/templates/siae_evaluations/includes/criterion_infos.html
@@ -5,9 +5,7 @@
         </h3>
     </div>
     <div class="col-md-3 mt-1 text-right">
-        {% if review_state == "PENDING" %}
-            <p class="text-success"><i class="ri-checkbox-circle-line"></i>En attente</p>
-        {% elif review_state == "ACCEPTED" %}
+        {% if review_state == "ACCEPTED" %}
             <p class="text-success"><i class="ri-checkbox-circle-line"></i> Validé</p>
         {% elif review_state == "REFUSED" or review_state == "REFUSED_2" %}
             <p class="text-danger"><i class="ri-indeterminate-circle-line"></i> Refusé</p>

--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
@@ -1,5 +1,5 @@
 <div class="row">
-    <div class="col-md-9">
+    <div class="col-md-8">
         <h3 class="h2">Auto-prescription pour
             <span class="text-muted">
                 {{job_seeker.get_full_name|title}}
@@ -7,7 +7,7 @@
         </h3>
         <p class="m-0">PASS IAE :&nbsp;<b>{{ approval.number_with_spaces }}</b> délivré le {{ approval.start_at|date:"d E Y" }}</p>
     </div>
-    <div class="col-md-3 text-right">
+    <div class="col-md-4 text-right">
         <p class="small mb-0">
             {% if state == "SUBMITTED" and reviewed_at%}
                 <p class="badge badge-pilotage float-right">Nouveaux justificatifs à traiter</p>

--- a/itou/templates/siae_evaluations/includes/siae_infos.html
+++ b/itou/templates/siae_evaluations/includes/siae_infos.html
@@ -7,15 +7,15 @@
     <div class="col-lg-3 col-md-3 col-4">
         <p class="small mb-0">
             {% if evaluated_siae.state == "SUBMITTED"%}
-                <p class="badge badge-pilotage float-right">À traiter</p>
+                <p class="badge badge-pilotage float-right">{%if evaluated_siae.reviewed_at%}Phase contradictoire - {%endif%}À traiter</p>
             {%elif evaluated_siae.state == "REFUSED" or evaluated_siae.state == "ACCEPTED" %}
-                <p class="badge badge-pilotage float-right">En cours</p>
+                <p class="badge badge-pilotage float-right">{%if evaluated_siae.reviewed_at%}Phase contradictoire - {%endif%}En cours</p>
             {%elif evaluated_siae.state == "REVIEWED" %}
                 <p class="badge badge-communaute-light float-right">Résultats transmis</p>
             {%elif evaluated_siae.state == "ADVERSARIAL_STAGE" %}
                 <p class="badge badge-marche-light float-right">Phase contradictoire</p>
             {%else%}
-                <p class="badge badge-emploi float-right">En attente</p>
+                <p class="badge badge-emploi float-right">{%if evaluated_siae.reviewed_at%}Phase contradictoire - {%endif%}En attente</p>
             {%endif%}
         </p>
     </div>


### PR DESCRIPTION
### Quoi ?

Rendre plus explicite les labels pour les DDETS pendant la phase contradictoire.
+ suppression du label "en attente" générateur d'ambiguité pour la SIAE.

### Pourquoi ?

Certains labels : 
* laissaient penser que le passage en phase contradictoire avait été annulé pour la SIAE et que par conséquent, tout le travail déjà réalisé par la DDETS était à refaire,
* ne permettaient pas aux DDETS de retrouver rapidement les dernières pièces à valider

### Comment ?

* mise à jour des templates
* inversion des contrôles dans la méthode `state` de `EvaluatedJobApplication`