### PR TITLE
Correction de dépendances

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,9 +15,10 @@ Unidecode==1.3.4  # https://github.com/avian2/unidecode
 django==4.0.7  # https://www.djangoproject.com/
 
 # django-allauth
-# Sticky to 0.47.0 until further notice
+# Sticky to 0.46.0 until further notice
 # v0.48.0 introduced a breaking change (SSO part) : subject needs investigation and fix
-django-allauth==0.47.0  # https://github.com/pennersr/django-allauth
+# v0.47.0 introduces a new ugly template step in PE Connect process. Should be investigated as well.
+django-allauth==0.46.0  # https://github.com/pennersr/django-allauth
 
 # django-anymail
 django-anymail==8.6  # https://github.com/anymail/django-anymail

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ Unidecode==1.3.4  # https://github.com/avian2/unidecode
 # Django
 # ------------------------------------------------------------------------------
 
-django==4.0.6  # https://www.djangoproject.com/
+django==4.0.7  # https://www.djangoproject.com/
 
 # django-allauth
 # Sticky to 0.47.0 until further notice

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,5 +1,10 @@
 -r ./base.txt
 
 uwsgi==2.0.20  # https://github.com/unbit/uwsgi
-sentry-sdk==1.7.2  # https://github.com/getsentry/sentry-python
+
+# FIXME(vperron): Sentry requirement has to be kept back since it makes PE connect
+# crash with a 409. Tried getting rid of the loggers, deactivating safe plugins, etc,
+# nothing helps. It seems just enabling this version of Sentry breaks PE Connect badly.
+# Investigation is ongoing about the "why".
+sentry-sdk==1.5.4  # https://github.com/getsentry/sentry-python
 elastic-apm==6.10.1  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html


### PR DESCRIPTION
### Quoi ?

Modifier certaines dépendances.

### Pourquoi ?
PE Connect semble cassé depuis une dizaine de jours.
Il demande en outre de valider une nouvelle étape, non nécessaire auparavant.
Enfin, il vient de sortir une mise à jour de sécurité de Django.

### Comment ?
En faisant des mises à jour d'urgence pour corriger le problème, mais des investigations plus poussées seront intéressantes et instructives.
