### PR TITLE
PEAMU : Ne plus générer d’événement Sentry si nous n'avons pas d'access token

### DIFF
--- a/itou/allauth_adapters/peamu/client.py
+++ b/itou/allauth_adapters/peamu/client.py
@@ -12,6 +12,11 @@ class PEAMUOAuth2Client(OAuth2Client):
     (╯°□°)╯︵ ┻━┻
     """
 
+    class NoAccessToken(OAuth2Error):
+        def __init__(self, response, *args: object):
+            self.response = response
+            super().__init__(*args)
+
     def get_access_token(self, code):
         """
         This whole method is unchanged except for the
@@ -49,5 +54,5 @@ class PEAMUOAuth2Client(OAuth2Client):
             else:
                 access_token = dict(parse_qsl(resp.text))
         if not access_token or "access_token" not in access_token:
-            raise OAuth2Error("Error retrieving access token: %s" % resp.content)
+            raise PEAMUOAuth2Client.NoAccessToken(resp)
         return access_token

--- a/itou/allauth_adapters/peamu/views.py
+++ b/itou/allauth_adapters/peamu/views.py
@@ -81,6 +81,13 @@ class PEAMUOAuth2CallbackView(OAuth2CallbackView):
             else:
                 login.state = SocialLogin.unstash_state(request)
             return complete_social_login(request, login)
+        except client.NoAccessToken as e:
+            logger.warning(
+                "Error retrieving access token: status=%s content=%s",
+                e.response.status_code,
+                e.response.content,
+            )
+            return render_authentication_error(request, self.adapter.provider_id, exception=e)
         except (PermissionDenied, OAuth2Error, RequestException, ProviderException) as e:
             logger.error("Unknown error in PEAMU dispatch with exception '%s'.", e)
             return render_authentication_error(request, self.adapter.provider_id, exception=e)


### PR DESCRIPTION
### Quoi ?

Erreur *très* récurrente (et bruyante) dans sentry.
### Pourquoi ?

L'exception génère de nombreux événements auxquels nous ne pouvons pas faire grand chose, on continue donc de logger mais sans le remonter dans sentry.