### PR TITLE
Le lien vers le formulaire de suspension pour les prescripteurs habilités est uniquement pour Pôle emploi

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -312,10 +312,12 @@
                                 Export des candidatures
                             </a>
                         </li>
-                        <li class="card-text mb-3">
-                            <i class="ri-pause-circle-line ri-lg"></i>
-                            <a href="https://tally.so/r/w2Ex0M" title="Suspendre un PASS IAE (ouverture dans un nouvel onglet)" target="_blank">Suspendre un PASS IAE</a><i class="ri-external-link-line ml-1"></i>
-                        </li>
+                        {% if current_prescriber_organization and current_prescriber_organization.kind == current_prescriber_organization.Kind.PE  %}
+                            <li class="card-text mb-3">
+                                <i class="ri-pause-circle-line ri-lg"></i>
+                                <a href="https://tally.so/r/w2Ex0M" title="Suspendre un PASS IAE (ouverture dans un nouvel onglet)" target="_blank">Suspendre un PASS IAE</a><i class="ri-external-link-line ml-1"></i>
+                            </li>
+                        {% endif %}
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
### Quoi ?

Le lien vers le formulaire de suspension pour les prescripteurs habilités est uniquement pour Pôle emploi

### Pourquoi ?

Le lien ne doit pas être visible par les autres prescripteur, non concerné.

### Comment ?

Une petit `if` dans le template !

### Captures d'écrans

![capture_lien_suspendre](https://user-images.githubusercontent.com/17601807/182349237-59801bc9-1e6c-4f06-b48c-583b360a349f.png)

