### PR TITLE
Ajout d'un message d'avertissement pour les prescripteurs en cours d'habilitation

### DIFF
--- a/itou/approvals/factories.py
+++ b/itou/approvals/factories.py
@@ -8,7 +8,7 @@ from faker import Faker
 
 from itou.approvals.models import Approval, PoleEmploiApproval, Prolongation, Suspension
 from itou.job_applications.models import JobApplicationWorkflow
-from itou.prescribers.factories import AuthorizedPrescriberOrganizationWithMembershipFactory
+from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import SiaeFactory
 from itou.users.factories import JobSeekerFactory
@@ -74,7 +74,7 @@ class ProlongationFactory(factory.django.DjangoModelFactory):
         if not create:
             # Simple build, do nothing.
             return
-        authorized_prescriber_org = AuthorizedPrescriberOrganizationWithMembershipFactory()
+        authorized_prescriber_org = PrescriberOrganizationWithMembershipFactory(authorized=True)
         self.validated_by = authorized_prescriber_org.members.first()
         self.save()
 

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -29,7 +29,7 @@ from itou.job_applications.factories import (
     JobApplicationWithoutApprovalFactory,
 )
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
-from itou.prescribers.factories import AuthorizedPrescriberOrganizationFactory, PrescriberOrganizationFactory
+from itou.prescribers.factories import PrescriberOrganizationFactory
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import Siae
@@ -812,7 +812,7 @@ class ApprovalsWrapperTest(TestCase):
         self.assertFalse(
             approvals_wrapper.cannot_bypass_waiting_period(
                 siae=SiaeFactory(kind=SiaeKind.ETTI),
-                sender_prescriber_organization=AuthorizedPrescriberOrganizationFactory(),
+                sender_prescriber_organization=PrescriberOrganizationFactory(authorized=True),
             )
         )
 

--- a/itou/eligibility/factories.py
+++ b/itou/eligibility/factories.py
@@ -2,7 +2,7 @@ import factory
 from django.utils import timezone
 
 from itou.eligibility import models
-from itou.prescribers.factories import AuthorizedPrescriberOrganizationWithMembershipFactory
+from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.factories import SiaeFactory
 from itou.users.factories import JobSeekerFactory
 
@@ -15,7 +15,7 @@ class EligibilityDiagnosisFactory(factory.django.DjangoModelFactory):
 
     author = factory.LazyAttribute(lambda obj: obj.author_prescriber_organization.members.first())
     author_kind = models.EligibilityDiagnosis.AUTHOR_KIND_PRESCRIBER
-    author_prescriber_organization = factory.SubFactory(AuthorizedPrescriberOrganizationWithMembershipFactory)
+    author_prescriber_organization = factory.SubFactory(PrescriberOrganizationWithMembershipFactory, authorized=True)
     job_seeker = factory.SubFactory(JobSeekerFactory)
 
 

--- a/itou/eligibility/tests.py
+++ b/itou/eligibility/tests.py
@@ -13,7 +13,7 @@ from itou.eligibility.factories import (
 )
 from itou.eligibility.models import AdministrativeCriteria, AdministrativeCriteriaQuerySet, EligibilityDiagnosis
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
-from itou.prescribers.factories import AuthorizedPrescriberOrganizationWithMembershipFactory
+from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.factories import SiaeFactory
 from itou.users.enums import KIND_PRESCRIBER, KIND_SIAE_STAFF
 from itou.users.factories import JobSeekerFactory
@@ -251,7 +251,7 @@ class EligibilityDiagnosisModelTest(TestCase):
     def test_create_diagnosis_with_administrative_criteria(self):
 
         job_seeker = JobSeekerFactory()
-        prescriber_organization = AuthorizedPrescriberOrganizationWithMembershipFactory()
+        prescriber_organization = PrescriberOrganizationWithMembershipFactory(authorized=True)
         user = prescriber_organization.members.first()
         user_info = UserInfo(
             user=user,

--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -8,10 +8,7 @@ from itou.eligibility.factories import EligibilityDiagnosisFactory
 from itou.job_applications import models
 from itou.job_applications.enums import SenderKind
 from itou.jobs.models import Appellation
-from itou.prescribers.factories import (
-    AuthorizedPrescriberOrganizationWithMembershipFactory,
-    PrescriberOrganizationWithMembershipFactory,
-)
+from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import SiaeJobDescription
 from itou.users.factories import (
@@ -94,7 +91,7 @@ class JobApplicationSentByPrescriberOrganizationFactory(JobApplicationSentByPres
 class JobApplicationSentByAuthorizedPrescriberOrganizationFactory(JobApplicationSentByPrescriberFactory):
     """Generates a JobApplication() object sent by a prescriber member of an authorized organization."""
 
-    sender_prescriber_organization = factory.SubFactory(AuthorizedPrescriberOrganizationWithMembershipFactory)
+    sender_prescriber_organization = factory.SubFactory(PrescriberOrganizationWithMembershipFactory, authorized=True)
     sender = factory.LazyAttribute(lambda obj: obj.sender_prescriber_organization.members.first())
 
 

--- a/itou/prescribers/factories.py
+++ b/itou/prescribers/factories.py
@@ -14,6 +14,15 @@ class PrescriberOrganizationFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.PrescriberOrganization
 
+    class Params:
+        authorized = factory.Trait(
+            is_authorized=True,
+            authorization_status=models.PrescriberOrganization.AuthorizationStatus.VALIDATED,
+        )
+        with_pending_authorization = factory.Trait(
+            authorization_status=models.PrescriberOrganization.AuthorizationStatus.NOT_SET,
+        )
+
     name = factory.Faker("name", locale="fr_FR")
     # Don't start a SIRET with 0.
     siret = factory.fuzzy.FuzzyText(length=13, chars=string.digits, prefix="1")
@@ -21,13 +30,6 @@ class PrescriberOrganizationFactory(factory.django.DjangoModelFactory):
     email = factory.Faker("email", locale="fr_FR")
     kind = models.PrescriberOrganization.Kind.PE
     department = factory.fuzzy.FuzzyChoice(DEPARTMENTS.keys())
-
-
-class AuthorizedPrescriberOrganizationFactory(PrescriberOrganizationFactory):
-    """Returns an authorized PrescriberOrganization() object."""
-
-    is_authorized = True
-    authorization_status = models.PrescriberOrganization.AuthorizationStatus.VALIDATED
 
 
 class PrescriberMembershipFactory(factory.django.DjangoModelFactory):
@@ -67,17 +69,6 @@ class PrescriberOrganizationWith2MembershipFactory(PrescriberOrganizationFactory
 
     membership1 = factory.RelatedFactory(PrescriberMembershipFactory, "organization")
     membership2 = factory.RelatedFactory(PrescriberMembershipFactory, "organization", is_admin=False)
-
-
-class AuthorizedPrescriberOrganizationWithMembershipFactory(PrescriberOrganizationWithMembershipFactory):
-    """
-    Returns a PrescriberOrganization() object with a related authorized PrescriberMembership() object.
-
-    https://factoryboy.readthedocs.io/en/latest/recipes.html#many-to-many-relation-with-a-through
-    """
-
-    is_authorized = True
-    authorization_status = models.PrescriberOrganization.AuthorizationStatus.VALIDATED
 
 
 class PrescriberPoleEmploiFactory(PrescriberOrganizationFactory):

--- a/itou/prescribers/tests.py
+++ b/itou/prescribers/tests.py
@@ -14,7 +14,6 @@ from django.utils.timezone import get_current_timezone
 
 from itou.job_applications import factories as job_applications_factories, models as job_applications_models
 from itou.prescribers.factories import (
-    AuthorizedPrescriberOrganizationFactory,
     PrescriberOrganizationFactory,
     PrescriberOrganizationWith2MembershipFactory,
     PrescriberOrganizationWithMembershipFactory,
@@ -34,19 +33,24 @@ class PrescriberOrganizationManagerTest(TestCase):
         """
         Test `get_accredited_orgs_for`.
         """
-        departmental_council_org = AuthorizedPrescriberOrganizationFactory(kind=PrescriberOrganization.Kind.DEPT)
+        departmental_council_org = PrescriberOrganizationFactory(
+            authorized=True, kind=PrescriberOrganization.Kind.DEPT
+        )
 
         # An org accredited by a departmental council:
         # - is in the same department
         # - is accredited BRSA
-        accredited_org = AuthorizedPrescriberOrganizationFactory(
+        accredited_org = PrescriberOrganizationFactory(
+            authorized=True,
             department=departmental_council_org.department,
             kind=PrescriberOrganization.Kind.OTHER,
             is_brsa=True,
         )
 
-        other_org = AuthorizedPrescriberOrganizationFactory(
-            department=departmental_council_org.department, kind=PrescriberOrganization.Kind.CAP_EMPLOI
+        other_org = PrescriberOrganizationFactory(
+            authorized=True,
+            department=departmental_council_org.department,
+            kind=PrescriberOrganization.Kind.CAP_EMPLOI,
         )
 
         # `expected_num` orgs should be accredited by the departmental council.
@@ -255,7 +259,8 @@ class PrescriberOrganizationAdminTest(TestCase):
     def test_refuse_prescriber_habilitation_by_superuser(self):
         self.client.login(username=self.superuser.email, password=DEFAULT_PASSWORD)
 
-        prescriberorganization = AuthorizedPrescriberOrganizationFactory(
+        prescriberorganization = PrescriberOrganizationFactory(
+            authorized=True,
             siret="83987278500010",
             department="14",
             post_code="14000",
@@ -299,7 +304,8 @@ class PrescriberOrganizationAdminTest(TestCase):
     def test_refuse_prescriber_habilitation_pending_status(self):
         self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
 
-        prescriberorganization = AuthorizedPrescriberOrganizationFactory(
+        prescriberorganization = PrescriberOrganizationFactory(
+            authorized=True,
             siret="83987278500010",
             department="14",
             post_code="14000",
@@ -341,7 +347,8 @@ class PrescriberOrganizationAdminTest(TestCase):
     def test_refuse_prescriber_habilitation_not_pending_status(self):
         self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
 
-        prescriberorganization = AuthorizedPrescriberOrganizationFactory(
+        prescriberorganization = PrescriberOrganizationFactory(
+            authorized=True,
             siret="83987278500010",
             department="14",
             post_code="14000",
@@ -384,7 +391,8 @@ class PrescriberOrganizationAdminTest(TestCase):
     def test_accept_prescriber_habilitation_by_superuser(self):
         self.client.login(username=self.superuser.email, password=DEFAULT_PASSWORD)
 
-        prescriberorganization = AuthorizedPrescriberOrganizationFactory(
+        prescriberorganization = PrescriberOrganizationFactory(
+            authorized=True,
             siret="83987278500010",
             department="14",
             post_code="14000",
@@ -428,7 +436,8 @@ class PrescriberOrganizationAdminTest(TestCase):
     def test_accept_prescriber_habilitation_pending_status(self):
         self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
 
-        prescriberorganization = AuthorizedPrescriberOrganizationFactory(
+        prescriberorganization = PrescriberOrganizationFactory(
+            authorized=True,
             siret="83987278500010",
             department="14",
             post_code="14000",
@@ -470,7 +479,8 @@ class PrescriberOrganizationAdminTest(TestCase):
     def test_accept_prescriber_habilitation_refused_status(self):
         self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
 
-        prescriberorganization = AuthorizedPrescriberOrganizationFactory(
+        prescriberorganization = PrescriberOrganizationFactory(
+            authorized=True,
             siret="83987278500010",
             department="14",
             post_code="14000",
@@ -512,7 +522,8 @@ class PrescriberOrganizationAdminTest(TestCase):
     def test_accept_prescriber_habilitation_other_status(self):
         self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
 
-        prescriberorganization = AuthorizedPrescriberOrganizationFactory(
+        prescriberorganization = PrescriberOrganizationFactory(
+            authorized=True,
             siret="83987278500010",
             department="14",
             post_code="14000",

--- a/itou/templates/apply/submit_step_pending_authorization.html
+++ b/itou/templates/apply/submit_step_pending_authorization.html
@@ -1,0 +1,36 @@
+{% extends "layout/content.html" %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-12 col-lg-7 pl-lg-5">
+            <div class="card c-card mb-3 mb-lg-5 p-3">
+                <div class="card-header">
+                    <h1 class="h2">Status de prescripteur habilité non vérifié</h1>
+                </div>
+                <div class="card-body">
+                    <div class="alert alert-warning" role="status">
+                        <div class="row">
+                            <div class="col-auto pr-0">
+                                <i class="ri-information-line ri-xl text-warning"></i>
+                            </div>
+                            <div class="col">
+                                <p class="mb-2"><strong>Attention, si vous souhaitez orienter un candidat auprès d'une SIAE, vous ne pourrez pas valider son éligibilité à l'IAE.</strong></p>
+                                <p class="mb-0">Votre statut de prescripteur habilité n'a pas encore été vérifié par nos équipes. Vous devriez être notifié(e) de sa confirmation dans un délai de 72h.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <strong>Êtes-vous certain de vouloir continuer ?</strong>
+                </div>
+                <div class="row mt-3 mt-lg-5 justify-content-end">
+                    <div class="col-6 col-lg-auto">
+                        <a class="btn btn-link" title="Revenir à la recherche" href="/">Revenir à la recherche</a>
+                    </div>
+                    <div class="col-6 col-lg-auto">
+                        <a href="{% url 'apply:step_check_job_seeker_nir' siae_pk=siae_pk %}" class="btn btn-primary">Suivant</a>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -17,11 +17,7 @@ from itou.institutions.factories import InstitutionWithMembershipFactory
 from itou.institutions.models import Institution
 from itou.job_applications.factories import JobApplicationSentByJobSeekerFactory
 from itou.job_applications.models import JobApplicationWorkflow
-from itou.prescribers.factories import (
-    AuthorizedPrescriberOrganizationWithMembershipFactory,
-    PrescriberMembershipFactory,
-    PrescriberOrganizationWithMembershipFactory,
-)
+from itou.prescribers.factories import PrescriberMembershipFactory, PrescriberOrganizationWithMembershipFactory
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import SiaeFactory
@@ -411,7 +407,7 @@ class ModelTest(TestCase):
     def test_can_add_nir(self):
         siae = SiaeFactory(with_membership=True)
         siae_staff = siae.members.first()
-        prescriber_org = AuthorizedPrescriberOrganizationWithMembershipFactory()
+        prescriber_org = PrescriberOrganizationWithMembershipFactory(authorized=True)
         authorized_prescriber = prescriber_org.members.first()
         unauthorized_prescriber = PrescriberFactory()
         job_seeker_no_nir = JobSeekerFactory(nir="")
@@ -496,8 +492,8 @@ class ModelTest(TestCase):
         CD as in "Conseil Départemental".
         """
         # Admin prescriber of authorized CD can access.
-        org = AuthorizedPrescriberOrganizationWithMembershipFactory(
-            kind=PrescriberOrganization.Kind.DEPT, department="93"
+        org = PrescriberOrganizationWithMembershipFactory(
+            authorized=True, kind=PrescriberOrganization.Kind.DEPT, department="93"
         )
         user = org.members.get()
         self.assertTrue(user.can_view_stats_cd(current_org=org))
@@ -505,8 +501,8 @@ class ModelTest(TestCase):
         self.assertEqual(user.get_stats_cd_department(current_org=org), org.department)
 
         # Non admin prescriber can access as well.
-        org = AuthorizedPrescriberOrganizationWithMembershipFactory(
-            kind=PrescriberOrganization.Kind.DEPT, membership__is_admin=False, department="93"
+        org = PrescriberOrganizationWithMembershipFactory(
+            authorized=True, kind=PrescriberOrganization.Kind.DEPT, membership__is_admin=False, department="93"
         )
         user = org.members.get()
         self.assertTrue(user.can_view_stats_cd(current_org=org))
@@ -519,7 +515,7 @@ class ModelTest(TestCase):
         self.assertFalse(user.can_view_stats_dashboard_widget(current_org=org))
 
         # Non CD organization does not give access.
-        org = AuthorizedPrescriberOrganizationWithMembershipFactory()
+        org = PrescriberOrganizationWithMembershipFactory(authorized=True)
         user = org.members.get()
         self.assertFalse(user.can_view_stats_cd(current_org=org))
         self.assertFalse(user.can_view_stats_dashboard_widget(current_org=org))

--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -14,11 +14,7 @@ from itou.job_applications.factories import (
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.jobs.factories import create_test_romes_and_appellations
 from itou.jobs.models import Appellation
-from itou.prescribers.factories import (
-    AuthorizedPrescriberOrganizationWithMembershipFactory,
-    PrescriberMembershipFactory,
-    PrescriberOrganizationWithMembershipFactory,
-)
+from itou.prescribers.factories import PrescriberMembershipFactory, PrescriberOrganizationWithMembershipFactory
 from itou.siaes.factories import SiaeFactory
 from itou.users.factories import DEFAULT_PASSWORD
 from itou.utils.widgets import DuetDatePickerWidget
@@ -45,8 +41,8 @@ class ProcessListTest(TestCase):
         """
 
         # Pole Emploi
-        pole_emploi = AuthorizedPrescriberOrganizationWithMembershipFactory(
-            name="Pôle emploi", membership__user__first_name="Thibault"
+        pole_emploi = PrescriberOrganizationWithMembershipFactory(
+            authorized=True, name="Pôle emploi", membership__user__first_name="Thibault"
         )
         PrescriberMembershipFactory(organization=pole_emploi, user__first_name="Laurie")
         thibault_pe = pole_emploi.members.get(first_name="Thibault")

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -10,6 +10,11 @@ urlpatterns = [
     # Submit.
     path("<int:siae_pk>/start", submit_views.start, name="start"),
     path("<int:siae_pk>/step_sender", submit_views.step_sender, name="step_sender"),
+    path(
+        "<int:siae_pk>/step_pending_authorization",
+        submit_views.step_pending_authorization,
+        name="step_pending_authorization",
+    ),
     path("<int:siae_pk>/step_job_seeker", submit_views.step_job_seeker, name="step_job_seeker"),
     path(
         "<int:siae_pk>/step_check_job_seeker_nir",

--- a/itou/www/approvals_views/tests/test_prolongation.py
+++ b/itou/www/approvals_views/tests/test_prolongation.py
@@ -9,7 +9,7 @@ from django.utils.http import urlencode
 from itou.approvals.models import Approval, Prolongation
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplicationWorkflow
-from itou.prescribers.factories import AuthorizedPrescriberOrganizationWithMembershipFactory
+from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.users.factories import DEFAULT_PASSWORD
 from itou.utils.widgets import DuetDatePickerWidget
 from itou.www.approvals_views.forms import DeclareProlongationForm
@@ -21,7 +21,7 @@ class ApprovalProlongationTest(TestCase):
         Create test objects.
         """
 
-        self.prescriber_organization = AuthorizedPrescriberOrganizationWithMembershipFactory()
+        self.prescriber_organization = PrescriberOrganizationWithMembershipFactory(authorized=True)
         self.prescriber = self.prescriber_organization.members.first()
 
         today = timezone.now().date()

--- a/itou/www/prescribers_views/tests/test_edit.py
+++ b/itou/www/prescribers_views/tests/test_edit.py
@@ -3,11 +3,7 @@ from unittest import mock
 from django.test import TestCase
 from django.urls import reverse
 
-from itou.prescribers.factories import (
-    AuthorizedPrescriberOrganizationWithMembershipFactory,
-    PrescriberOrganizationFactory,
-    PrescriberOrganizationWithMembershipFactory,
-)
+from itou.prescribers.factories import PrescriberOrganizationFactory, PrescriberOrganizationWithMembershipFactory
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.factories import DEFAULT_PASSWORD
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
@@ -27,8 +23,8 @@ class EditOrganizationTest(TestCase):
     def test_edit(self, mock_call_ban_geocoding_api):
         """Edit a prescriber organization."""
 
-        organization = AuthorizedPrescriberOrganizationWithMembershipFactory(
-            kind=PrescriberOrganization.Kind.CAP_EMPLOI
+        organization = PrescriberOrganizationWithMembershipFactory(
+            authorized=True, kind=PrescriberOrganization.Kind.CAP_EMPLOI
         )
         user = organization.members.first()
 

--- a/itou/www/search/tests.py
+++ b/itou/www/search/tests.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from itou.cities.factories import create_city_guerande, create_city_saint_andre, create_city_vannes
 from itou.cities.models import City
 from itou.job_applications.factories import JobApplicationFactory
-from itou.prescribers.factories import AuthorizedPrescriberOrganizationFactory
+from itou.prescribers.factories import PrescriberOrganizationFactory
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import SiaeFactory
 
@@ -146,8 +146,8 @@ class SearchPrescriberTest(TestCase):
 
         vannes = create_city_vannes()
         guerande = create_city_guerande()
-        AuthorizedPrescriberOrganizationFactory(coords=guerande.coords)
-        AuthorizedPrescriberOrganizationFactory(coords=vannes.coords)
+        PrescriberOrganizationFactory(authorized=True, coords=guerande.coords)
+        PrescriberOrganizationFactory(authorized=True, coords=vannes.coords)
 
         response = self.client.get(url, {"city": guerande.slug, "distance": 100})
         self.assertContains(response, "<b>2</b> résultats")


### PR DESCRIPTION
### Quoi ?

Ajout d'un message d'avertissement lors du dépôt de candidature pour les prescripteurs en cours d'habilitation.

### Pourquoi ?

Pour éviter la confusion lorsque les employeurs doivent valider les critères d'éligibilité IAE pour une candidature provenant d'un prescripteur habilité entre temps.

### Comment ?

Ajout d'une étape en tout début de parcours de dépôt de candidature.

### Captures d'écran

![Capture du message d'avertissement](https://user-images.githubusercontent.com/17601807/180167194-4415c0e7-7f4b-4f36-b573-d05746e41db9.png)

