### PR TITLE
Ajout d'une option de "preflight" pour les management commands des fiches salarié

### DIFF
--- a/itou/employee_record/exceptions.py
+++ b/itou/employee_record/exceptions.py
@@ -1,0 +1,2 @@
+class SerializationError(Exception):
+    """Mainly raised during serialization phases in employee record management commands."""

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -622,7 +622,11 @@ class EmployeeRecordBatch:
             er.asp_processing_label = None
 
     def __str__(self):
-        return f"FIL£NAME:{self.upload_filename} NB_RECORDS:{len(self.elements)}"
+        return f"FILENAME={self.upload_filename}, NB_RECORDS={len(self.elements)}"
+
+    def __repr__(self):
+        # String formating with {field_name=...} forms use __repr__ and not __str__
+        return f"{self.upload_filename=}, {len(self.elements)=}"
 
     @staticmethod
     def feedback_filename(filename):
@@ -734,6 +738,9 @@ class EmployeeRecordUpdateNotification(models.Model):
     class Meta:
         verbose_name = "Modification de changement de la fiche salarié"
         verbose_name_plural = "Modifications de changement des fiches salarié"
+
+    def __repr__(self):
+        return f"<{type(self).__name__} pk={self.pk}>"
 
     def update_as_sent(self, filename, line_number):
         if self.status not in [NotificationStatus.NEW, NotificationStatus.REJECTED]:


### PR DESCRIPTION
### Quoi ?

- Ajout d'une option `--preflight` pour les management commands des fiches salarié (fiches et notifications de modification).
- Renforcement de la robustesse générale des commandes en cas de problèmes de sérialisation JSON.

### Pourquoi ?

Certaines fiches ou notifications peuvent contenir des erreurs de structure menant a des blocages de transferts de données vers l'ASP (dans certains cas aux limites). 

### Comment ?

Ajout d'une fonctionnalité / option sur les management commands impactées permettant de : 
- vérifier la sérialisation de l'ensemble des objets à envoyer à l'ASP
- pointer précisément quelle est la première occurrence en erreur (type d'objet, PK, et détails de l'erreur de sérialisation) par le jet d'une exception détaillé (custom).

L'utilisation de cette option de commande n'est pas actuellement planifiée via CRON : 
- son utilisation systématique peut entraîner des lenteurs en production,
- elle est essentiellement à objectif de dépannage et de ciblage des fiches salarié ayant des problèmes de structure,
- elle sera utilisée au fil de l'eau, en cas de problème.