### PR TITLE
Se débarrasser de ApprovalsWrapper, phase 2

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -12,7 +12,6 @@ from django.db.models import Count, Q
 from django.db.models.functions import TruncDate
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.safestring import mark_safe
 from unidecode import unidecode
 
 from itou.approvals.notifications import NewProlongationToAuthorizedPrescriberNotification
@@ -21,7 +20,6 @@ from itou.siaes import enums as siae_enums
 from itou.utils.apis import enums as api_enums
 from itou.utils.apis.pole_emploi import PoleEmploiAPIBadResponse, PoleEmploiApiClient, PoleEmploiAPIException
 from itou.utils.models import DateRange
-from itou.utils.urls import get_external_link_markup
 from itou.utils.validators import alphanumeric, validate_siret
 
 
@@ -1431,29 +1429,6 @@ class ApprovalsWrapper:
     NONE_FOUND = "NONE_FOUND"
     VALID = "VALID"
     IN_WAITING_PERIOD = "IN_WAITING_PERIOD"
-
-    # Error messages.
-    WAITING_PERIOD_DOC_LINK = get_external_link_markup(
-        url=f"{settings.ITOU_COMMUNITY_URL }/doc/emplois/derogation-au-delai-de-carence/",
-        text="En savoir plus sur la dérogation du délai de carence",
-    )
-    ERROR_CANNOT_OBTAIN_NEW_FOR_USER = mark_safe(
-        (
-            "Vous avez terminé un parcours il y a moins de deux ans.<br>"
-            "Pour prétendre à nouveau à un parcours en structure d'insertion "
-            "par l'activité économique vous devez rencontrer un prescripteur "
-            "habilité : Pôle emploi, Mission Locale, CAP Emploi, etc."
-        )
-    )
-    ERROR_CANNOT_OBTAIN_NEW_FOR_PROXY = mark_safe(
-        (
-            "Le candidat a terminé un parcours il y a moins de deux ans.<br>"
-            "Pour prétendre à nouveau à un parcours en structure d'insertion "
-            "par l'activité économique il doit rencontrer un prescripteur "
-            "habilité : Pôle emploi, Mission Locale, CAP Emploi, etc."
-            f"<br>{WAITING_PERIOD_DOC_LINK}"  # Display doc link only for proxies.
-        )
-    )
 
     def __init__(self, user):
         self.user = user

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1454,6 +1454,3 @@ class ApprovalsWrapper:
     @property
     def has_valid_pole_emploi_eligibility_diagnosis(self):
         return self.user.has_valid_pe_eligibility_diagnosis
-
-    def cannot_bypass_waiting_period(self, siae, sender_prescriber_organization):
-        return self.user.cannot_bypass_approval_waiting_period(siae, sender_prescriber_organization)

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1474,6 +1474,7 @@ class ApprovalsWrapper:
                 self.status = self.IN_WAITING_PERIOD
 
         # Only one of the following attributes can be True at a time.
+        self.has_none = self.status == self.NONE_FOUND
         self.has_valid = self.status == self.VALID
         self.has_in_waiting_period = self.status == self.IN_WAITING_PERIOD
 

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -677,34 +677,6 @@ class ApprovalsWrapperTest(TestCase):
         approvals_wrapper = ApprovalsWrapper(user)
         self.assertEqual(approvals_wrapper.latest_approval, pe_approval_2)
 
-    def test_merge_approvals_discard_pe_approval_in_future(self):
-        # FIXME(vperron): Remove this test, as pe_approvals in the future do not exist anymore
-        user = JobSeekerFactory()
-
-        start_at_in_the_future = timezone.now() + relativedelta(months=2)
-        end_at = start_at_in_the_future + relativedelta(years=Approval.DEFAULT_APPROVAL_YEARS)
-        # PoleEmploiApproval 1.
-        # It should be discarded since its starts in the future
-        PoleEmploiApprovalFactory(
-            pole_emploi_id=user.pole_emploi_id,
-            birthdate=user.birthdate,
-            start_at=start_at_in_the_future,
-            end_at=end_at,
-        )
-
-        # PoleEmploiApproval 2.
-        start_at_in_the_past = timezone.now() - relativedelta(months=2)
-        pe_approval_2 = PoleEmploiApprovalFactory(
-            pole_emploi_id=user.pole_emploi_id,
-            birthdate=user.birthdate,
-            start_at=start_at_in_the_past,
-            end_at=start_at_in_the_past + relativedelta(years=Approval.DEFAULT_APPROVAL_YEARS),
-        )
-
-        # Check that only one approval is taken into account
-        approvals_wrapper = ApprovalsWrapper(user)
-        self.assertEqual(approvals_wrapper.latest_approval, pe_approval_2)
-
     def test_merge_approvals_pass_and_pe_valid(self):
         user = JobSeekerFactory()
         start_at = timezone.now() - relativedelta(months=2)

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -335,6 +335,7 @@ class ApprovalModelTest(TestCase):
         self.assertFalse(approval.is_open_to_prolongation)
 
     def test_get_or_create_from_valid(self):
+        # FIXME(vperron): This test should be moved to users.tests or jobseekerprofile.tests.
 
         # With an existing valid `PoleEmploiApproval`.
 
@@ -342,9 +343,7 @@ class ApprovalModelTest(TestCase):
         valid_pe_approval = PoleEmploiApprovalFactory(
             pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate, number="625741810182"
         )
-        approvals_wrapper = ApprovalsWrapper(user)
-
-        approval = Approval.get_or_create_from_valid(approvals_wrapper)
+        approval = user.get_or_create_approval()
 
         self.assertTrue(isinstance(approval, Approval))
         self.assertEqual(approval.start_at, valid_pe_approval.start_at)
@@ -357,9 +356,7 @@ class ApprovalModelTest(TestCase):
 
         user = JobSeekerFactory()
         valid_approval = ApprovalFactory(user=user, start_at=timezone.now().date() - relativedelta(days=1))
-        approvals_wrapper = ApprovalsWrapper(user)
-
-        approval = Approval.get_or_create_from_valid(approvals_wrapper)
+        approval = user.get_or_create_approval()
         self.assertTrue(isinstance(approval, Approval))
         self.assertEqual(approval, valid_approval)
 

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -835,15 +835,14 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         if not self.hiring_without_approval and self.to_siae.is_subject_to_eligibility_rules:
 
             approvals_wrapper = self.job_seeker.approvals_wrapper
-
-            if approvals_wrapper.has_in_waiting_period:
-                if approvals_wrapper.cannot_bypass_waiting_period(
+            if self.job_seeker.has_approval_in_waiting_period:
+                if self.job_seeker.cannot_bypass_approval_waiting_period(
                     siae=self.to_siae, sender_prescriber_organization=self.sender_prescriber_organization
                 ):
                     # Security check: it's supposed to be blocked upstream.
                     raise xwf_models.AbortTransition("Job seeker has an approval in waiting period.")
 
-            if approvals_wrapper.has_valid:
+            if self.job_seeker.has_valid_approval:
                 # Automatically reuse an existing valid Itou or PE approval.
                 self.approval = Approval.get_or_create_from_valid(approvals_wrapper)
                 if self.approval.start_at > self.hiring_start_at:

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -852,6 +852,13 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
                     self.approval.update_start_date(new_start_date=self.hiring_start_at)
                 emails.append(self.email_deliver_approval(accepted_by))
             elif (
+                not self.job_seeker.pole_emploi_id
+                and self.job_seeker.lack_of_pole_emploi_id_reason == self.job_seeker.REASON_FORGOTTEN
+            ):
+                # Trigger a manual approval creation.
+                self.approval_delivery_mode = self.APPROVAL_DELIVERY_MODE_MANUAL
+                emails.append(self.email_manual_approval_delivery_required_notification(accepted_by))
+            elif (approvals_wrapper.has_none and (self.job_seeker.nir or self.job_seeker.pole_emploi_id)) or (
                 self.job_seeker.pole_emploi_id
                 or self.job_seeker.lack_of_pole_emploi_id_reason == self.job_seeker.REASON_NOT_REGISTERED
             ):
@@ -864,10 +871,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
                 new_approval.save()
                 self.approval = new_approval
                 emails.append(self.email_deliver_approval(accepted_by))
-            elif self.job_seeker.lack_of_pole_emploi_id_reason == self.job_seeker.REASON_FORGOTTEN:
-                # Trigger a manual approval creation.
-                self.approval_delivery_mode = self.APPROVAL_DELIVERY_MODE_MANUAL
-                emails.append(self.email_manual_approval_delivery_required_notification(accepted_by))
             else:
                 raise xwf_models.AbortTransition("Job seeker has an invalid PE status, cannot issue approval.")
 
@@ -1062,9 +1065,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         return self._get_transfer_email(to, subject, body, transferred_by, origin_siae, target_siae)
 
     def manually_deliver_approval(self, delivered_by):
-        """
-        Manually deliver an approval.
-        """
         self.approval_number_sent_by_email = True
         self.approval_number_sent_at = timezone.now()
         self.approval_manually_delivered_by = delivered_by
@@ -1074,9 +1074,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         email.send()
 
     def manually_refuse_approval(self, refused_by):
-        """
-        Manually refuse an approval.
-        """
         self.approval_manually_refused_by = refused_by
         self.approval_manually_refused_at = timezone.now()
         self.save()

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -844,7 +844,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
 
             if self.job_seeker.has_valid_approval:
                 # Automatically reuse an existing valid Itou or PE approval.
-                self.approval = Approval.get_or_create_from_valid(approvals_wrapper)
+                self.approval = self.job_seeker.get_or_create_approval()
                 if self.approval.start_at > self.hiring_start_at:
                     # As a job seeker can have multiple contracts at the same time,
                     # the approval should start at the same time as most recent contract.

--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -1099,6 +1099,7 @@ class JobApplicationWorkflowTest(TestCase):
         When a Pôle emploi approval already exists, it is reused.
         Some Pole Emploi approvals have a starting date in the future, we discard them
         """
+        # FIXME(vperron): Remove this test, as pe_approvals in the future do not exist anymore
         hiring_start_at = datetime.date.today()
         start_at = datetime.date.today() + relativedelta(months=1)
         end_at = start_at + relativedelta(months=3)

--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -1092,42 +1092,6 @@ class JobApplicationWorkflowTest(TestCase):
         # Approval delivered -> Pole Emploi is notified
         notify_mock.assert_called()
 
-    def test_accept_job_application_sent_by_job_seeker_with_already_existing_valid_approval_in_the_future(
-        self, notify_mock
-    ):
-        """
-        When a Pôle emploi approval already exists, it is reused.
-        Some Pole Emploi approvals have a starting date in the future, we discard them
-        """
-        # FIXME(vperron): Remove this test, as pe_approvals in the future do not exist anymore
-        hiring_start_at = datetime.date.today()
-        start_at = datetime.date.today() + relativedelta(months=1)
-        end_at = start_at + relativedelta(months=3)
-
-        job_seeker = JobSeekerFactory()
-        pe_approval = PoleEmploiApprovalFactory(
-            start_at=start_at,
-            end_at=end_at,
-            pole_emploi_id=job_seeker.pole_emploi_id,
-            birthdate=job_seeker.birthdate,
-        )
-        job_application = JobApplicationSentByJobSeekerFactory(
-            job_seeker=job_seeker, state=JobApplicationWorkflow.STATE_PROCESSING, hiring_start_at=hiring_start_at
-        )
-        # the job application can be accepted but the approval is not attached to the PE approval
-        job_application.accept(user=job_application.to_siae.members.first())
-        self.assertIsNotNone(job_application.approval)
-        self.assertNotEqual(job_application.approval.number, pe_approval.number[0:12])
-        pe_approval.refresh_from_db()
-        # The job application is accepted
-        self.assertTrue(job_application.state.is_accepted)
-        # The Pole emploi approval is not updated
-        self.assertNotEqual(hiring_start_at, pe_approval.start_at)
-        # The job application is accepted, with an approval with the requested hiring start date
-        self.assertEqual(hiring_start_at, job_application.approval.start_at)
-        # Approval delivered -> Pole Emploi is notified
-        notify_mock.assert_called()
-
     def test_accept_job_application_sent_by_job_seeker_with_forgotten_pole_emploi_id(self, notify_mock):
         """
         When a Pôle emploi ID is forgotten, a manual approval delivery is triggered.

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -25,7 +25,7 @@
                     {# Approval status. #}
                     <div class="card-text">
                         {% if job_application.approval %}
-                            {% include "approvals/includes/status.html" with approval=job_application.approval %}
+                            {% include "approvals/includes/status.html" with common_approval=job_application.approval %}
                         {% elif job_application.hiring_without_approval %}
                             Vous n'avez pas demandé de PASS IAE (agrément).
                         {% elif job_application.approval_manually_refused_at %}
@@ -74,19 +74,10 @@
                 </div>
             </div>
 
-        {% elif not job_application.state.is_cancelled and approvals_wrapper.latest_approval %}
-
-            <div class="card my-3">
-                <div class="card-body">
-                    {# Approval status. #}
-                    <div class="card-text">
-                        {# Employers need to know the expiration date of an approval #}
-                        {# to decide whether they may accept a job application or not. #}
-                        {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval job_application=job_application %}
-                    </div>
-                </div>
-            </div>
-
+        {% elif not job_application.state.is_cancelled %}
+            {# Employers need to know the expiration date of an approval #}
+            {# to decide whether they may accept a job application or not. #}
+            {% include "approvals/includes/card.html" with common_approval=job_application.job_seeker.latest_common_approval job_application=job_application %}
         {% endif %}
 
     {% endif %}

--- a/itou/templates/apply/submit_base.html
+++ b/itou/templates/apply/submit_base.html
@@ -17,15 +17,6 @@
         <h2 class="h1">{{ job_seeker.get_full_name|title }}</h2>
     {% endif %}
 
-    {% if approvals_wrapper.latest_approval %}
-        {# Approval status. #}
-        <div class="card my-3">
-            <div class="card-body">
-                <div class="card-text">
-                    {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
-                </div>
-            </div>
-        </div>
-    {% endif %}
+    {% include "approvals/includes/card.html" with common_approval=job_seeker.latest_common_approval %}
 
 {% endblock %}

--- a/itou/templates/apply/submit_base_two_columns.html
+++ b/itou/templates/apply/submit_base_two_columns.html
@@ -22,16 +22,7 @@
                         <h2 class="h1">{{ job_seeker.get_full_name|title }}</h2>
                     {% endif %}
 
-                    {% if approvals_wrapper.latest_approval %}
-                        {# Approval status. #}
-                        <div class="card my-3">
-                            <div class="card-body">
-                                <div class="card-text">
-                                    {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
-                                </div>
-                            </div>
-                        </div>
-                    {% endif %}
+                    {% include "approvals/includes/card.html" with common_approval=job_seeker.latest_common_approval %}
 
                     <div class="card c-card c-card--emploi mb-3 mb-lg-5">
                         <div class="card-body">

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -14,14 +14,7 @@
 
     {% if not preview %}{# Edit mode. #}
 
-        {# Approval status. #}
-        <div class="card my-3">
-            <div class="card-body">
-                <div class="card-text">
-                    {% include "approvals/includes/status.html" with approval=approval %}
-                </div>
-            </div>
-        </div>
+        {% include "approvals/includes/card.html" with common_approval=approval %}
 
         <form method="post" action="" class="js-prevent-multiple-submit">
 

--- a/itou/templates/approvals/includes/card.html
+++ b/itou/templates/approvals/includes/card.html
@@ -1,0 +1,9 @@
+{% if common_approval %}
+    <div class="card my-3">
+        <div class="card-body">
+            <div class="card-text">
+                {% include "approvals/includes/status.html" with common_approval=common_approval %}
+            </div>
+        </div>
+    </div>
+{% endif %}

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -2,15 +2,17 @@
 {% load call_method %}
 {% comment %}
 
-    Usage:
-        {% include "approvals/includes/status.html" with approval=approval %}
-        {% include "approvals/includes/status.html" with approval=approval job_application=job_application %}
+Arguments:
+
+    user
+    common_approval  (which may be an Approval or PE Approval)
+    job_application
 
 {% endcomment %}
 
-{% if approval.is_pass_iae %}
+{% if common_approval.is_pass_iae %}
     <p class="text-center">
-        {% if approval.is_pass_iae and approval.is_suspended %}
+        {% if common_approval.is_suspended %}
             <img src="{% static 'img/pass_iae/logo_pass_iae_suspended.svg' %}" alt="Logo du PASS IAE">
             <br>
             <span class="badge badge-warning">PASS IAE suspendu</span>
@@ -21,7 +23,7 @@
 {% endif %}
 
 <p class="mb-0">
-    {% if approval.is_pass_iae %}
+    {% if common_approval.is_pass_iae %}
         PASS IAE (agrément) disponible :
     {% else %}
         Agrément existant :
@@ -38,7 +40,7 @@
     </p>
 {% else %}
     <p>
-        <b>{{ approval.number_with_spaces }}</b>
+        <b>{{ common_approval.number_with_spaces }}</b>
     </p>
 {% endif %}
 
@@ -46,80 +48,82 @@
     <p>Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
 {% endif %}
 
-{% if approval.is_valid %}
+{% if common_approval.is_valid %}
 
     <ul class="list-unstyled pl-2 border-left" style="border-left-width: 3px !important;">
 
         {# Validity. #}
-        <li{% if not approval.is_suspended %} class="text-success"{% endif %}>
-            Valide du {{ approval.start_at|date:"d/m/Y" }} au {{ approval.end_at|date:"d/m/Y" }}
+        <li{% if not common_approval.is_suspended %} class="text-success"{% endif %}>
+            Valide du {{ common_approval.start_at|date:"d/m/Y" }} au {{ common_approval.end_at|date:"d/m/Y" }}
         </li>
 
         {# Delivery date. #}
         <li>
-            Délivrance : le {{ approval.start_at|date:"d/m/Y" }}
+            Délivrance : le {{ common_approval.start_at|date:"d/m/Y" }}
         </li>
 
-        {# Suspensions history. #}
-        {% with approval.suspensions_by_start_date_asc as suspensions %}
-            {% if suspensions %}
-                Suspensions :
-                <ul>
-                    {% for s in suspensions %}
-                        <li>
-                            <span{% if s.is_in_progress %} class="text-danger"{% endif %}>
-                                du {{ s.start_at|date:"d/m/Y" }} au {{ s.end_at|date:"d/m/Y" }}
-                            </span>
-                            {% if s.is_in_progress %}
-                                <small>
-                                    <b>En cours</b>
-                                </small>
-                            {% endif %}
-                            {% if current_siae %}
-                                {% call_method s "can_be_handled_by_siae" current_siae as can_be_handled %}
-                                {% if can_be_handled %}
+        {% if common_approval.is_pass_iae %}
+            {# Suspensions history. #}
+            {% with common_approval.suspensions_by_start_date_asc as suspensions %}
+                {% if suspensions %}
+                    Suspensions :
+                    <ul>
+                        {% for s in suspensions %}
+                            <li>
+                                <span{% if s.is_in_progress %} class="text-danger"{% endif %}>
+                                    du {{ s.start_at|date:"d/m/Y" }} au {{ s.end_at|date:"d/m/Y" }}
+                                </span>
+                                {% if s.is_in_progress %}
                                     <small>
-                                        <a href="{% url 'approvals:suspension_update' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">Modifier</a>
-                                        <a href="{% url 'approvals:suspension_delete' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">Annuler</a>
+                                        <b>En cours</b>
                                     </small>
                                 {% endif %}
-                            {% endif %}
-                            <br>
-                            <small>{{ s.get_reason_display }}</small>
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-        {% endwith %}
-
-        {# Prolongations history. #}
-        {% with approval.prolongations_by_start_date_asc as prolongations %}
-            {% if prolongations %}
-                Prolongations :
-                <ul>
-                    {% for p in prolongations %}
-                        <li{% if p.is_in_progress %} class="font-weight-bold"{% endif %}>
-                            du {{ p.start_at|date:"d/m/Y" }} au {{ p.end_at|date:"d/m/Y" }}
-                            <br>
-                            <small>{{ p.get_reason_display }}</small>
-                            {% if p.validated_by %}
+                                {% if current_siae %}
+                                    {% call_method s "can_be_handled_by_siae" current_siae as can_be_handled %}
+                                    {% if can_be_handled %}
+                                        <small>
+                                            <a href="{% url 'approvals:suspension_update' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">Modifier</a>
+                                            <a href="{% url 'approvals:suspension_delete' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">Annuler</a>
+                                        </small>
+                                    {% endif %}
+                                {% endif %}
                                 <br>
-                                <small>
-                                    Autorisation par <i>{{ p.validated_by.get_full_name|title }}</i> ({{ p.validated_by.email }})
-                                </small>
-                            {% endif %}
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-        {% endwith %}
+                                <small>{{ s.get_reason_display }}</small>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            {% endwith %}
+
+            {# Prolongations history. #}
+            {% with common_approval.prolongations_by_start_date_asc as prolongations %}
+                {% if prolongations %}
+                    Prolongations :
+                    <ul>
+                        {% for p in prolongations %}
+                            <li{% if p.is_in_progress %} class="font-weight-bold"{% endif %}>
+                                du {{ p.start_at|date:"d/m/Y" }} au {{ p.end_at|date:"d/m/Y" }}
+                                <br>
+                                <small>{{ p.get_reason_display }}</small>
+                                {% if p.validated_by %}
+                                    <br>
+                                    <small>
+                                        Autorisation par <i>{{ p.validated_by.get_full_name|title }}</i> ({{ p.validated_by.email }})
+                                    </small>
+                                {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            {% endwith %}
+        {% endif %}
 
     </ul>
 
-{% elif approval.is_in_waiting_period %}
+{% elif common_approval.is_in_waiting_period %}
 
     <p class="text-danger">
-        <b>Expiré</b> le {{ approval.end_at|date:"d/m/Y" }} (depuis {{ approval.end_at|timesince }})
+        <b>Expiré</b> le {{ common_approval.end_at|date:"d/m/Y" }} (depuis {{ common_approval.end_at|timesince }})
     </p>
 
     {% if user.is_siae_staff %}

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -7,44 +7,38 @@
     <h1 class="h1-hero-c1">Prolonger ou suspendre un agrément émis par Pôle emploi</h1>
 
     {% if approval.is_valid %}
-        {% if approval.originates_from_itou %}
+
+        {% if approval.is_pass_iae %}
             <div class="alert alert-danger" role="status">
-                <p class="mb-0">Le numéro <strong>{{ approval.number|slice:12 }}</strong> correspond à un PASS IAE.</p>
+                {% if approval.originates_from_itou %}
+                    <p class="mb-0">Le numéro <strong>{{ approval.number }}</strong> correspond à un PASS IAE.</p>
+                {% else %}
+                    {% comment %}
+                        The approval has been issued by Pôle emploi and transformed into an Approval.
+                        A redirection is made upstream if the current SIAE can prolong or suspend it.
+                        It means another SIAE is using it right now.
+                    {% endcomment %}
+                    <p class="mb-0">L'agrément <strong>{{ approval.number }}</strong> a déjà été converti en PASS IAE.</p>
+                {% endif %}
             </div>
             <p>
-                Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">réaliser une auto-prescription</a>. Il sera automatiquement importé dans votre compte.
+                Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">réaliser une auto-prescription</a>.
             </p>
             <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
-
         {% else %}
-            {% if approval.is_pass_iae %}
-                {% comment %}
-                    The approval has been issued by Pôle emploi and transformed into an Approval.
-                    A redirection is made upstream if the current SIAE can prolong or suspend it.
-                    It means another SIAE is using it right now.
-                {% endcomment %}
-                <div class="alert alert-danger" role="status">
-                    <p class="mb-0">L'agrément <strong>{{ approval.number|slice:12 }}</strong> a déjà été converti en PASS IAE.</p>
-                </div>
-                <p>
-                    Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">réaliser une auto-prescription</a>.
-                </p>
-                <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
-            {% else %}
-                <p>
-                    L'agrément <strong>{{ approval.number|slice:12 }}</strong> a été délivré pour <strong>{{ approval.first_name|title }} {{ approval.last_name|title }}</strong>.
-                </p>
-                <p>
-                    Nous allons l'importer dans votre compte pour vous permettre de le suspendre ou de le prolonger.
-                </p>
-                <p>
-                    Mais avant, nous avons besoin de connaître l'adresse e-mail de votre salarié(e).
-                </p>
-                <a class="btn btn-outline-primary" href="{{ back_url }}">Annuler</a>
-                <a class="btn btn-primary" href="{% url 'approvals:pe_approval_search_user' approval.pk %}">
-                    Continuer
-                </a>
-            {% endif %}
+            <p>
+                L'agrément <strong>{{ approval.number|slice:12 }}</strong> a été délivré pour <strong>{{ approval.first_name|title }} {{ approval.last_name|title }}</strong>.
+            </p>
+            <p>
+                Nous allons l'importer dans votre compte pour vous permettre de le suspendre ou de le prolonger.
+            </p>
+            <p>
+                Mais avant, nous avons besoin de connaître l'adresse e-mail de votre salarié(e).
+            </p>
+            <a class="btn btn-outline-primary" href="{{ back_url }}">Annuler</a>
+            <a class="btn btn-primary" href="{% url 'approvals:pe_approval_search_user' approval.pk %}">
+                Continuer
+            </a>
         {% endif %}
 
     {% else %}

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -14,14 +14,7 @@
 
     {% if not preview %}{# Edit mode. #}
 
-        {# Approval status. #}
-        <div class="card my-3">
-            <div class="card-body">
-                <div class="card-text">
-                    {% include "approvals/includes/status.html" with approval=approval %}
-                </div>
-            </div>
-        </div>
+        {% include "approvals/includes/card.html" with common_approval=approval %}
 
         <form method="post" action="" class="js-prevent-multiple-submit">
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -207,41 +207,38 @@
                 </div>
             </div>
 
-            {% with user.approvals_wrapper as approvals_wrapper %}
-                {% if approvals_wrapper.latest_approval %}
-                    <div class="card">
-                        <p class="h4 card-header">Numéro d'agrément</p>
-                        <div class="card-body">
-                            <ul class="list-unstyled">
-                                {# Approval status. #}
+            {% if user.latest_common_approval %}
+                <div class="card">
+                    <p class="h4 card-header">Numéro d'agrément</p>
+                    <div class="card-body">
+                        <ul class="list-unstyled">
+                            <li class="card-text mb-3">
+                                {% include "approvals/includes/status.html" with approval=user.latest_common_approval %}
+                            </li>
+                            {% if user.has_approval_in_waiting_period %}
                                 <li class="card-text mb-3">
-                                    {% include "approvals/includes/status.html" with approval=approvals_wrapper.latest_approval %}
-                                </li>
-                                {% if approvals_wrapper.has_in_waiting_period %}
-                                    <li class="card-text mb-3">
-                                        {% if user.has_valid_diagnosis %}
-                                            <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
-                                        {% else %}
-                                            <small>
-                                                {% comment %}
+                                    {% if user.has_valid_diagnosis %}
+                                        <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
+                                    {% else %}
+                                        <small>
+                                            {% comment %}
                                                 This text is a duplicata from an alert that is in the apply views. But I have rather
                                                 repeating it there instead of injecting it using a context processor or template context.
                                                 There is no strong reason that this test should be exactly the same as the one when an
                                                 error is raised in the apply views by the way, they could evolve differently.
                                                 {% endcomment %}
-                                                Vous avez terminé un parcours il y a moins de deux ans.
-                                                <br>
-                                                Pour prétendre à nouveau à un parcours en structure d'insertion par l'activité économique vous devez rencontrer un prescripteur
-                                                habilité : Pôle emploi, Mission Locale, CAP Emploi, etc.
-                                            </small>
-                                        {% endif %}
-                                    </li>
-                                {% endif %}
-                            </ul>
-                        </div>
+                                            Vous avez terminé un parcours il y a moins de deux ans.
+                                            <br>
+                                            Pour prétendre à nouveau à un parcours en structure d'insertion par l'activité économique vous devez rencontrer un prescripteur
+                                            habilité : Pôle emploi, Mission Locale, CAP Emploi, etc.
+                                        </small>
+                                    {% endif %}
+                                </li>
+                            {% endif %}
+                        </ul>
                     </div>
-                {% endif %}
-            {% endwith %}
+                </div>
+            {% endif %}
 
         {% endif %}{# end of if user.is_job_seeker #}
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -223,7 +223,16 @@
                                             <p>Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b></p>
                                         {% else %}
                                             <small>
-                                                {{ user.approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER }}
+                                                {% comment %}
+                                                This text is a duplicata from an alert that is in the apply views. But I have rather
+                                                repeating it there instead of injecting it using a context processor or template context.
+                                                There is no strong reason that this test should be exactly the same as the one when an
+                                                error is raised in the apply views by the way, they could evolve differently.
+                                                {% endcomment %}
+                                                Vous avez terminé un parcours il y a moins de deux ans.
+                                                <br>
+                                                Pour prétendre à nouveau à un parcours en structure d'insertion par l'activité économique vous devez rencontrer un prescripteur
+                                                habilité : Pôle emploi, Mission Locale, CAP Emploi, etc.
                                             </small>
                                         {% endif %}
                                     </li>

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1,4 +1,3 @@
-import datetime
 import time
 import uuid
 from collections import Counter
@@ -349,11 +348,7 @@ class User(AbstractUser, AddressMixin):
         if not self.is_job_seeker:
             return None
         approval_numbers = Approval.objects.filter(user=self).values_list("number", flat=True)
-        pe_approvals = (
-            PoleEmploiApproval.objects.find_for(self)
-            # FIXME(vperron): We can safely remove this date check, no PE approval is concerned now.
-            .filter(start_at__lte=datetime.date.today()).exclude(number__in=approval_numbers)
-        )
+        pe_approvals = PoleEmploiApproval.objects.find_for(self).exclude(number__in=approval_numbers)
         if not pe_approvals:
             return None
         pe_approval = sort_longest_most_recent(pe_approvals)[0]

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -267,7 +267,7 @@ class ApplyAsJobSeekerTest(TestCase):
 
             # …until the expected 403.
             self.assertEqual(response.status_code, 403)
-            self.assertEqual(response.context["exception"], ApprovalsWrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_USER)
+            self.assertIn("Vous avez terminé un parcours", response.context["exception"])
             last_url = response.redirect_chain[-1][0]
             self.assertEqual(last_url, reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": siae.pk}))
 
@@ -1159,7 +1159,7 @@ class ApplyAsPrescriberTest(TestCase):
 
         # …until the expected 403.
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.context["exception"], ApprovalsWrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_PROXY)
+        self.assertIn("Le candidat a terminé un parcours", response.context["exception"])
         last_url = response.redirect_chain[-1][0]
         self.assertEqual(last_url, reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": siae.pk}))
 
@@ -1563,7 +1563,7 @@ class ApplyAsSiaeTest(TestCase):
 
         # …until the expected 403.
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.context["exception"], ApprovalsWrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_PROXY)
+        self.assertIn("Le candidat a terminé un parcours", response.context["exception"])
         last_url = response.redirect_chain[-1][0]
         self.assertEqual(last_url, reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": siae.pk}))
 

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -9,7 +9,6 @@ from django.urls import resolve, reverse
 from django.utils import timezone
 
 from itou.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
-from itou.approvals.models import ApprovalsWrapper
 from itou.asp.models import RSAAllocation
 from itou.cities.factories import create_test_cities
 from itou.cities.models import City

--- a/itou/www/apply/views/constants.py
+++ b/itou/www/apply/views/constants.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from django.utils.safestring import mark_safe
+
+from itou.utils.urls import get_external_link_markup
+
+
+ERROR_CANNOT_OBTAIN_NEW_FOR_USER = mark_safe(
+    (
+        "Vous avez terminé un parcours il y a moins de deux ans.<br>"
+        "Pour prétendre à nouveau à un parcours en structure d'insertion "
+        "par l'activité économique vous devez rencontrer un prescripteur "
+        "habilité : Pôle emploi, Mission Locale, CAP Emploi, etc."
+    )
+)
+
+_doc_link = get_external_link_markup(
+    url=f"{settings.ITOU_COMMUNITY_URL }/doc/emplois/derogation-au-delai-de-carence/",
+    text="En savoir plus sur la dérogation du délai de carence",
+)
+
+ERROR_CANNOT_OBTAIN_NEW_FOR_PROXY = mark_safe(
+    (
+        "Le candidat a terminé un parcours il y a moins de deux ans.<br>"
+        "Pour prétendre à nouveau à un parcours en structure d'insertion "
+        "par l'activité économique il doit rencontrer un prescripteur "
+        "habilité : Pôle emploi, Mission Locale, CAP Emploi, etc."
+        f"<br>{_doc_link}"  # Display doc link only for proxies.
+    )
+)

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -13,10 +13,10 @@ from django.utils.safestring import mark_safe
 from django.views.decorators.http import require_http_methods
 from django_xworkflows import models as xwf_models
 
-from itou.approvals.models import ApprovalAlreadyExistsError
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.models import Siae
+from itou.users.models import ApprovalAlreadyExistsError
 from itou.utils.perms.prescriber import get_all_available_job_applications_as_prescriber
 from itou.utils.perms.user import get_user_info
 from itou.utils.urls import get_external_link_markup, get_safe_url

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -20,6 +20,7 @@ from itou.siaes.models import Siae
 from itou.utils.perms.prescriber import get_all_available_job_applications_as_prescriber
 from itou.utils.perms.user import get_user_info
 from itou.utils.urls import get_external_link_markup, get_safe_url
+from itou.www.apply.views import constants as apply_view_constants
 from itou.www.apply.forms import AcceptForm, AnswerForm, JobSeekerPoleEmploiStatusForm, RefusalForm, UserAddressForm
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm, ConfirmEligibilityForm
 
@@ -33,8 +34,7 @@ def check_waiting_period(approvals_wrapper, job_application):
     if approvals_wrapper.cannot_bypass_waiting_period(
         siae=job_application.to_siae, sender_prescriber_organization=job_application.sender_prescriber_organization
     ):
-        error = approvals_wrapper.ERROR_CANNOT_OBTAIN_NEW_FOR_PROXY
-        raise PermissionDenied(error)
+        raise PermissionDenied(apply_view_constants.ERROR_CANNOT_OBTAIN_NEW_FOR_PROXY)
 
 
 @login_required

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -217,15 +217,12 @@ class SuspensionForm(forms.ModelForm):
 
 
 class PoleEmploiApprovalSearchForm(forms.Form):
-    """
-    Search for a PoleEmploiApproval by number
-    """
 
     number = forms.CharField(
         label="Numéro",
         required=True,
         min_length=12,
-        max_length=15,
+        max_length=12,
         strip=True,
         help_text=("Le numéro d'agrément est composé de 12 chiffres (ex. 123456789012)."),
     )

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -7,7 +9,7 @@ from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
-from itou.approvals.models import Approval, ApprovalsWrapper, PoleEmploiApproval, Suspension
+from itou.approvals.models import Approval, PoleEmploiApproval, Suspension
 from itou.job_applications.enums import SenderKind
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.users.models import User
@@ -232,21 +234,30 @@ def pe_approval_search(request, template_name="approvals/pe_approval_search.html
 
     if form.is_valid():
         number = form.cleaned_data["number"]
-        approvals_wrapper = ApprovalsWrapper(number=number)
-        approval = approvals_wrapper.latest_approval
 
+        # First try to get a matching PASS IAE, and guide the user towards eventual different paths
+        approval = Approval.objects.filter(number=number).first()
         if approval:
-            if approval.is_pass_iae:
-                job_application = approval.user.last_accepted_job_application
-                if job_application and job_application.to_siae == siae:
-                    # Suspensions and prolongations links are available in the job application details page.
-                    application_details_url = reverse(
-                        "apply:details_for_siae", kwargs={"job_application_id": job_application.pk}
-                    )
-                    return HttpResponseRedirect(application_details_url)
-                # The employer cannot handle the PASS as it's already used by another one.
-                # Suggest him to make a self-prescription. A link is offered in the template.
+            job_application = approval.user.last_accepted_job_application
+            if job_application and job_application.to_siae == siae:
+                # Suspensions and prolongations links are available in the job application details page.
+                application_details_url = reverse(
+                    "apply:details_for_siae", kwargs={"job_application_id": job_application.pk}
+                )
+                return HttpResponseRedirect(application_details_url)
 
+            # The employer cannot handle the PASS as it's already used by another one.
+            # Suggest him to make a self-prescription. A link is offered in the template.
+            context = {
+                "approval": approval,
+                "back_url": back_url,
+            }
+            return render(request, "approvals/pe_approval_search_found.html", context)
+
+        # If none was found, try and find a PoleEmploiApproval.
+        today = datetime.date.today()
+        approval = PoleEmploiApproval.objects.filter(number=number, start_at__lte=today).first()
+        if approval:
             context = {
                 "approval": approval,
                 "back_url": back_url,

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -250,9 +250,6 @@ def pe_approval_search(request, template_name="approvals/pe_approval_search.html
             context = {
                 "approval": approval,
                 "back_url": back_url,
-                "form": form,
-                "number": number,
-                "siae": siae,
             }
             return render(request, "approvals/pe_approval_search_found.html", context)
 


### PR DESCRIPTION
### Quoi ?

Retirer toute utilisation de ApprovalsWrapper et surtout éviter d'avoir un objet multiforme `latest_approval`.

### Pourquoi ?
Cela engendre une complexité de code assez énorme.
En outre les agréments Pôle Emploi feront bientôt partie du passé.

### Comment ?
En déplaçant les méthodes liées au PASS ou agrément d'un utilisateur sur le modèle User ou JobSeekerProfile, en découplant la logique, en essayant de simplifier partout où cela est possible.
