### PR TITLE
Mise à jour de Django vers la version 4.0.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 Pillow==8.4.0  # https://github.com/python-pillow/Pillow
 psycopg2-binary==2.9.2  # https://github.com/psycopg/psycopg2
-requests==2.26.0  # https://github.com/psf/requests
+requests==2.28.1  # https://github.com/psf/requests
 python-dateutil==2.8.2  # https://pypi.org/project/python-dateutil/
 openpyxl==3.0.9  # https://openpyxl.readthedocs.io/en/stable/
 
@@ -12,19 +12,19 @@ Unidecode==1.3.2  # https://github.com/avian2/unidecode
 # Django
 # ------------------------------------------------------------------------------
 
-django==4.0.5  # https://www.djangoproject.com/
+django==4.0.6  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.46.0  # https://github.com/pennersr/django-allauth
 
 # django-anymail
-django-anymail==8.4  # https://github.com/anymail/django-anymail
+django-anymail==8.6  # https://github.com/anymail/django-anymail
 
 # Django-XWorkflows
 django-xworkflows==1.0.0  # https://github.com/rbarrois/django_xworkflows
 
 # DRF (Django Rest Framework)
-djangorestframework==3.12.4  # https://www.django-rest-framework.org/
+djangorestframework==3.13.1  # https://www.django-rest-framework.org/
 
 # DRF-Spectacular (Django Rest Framework Spectacular, open API schema browser)
 drf-spectacular==0.21.0  # https://github.com/tfranzel/drf-spectacular
@@ -36,13 +36,13 @@ django-filter==21.1 # https://django-filter.readthedocs.io/en/stable/
 # ------------------------------------------------------------------------------
 
 # Bootstrap 4 for Django
-django-bootstrap4==21.1  # https://github.com/zostera/django-bootstrap4
+django-bootstrap4==22.1  # https://github.com/zostera/django-bootstrap4
 
 # Enhance select fields in forms with jQuery Select plugin
-django_select2==7.9.0  # https://github.com/codingjoe/django-select2
+django_select2==7.10.0  # https://github.com/codingjoe/django-select2
 
 # Render Markdown in HTML
-markdown==3.3.6  # https://github.com/Python-Markdown/markdown
+markdown==3.3.7  # https://github.com/Python-Markdown/markdown
 
 # Data management
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
### Quoi ?

Mise à jour de Django vers la version 4.0.6 et de quelques paquets liés à Django (pas forcément nécessaire, mais de bon augure).

### Pourquoi ?

Une CVE est apparue le 4 juillet : https://www.djangoproject.com/weblog/2022/jul/04/security-releases/ 

### Comment ?

Changement des versions dans les dépendances.
