### PR TITLE
Empêcher qu'un utilisateur cumule les types (candidat, prescripteur, etc)

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -297,6 +297,12 @@ class User(AbstractUser, AddressMixin):
         # Update department from postal code (if possible).
         self.department = department_from_postcode(self.post_code)
         self.validate_unique()
+
+        # TODO(rsebille): Replace by a UniqueConstraint once the data have been cleaned
+        user_kinds = [self.is_job_seeker, self.is_prescriber, self.is_siae_staff, self.is_labor_inspector]
+        if user_kinds.count(True) > 1:
+            raise ValidationError("A User can not have more than one kind")
+
         super().save(*args, **kwargs)
 
     def can_edit_email(self, user):

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+import itertools
 import json
 import uuid
 from unittest import mock
@@ -601,6 +602,17 @@ class ModelTest(TestCase):
         user = institution.members.get()
         self.assertFalse(user.can_view_stats_dgefp(current_org=institution))
         self.assertFalse(user.can_view_stats_dashboard_widget(current_org=institution))
+
+    def test_a_user_can_only_have_one_kind(self):
+        unique_fields = ["is_job_seeker", "is_prescriber", "is_siae_staff", "is_labor_inspector"]
+
+        for field in unique_fields:
+            UserFactory(**{field: True})
+
+        for n in range(2, 5):
+            for fields in itertools.combinations(unique_fields, n):
+                with self.assertRaises(ValidationError):
+                    UserFactory(**dict(zip(fields, itertools.repeat(True))))
 
 
 def mock_get_geocoding_data(address, post_code=None, limit=1):


### PR DESCRIPTION
### Quoi ?

Vérifier que les personnes qui se connecte avec FranceConnect/InclusionConnect ne sont pas d'un autre type que celui prévu.
Si son compte est d’un autre type, il doit être redirigé vers la page de connexion.

### Pourquoi ?

Un employeur c'est retrouvé à la fois candidat et employeur car il s’est connecté avec FranceConnect.
Le système ne vérifie pas le type d’utilisateur.

### Comment ?

1. Le model n'autorise plus d'avoir plusieurs types, il faudrait que ce soit une contrainte mais il faut nettoyer de la donnée avant. Et idéalement il ne faudrait avoir que un seul champs et pas 4 comme actuellement.
2. On affiche un message (avant que le model nous envois bouler) si jamais quelqu'un passe par FC ou IC et que le compte existant n'est pas du bon type.
