### PR TITLE
Nettoyage du code ApprovalsWrapper (phase 1)

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1474,6 +1474,7 @@ class ApprovalsWrapper:
                 self.status = self.IN_WAITING_PERIOD
 
         # Only one of the following attributes can be True at a time.
+        self.has_none = self.status == self.NONE_FOUND
         self.has_valid = self.status == self.VALID
         self.has_in_waiting_period = self.status == self.IN_WAITING_PERIOD
 

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -7,49 +7,43 @@
     <h1 class="h1-hero-c1">Prolonger ou suspendre un agrément émis par Pôle emploi</h1>
 
     {% if approval.is_valid %}
-        {% if approval.originates_from_itou %}
+
+        {% if approval.is_pass_iae %}
             <div class="alert alert-danger" role="status">
-                <p class="mb-0">Le numéro <strong>{{ approval.number|slice:12 }}</strong> correspond à un PASS IAE.</p>
+                {% if approval.originates_from_itou %}
+                    <p class="mb-0">Le numéro <strong>{{ approval.number }}</strong> correspond à un PASS IAE.</p>
+                {% else %}
+                    {% comment %}
+                        The approval has been issued by Pôle emploi and transformed into an Approval.
+                        A redirection is made upstream if the current SIAE can prolong or suspend it.
+                        It means another SIAE is using it right now.
+                    {% endcomment %}
+                    <p class="mb-0">L'agrément <strong>{{ approval.number }}</strong> a déjà été converti en PASS IAE.</p>
+                {% endif %}
             </div>
             <p>
-                Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">réaliser une auto-prescription</a>. Il sera automatiquement importé dans votre compte.
+                Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">réaliser une auto-prescription</a>.
             </p>
             <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
-
         {% else %}
-            {% if approval.is_pass_iae %}
-                {% comment %}
-                    The approval has been issued by Pôle emploi and transformed into an Approval.
-                    A redirection is made upstream if the current SIAE can prolong or suspend it.
-                    It means another SIAE is using it right now.
-                {% endcomment %}
-                <div class="alert alert-danger" role="status">
-                    <p class="mb-0">L'agrément <strong>{{ approval.number|slice:12 }}</strong> a déjà été converti en PASS IAE.</p>
-                </div>
-                <p>
-                    Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">réaliser une auto-prescription</a>.
-                </p>
-                <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
-            {% else %}
-                <p>
-                    L'agrément <strong>{{ approval.number|slice:12 }}</strong> a été délivré pour <strong>{{ approval.first_name|title }} {{ approval.last_name|title }}</strong>.
-                </p>
-                <p>
-                    Nous allons l'importer dans votre compte pour vous permettre de le suspendre ou de le prolonger.
-                </p>
-                <p>
-                    Mais avant, nous avons besoin de connaître l'adresse e-mail de votre salarié(e).
-                </p>
-                <a class="btn btn-outline-primary" href="{{ back_url }}">Annuler</a>
-                <a class="btn btn-primary" href="{% url 'approvals:pe_approval_search_user' approval.pk %}">
-                    Continuer
-                </a>
-            {% endif %}
+            <p>
+                L'agrément <strong>{{ approval.number }}</strong> a été délivré pour <strong>{{ approval.first_name|title }} {{ approval.last_name|title }}</strong>.
+            </p>
+            <p>
+                Nous allons l'importer dans votre compte pour vous permettre de le suspendre ou de le prolonger.
+            </p>
+            <p>
+                Mais avant, nous avons besoin de connaître l'adresse e-mail de votre salarié(e).
+            </p>
+            <a class="btn btn-outline-primary" href="{{ back_url }}">Annuler</a>
+            <a class="btn btn-primary" href="{% url 'approvals:pe_approval_search_user' approval.pk %}">
+                Continuer
+            </a>
         {% endif %}
 
     {% else %}
         <div class="alert alert-danger" role="status">
-            <p class="mb-0">L'agrément <strong>{{ approval.number|slice:12 }}</strong> est expiré depuis le {{ approval.end_at|date:"d/m/Y" }}. Vous ne pouvez pas le prolonger ou le suspendre.</p>
+            <p class="mb-0">L'agrément <strong>{{ approval.number }}</strong> est expiré depuis le {{ approval.end_at|date:"d/m/Y" }}. Vous ne pouvez pas le prolonger ou le suspendre.</p>
         </div>
         <p>
             S'il s'agit d'un nouveau contrat, vous pouvez solliciter <a href="{% url 'search:prescribers_home' %}" title="Solliciter un prescripteur habilité">un prescripteur habilité</a> pour qu'il puisse vous orienter le candidat.

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -217,15 +217,12 @@ class SuspensionForm(forms.ModelForm):
 
 
 class PoleEmploiApprovalSearchForm(forms.Form):
-    """
-    Search for a PoleEmploiApproval by number
-    """
 
     number = forms.CharField(
         label="Numéro",
         required=True,
         min_length=12,
-        max_length=15,
+        max_length=12,
         strip=True,
         help_text=("Le numéro d'agrément est composé de 12 chiffres (ex. 123456789012)."),
     )

--- a/itou/www/approvals_views/tests/test_pe_approval.py
+++ b/itou/www/approvals_views/tests/test_pe_approval.py
@@ -1,8 +1,6 @@
-from dateutil.relativedelta import relativedelta
 from django.contrib.messages import get_messages
 from django.test import TestCase
 from django.urls import reverse
-from django.utils import timezone
 
 from itou.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
 from itou.approvals.models import Approval
@@ -76,22 +74,6 @@ class PoleEmploiApprovalSearchTest(TestCase):
         self.client.login(username=siae.user.email, password=DEFAULT_PASSWORD)
 
         response = self.client.get(self.url, {"number": 123123123123})
-        self.assertNotContains(response, "Continuer")
-
-    def test_approval_in_the_future(self):
-        """
-        The search for PE approval screen should display that there is no results
-        if a PE approval number was searched for but it is in the future
-        """
-        today = timezone.now().date()
-
-        pe_approval = PoleEmploiApprovalFactory(start_at=today + relativedelta(days=10))
-
-        job_application = JobApplicationWithApprovalFactory(state=JobApplicationWorkflow.STATE_ACCEPTED)
-        siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
-
-        response = self.client.get(self.url, {"number": pe_approval.number})
         self.assertNotContains(response, "Continuer")
 
     def test_has_matching_pass_iae(self):

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -250,9 +250,6 @@ def pe_approval_search(request, template_name="approvals/pe_approval_search.html
             context = {
                 "approval": approval,
                 "back_url": back_url,
-                "form": form,
-                "number": number,
-                "siae": siae,
             }
             return render(request, "approvals/pe_approval_search_found.html", context)
 


### PR DESCRIPTION
### Quoi ?

Retirer une partie de l'utilisation de l'Approval Wrapper.

### Pourquoi ?
Ce code est ancien, complexe et probablement source de confusion dès que nous cherchons à intervenir sur les PASS et agréments.

Il crée du couplage fort entre plusieurs applications du système d'information et est en grande partie obsolète aujourd'hui.

Il est bon de le retirer en vérifiant au passage que certains bugs ne peuvent pas être corrigés par la même occasion.

### Comment ?
Quatre étapes (vues commit par commit)

- Nettoyage de certaines incohérences (attente sur le numéro de pass/agrément qui aujourd'hui est toujours unique et à 12 chiffres car consolidé, templates imprécises ou variables non nécessaires, étapes superflues...)
- Nettoyage de l'utilisation du ApprovalsWrapper en mode "recherche d'agrément pour sa transformation manuelle"
- Evolution métier (Eric): si aucun PASS ni agrément n'existe lors de la validation d'une embauche pour un demandeur d'emploi, alors il faut créer un PASS automatiquement, pas passer en mode manueL.

### Reste à faire (phase 2 car bien plus long):
- Nettoyage du ApprovalsWrapper en tant que "lien vers le dernier agrément ou PASS sur un demandeur d'emploi"