### PR TITLE
Ajout d'une icône à droite du lien pour suspendre quand l'employeur n'a plus la main.

### DIFF
--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -40,14 +40,21 @@
                         {% if approval_can_be_suspended_by_siae %}
                             <a
                                 href="{% url 'approvals:suspend' approval_id=job_application.approval.id %}?back_url={{ request.get_full_path|urlencode }}"
-                                class="btn btn btn-link">
+                                class="btn btn-link">
                                 Suspendre
                             </a>
+                        {% elif hire_by_other_siae %}
+                            <span class="btn btn-link disabled text-muted">Suspendre</span>
+                            <i
+                                class="ri-information-line ri-xl text-info"
+                                data-toggle="tooltip"
+                                title="La suspension n’est pas possible, un autre employeur a embauché le candidat.">
+                            </i>
                         {% endif %}
                         {% if approval_can_be_prolonged_by_siae %}
                             <a
                                 href="{% url 'approvals:declare_prolongation' approval_id=job_application.approval.id %}?back_url={{ request.get_full_path|urlencode }}"
-                                class="btn btn btn-link">
+                                class="btn btn-link">
                                 Prolonger
                             </a>
                         {% endif %}

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -65,6 +65,11 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
     approval_can_be_suspended_by_siae = job_application.approval and job_application.approval.can_be_suspended_by_siae(
         job_application.to_siae
     )
+
+    hire_by_other_siae = job_application.approval and not job_application.approval.user.last_hire_was_made_by_siae(
+        job_application.to_siae
+    )
+
     approval_can_be_prolonged_by_siae = job_application.approval and job_application.approval.can_be_prolonged_by_siae(
         job_application.to_siae
     )
@@ -76,6 +81,7 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
     context = {
         "approvals_wrapper": job_application.job_seeker.approvals_wrapper,
         "approval_can_be_suspended_by_siae": approval_can_be_suspended_by_siae,
+        "hire_by_other_siae": hire_by_other_siae,
         "approval_can_be_prolonged_by_siae": approval_can_be_prolonged_by_siae,
         "eligibility_diagnosis": job_application.get_eligibility_diagnosis(),
         "expired_eligibility_diagnosis": expired_eligibility_diagnosis,


### PR DESCRIPTION
### Quoi ?

Ajout d'une icône à droite du lien pour suspendre quand l'employeur n'a plus la main.

### Pourquoi ?

Pour éviter de l'incompréhension liée à la disparition du bouton pour suspendre.

### Comment ?

Ajout d'une icône et d'une infos bulle à son survol.

### Captures d'écran

![Capture d'écran de l'info bulle](https://user-images.githubusercontent.com/17601807/179714197-cd0a471a-b2a9-4adb-af85-288e024455c9.png)



