### PR TITLE
Déplacement des types de prescripteurs et des institutions dans des fichiers dédiées pour en améliorer la lecture

### DIFF
--- a/itou/institutions/enums.py
+++ b/itou/institutions/enums.py
@@ -1,0 +1,8 @@
+from django.db import models
+
+
+class InstitutionKind(models.TextChoices):
+    DDETS = ("DDETS", "Direction départementale de l'emploi, du travail et des solidarités")
+    DREETS = ("DREETS", "Direction régionale de l'économie, de l'emploi, du travail et des solidarités")
+    DGEFP = ("DGEFP", "Délégation générale à l'emploi et à la formation professionnelle")
+    OTHER = ("Autre", "Autre")

--- a/itou/institutions/factories.py
+++ b/itou/institutions/factories.py
@@ -1,6 +1,7 @@
 import factory
 
-from itou.institutions import models
+from itou.institutions.enums import InstitutionKind
+from itou.institutions.models import Institution, InstitutionMembership
 from itou.users.factories import LaborInspectorFactory
 
 
@@ -8,10 +9,10 @@ class InstitutionFactory(factory.django.DjangoModelFactory):
     """Returns an Institution() object."""
 
     class Meta:
-        model = models.Institution
+        model = Institution
 
     name = factory.Faker("name", locale="fr_FR")
-    kind = models.Institution.Kind.DDETS
+    kind = InstitutionKind.DDETS
 
 
 class InstitutionMembershipFactory(factory.django.DjangoModelFactory):
@@ -24,7 +25,7 @@ class InstitutionMembershipFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = models.InstitutionMembership
+        model = InstitutionMembership
 
     user = factory.SubFactory(LaborInspectorFactory)
     institution = factory.SubFactory(InstitutionFactory)

--- a/itou/institutions/models.py
+++ b/itou/institutions/models.py
@@ -14,20 +14,17 @@ from django.db import models
 
 from itou.common_apps.address.models import AddressMixin
 from itou.common_apps.organizations.models import MembershipAbstract, OrganizationAbstract, OrganizationQuerySet
+from itou.institutions.enums import InstitutionKind
 
 
 class Institution(AddressMixin, OrganizationAbstract):
-    class Kind(models.TextChoices):
-        DDETS = ("DDETS", "Direction départementale de l'emploi, du travail et des solidarités")
-        DREETS = ("DREETS", "Direction régionale de l'économie, de l'emploi, du travail et des solidarités")
-        DGEFP = ("DGEFP", "Délégation générale à l'emploi et à la formation professionnelle")
-        OTHER = "Autre", "Autre"
-
     class Meta:
         verbose_name = "Institution partenaire"
         verbose_name_plural = "Institutions partenaires"
 
-    kind = models.CharField(verbose_name="Type", max_length=20, choices=Kind.choices, default=Kind.OTHER)
+    kind = models.CharField(
+        verbose_name="Type", max_length=20, choices=InstitutionKind.choices, default=InstitutionKind.OTHER
+    )
     members = models.ManyToManyField(
         settings.AUTH_USER_MODEL,
         verbose_name="Membres",

--- a/itou/metabase/management/commands/_organizations.py
+++ b/itou/metabase/management/commands/_organizations.py
@@ -8,6 +8,7 @@ from itou.metabase.management.commands._utils import (
     get_establishment_last_login_date_column,
     get_first_membership_join_date,
 )
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.models import User
 
@@ -84,11 +85,11 @@ def get_org_last_job_application_creation_date(org):
 
 
 ORGANIZATION_KIND_TO_READABLE_KIND = {
-    PrescriberOrganization.Kind.PE: "Pôle emploi",
-    PrescriberOrganization.Kind.CAP_EMPLOI: "CAP emploi",
-    PrescriberOrganization.Kind.ML: "Mission locale",
-    PrescriberOrganization.Kind.DEPT: "Département",
-    PrescriberOrganization.Kind.OTHER: "Autre",
+    PrescriberOrganizationKind.PE: "Pôle emploi",
+    PrescriberOrganizationKind.CAP_EMPLOI: "CAP emploi",
+    PrescriberOrganizationKind.ML: "Mission locale",
+    PrescriberOrganizationKind.DEPT: "Département",
+    PrescriberOrganizationKind.OTHER: "Autre",
 }
 
 TABLE_COLUMNS = [
@@ -104,7 +105,7 @@ TABLE_COLUMNS = [
         "name": "type_complet",
         "type": "varchar",
         "comment": "Type organisation (détaillé)",
-        "fn": lambda o: get_choice(choices=PrescriberOrganization.Kind.choices, key=o.kind),
+        "fn": lambda o: get_choice(choices=PrescriberOrganizationKind.choices, key=o.kind),
     },
     {
         "name": "habilitée",

--- a/itou/prescribers/enums.py
+++ b/itou/prescribers/enums.py
@@ -1,0 +1,51 @@
+from django.db import models
+
+
+class PrescriberOrganizationKind(models.TextChoices):
+    CAP_EMPLOI = "CAP_EMPLOI", "CAP emploi"
+    ML = "ML", "Mission locale"
+    OIL = "OIL", "Opérateur d'intermédiation locative"
+    ODC = "ODC", "Organisation délégataire d'un CD"
+    PENSION = "PENSION", "Pension de famille / résidence accueil"
+    PE = "PE", "Pôle emploi"
+    RS_FJT = "RS_FJT", "Résidence sociale / FJT - Foyer de Jeunes Travailleurs"
+    PREVENTION = "PREVENTION", "Service ou club de prévention"
+    DEPT = "DEPT", "Service social du conseil départemental"
+    AFPA = ("AFPA", "AFPA - Agence nationale pour la formation professionnelle des adultes")
+    ASE = "ASE", "ASE - Aide sociale à l'enfance"
+    CAARUD = (
+        "CAARUD",
+        ("CAARUD - Centre d'accueil et d'accompagnement à la réduction de risques pour usagers de drogues"),
+    )
+    CADA = "CADA", "CADA - Centre d'accueil de demandeurs d'asile"
+    CAF = "CAF", "CAF - Caisse d'allocations familiales"
+    CAVA = "CAVA", "CAVA - Centre d'adaptation à la vie active"
+    CCAS = ("CCAS", "CCAS - Centre communal d'action sociale ou centre intercommunal d'action sociale")
+    CHRS = "CHRS", "CHRS - Centre d'hébergement et de réinsertion sociale"
+    CHU = "CHU", "CHU - Centre d'hébergement d'urgence"
+    CIDFF = ("CIDFF", "CIDFF - Centre d'information sur les droits des femmes et des familles")
+    CPH = "CPH", "CPH - Centre provisoire d'hébergement"
+    CSAPA = "CSAPA", "CSAPA - Centre de soins, d'accompagnement et de prévention en addictologie"
+    E2C = "E2C", "E2C - École de la deuxième chance"
+    EPIDE = "EPIDE", "EPIDE - Établissement pour l'insertion dans l'emploi"
+    HUDA = "HUDA", "HUDA - Hébergement d'urgence pour demandeurs d'asile"
+    MSA = "MSA", "MSA - Mutualité Sociale Agricole"
+    OACAS = (
+        "OACAS",
+        (
+            "OACAS - Structure porteuse d'un agrément national organisme "
+            "d'accueil communautaire et d'activité solidaire"
+        ),
+    )
+    PIJ_BIJ = "PIJ_BIJ", "PIJ-BIJ - Point/Bureau information jeunesse"
+    PJJ = "PJJ", "PJJ - Protection judiciaire de la jeunesse"
+    PLIE = "PLIE", "PLIE - Plan local pour l'insertion et l'emploi"
+    SPIP = "SPIP", "SPIP - Service pénitentiaire d'insertion et de probation"
+    OTHER = "Autre", "Autre"
+
+
+class PrescriberAuthorizationStatus(models.TextChoices):
+    NOT_SET = "NOT_SET", "Habilitation en attente de validation"
+    VALIDATED = "VALIDATED", "Habilitation validée"
+    REFUSED = "REFUSED", "Validation de l'habilitation refusée"
+    NOT_REQUIRED = "NOT_REQUIRED", "Pas d'habilitation nécessaire"

--- a/itou/prescribers/factories.py
+++ b/itou/prescribers/factories.py
@@ -4,7 +4,8 @@ import factory
 import factory.fuzzy
 
 from itou.common_apps.address.departments import DEPARTMENTS
-from itou.prescribers import models
+from itou.prescribers.enums import PrescriberAuthorizationStatus, PrescriberOrganizationKind
+from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
 from itou.users.factories import PrescriberFactory
 
 
@@ -12,15 +13,15 @@ class PrescriberOrganizationFactory(factory.django.DjangoModelFactory):
     """Returns a PrescriberOrganization() object."""
 
     class Meta:
-        model = models.PrescriberOrganization
+        model = PrescriberOrganization
 
     class Params:
         authorized = factory.Trait(
             is_authorized=True,
-            authorization_status=models.PrescriberOrganization.AuthorizationStatus.VALIDATED,
+            authorization_status=PrescriberAuthorizationStatus.VALIDATED,
         )
         with_pending_authorization = factory.Trait(
-            authorization_status=models.PrescriberOrganization.AuthorizationStatus.NOT_SET,
+            authorization_status=PrescriberAuthorizationStatus.NOT_SET,
         )
 
     name = factory.Faker("name", locale="fr_FR")
@@ -28,7 +29,7 @@ class PrescriberOrganizationFactory(factory.django.DjangoModelFactory):
     siret = factory.fuzzy.FuzzyText(length=13, chars=string.digits, prefix="1")
     phone = factory.fuzzy.FuzzyText(length=10, chars=string.digits)
     email = factory.Faker("email", locale="fr_FR")
-    kind = models.PrescriberOrganization.Kind.PE
+    kind = PrescriberOrganizationKind.PE
     department = factory.fuzzy.FuzzyChoice(DEPARTMENTS.keys())
 
 
@@ -42,7 +43,7 @@ class PrescriberMembershipFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = models.PrescriberMembership
+        model = PrescriberMembership
 
     user = factory.SubFactory(PrescriberFactory)
     organization = factory.SubFactory(PrescriberOrganizationFactory)
@@ -74,5 +75,5 @@ class PrescriberOrganizationWith2MembershipFactory(PrescriberOrganizationFactory
 class PrescriberPoleEmploiFactory(PrescriberOrganizationFactory):
     code_safir_pole_emploi = factory.fuzzy.FuzzyText(length=5, chars=string.digits)
     is_authorized = True
-    kind = models.PrescriberOrganization.Kind.PE
-    authorization_status = models.PrescriberOrganization.AuthorizationStatus.VALIDATED
+    kind = PrescriberOrganizationKind.PE
+    authorization_status = PrescriberAuthorizationStatus.VALIDATED

--- a/itou/prescribers/management/commands/import_pole_emploi_agencies.py
+++ b/itou/prescribers/management/commands/import_pole_emploi_agencies.py
@@ -4,6 +4,7 @@ import logging
 from django.core.management.base import BaseCommand
 
 from itou.common_apps.address.departments import DEPARTMENTS, department_from_postcode
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 
 
@@ -107,7 +108,7 @@ class Command(BaseCommand):
                     continue
 
                 if not dry_run:
-                    pe_kind = PrescriberOrganization.Kind.PE
+                    pe_kind = PrescriberOrganizationKind.PE
 
                     org, _created = PrescriberOrganization.objects.get_or_create(
                         code_safir_pole_emploi=code_safir,

--- a/itou/prescribers/migrations/0017_update_authorization_status.py
+++ b/itou/prescribers/migrations/0017_update_authorization_status.py
@@ -12,24 +12,8 @@ from django.db import migrations
 
 
 def update_authorization_status(apps, schema_editor):
-    PrescriberOrganization = apps.get_model("prescribers", "PrescriberOrganization")
-    for org in PrescriberOrganization.objects.filter(is_authorized=False):
-        # Orgs that are not PE and with no habilitation
-        org.authorization_status = PrescriberOrganization.AuthorizationStatus.NOT_REQUIRED
-        org.save()
-
-    for org in PrescriberOrganization.objects.filter(is_authorized=True):
-        if org.kind == PrescriberOrganization.Kind.PE:
-            # PE always authorized and validated
-            org.authorization_status = PrescriberOrganization.AuthorizationStatus.VALIDATED
-        elif not org.has_members:
-            # Remove authorization status 'VALIDATED' for prescriber organizations without members
-            org.is_authorized = False
-            org.authorization_status = PrescriberOrganization.AuthorizationStatus.NOT_SET
-        else:
-            org.authorization_status = PrescriberOrganization.AuthorizationStatus.VALIDATED
-
-        org.save()
+    # This migration already done on master and KIND is now in enums dedicated file
+    pass
 
 
 class Migration(migrations.Migration):

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 
 from itou.eligibility.models import AdministrativeCriteria
+from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siae_evaluations import enums as evaluation_enums
@@ -44,8 +45,8 @@ def validate_institution(institution_id):
     except Institution.DoesNotExist as exception:
         raise ValidationError("L'institution sélectionnée n'existe pas.") from exception
 
-    if institution.kind != Institution.Kind.DDETS:
-        raise ValidationError(f"Sélectionnez une institution de type {Institution.Kind.DDETS}")
+    if institution.kind != InstitutionKind.DDETS:
+        raise ValidationError(f"Sélectionnez une institution de type {InstitutionKind.DDETS}")
 
 
 def create_campaigns(evaluated_period_start_at, evaluated_period_end_at, ratio_selection_end_at):
@@ -59,7 +60,7 @@ def create_campaigns(evaluated_period_start_at, evaluated_period_end_at, ratio_s
         f"au {evaluated_period_end_at.strftime('%d/%m/%Y')}"
     )
 
-    institutions = Institution.objects.filter(kind=Institution.Kind.DDETS)
+    institutions = Institution.objects.filter(kind=InstitutionKind.DDETS)
 
     evaluation_campaign_list = EvaluationCampaign.objects.bulk_create(
         EvaluationCampaign(

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -10,8 +10,8 @@ from django.urls import reverse
 from django.utils import dateformat, timezone
 
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
+from itou.institutions.enums import InstitutionKind
 from itou.institutions.factories import InstitutionFactory, InstitutionWith2MembershipFactory
-from itou.institutions.models import Institution
 from itou.job_applications.factories import JobApplicationFactory, JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication, JobApplicationQuerySet, JobApplicationWorkflow
 from itou.siae_evaluations import enums as evaluation_enums
@@ -168,7 +168,7 @@ class EvaluationCampaignManagerTest(TestCase):
         with self.assertRaises(ValidationError):
             validate_institution(0)
 
-        for kind in [k for k in Institution.Kind if k != Institution.Kind.DDETS]:
+        for kind in [k for k in InstitutionKind if k != InstitutionKind.DDETS]:
             with self.subTest(kind=kind):
                 institution = InstitutionFactory(kind=kind)
                 with self.assertRaises(ValidationError):
@@ -195,7 +195,7 @@ class EvaluationCampaignManagerTest(TestCase):
         ratio_selection_end_at = timezone.now() + relativedelta(months=1)
 
         # not DDETS
-        for kind in [k for k in Institution.Kind if k != Institution.Kind.DDETS]:
+        for kind in [k for k in InstitutionKind if k != InstitutionKind.DDETS]:
             with self.subTest(kind=kind):
                 InstitutionFactory(kind=kind)
                 self.assertEqual(
@@ -205,7 +205,7 @@ class EvaluationCampaignManagerTest(TestCase):
                 self.assertEqual(len(mail.outbox), 0)
 
         # institution DDETS
-        InstitutionWith2MembershipFactory.create_batch(2, kind=Institution.Kind.DDETS)
+        InstitutionWith2MembershipFactory.create_batch(2, kind=InstitutionKind.DDETS)
         self.assertEqual(
             2,
             create_campaigns(evaluated_period_start_at, evaluated_period_end_at, ratio_selection_end_at),

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -269,7 +269,7 @@
                                     Gérer vos collaborateurs
                                 </a>
                             </li>
-                            {% if current_prescriber_organization.kind == current_prescriber_organization.Kind.DEPT and user_is_prescriber_org_admin %}
+                            {% if current_prescriber_organization.kind == precriber_kind_dept and user_is_prescriber_org_admin %}
                                 <li class="card-text mb-3">
                                     <i class="ri-list-unordered ri-lg"></i>
                                     <a href="{% url 'prescribers_views:list_accredited_organizations' %}">
@@ -312,7 +312,7 @@
                                 Export des candidatures
                             </a>
                         </li>
-                        {% if current_prescriber_organization and current_prescriber_organization.kind == current_prescriber_organization.Kind.PE  %}
+                        {% if current_prescriber_organization and current_prescriber_organization.kind == precriber_kind_pe %}
                             <li class="card-text mb-3">
                                 <i class="ri-pause-circle-line ri-lg"></i>
                                 <a href="https://tally.so/r/w2Ex0M" title="Suspendre un PASS IAE (ouverture dans un nouvel onglet)" target="_blank">Suspendre un PASS IAE</a><i class="ri-external-link-line ml-1"></i>

--- a/itou/users/management/commands/extract_c2_users.py
+++ b/itou/users/management/commands/extract_c2_users.py
@@ -6,8 +6,10 @@ from django.core.management.base import BaseCommand
 from django.db.models import Q
 
 from itou.common_apps.address.departments import DEPARTMENTS
-from itou.institutions.models import Institution, InstitutionMembership
-from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
+from itou.institutions.enums import InstitutionKind
+from itou.institutions.models import InstitutionMembership
+from itou.prescribers.enums import PrescriberOrganizationKind
+from itou.prescribers.models import PrescriberMembership
 from itou.siaes.models import SiaeMembership
 
 
@@ -78,10 +80,10 @@ class Command(BaseCommand):
             org = membership.institution
             row = self.get_basic_row(membership=membership, org=org)
 
-            if org.kind == Institution.Kind.DDETS:
+            if org.kind == InstitutionKind.DDETS:
                 ddets_csv_rows.append(row)
 
-            if org.kind == Institution.Kind.DREETS:
+            if org.kind == InstitutionKind.DREETS:
                 # Departement does not make sense for DREETS, as there is one per region.
                 del row["Département"]
                 dreets_csv_rows.append(row)
@@ -90,7 +92,7 @@ class Command(BaseCommand):
 
         cd_memberships = PrescriberMembership.objects.select_related("user", "organization").filter(
             is_active=True,
-            organization__kind=PrescriberOrganization.Kind.DEPT,
+            organization__kind=PrescriberOrganizationKind.DEPT,
         )
 
         for membership in cd_memberships:

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -28,7 +28,9 @@ from itou.asp.models import (
 from itou.common_apps.address.departments import department_from_postcode
 from itou.common_apps.address.format import format_address
 from itou.common_apps.address.models import AddressMixin
+from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
+from itou.prescribers.enums import PrescriberAuthorizationStatus, PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae
 from itou.utils.validators import validate_birthdate, validate_nir, validate_pole_emploi_id
@@ -476,7 +478,7 @@ class User(AbstractUser, AddressMixin):
 
         CD as in "Conseil Départemental".
 
-        Unfortunately the `PrescriberOrganization.Kind.DEPT` kind contains not only the real CD but also some random
+        Unfortunately the `PrescriberOrganizationKind.DEPT` kind contains not only the real CD but also some random
         organizations authorized by some CD.
         When such a random non-CD org is registered, it is not authorized yet, thus will be filtered out correctly.
         Later, our staff will authorize the random non-CD org, flag it as `is_brsa` and change its kind to `OTHER`.
@@ -487,9 +489,9 @@ class User(AbstractUser, AddressMixin):
         return (
             self.is_prescriber
             and isinstance(current_org, PrescriberOrganization)
-            and current_org.kind == current_org.Kind.DEPT
+            and current_org.kind == PrescriberOrganizationKind.DEPT
             and current_org.is_authorized
-            and current_org.authorization_status == current_org.AuthorizationStatus.VALIDATED
+            and current_org.authorization_status == PrescriberAuthorizationStatus.VALIDATED
             and not current_org.is_brsa
         )
 
@@ -506,9 +508,9 @@ class User(AbstractUser, AddressMixin):
         return (
             self.is_prescriber
             and isinstance(current_org, PrescriberOrganization)
-            and current_org.kind == current_org.Kind.PE
+            and current_org.kind == PrescriberOrganizationKind.PE
             and current_org.is_authorized
-            and current_org.authorization_status == current_org.AuthorizationStatus.VALIDATED
+            and current_org.authorization_status == PrescriberAuthorizationStatus.VALIDATED
             and current_org.department in settings.STATS_PE_DEPARTMENT_WHITELIST
         )
 
@@ -525,7 +527,7 @@ class User(AbstractUser, AddressMixin):
         return (
             self.is_labor_inspector
             and isinstance(current_org, Institution)
-            and current_org.kind == current_org.Kind.DDETS
+            and current_org.kind == InstitutionKind.DDETS
         )
 
     def get_stats_ddets_department(self, current_org):
@@ -545,7 +547,7 @@ class User(AbstractUser, AddressMixin):
         return (
             self.is_labor_inspector
             and isinstance(current_org, Institution)
-            and current_org.kind == current_org.Kind.DREETS
+            and current_org.kind == InstitutionKind.DREETS
         )
 
     def get_stats_dreets_region(self, current_org):
@@ -564,7 +566,7 @@ class User(AbstractUser, AddressMixin):
         return (
             self.is_labor_inspector
             and isinstance(current_org, Institution)
-            and current_org.kind == current_org.Kind.DGEFP
+            and current_org.kind == InstitutionKind.DGEFP
         )
 
     def update_external_data_source_history_field(self, provider, field, value) -> bool:

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -14,12 +14,12 @@ from django.utils import timezone
 import itou.asp.factories as asp
 from itou.asp.models import AllocationDuration, EmployerType
 from itou.common_apps.address.departments import DEPARTMENTS
+from itou.institutions.enums import InstitutionKind
 from itou.institutions.factories import InstitutionWithMembershipFactory
-from itou.institutions.models import Institution
 from itou.job_applications.factories import JobApplicationSentByJobSeekerFactory
 from itou.job_applications.models import JobApplicationWorkflow
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.factories import PrescriberMembershipFactory, PrescriberOrganizationWithMembershipFactory
-from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import SiaeFactory
 from itou.users.enums import IdentityProvider, Title
@@ -494,7 +494,7 @@ class ModelTest(TestCase):
         """
         # Admin prescriber of authorized CD can access.
         org = PrescriberOrganizationWithMembershipFactory(
-            authorized=True, kind=PrescriberOrganization.Kind.DEPT, department="93"
+            authorized=True, kind=PrescriberOrganizationKind.DEPT, department="93"
         )
         user = org.members.get()
         self.assertTrue(user.can_view_stats_cd(current_org=org))
@@ -503,14 +503,14 @@ class ModelTest(TestCase):
 
         # Non admin prescriber can access as well.
         org = PrescriberOrganizationWithMembershipFactory(
-            authorized=True, kind=PrescriberOrganization.Kind.DEPT, membership__is_admin=False, department="93"
+            authorized=True, kind=PrescriberOrganizationKind.DEPT, membership__is_admin=False, department="93"
         )
         user = org.members.get()
         self.assertTrue(user.can_view_stats_cd(current_org=org))
         self.assertTrue(user.can_view_stats_dashboard_widget(current_org=org))
 
         # Non authorized organization does not give access.
-        org = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganization.Kind.DEPT)
+        org = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganizationKind.DEPT)
         user = org.members.get()
         self.assertFalse(user.can_view_stats_cd(current_org=org))
         self.assertFalse(user.can_view_stats_dashboard_widget(current_org=org))
@@ -532,7 +532,7 @@ class ModelTest(TestCase):
         DDETS as in "Directions départementales de l’emploi, du travail et des solidarités"
         """
         # Admin member of DDETS can access.
-        institution = InstitutionWithMembershipFactory(kind=Institution.Kind.DDETS, department="93")
+        institution = InstitutionWithMembershipFactory(kind=InstitutionKind.DDETS, department="93")
         user = institution.members.get()
         self.assertTrue(user.can_view_stats_ddets(current_org=institution))
         self.assertTrue(user.can_view_stats_dashboard_widget(current_org=institution))
@@ -540,7 +540,7 @@ class ModelTest(TestCase):
 
         # Non admin member of DDETS can access as well.
         institution = InstitutionWithMembershipFactory(
-            kind=Institution.Kind.DDETS, membership__is_admin=False, department="93"
+            kind=InstitutionKind.DDETS, membership__is_admin=False, department="93"
         )
         user = institution.members.get()
         self.assertTrue(user.can_view_stats_ddets(current_org=institution))
@@ -548,7 +548,7 @@ class ModelTest(TestCase):
         self.assertEqual(user.get_stats_ddets_department(current_org=institution), institution.department)
 
         # Member of institution of wrong kind cannot access.
-        institution = InstitutionWithMembershipFactory(kind=Institution.Kind.OTHER, department="93")
+        institution = InstitutionWithMembershipFactory(kind=InstitutionKind.OTHER, department="93")
         user = institution.members.get()
         self.assertFalse(user.can_view_stats_ddets(current_org=institution))
         self.assertFalse(user.can_view_stats_dashboard_widget(current_org=institution))
@@ -558,7 +558,7 @@ class ModelTest(TestCase):
         DREETS as in "Directions régionales de l’économie, de l’emploi, du travail et des solidarités"
         """
         # Admin member of DREETS can access.
-        institution = InstitutionWithMembershipFactory(kind=Institution.Kind.DREETS, department="93")
+        institution = InstitutionWithMembershipFactory(kind=InstitutionKind.DREETS, department="93")
         user = institution.members.get()
         self.assertTrue(user.can_view_stats_dreets(current_org=institution))
         self.assertTrue(user.can_view_stats_dashboard_widget(current_org=institution))
@@ -566,7 +566,7 @@ class ModelTest(TestCase):
 
         # Non admin member of DREETS can access as well.
         institution = InstitutionWithMembershipFactory(
-            kind=Institution.Kind.DREETS, membership__is_admin=False, department="93"
+            kind=InstitutionKind.DREETS, membership__is_admin=False, department="93"
         )
         user = institution.members.get()
         self.assertTrue(user.can_view_stats_dreets(current_org=institution))
@@ -574,7 +574,7 @@ class ModelTest(TestCase):
         self.assertEqual(user.get_stats_dreets_region(current_org=institution), institution.region)
 
         # Member of institution of wrong kind cannot access.
-        institution = InstitutionWithMembershipFactory(kind=Institution.Kind.OTHER, department="93")
+        institution = InstitutionWithMembershipFactory(kind=InstitutionKind.OTHER, department="93")
         user = institution.members.get()
         self.assertFalse(user.can_view_stats_dreets(current_org=institution))
         self.assertFalse(user.can_view_stats_dashboard_widget(current_org=institution))
@@ -584,21 +584,21 @@ class ModelTest(TestCase):
         DGEFP as in "délégation générale à l'Emploi et à la Formation professionnelle"
         """
         # Admin member of DGEFP can access.
-        institution = InstitutionWithMembershipFactory(kind=Institution.Kind.DGEFP, department="93")
+        institution = InstitutionWithMembershipFactory(kind=InstitutionKind.DGEFP, department="93")
         user = institution.members.get()
         self.assertTrue(user.can_view_stats_dgefp(current_org=institution))
         self.assertTrue(user.can_view_stats_dashboard_widget(current_org=institution))
 
         # Non admin member of DGEFP can access as well.
         institution = InstitutionWithMembershipFactory(
-            kind=Institution.Kind.DGEFP, membership__is_admin=False, department="93"
+            kind=InstitutionKind.DGEFP, membership__is_admin=False, department="93"
         )
         user = institution.members.get()
         self.assertTrue(user.can_view_stats_dgefp(current_org=institution))
         self.assertTrue(user.can_view_stats_dashboard_widget(current_org=institution))
 
         # Member of institution of wrong kind cannot access.
-        institution = InstitutionWithMembershipFactory(kind=Institution.Kind.OTHER, department="93")
+        institution = InstitutionWithMembershipFactory(kind=InstitutionKind.OTHER, department="93")
         user = institution.members.get()
         self.assertFalse(user.can_view_stats_dgefp(current_org=institution))
         self.assertFalse(user.can_view_stats_dashboard_widget(current_org=institution))

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -18,7 +18,7 @@ from itou.job_applications.notifications import (
     NewSpontaneousJobAppEmployersNotification,
 )
 from itou.prescribers import factories as prescribers_factories
-from itou.prescribers.models import PrescriberOrganization
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.siae_evaluations.factories import EvaluatedSiaeFactory, EvaluationCampaignFactory
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import (
@@ -255,7 +255,7 @@ class DashboardViewTest(TestCase):
         self.assertNotContains(response, "Suspendre un PASS IAE")
 
         prescriber_org = prescribers_factories.PrescriberOrganizationWithMembershipFactory(
-            kind=PrescriberOrganization.Kind.CAP_EMPLOI
+            kind=PrescriberOrganizationKind.CAP_EMPLOI
         )
         prescriber = prescriber_org.members.first()
         self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
@@ -263,7 +263,7 @@ class DashboardViewTest(TestCase):
         self.assertNotContains(response, "Suspendre un PASS IAE")
 
         prescriber_org_pe = prescribers_factories.PrescriberOrganizationWithMembershipFactory(
-            kind=PrescriberOrganization.Kind.PE
+            kind=PrescriberOrganizationKind.PE
         )
         prescriber_pe = prescriber_org_pe.members.first()
         self.client.login(username=prescriber_pe.email, password=DEFAULT_PASSWORD)

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -13,6 +13,7 @@ from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
 from itou.institutions.models import Institution
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 from itou.siae_evaluations.models import EvaluatedSiae, EvaluationCampaign
 from itou.siaes.models import Siae
@@ -102,6 +103,8 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_view_stats_dgefp": request.user.can_view_stats_dgefp(current_org=current_org),
         "num_rejected_employee_records": num_rejected_employee_records,
         "active_campaigns": active_campaigns,
+        "precriber_kind_pe": PrescriberOrganizationKind.PE,
+        "precriber_kind_dept": PrescriberOrganizationKind.DEPT,
     }
 
     return render(request, template_name, context)

--- a/itou/www/invitations_views/forms.py
+++ b/itou/www/invitations_views/forms.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.forms.models import modelformset_factory
 
 from itou.invitations.models import LaborInspectorInvitation, PrescriberWithOrgInvitation, SiaeStaffInvitation
-from itou.prescribers.models import PrescriberOrganization
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.users.models import User
 
 
@@ -45,7 +45,7 @@ class PrescriberWithOrgInvitationForm(forms.ModelForm):
         email = self.cleaned_data["email"]
 
         self._invited_user_exists_error(email)
-        if self.organization.kind == PrescriberOrganization.Kind.PE and not email.endswith(
+        if self.organization.kind == PrescriberOrganizationKind.PE and not email.endswith(
             settings.POLE_EMPLOI_EMAIL_SUFFIX
         ):
             error = forms.ValidationError("L'adresse e-mail doit être une adresse Pôle emploi")

--- a/itou/www/invitations_views/tests/tests_prescriber_organization.py
+++ b/itou/www/invitations_views/tests/tests_prescriber_organization.py
@@ -14,8 +14,8 @@ from django.utils.html import escape
 from itou.invitations.factories import PrescriberWithOrgSentInvitationFactory
 from itou.invitations.models import PrescriberWithOrgInvitation
 from itou.openid_connect.inclusion_connect.tests import OIDC_USERINFO, mock_oauth_dance
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory, PrescriberPoleEmploiFactory
-from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.factories import SiaeFactory
 from itou.users.enums import KIND_PRESCRIBER
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory, UserFactory
@@ -35,7 +35,7 @@ INVITATION_URL = reverse("invitations_views:invite_prescriber_with_org")
 
 class TestSendPrescriberWithOrgInvitation(TestCase):
     def setUp(self):
-        self.organization = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganization.Kind.CAP_EMPLOI)
+        self.organization = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganizationKind.CAP_EMPLOI)
         self.sender = self.organization.members.first()
         self.guest_data = {"first_name": "Léonie", "last_name": "Bathiat", "email": "leonie@example.com"}
         self.post_data = POST_DATA | {
@@ -102,7 +102,7 @@ class TestSendPrescriberWithOrgInvitation(TestCase):
 
 class TestSendPrescriberWithOrgInvitationExceptions(TestCase):
     def setUp(self):
-        self.organization = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganization.Kind.CAP_EMPLOI)
+        self.organization = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganizationKind.CAP_EMPLOI)
         self.sender = self.organization.members.first()
         self.post_data = POST_DATA
 

--- a/itou/www/prescribers_views/forms.py
+++ b/itou/www/prescribers_views/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 
 
@@ -15,7 +16,7 @@ class EditPrescriberOrganizationForm(forms.ModelForm):
         for required_field in required_fields:
             self.fields[required_field].required = True
 
-        if self.instance.kind == self.instance.Kind.PE:
+        if self.instance.kind == PrescriberOrganizationKind.PE:
             # Do not edit the name of a Pôle emploi agency.
             del self.fields["name"]
             # Duplicates are identified through SAFIR code which makes the SIRET not required.

--- a/itou/www/prescribers_views/tests/test_edit.py
+++ b/itou/www/prescribers_views/tests/test_edit.py
@@ -3,6 +3,7 @@ from unittest import mock
 from django.test import TestCase
 from django.urls import reverse
 
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.factories import PrescriberOrganizationFactory, PrescriberOrganizationWithMembershipFactory
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.factories import DEFAULT_PASSWORD
@@ -24,7 +25,7 @@ class EditOrganizationTest(TestCase):
         """Edit a prescriber organization."""
 
         organization = PrescriberOrganizationWithMembershipFactory(
-            authorized=True, kind=PrescriberOrganization.Kind.CAP_EMPLOI
+            authorized=True, kind=PrescriberOrganizationKind.CAP_EMPLOI
         )
         user = organization.members.first()
 
@@ -86,11 +87,11 @@ class EditOrganizationTest(TestCase):
         when user is member of multiple orgs with the same SIRET (and different types)
         (was a regression)
         """
-        organization = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganization.Kind.ML)
+        organization = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganizationKind.ML)
         siret = organization.siret
         user = organization.members.first()
 
-        org2 = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganization.Kind.PLIE, siret=siret)
+        org2 = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganizationKind.PLIE, siret=siret)
         org2.members.add(user)
         org2.save()
 

--- a/itou/www/prescribers_views/views.py
+++ b/itou/www/prescribers_views/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse_lazy
 
 from itou.common_apps.organizations.views import deactivate_org_member, update_org_admin_role
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.models import User
 from itou.utils.apis.geocoding import GeocodingDataException
@@ -114,7 +115,7 @@ def list_accredited_organizations(request, template_name="prescribers/list_accre
 
     required_permissions = [
         prescriber_org.is_authorized,
-        prescriber_org.kind == prescriber_org.Kind.DEPT,
+        prescriber_org.kind == PrescriberOrganizationKind.DEPT,
         prescriber_org.has_admin(request.user),
     ]
 

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -7,6 +7,7 @@ from django.utils.http import urlsafe_base64_decode
 from django.utils.safestring import mark_safe
 
 from itou.common_apps.address.departments import DEPARTMENTS
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae, SiaeMembership
 from itou.users.models import User
@@ -337,7 +338,7 @@ class PrescriberChooseOrgKindForm(forms.Form):
     kind = forms.ChoiceField(
         label="Pour qui travaillez-vous ?",
         widget=forms.RadioSelect,
-        choices=PrescriberOrganization.Kind.choices,
+        choices=PrescriberOrganizationKind.choices,
     )
 
     def clean_kind(self):


### PR DESCRIPTION
### Quoi ?

Déplacement des types de prescripteurs et des institutions dans des fichiers dédiées.

### Pourquoi ?

Pour améliorer la lecture du code des modèles et des `enums`.

### Comment ?

En créant des fichiers `enums.py`.