### PR TITLE
Correction de la déconnextion des utilisateurs anonymes n°2

### DIFF
--- a/itou/users/adapter.py
+++ b/itou/users/adapter.py
@@ -49,7 +49,7 @@ class UserAdapter(DefaultAccountAdapter):
             fc_base_logout_url = reverse("france_connect:logout")
             redirect_url = f"{fc_base_logout_url}?{urlencode(params)}"
         # PE Connect
-        peamu_id_token = getattr(request.user, "peamu_id_token")
+        peamu_id_token = getattr(request.user, "peamu_id_token", None)
         if peamu_id_token:
             hp_url = get_absolute_url(reverse("home:hp"))
             params = {"id_token_hint": peamu_id_token, "redirect_uri": hp_url}


### PR DESCRIPTION
### Quoi ?

Un [AnonymousUser](https://docs.djangoproject.com/en/4.0/ref/contrib/auth/) (utilisateur non authentifié) n'a pas accès aux attributs de notre class User, ce qui fait que si on arrive dans la fonction de logout sur un tel utilisateur, le code va planter.

Sans la valeur par défaut dans getattr, ça ne fonctionnera pas mieux qu'avant.
