### PR TITLE
Retrait du message d'information concernant le dysfonctionnement des fiches salarié

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -4,13 +4,6 @@
 
 {% block messages %}
     {{ block.super }}
-    {% if can_show_employee_records %}
-        <div class="alert alert-danger">
-            <p class="mb-0">
-                La transmission des fiches salarié est actuellement indisponible. Veuillez nous excuser pour la gêne occasionnée.
-            </p>
-        </div>
-    {% endif %}
 
     {% if current_siae and not current_siae.jobs.exists %}
         <div class="alert alert-warning">


### PR DESCRIPTION
### Quoi ?

Retrait du message d'information concernant l'incident de juillet 2022 et l'arrêt de la transmission des fiches salarié.

### Pourquoi ?

Problème résolu par l'ASP.

### Comment ?

Modification du template du dashboard.
