### PR TITLE
Résolution d'un nouveau cas tordu de l'import SIAE

### DIFF
--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -26,12 +26,15 @@ def update_existing_conventions():
         assert convention.kind == siae.kind
         assert convention.siren_signature == siae.siren
 
-        if not convention.is_active and siae.siret not in SIRET_TO_ASP_ID:
-            # Old inactive siaes which could not deleted because they have data will stay in our database forever.
-            # At some point they no longer exist in the latest FluxIAE file thus we should leave them untouched.
+        if siae.siret not in SIRET_TO_ASP_ID:
+            # At some point, old C1 siaes stop existing in the latest FluxIAE file.
+            # If they still have C1 data they could not be deleted in an earlier step and thus will stay in
+            # the C1 database forever, we should leave them untouched.
+            if convention.is_active:
+                assert not does_siae_have_an_active_convention(siae)
+                conventions_to_deactivate.append(convention)
             continue
 
-        assert siae.siret in SIRET_TO_ASP_ID
         asp_id = SIRET_TO_ASP_ID[siae.siret]
         siret_signature = ASP_ID_TO_SIRET_SIGNATURE[asp_id]
 


### PR DESCRIPTION
### Quoi ?

Résolution d'un nouveau cas tordu de l'import SIAE.

### Pourquoi ?

Parce qu'il s'est produit ce début de semaine.

D'habitude, quand une SIAE est déconventionnée, toutes ses AF dans les données ASP sont marquées invalides, sa convention C1 est alors désactivée, et ce n'est que bien plus tard (voire jamais) que toute trace de cette structure disparait des données ASP.

Cette fois une SIAE, active jusque là, a subitement disparu des données ASP. Du coup on s'est trouvé dans le cas `convention.is_active and siae.siret not in SIRET_TO_ASP_ID` qui n'était pas traité avant cette PR, et le sera dorénavant.

### Comment ?

En traitant non seulement l'ancien cas `not convention.is_active and siae.siret not in SIRET_TO_ASP_ID` mais aussi le nouveau `convention.is_active and siae.siret not in SIRET_TO_ASP_ID`.