### PR TITLE
Correction de la connexion avec France Connect 

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -408,7 +408,7 @@ SOCIALACCOUNT_ADAPTER = "itou.allauth_adapters.peamu.adapter.PEAMUSocialAccountA
 # France Connect is enabled by default, but a feature flag allows to deactivate it.
 # Disabled in the DEMO environment.
 FRANCE_CONNECT_ENABLED = os.environ.get("FRANCE_CONNECT_ENABLED", "True") == "True"
-FRANCE_CONNECT_BASE_URL = "https://app.franceconnect.gouv.fr/api/v1/"
+FRANCE_CONNECT_BASE_URL = "https://app.franceconnect.gouv.fr/api/v1"
 FRANCE_CONNECT_CLIENT_ID = os.environ.get("FRANCE_CONNECT_CLIENT_ID")
 FRANCE_CONNECT_CLIENT_SECRET = os.environ.get("FRANCE_CONNECT_CLIENT_SECRET")
 

--- a/config/settings/demo.py
+++ b/config/settings/demo.py
@@ -28,4 +28,4 @@ sentry_init(dsn=os.environ["SENTRY_DSN_DEMO"])
 ASP_ITOU_PREFIX = "XXXXX"
 
 SHOW_TEST_ACCOUNTS_BANNER = True
-FRANCE_CONNECT_BASE_URL = "https://fcp.integ01.dev-franceconnect.fr/api/v1/"
+FRANCE_CONNECT_BASE_URL = "https://fcp.integ01.dev-franceconnect.fr/api/v1"

--- a/config/settings/dev.py.template
+++ b/config/settings/dev.py.template
@@ -87,4 +87,4 @@ ASP_ITOU_PREFIX = "XXXXX"
 
 # Integration platform and associated public key (non confidential)
 # When the integration platform is used, an endpoint called "/callback" should be defined in itou.
-FRANCE_CONNECT_BASE_URL = "https://fcp.integ01.dev-franceconnect.fr/api/v1/"
+FRANCE_CONNECT_BASE_URL = "https://fcp.integ01.dev-franceconnect.fr/api/v1"

--- a/config/settings/review_apps.py
+++ b/config/settings/review_apps.py
@@ -44,4 +44,4 @@ ELASTIC_APM = {
     "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
     "TRANSACTION_SAMPLE_RATE": 1,
 }
-FRANCE_CONNECT_BASE_URL = "https://fcp.integ01.dev-franceconnect.fr/api/v1/"
+FRANCE_CONNECT_BASE_URL = "https://fcp.integ01.dev-franceconnect.fr/api/v1"

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -27,4 +27,4 @@ sentry_init(dsn=os.environ["SENTRY_DSN_STAGING"])
 
 ASP_ITOU_PREFIX = "YYYYY"
 
-FRANCE_CONNECT_BASE_URL = "https://fcp.integ01.dev-franceconnect.fr/api/v1/"
+FRANCE_CONNECT_BASE_URL = "https://fcp.integ01.dev-franceconnect.fr/api/v1"


### PR DESCRIPTION
### Quoi ?

Correction de la connexion avec France Connect 

### Pourquoi ?

La connexion n'est plus possible (Page blanche Error).

### Comment ?

En supprimant le `/` de fin en trop.
