### PR TITLE
feat(api): ajout des données organisations à la vue d'api data.inclusion

### DIFF
--- a/itou/api/data_inclusion_api/enums.py
+++ b/itou/api/data_inclusion_api/enums.py
@@ -1,0 +1,6 @@
+import enum
+
+
+class StructureTypeStr(str, enum.Enum):
+    ORGA = "orga"
+    SIAE = "siae"

--- a/itou/api/data_inclusion_api/serializers.py
+++ b/itou/api/data_inclusion_api/serializers.py
@@ -1,13 +1,14 @@
 from typing import Optional
 
-from django.utils import text
+from django.utils import text, timezone
 from rest_framework import serializers
 
+from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.enums import SiaeKind
 from itou.siaes.models import Siae
 
 
-class DataInclusionStructureSerializer(serializers.ModelSerializer):
+class SiaeStructureSerializer(serializers.ModelSerializer):
     """Serialize SIAE instance to the data.inclusion structure schema.
 
     Fields are based on https://github.com/betagouv/data-inclusion-schema.
@@ -27,7 +28,7 @@ class DataInclusionStructureSerializer(serializers.ModelSerializer):
     commune = serializers.CharField(source="city")
     adresse = serializers.CharField(source="address_line_1")
     complement_adresse = serializers.CharField(source="address_line_2")
-    date_maj = serializers.DateTimeField(source="updated_at")
+    date_maj = serializers.SerializerMethodField()
     structure_parente = serializers.SerializerMethodField()
 
     class Meta:
@@ -76,3 +77,73 @@ class DataInclusionStructureSerializer(serializers.ModelSerializer):
             return None
 
         return structure_parente.uid
+
+    def get_date_maj(self, obj) -> str:
+        dt = obj.updated_at or obj.created_at
+        return dt.astimezone(timezone.get_current_timezone()).isoformat()
+
+
+class PrescriberOrgStructureSerializer(serializers.ModelSerializer):
+    """Serialize Prescriber Organization instance to the data.inclusion structure schema.
+
+    Fields are based on https://github.com/betagouv/data-inclusion-schema.
+    """
+
+    id = serializers.UUIDField(source="uid")
+    typologie = serializers.ChoiceField(source="kind", choices=SiaeKind.choices)
+    nom = serializers.CharField(source="name")
+    rna = serializers.ReadOnlyField(default="")
+    presentation_resume = serializers.SerializerMethodField()
+    presentation_detail = serializers.SerializerMethodField()
+    site_web = serializers.CharField(source="website")
+    telephone = serializers.CharField(source="phone")
+    courriel = serializers.CharField(source="email")
+    code_postal = serializers.CharField(source="post_code")
+    code_insee = serializers.ReadOnlyField(default="")
+    commune = serializers.CharField(source="city")
+    adresse = serializers.CharField(source="address_line_1")
+    complement_adresse = serializers.CharField(source="address_line_2")
+    source = serializers.ReadOnlyField(default="")
+    date_maj = serializers.SerializerMethodField()
+    structure_parente = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PrescriberOrganization
+        fields = [
+            "id",
+            "typologie",
+            "nom",
+            "siret",
+            "rna",
+            "presentation_resume",
+            "presentation_detail",
+            "site_web",
+            "telephone",
+            "courriel",
+            "code_postal",
+            "code_insee",
+            "commune",
+            "adresse",
+            "complement_adresse",
+            "longitude",
+            "latitude",
+            "source",
+            "date_maj",
+            "structure_parente",
+        ]
+        read_only_fields = fields
+
+    def get_presentation_resume(self, obj) -> str:
+        return text.Truncator(obj.description).chars(280)
+
+    def get_presentation_detail(self, obj) -> str:
+        if len(obj.description) < 280:
+            return ""
+        return obj.description
+
+    def get_date_maj(self, obj) -> str:
+        dt = obj.updated_at or obj.created_at
+        return dt.astimezone(timezone.get_current_timezone()).isoformat()
+
+    def get_structure_parente(self, obj) -> Optional[str]:
+        return None

--- a/itou/api/data_inclusion_api/views.py
+++ b/itou/api/data_inclusion_api/views.py
@@ -42,6 +42,10 @@ class DataInclusionStructureView(generics.ListAPIView):
             enums.StructureTypeStr.SIAE: Siae.objects.active().select_related("convention"),
         }
 
+        # * ordered by ascending creation date : if any instances are added during the querying
+        # of the endpoint, they will appeared in the last page.
+        # * ordered by pk : given that some instances share the same creation date, it ensures
+        # repeatable order between page evaluation
         return qs_by_structure_type_str[valid_type_str].order_by("created_at", "pk")
 
     def get_serializer_class(self):

--- a/itou/api/data_inclusion_api/views.py
+++ b/itou/api/data_inclusion_api/views.py
@@ -1,15 +1,8 @@
-import enum
-
 from rest_framework import authentication, exceptions, generics
 
-from itou.api.data_inclusion_api import serializers
+from itou.api.data_inclusion_api import enums, serializers
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae
-
-
-class StructureTypeStr(str, enum.Enum):
-    ORGA = "orga"
-    SIAE = "siae"
 
 
 class DataInclusionStructureView(generics.ListAPIView):
@@ -36,7 +29,7 @@ class DataInclusionStructureView(generics.ListAPIView):
 
         if unsafe_type_str is None:
             raise exceptions.ValidationError("Le paramètre `type` est obligatoire.")
-        elif unsafe_type_str not in list(StructureTypeStr):
+        elif unsafe_type_str not in list(enums.StructureTypeStr):
             raise exceptions.ValidationError("La valeur du paramètre `type` doit être `siae` ou `orga`.")
 
         return super().list(request, *args, **kwargs)
@@ -45,8 +38,8 @@ class DataInclusionStructureView(generics.ListAPIView):
         valid_type_str = self.request.query_params.get("type")
 
         qs_by_structure_type_str = {
-            StructureTypeStr.ORGA: PrescriberOrganization.objects.all(),
-            StructureTypeStr.SIAE: Siae.objects.active().order_by("created_at").select_related("convention"),
+            enums.StructureTypeStr.ORGA: PrescriberOrganization.objects.all(),
+            enums.StructureTypeStr.SIAE: Siae.objects.active().order_by("created_at").select_related("convention"),
         }
 
         return qs_by_structure_type_str[valid_type_str]
@@ -55,8 +48,8 @@ class DataInclusionStructureView(generics.ListAPIView):
         valid_type_str = self.request.query_params.get("type")
 
         serializer_class_by_structure_type_str = {
-            StructureTypeStr.ORGA: serializers.PrescriberOrgStructureSerializer,
-            StructureTypeStr.SIAE: serializers.SiaeStructureSerializer,
+            enums.StructureTypeStr.ORGA: serializers.PrescriberOrgStructureSerializer,
+            enums.StructureTypeStr.SIAE: serializers.SiaeStructureSerializer,
         }
 
         return serializer_class_by_structure_type_str[valid_type_str]

--- a/itou/api/data_inclusion_api/views.py
+++ b/itou/api/data_inclusion_api/views.py
@@ -39,10 +39,10 @@ class DataInclusionStructureView(generics.ListAPIView):
 
         qs_by_structure_type_str = {
             enums.StructureTypeStr.ORGA: PrescriberOrganization.objects.all(),
-            enums.StructureTypeStr.SIAE: Siae.objects.active().order_by("created_at").select_related("convention"),
+            enums.StructureTypeStr.SIAE: Siae.objects.active().select_related("convention"),
         }
 
-        return qs_by_structure_type_str[valid_type_str]
+        return qs_by_structure_type_str[valid_type_str].order_by("created_at", "pk")
 
     def get_serializer_class(self):
         valid_type_str = self.request.query_params.get("type")


### PR DESCRIPTION
### Quoi ?

Ajout des données organisations (`PrescriberOrganization`) au endpoint représentant les données au format data.inclusion.

### Pourquoi ?

dans la continuité des travaux entamés avec #1314

### Comment ?

* Un seul endpoint pour les données provenant des 2 tables `Siae` et `PrescriberOrganization`.
* Récupération de l'une ou de l'utre table via le query param `?type=siae` ou `?type=orga`