### PR TITLE
Boost dev

### DIFF
--- a/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
+++ b/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
@@ -12,9 +12,6 @@ Bonjour,
 - Fin de la prolongation : {{ prolongation.end_at|date:"d/m/Y" }}
 - Motif de prolongation : {{ prolongation.get_reason_display }}
 
-Pour confirmer et valider cette prolongation, merci de nous transférer
-ce message à : {{ itou_email_prolongation }}
-
-Si vous n'avez pas autorisé cette prolongation, merci de contacter notre assistance technique : {{ itou_assistance_url }}
+Pour valider ou refuser cette prolongation, merci de nous transférer ce message à l'adresse suivante : {{ itou_email_prolongation }}
 
 {% endblock body %}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -68,7 +68,7 @@ class CheckJobSeekerNirForm(forms.Form):
             self.fields["nir"].label = "Numéro de sécurité sociale du candidat"
 
     def clean_nir(self):
-        nir = self.cleaned_data["nir"]
+        nir = self.cleaned_data["nir"].upper()
         nir = nir.replace(" ", "")
         existing_account = User.objects.filter(nir=nir).first()
 

--- a/itou/www/apply/tests/tests_forms.py
+++ b/itou/www/apply/tests/tests_forms.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+
+from itou.users.factories import JobSeekerFactory
+from itou.www.apply import forms as apply_forms
+
+
+class CheckJobSeekerNirFormTest(TestCase):
+    def test_form_job_seeker_not_found(self):
+        # This NIR is unique.
+        nir = JobSeekerFactory.build().nir
+        form_data = {"nir": nir}
+        form = apply_forms.CheckJobSeekerNirForm(data=form_data)
+        self.assertTrue(form.is_valid())
+        self.assertIsNone(form.job_seeker)
+
+    def test_form_job_seeker_found(self):
+        # A job seeker with this NIR already exists.
+        nir = "141062A78200555"
+        job_seeker = JobSeekerFactory(nir=nir)
+        form_data = {"nir": job_seeker.nir}
+        form = apply_forms.CheckJobSeekerNirForm(data=form_data)
+        # A job seeker has been found.
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.job_seeker, job_seeker)
+
+        # NIR should be case insensitive.
+        form_data = {"nir": job_seeker.nir.lower()}
+        form = apply_forms.CheckJobSeekerNirForm(data=form_data)
+        # A job seeker has been found.
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.job_seeker, job_seeker)
+
+    def test_form_not_valid(self):
+        # Application sent by a job seeker whose NIR is already used by another account.
+        existing_account = JobSeekerFactory()
+        user = JobSeekerFactory()
+        form_data = {"nir": existing_account.nir}
+        form = apply_forms.CheckJobSeekerNirForm(job_seeker=user, data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("Ce numéro de sécurité sociale est déjà utilisé par un autre compte.", form.errors["nir"][0])

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -51,9 +51,7 @@ def list_for_prescriber(request, template_name="apply/list_for_prescriber.html")
     filters_form = PrescriberFilterJobApplicationsForm(job_applications, request.GET or None)
 
     # Add related data giving the criteria for adding the necessary annotations
-    job_applications = job_applications.not_archived().with_list_related_data(
-        criteria=filters_form.data.getlist("criteria", [])
-    )
+    job_applications = job_applications.with_list_related_data(criteria=filters_form.data.getlist("criteria", []))
 
     filters_counter = 0
     if filters_form.is_valid():

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,7 +30,7 @@ djhtml==1.5.0  # https://github.com/rtts/djhtml
 factory-boy==3.2.1  # https://github.com/FactoryBoy/factory_boy
 
 django-debug-toolbar==3.4  # https://github.com/jazzband/django-debug-toolbar
-django-extensions==3.1.5  # https://github.com/django-extensions/django-extensions
+django-extensions==3.2.0 # https://github.com/django-extensions/django-extensions
 django-admin-logs==1.0.2  # https://pypi.org/project/django-admin-logs/
 
 # Test & Mock


### PR DESCRIPTION
### Quoi ?

- [x] La vérification du NIR pendant le parcours de candidature ne doit pas prendre en compte la casse pour éviter de créer des doublons.
- [x] Ajout de trois champs au CSV `hard_duplicates_{env}` : NIR, date de naissance et lien vers les candidatures de moins de trois mois.
- [x] Mise à jour du message envoyé au prescripteur quand une demande de prolongation est faite.
- [x] Mise à jour de la librairie django-extensions-plus en local pour [corriger un bug](https://github.com/django-extensions/django-extensions/pull/1718) apparu avec Python 3.10.
- [x] Correction d'un bug : affichage sur le tableau de bord des prescripteur des candidatures masquées par l'employeur (ticket à créer)