### PR TITLE
Montée de CC_PYTHON_VERSION à 3.10 pour fast-machine

### DIFF
--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -30,7 +30,7 @@ fi
 ORGANIZATION_NAME=Itou
 IMPORT_APP_NAME=c1-imports-$(date +%y-%m-%d-%Hh-%M)
 DEPLOY_BRANCH=master_clever
-CC_PYTHON_VERSION=3.9
+CC_PYTHON_VERSION=3.10
 
 clever login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
 # Create a new application on Clever Cloud.


### PR DESCRIPTION
### Quoi ?

Montée de CC_PYTHON_VERSION à 3.10 pour fast-machine.

### Pourquoi ?

La version avait été montée partout dans la base de code sauf cet endroit, petit oubli.

Pas de revue, trivial.