### PR TITLE
Réparer la colonne Metabase `candidatures.motif_de_refus` qui est devenue 100% vide

### DIFF
--- a/itou/metabase/management/commands/_job_applications.py
+++ b/itou/metabase/management/commands/_job_applications.py
@@ -165,7 +165,7 @@ TABLE_COLUMNS = [
         "name": "motif_de_refus",
         "type": "varchar",
         "comment": "Motif de refus de la candidature",
-        "fn": lambda o: getattr(o.refusal_reason, "label", None),
+        "fn": lambda o: o.get_refusal_reason_display() if o.refusal_reason != "" else None,
     },
     {
         "name": "id_candidat_anonymisé",

--- a/itou/metabase/tests/test_job_applications.py
+++ b/itou/metabase/tests/test_job_applications.py
@@ -17,13 +17,13 @@ class MetabaseJobApplicationTest(TestCase):
         fn = self.get_fn_by_name("motif_de_refus")
         ja = JobApplicationFactory(refusal_reason=RefusalReason.ELIGIBILITY_DOUBT.value)
         self.assertIn(ja.refusal_reason, RefusalReason.hidden())
-        self.assertEqual(fn(ja), ja.refusal_reason.label)
+        self.assertEqual(fn(ja), ja.get_refusal_reason_display())
 
     def test_refusal_reason_current_value(self):
         fn = self.get_fn_by_name("motif_de_refus")
         ja = JobApplicationFactory(refusal_reason=RefusalReason.DID_NOT_COME.value)
         self.assertNotIn(ja.refusal_reason, RefusalReason.hidden())
-        self.assertEqual(fn(ja), ja.refusal_reason.label)
+        self.assertEqual(fn(ja), ja.get_refusal_reason_display())
 
     def test_refusal_reason_empty_value(self):
         fn = self.get_fn_by_name("motif_de_refus")

--- a/itou/metabase/tests/test_job_applications.py
+++ b/itou/metabase/tests/test_job_applications.py
@@ -15,13 +15,13 @@ class MetabaseJobApplicationTest(TestCase):
 
     def test_refusal_reason_old_value(self):
         fn = self.get_fn_by_name("motif_de_refus")
-        ja = JobApplicationFactory(refusal_reason=RefusalReason.ELIGIBILITY_DOUBT)
+        ja = JobApplicationFactory(refusal_reason=RefusalReason.ELIGIBILITY_DOUBT.value)
         self.assertIn(ja.refusal_reason, RefusalReason.hidden())
         self.assertEqual(fn(ja), ja.refusal_reason.label)
 
     def test_refusal_reason_current_value(self):
         fn = self.get_fn_by_name("motif_de_refus")
-        ja = JobApplicationFactory(refusal_reason=RefusalReason.DID_NOT_COME)
+        ja = JobApplicationFactory(refusal_reason=RefusalReason.DID_NOT_COME.value)
         self.assertNotIn(ja.refusal_reason, RefusalReason.hidden())
         self.assertEqual(fn(ja), ja.refusal_reason.label)
 


### PR DESCRIPTION
### Quoi ?

Réparer la colonne Metabase `candidatures.motif_de_refus` qui est devenue 100% vide.

### Pourquoi ?

Elle est devenue vide suite à la MEP de cette PR ([lien](https://github.com/betagouv/itou/pull/1427)) et en particulier de ce changement ([lien](https://github.com/betagouv/itou/pull/1427#discussion_r938002402)) :

![image](https://user-images.githubusercontent.com/10533583/183393040-21ab4f97-7f92-4bab-88ad-86bafcb8242d.png)

### Mais pourquoi ça a cassé et pourquoi les tests ont rien détecté ?

En raison d'une coicidence malheureuse de deux boulettes.

1) L'oubli de `*.value` sur le enum dans les tests, réparé par la présente PR.

2) Le changement de dernière minute de`None if o.refusal_reason == "" else o.refusal_reason.label` (qui aurait cassé bruyamment au prochain run, même si pas dans les tests) en `getattr(o.refusal_reason, "label", None)` qui renvoit `None` 100% du temps car `o.refusal_reason` est un `str` et donc n'a jamais de champ `label`.

### Comment ?

1) Utilisation correcte du `*.value` dans les tests.

2) Utilisation de `get_refusal_reason_display()` qui est la bonne façon d'accéder au label.