### PR TITLE
Ajout d'une colonne candidatures.nom_complet_structure dans Metabase

### DIFF
--- a/itou/metabase/management/commands/_job_applications.py
+++ b/itou/metabase/management/commands/_job_applications.py
@@ -191,6 +191,12 @@ TABLE_COLUMNS = [
         "comment": "Nom de la structure destinaire de la candidature",
         "fn": lambda o: o.to_siae.display_name,
     },
+    {
+        "name": "nom_complet_structure",
+        "type": "varchar",
+        "comment": "Nom complet de la structure destinaire de la candidature",
+        "fn": lambda o: f"{o.to_siae.kind} - ID {o.to_siae.id} - {o.to_siae.display_name}",
+    },
 ]
 
 TABLE_COLUMNS += get_department_and_region_columns(


### PR DESCRIPTION
### Quoi ?

Ajout d'une colonne candidatures.nom_complet_structure dans Metabase.

### Pourquoi ?

Pour éviter à Yannick quelques jointures.

### Et la revue ?

Pas de revue car trivial. Testé en dry run, ok.