### PR TITLE
Ajout d'un message pour informer l’employeur lorsque l’adresse de son entreprise est erronée.

### DIFF
--- a/itou/common_apps/address/format.py
+++ b/itou/common_apps/address/format.py
@@ -3,7 +3,7 @@ import re
 from unidecode import unidecode
 
 from itou.asp.models import LaneExtension, LaneType, find_lane_type_aliases
-from itou.utils.apis.geocoding import get_geocoding_data
+from itou.utils.apis.geocoding import GeocodingDataException, get_geocoding_data
 
 
 ERROR_HEXA_CONVERSION = "Impossible de transformer cet objet en adresse HEXA"
@@ -52,10 +52,10 @@ def format_address(obj):
     if not obj.post_code or not obj.address_line_1:
         return None, ERROR_INCOMPLETE_ADDRESS_DATA
 
-    # first we use geo API to get a 'lane' and a number
-    address = get_geocoding_data(obj.address_line_1, post_code=obj.post_code)
-
-    if not address:
+    try:
+        # first we use geo API to get a 'lane' and a number
+        address = get_geocoding_data(obj.address_line_1, post_code=obj.post_code)
+    except GeocodingDataException:
         return None, ERROR_GEOCODING_API
 
     # Default values

--- a/itou/common_apps/address/models.py
+++ b/itou/common_apps/address/models.py
@@ -115,19 +115,6 @@ class AddressMixin(models.Model):
         self.coords = geocoding_data["coords"]
         self.geocoding_score = geocoding_data["score"]
 
-    def set_coords_and_address(self, address, post_code=None):
-        geocoding_data = get_geocoding_data(address, post_code=post_code)
-        if not geocoding_data:
-            logger.error("No geocoding data could be found for `%s - %s`", address, post_code)
-            return
-        self.coords = geocoding_data["coords"]
-        self.geocoding_score = geocoding_data["score"]
-        self.address_line_1 = geocoding_data["address_line_1"]
-        self.address_line_2 = ""
-        self.post_code = geocoding_data["post_code"]
-        self.department = department_from_postcode(self.post_code)
-        self.city = geocoding_data["city"]
-
     def clean(self):
         if self.department != department_from_postcode(self.post_code):
             raise ValidationError("Le département doit correspondre au code postal.")

--- a/itou/common_apps/address/tests.py
+++ b/itou/common_apps/address/tests.py
@@ -12,7 +12,8 @@ from itou.common_apps.address.models import lat_lon_to_coords
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.factories import JobSeekerFactory
 from itou.users.models import User
-from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
+from itou.utils.apis.geocoding import GeocodingDataException
+from itou.utils.mocks.geocoding import BAN_GEOCODING_API_NO_RESULT_MOCK, BAN_GEOCODING_API_RESULT_MOCK
 
 
 class UtilsAddressMixinTest(TestCase):
@@ -46,6 +47,17 @@ class UtilsAddressMixinTest(TestCase):
         self.assertEqual(prescriber.geocoding_score, expected_geocoding_score)
         self.assertEqual(prescriber.latitude, expected_latitude)
         self.assertEqual(prescriber.longitude, expected_longitude)
+
+    @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_NO_RESULT_MOCK)
+    def test_set_coords_with_bad_address(self, _mock_call_ban_geocoding_api):
+        """
+        Test `AddressMixin.set_coords()` with bad address.
+        Use `PrescriberOrganization` which inherits from abstract `AddressMixin`.
+        """
+        prescriber = PrescriberOrganization.objects.create(siret="12000015300011")
+
+        with self.assertRaises(GeocodingDataException):
+            prescriber.set_coords("10 PL 5 ANATOLE", post_code="75010")
 
 
 class UtilsDepartmentsTest(TestCase):

--- a/itou/common_apps/address/tests.py
+++ b/itou/common_apps/address/tests.py
@@ -47,44 +47,6 @@ class UtilsAddressMixinTest(TestCase):
         self.assertEqual(prescriber.latitude, expected_latitude)
         self.assertEqual(prescriber.longitude, expected_longitude)
 
-    @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
-    def test_set_coords_and_address(self, _mock_call_ban_geocoding_api):
-        """
-        Test `AddressMixin.set_coords_and_address()`.
-        Use `PrescriberOrganization` which inherits from abstract `AddressMixin`.
-        """
-        prescriber = PrescriberOrganization.objects.create(siret="12000015300011")
-
-        self.assertEqual(prescriber.address_line_1, "")
-        self.assertEqual(prescriber.address_line_2, "")
-        self.assertEqual(prescriber.post_code, "")
-        self.assertEqual(prescriber.city, "")
-        self.assertEqual(prescriber.coords, None)
-        self.assertEqual(prescriber.geocoding_score, None)
-        self.assertEqual(prescriber.latitude, None)
-        self.assertEqual(prescriber.longitude, None)
-
-        prescriber.set_coords_and_address("10 PL 5 MARTYRS LYCEE BUFFON", post_code="75015")
-        prescriber.save()
-
-        # Expected data comes from BAN_GEOCODING_API_RESULT_MOCK.
-        expected_address_line_1 = "10 Pl des Cinq Martyrs du Lycee Buffon"
-        expected_post_code = "75015"
-        expected_city = "Paris"
-        expected_coords = "SRID=4326;POINT (2.316754 48.838411)"
-        expected_latitude = 48.838411
-        expected_longitude = 2.316754
-        expected_geocoding_score = 0.587663373207207
-
-        self.assertEqual(prescriber.address_line_1, expected_address_line_1)
-        self.assertEqual(prescriber.address_line_2, "")
-        self.assertEqual(prescriber.post_code, expected_post_code)
-        self.assertEqual(prescriber.city, expected_city)
-        self.assertEqual(prescriber.coords, expected_coords)
-        self.assertEqual(prescriber.geocoding_score, expected_geocoding_score)
-        self.assertEqual(prescriber.latitude, expected_latitude)
-        self.assertEqual(prescriber.longitude, expected_longitude)
-
 
 class UtilsDepartmentsTest(TestCase):
     def test_department_from_postcode(self):

--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -1,4 +1,4 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.gis import forms as gis_forms
 from django.contrib.gis.db import models as gis_models
 from django.core.exceptions import PermissionDenied
@@ -8,6 +8,7 @@ from itou.common_apps.organizations.admin import HasMembersFilter, MembersInline
 from itou.prescribers import models
 from itou.prescribers.admin_forms import PrescriberOrganizationAdminForm
 from itou.utils.admin import PkSupportRemarkInline
+from itou.utils.apis.geocoding import GeocodingDataException
 
 
 class TmpMissingSiretFilter(admin.SimpleListFilter):
@@ -181,12 +182,19 @@ class PrescriberOrganizationAdmin(OrganizationAdmin):
         if not change:
             obj.created_by = request.user
             if not obj.geocoding_score and obj.geocoding_address:
-                # Set geocoding.
-                obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
+                try:
+                    # Set geocoding.
+                    obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
+                except GeocodingDataException:
+                    # do nothing, the user has not made any changes to the address
+                    pass
 
         if change and form.cleaned_data.get("extra_field_refresh_geocoding") and obj.geocoding_address:
-            # Refresh geocoding.
-            obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
+            try:
+                # Refresh geocoding.
+                obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
+            except GeocodingDataException:
+                messages.error(request, "L'adresse semble erronée car le geocoding n'a pas pu être recalculé.")
 
         super().save_model(request, obj, form, change)
 

--- a/itou/prescribers/management/commands/import_prescribers.py
+++ b/itou/prescribers/management/commands/import_prescribers.py
@@ -5,7 +5,7 @@ import os
 from django.core.management.base import BaseCommand
 
 from itou.common.address.departments import DEPARTMENTS
-from itou.common_apps.apis.geocoding import get_geocoding_data
+from itou.common_apps.apis.geocoding import GeocodingDataException, get_geocoding_data
 from itou.prescribers.models import PrescriberOrganization
 
 
@@ -131,14 +131,17 @@ class Command(BaseCommand):
                     prescriber_organization.city = city
                     prescriber_organization.department = department
 
-                    geocoding_data = get_geocoding_data(
-                        "{}, {} {}".format(
-                            prescriber_organization.address_line_1,
-                            prescriber_organization.post_code,
-                            prescriber_organization.city,
+                    try:
+                        geocoding_data = get_geocoding_data(
+                            "{}, {} {}".format(
+                                prescriber_organization.address_line_1,
+                                prescriber_organization.post_code,
+                                prescriber_organization.city,
+                            )
                         )
-                    )
-                    prescriber_organization.coords = geocoding_data["coords"]
+                        prescriber_organization.coords = geocoding_data["coords"]
+                    except GeocodingDataException:
+                        prescriber_organization.coords = ""
 
                     prescriber_organization.save()
 

--- a/itou/siaes/management/commands/_import_siae/utils.py
+++ b/itou/siaes/management/commands/_import_siae/utils.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 
 from itou.common_apps.address.models import AddressMixin
 from itou.siaes.models import Siae
-from itou.utils.apis.geocoding import get_geocoding_data
+from itou.utils.apis.geocoding import GeocodingDataException, get_geocoding_data
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -137,9 +137,9 @@ def geocode_siae(siae):
     if siae.geocoding_address is None:
         return siae
 
-    geocoding_data = get_geocoding_data(siae.geocoding_address, post_code=siae.post_code)
+    try:
+        geocoding_data = get_geocoding_data(siae.geocoding_address, post_code=siae.post_code)
 
-    if geocoding_data:
         siae.geocoding_score = geocoding_data["score"]
         # If the score is greater than API_BAN_RELIABLE_MIN_SCORE, coords are reliable:
         # use data returned by the BAN API because it's better written using accents etc.
@@ -152,6 +152,8 @@ def geocode_siae(siae):
         siae.city = geocoding_data["city"]
 
         siae.coords = geocoding_data["coords"]
+    except GeocodingDataException:
+        pass
 
     return siae
 

--- a/itou/utils/apis/geocoding.py
+++ b/itou/utils/apis/geocoding.py
@@ -9,6 +9,10 @@ from django.utils.http import urlencode
 logger = logging.getLogger(__name__)
 
 
+class GeocodingDataException(Exception):
+    pass
+
+
 def call_ban_geocoding_api(address, post_code=None, limit=1):
 
     api_url = f"{settings.API_BAN_BASE_URL}/search/"
@@ -44,10 +48,8 @@ def process_geocoding_data(data):
     - lane
     - address (different from address_line_1)
     """
-    if not data:
-        return None
-    if not data.get("properties"):
-        return None
+    if not data or not data.get("properties"):
+        raise GeocodingDataException()
 
     longitude = data["geometry"]["coordinates"][0]
     latitude = data["geometry"]["coordinates"][1]

--- a/itou/utils/mocks/geocoding.py
+++ b/itou/utils/mocks/geocoding.py
@@ -24,3 +24,18 @@ BAN_GEOCODING_API_RESULT_MOCK = {
         "street": "Pl des Cinq Martyrs du Lycee Buffon",
     },
 }
+
+"""
+Result for a call to:
+https://api-adresse.data.gouv.fr/search/?q=10+PL+5+ANATOLE&limit=1&postcode=75010
+"""
+
+BAN_GEOCODING_API_NO_RESULT_MOCK = {
+    "type": "FeatureCollection",
+    "features": [],
+    "attribution": "BAN",
+    "licence": "ETALAB-2.0",
+    "query": "10 PL 5 ANATOLE",
+    "filters": {"postcode": "75010"},
+    "limit": 1,
+}

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -37,11 +37,11 @@ from itou.users.enums import KIND_JOB_SEEKER, KIND_PRESCRIBER, KIND_SIAE_STAFF
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory, UserFactory
 from itou.users.models import User
 from itou.utils.apis import api_entreprise
-from itou.utils.apis.geocoding import process_geocoding_data
+from itou.utils.apis.geocoding import GeocodingDataException, process_geocoding_data
 from itou.utils.apis.pole_emploi import PoleEmploiAPIBadResponse, PoleEmploiApiClient, PoleEmploiAPIException
 from itou.utils.emails import sanitize_mailjet_recipients
 from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK, INSEE_API_RESULT_MOCK
-from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
+from itou.utils.mocks.geocoding import BAN_GEOCODING_API_NO_RESULT_MOCK, BAN_GEOCODING_API_RESULT_MOCK
 from itou.utils.mocks.pole_emploi import (
     API_MAJPASS_RESULT_ERROR,
     API_MAJPASS_RESULT_OK,
@@ -299,6 +299,13 @@ class UtilsGeocodingTest(TestCase):
             "coords": GEOSGeometry("POINT(2.316754 48.838411)"),
         }
         self.assertEqual(result, expected)
+
+    @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_NO_RESULT_MOCK)
+    def test_process_geocoding_data_error(self, mock_call_ban_geocoding_api):
+        geocoding_data = mock_call_ban_geocoding_api()
+
+        with self.assertRaises(GeocodingDataException):
+            process_geocoding_data(geocoding_data)
 
 
 class UtilsValidatorsTest(TestCase):

--- a/itou/www/prescribers_views/views.py
+++ b/itou/www/prescribers_views/views.py
@@ -8,6 +8,7 @@ from django.urls import reverse_lazy
 from itou.common_apps.organizations.views import deactivate_org_member, update_org_admin_role
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.models import User
+from itou.utils.apis.geocoding import GeocodingDataException
 from itou.utils.perms.prescriber import get_current_org_or_404
 from itou.utils.urls import get_safe_url
 from itou.www.prescribers_views.forms import EditPrescriberOrganizationForm
@@ -35,9 +36,14 @@ def edit_organization(request, template_name="prescribers/edit_organization.html
     form = EditPrescriberOrganizationForm(instance=organization, data=request.POST or None)
 
     if request.method == "POST" and form.is_valid():
-        form.save()
-        messages.success(request, "Mise à jour effectuée !")
-        return HttpResponseRedirect(reverse_lazy("dashboard:index"))
+        try:
+            form.save()
+            messages.success(request, "Mise à jour effectuée !")
+            return HttpResponseRedirect(reverse_lazy("dashboard:index"))
+        except GeocodingDataException:
+            messages.error(
+                request, "L'adresse semble erronée. Veuillez la corriger avant de pouvoir « Enregistrer »."
+            ),
 
     context = {"form": form, "organization": organization}
     return render(request, template_name, context)

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -160,12 +160,6 @@ class EditSiaeDescriptionForm(forms.ModelForm):
             "provided_support": "Type d'accompagnement proposé",
         }
 
-    def save(self):
-        siae = super().save(commit=False)
-        siae.set_coords(siae.geocoding_address, post_code=siae.post_code)
-        siae.save()
-        return siae
-
 
 class BlockJobApplicationsForm(forms.ModelForm):
     """

--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -414,9 +414,13 @@ def create_siae(request, template_name="siaes/create_siae.html"):
     )
 
     if request.method == "POST" and form.is_valid():
-        siae = form.save()
-        request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = siae.pk
-        return HttpResponseRedirect(reverse("dashboard:index"))
+
+        try:
+            siae = form.save()
+            request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = siae.pk
+            return HttpResponseRedirect(reverse("dashboard:index"))
+        except GeocodingDataException:
+            messages.error(request, "L'adresse semble erronée. Veuillez la corriger avant de pouvoir « Enregistrer ».")
 
     context = {"form": form}
     return render(request, template_name, context)

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -12,7 +12,7 @@ from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
 from itou.siaes.models import Siae, SiaeMembership
 from itou.users.models import User
 from itou.utils.apis.api_entreprise import etablissement_get_or_error
-from itou.utils.apis.geocoding import get_geocoding_data
+from itou.utils.apis.geocoding import GeocodingDataException, get_geocoding_data
 from itou.utils.password_validation import CnilCompositionPasswordValidator
 from itou.utils.tokens import siae_signup_token_generator
 from itou.utils.validators import validate_code_safir, validate_nir, validate_siren, validate_siret
@@ -285,7 +285,10 @@ class APIEntrepriseSearchForm(forms.Form):
             etablissement.department,
         ]
         address_on_one_line = ", ".join([field for field in address_fields if field])
-        geocoding_data = get_geocoding_data(address_on_one_line, post_code=etablissement.post_code) or {}
+        try:
+            geocoding_data = get_geocoding_data(address_on_one_line, post_code=etablissement.post_code)
+        except GeocodingDataException:
+            geocoding_data = {}
 
         self.org_data = {
             "siret": siret,


### PR DESCRIPTION
### Quoi ?

Affichage d'un message en cas d'erreur de géocodage.

### Pourquoi ?

L'erreur remonte dans Sentry, mais l'utilisateur n'en n'a pas connaissance.

### Comment ?

Ajout d'une exception spécifique et gestion aux différents endroits où celle-ci peut surgir.

### Captures d'écran

Message dans la modification de la fiche de la structure
![Message dans la modification de la fiche de la structure](https://user-images.githubusercontent.com/17601807/177778761-a67164f9-6ad3-4e63-a9ca-9d48460bf2a6.png)

