### PR TITLE
Conserver le NIR lors de l'inscription avec France Connect

### DIFF
--- a/itou/allauth_adapters/peamu/adapter.py
+++ b/itou/allauth_adapters/peamu/adapter.py
@@ -12,6 +12,9 @@ class PEAMUSocialAccountAdapter(DefaultSocialAccountAdapter):
         user = super().populate_user(request, sociallogin, data)
         setattr(user, "is_job_seeker", True)
         setattr(user, "identity_provider", users_enums.IdentityProvider.PE_CONNECT)
+        nir = request.session.get(settings.ITOU_SESSION_NIR_KEY)
+        if nir:
+            setattr(user, "nir", nir)
         return user
 
 

--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -122,6 +122,12 @@ def france_connect_callback(request):  # pylint: disable=too-many-return-stateme
 
     # At this step, we can update the user's fields in DB and create a session if required
     user, _ = fc_user_data.create_or_update_user()
+
+    nir = request.session.get(settings.ITOU_SESSION_NIR_KEY)
+    if nir:
+        user.nir = nir
+        user.save(update_fields=["nir"])
+
     # Because we have more than one Authentication backend in our settings, we need to specify
     # the one we want to use in login
     login(request, user, backend="django.contrib.auth.backends.ModelBackend")


### PR DESCRIPTION
### Quoi ?

Conserver le NIR lors de l'inscription avec France Connect

### Pourquoi ?

On ne conserve le NIR que lorsqu'on s'inscrit via le formulaire django.
Il faut aussi le conserver en passant par la mire de connexion France Connect.

NB: Je constate qu'on ne le conserve pas non plus en passant par PE Connect, @celine-m-s on est d'accord que je ne cherche pas à corriger ça ? 
