### PR TITLE
Retirer le "Bienvenue" de la page de connection

### DIFF
--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -58,7 +58,8 @@
             </p>
         {% endif %}
 
-        <p class="display-1 ff-extra-01 mb-5">Bienvenue !</p>
+        <br>
+        <br>
         <img class="img-fluid img-fitcover w-50 w-md-auto" src="{% static 'img/login.svg' %}" alt="">
     </div>
 {% endblock %}

--- a/itou/templates/account/login_job_seeker.html
+++ b/itou/templates/account/login_job_seeker.html
@@ -67,7 +67,8 @@
                 Créer un compte candidat
             </a>
         </p>
-        <p class="display-1 ff-extra-01 mb-5">Bienvenue !</p>
+        <br>
+        <br>
         <img class="img-fluid img-fitcover w-50 w-md-auto" src="{% static 'img/login.svg' %}" alt="">
     </div>
 {% endblock %}


### PR DESCRIPTION
### Quoi ?

Le mot bienvenue n’est pas à l’endroit où il se trouvait dans la maquette. Pour éviter qu’il gène le bouton de création de compte, il faudrait le retirer.

### Captures d'écran (optionnel)

![Screenshot from 2022-08-02 13-36-46](https://user-images.githubusercontent.com/7632730/182365645-44fa0614-5675-4993-a463-2c6823aa8c8d.png)
![Screenshot from 2022-08-02 13-36-51](https://user-images.githubusercontent.com/7632730/182365652-bd40813f-5f39-4f5d-8c48-3cf059e0f6b7.png)