### PR TITLE
Fix flaky test

### DIFF
--- a/itou/www/search/tests.py
+++ b/itou/www/search/tests.py
@@ -110,11 +110,6 @@ class SearchSiaeTest(TestCase):
         JobApplicationFactory(to_siae=siae)
         created_siaes.append(siae)
 
-        # No job description and a job application
-        siae = SiaeFactory(department="44", coords=guerande.coords, post_code="44350")
-        JobApplicationFactory(to_siae=siae)
-        created_siaes.append(siae)
-
         # No job description, no job application.
         siae = SiaeFactory(department="44", coords=guerande.coords, post_code="44350")
         created_siaes.append(siae)
@@ -126,8 +121,10 @@ class SearchSiaeTest(TestCase):
         response = self.client.get(self.url, {"city": guerande.slug})
         siaes_results = response.context["siaes_page"]
 
-        for i, siae in enumerate(siaes_results):
-            self.assertEqual(siae.pk, created_siaes[i].pk)
+        self.assertEqual(
+            [siae.pk for siae in siaes_results],
+            [siae.pk for siae in created_siaes],
+        )
 
     def test_opcs_displays_card_differently(self):
         city = create_city_saint_andre()


### PR DESCRIPTION
job_app_score is None if there are no job descriptions, so the two
following factories have the same score, and their order in the
query_set is not always the same:
- No job description and a job application
- No job description, no job application.

### Quoi ?

Résumé des changements apportés.

### Pourquoi ?

Indiquer le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements.

### Comment ?

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.

### Autre (optionnel)

- si des tests manquent, indiquer la raison, la probabilité, et les risques associés à ce manque
- être explicite sur le délai attendu pour une revue de code
- être explicite sur la qualité attendue pour la revue de code
- etc.
