### PR TITLE
Correctif : Faire en sorte que les candidats qui n’ont pas été enregistrés en tant que “inscrit chez Pôle emploi” soient identifiés comme “non inscrit chez Pôle emploi”

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -239,7 +239,7 @@ class CreateJobSeekerStep3ForSenderForm(forms.ModelForm):
         else:
             self.cleaned_data["pole_emploi_id_forgotten"] = ""
             self.cleaned_data["pole_emploi_id"] = ""
-            self.cleaned_data["lack_of_pole_emploi_id_reason"] = ""
+            self.cleaned_data["lack_of_pole_emploi_id_reason"] = User.REASON_NOT_REGISTERED
 
         # Handle RSA extra fields
         if self.cleaned_data["rsa_allocation"]:

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -464,7 +464,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": "",
+            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
         }
         self.assertEqual(self.client.session[job_seeker_session_name], expected_job_seeker_session)
 
@@ -678,7 +678,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": "",
+            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
         }
         self.assertEqual(self.client.session[job_seeker_session_name], expected_job_seeker_session)
 
@@ -1044,7 +1044,7 @@ class ApplyAsPrescriberTest(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": "",
+            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
         }
         self.assertEqual(self.client.session[job_seeker_session_name], expected_job_seeker_session)
 
@@ -1455,7 +1455,7 @@ class ApplyAsSiaeTest(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": "",
+            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
         }
         self.assertEqual(self.client.session[job_seeker_session_name], expected_job_seeker_session)
 


### PR DESCRIPTION
### Pourquoi ?

Suite à la refonte du parcours de création de compte candidat par un tiers (pro) , nous avons retiré le motif d’absence d’identifiant PE “Non inscrit chez Pôle emploi”, les utilisateurs peuvent uniquement cocher “inscrit chez Pole emploi”.
Les candidats enregistrés sans cette case cochée n'ont donc eu aucun statut attribué.

### Comment ?

Si on ne coche pas “Inscrit chez Pôle emploi” on doit attribuer par défaut le statut “Non inscrit chez Pôle emploi”.
