### PR TITLE
Evaluation a postériori - simplification des URLs - ajout des ID

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -591,7 +591,7 @@
                             {% else %}
                                 <li class="card-text mb-3">
                                     <i class="ri-pulse-line ri-lg mr-1"></i>
-                                    <a href="{% url 'siae_evaluations_views:samples_selection' %}">Sélectionner l'échantillon</a>
+                                    <a href="{% url 'siae_evaluations_views:samples_selection' active_campaign.pk%}">Sélectionner l'échantillon pour {{active_campaign.name}}</a>
                                 </li>
                             {% endif %}
                         {% endfor %}

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -178,12 +178,17 @@ class DashboardViewTest(TestCase):
 
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Contrôle a posteriori")
-        self.assertNotContains(response, reverse("siae_evaluations_views:samples_selection"))
 
         evaluation_campaign = EvaluationCampaignFactory(institution=institution)
         response = self.client.get(reverse("dashboard:index"))
         self.assertContains(response, "Contrôle a posteriori")
-        self.assertContains(response, reverse("siae_evaluations_views:samples_selection"))
+        self.assertContains(
+            response,
+            reverse(
+                "siae_evaluations_views:samples_selection",
+                kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
+            ),
+        )
         self.assertNotContains(
             response,
             reverse(
@@ -196,7 +201,13 @@ class DashboardViewTest(TestCase):
         evaluation_campaign.save(update_fields=["evaluations_asked_at"])
         response = self.client.get(reverse("dashboard:index"))
         self.assertContains(response, "Contrôle a posteriori")
-        self.assertNotContains(response, reverse("siae_evaluations_views:samples_selection"))
+        self.assertNotContains(
+            response,
+            reverse(
+                "siae_evaluations_views:samples_selection",
+                kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
+            ),
+        )
         self.assertContains(
             response,
             reverse(
@@ -209,7 +220,13 @@ class DashboardViewTest(TestCase):
         evaluation_campaign.save(update_fields=["ended_at"])
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Contrôle a posteriori")
-        self.assertNotContains(response, reverse("siae_evaluations_views:samples_selection"))
+        self.assertNotContains(
+            response,
+            reverse(
+                "siae_evaluations_views:samples_selection",
+                kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
+            ),
+        )
         self.assertNotContains(
             response,
             reverse(

--- a/itou/www/siae_evaluations_views/urls.py
+++ b/itou/www/siae_evaluations_views/urls.py
@@ -7,7 +7,7 @@ from itou.www.siae_evaluations_views import views
 app_name = "siae_evaluations_views"
 
 urlpatterns = [
-    path("samples_selection", views.samples_selection, name="samples_selection"),
+    path("samples_selection/<int:evaluation_campaign_pk>/", views.samples_selection, name="samples_selection"),
     path(
         "institution_evaluated_siae_list/<int:evaluation_campaign_pk>/",
         views.institution_evaluated_siae_list,

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -28,9 +28,9 @@ from itou.www.siae_evaluations_views.forms import (
 
 
 @login_required
-def samples_selection(request, template_name="siae_evaluations/samples_selection.html"):
+def samples_selection(request, evaluation_campaign_pk, template_name="siae_evaluations/samples_selection.html"):
     institution = get_current_institution_or_404(request)
-    evaluation_campaign = EvaluationCampaign.objects.first_active_campaign(institution)
+    evaluation_campaign = get_object_or_404(EvaluationCampaign, pk=evaluation_campaign_pk, institution=institution)
 
     back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
 


### PR DESCRIPTION
### Quoi ?

3 utiliser les ID des objets danst toutes les URLs du contrôle a posteriori pour simplifier le code.

### Pourquoi ?

Keep it simple. Period.

### Comment ?

Ajout des ID pour les urls : 
- `samples_selection` : selection du ratio de la campagne par la DDETS
- `siae_job_applications_list` : accès à la liste des autoprescriptions à justifier par la SIAE
- `siae_submit_proofs` : soumission des justifitcatifs par la SIAE