### PR TITLE
Invitations de prescripteurs avec Inclusion Connect

### DIFF
--- a/itou/openid_connect/inclusion_connect/enums.py
+++ b/itou/openid_connect/inclusion_connect/enums.py
@@ -1,0 +1,10 @@
+import enum
+
+
+class InclusionConnectChannel(str, enum.Enum):
+    """This enum is stored in the session, and allow us to change the error message
+    in the callback view depending on where the user came from.
+    """
+
+    INVITATION = "invitation"
+    POLE_EMPLOI = "pole_emploi"

--- a/itou/openid_connect/inclusion_connect/tests.py
+++ b/itou/openid_connect/inclusion_connect/tests.py
@@ -470,3 +470,19 @@ class InclusionConnectLogoutTest(TestCase):
         expected_redirection = reverse("home:hp")
         self.assertRedirects(response, expected_redirection)
         self.assertFalse(auth.get_user(self.client).is_authenticated)
+
+    @respx.mock
+    def test_logout_with_incomplete_state(self):
+        # This happens while testing. It should never happen for real users, but it's still painful for us.
+
+        mock_oauth_dance(self)
+        respx.get(constants.INCLUSION_CONNECT_ENDPOINT_LOGOUT).respond(200)
+
+        session = self.client.session
+        session[constants.INCLUSION_CONNECT_SESSION_KEY]["token"] = None
+        session[constants.INCLUSION_CONNECT_SESSION_KEY]["state"] = None
+        session.save()
+
+        response = self.client.post(reverse("account_logout"))
+        expected_redirection = reverse("home:hp")
+        self.assertRedirects(response, expected_redirection)

--- a/itou/openid_connect/inclusion_connect/tests.py
+++ b/itou/openid_connect/inclusion_connect/tests.py
@@ -44,6 +44,7 @@ def mock_oauth_dance(
     expected_route="welcoming_tour:index",
     login_hint=None,
     user_info_email=None,
+    channel=None,
 ):
     respx.get(constants.INCLUSION_CONNECT_ENDPOINT_AUTHORIZE).respond(302)
     # Authorize params depend on user kind.
@@ -52,6 +53,7 @@ def mock_oauth_dance(
         "previous_url": previous_url,
         "next_url": next_url,
         "login_hint": login_hint,
+        "channel": channel,
     }
     authorize_params = {k: v for k, v in authorize_params.items() if v}
 
@@ -270,7 +272,7 @@ class InclusionConnectViewTest(TestCase):
 
     def test_authorize_endpoint_with_params(self):
         email = "porthos@touspourun.com"
-        params = {"login_hint": email, "user_kind": KIND_PRESCRIBER}
+        params = {"login_hint": email, "user_kind": KIND_PRESCRIBER, "channel": "invitation"}
         url = f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
         response = self.client.get(url, follow=False)
         self.assertIn(quote(email), response.url)

--- a/itou/templates/invitations_views/includes/invitation_errors.html
+++ b/itou/templates/invitations_views/includes/invitation_errors.html
@@ -1,8 +1,0 @@
-
-{% if invitation.has_expired %}
-    <h1 class="h1-hero-c1">Invitation expirée</h1>
-    <p>Cette invitation est expirée. Merci de contacter la personne qui vous a invité(e) afin d'en recevoir une nouvelle.</p>
-{% elif invitation.accepted %}
-    <h1 class="h1-hero-c1">Invitation acceptée</h1>
-    <p>Cette invitation a déjà été acceptée.</p>
-{% endif %}

--- a/itou/templates/invitations_views/invitation_errors.html
+++ b/itou/templates/invitations_views/invitation_errors.html
@@ -1,0 +1,21 @@
+{% extends "layout/content_small.html" %}
+{% load bootstrap4 %}
+
+{% block title %}Invitation{{ block.super }}{% endblock %}
+
+{% block content %}
+
+    {% if invitation.has_expired %}
+        <h1 class="h1-hero-c1">Invitation expirée</h1>
+        <p>Cette invitation est expirée. Merci de contacter la personne qui vous a invité(e) afin d'en recevoir une nouvelle.</p>
+    {% elif invitation.accepted %}
+        <h1 class="h1-hero-c1">Invitation acceptée</h1>
+        <p>Cette invitation a déjà été acceptée.</p>
+    {% endif %}
+
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    {{ form.media }}
+{% endblock %}

--- a/itou/templates/invitations_views/new_prescriber.html
+++ b/itou/templates/invitations_views/new_prescriber.html
@@ -1,0 +1,20 @@
+{% extends "layout/content_small.html" %}
+{% load bootstrap4 %}
+
+{% block title %}Invitation{{ block.super }}{% endblock %}
+
+{% block content %}
+
+    <h1 class="h1-hero-c1">Bienvenue {{ invitation.first_name }} {{ invitation.last_name }} !</h1>
+    <div class="">
+        Vous allez rejoindre le tableau de bord de <span class="font-weight-bold">{{ invitation.organization.name }}</span>
+    </div>
+
+    {% include "inclusion_connect/includes/description.html" %}
+
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    {{ form.media }}
+{% endblock %}

--- a/itou/templates/invitations_views/new_user.html
+++ b/itou/templates/invitations_views/new_user.html
@@ -5,8 +5,6 @@
 
 {% block content %}
 
-    {% include "invitations_views/includes/invitation_errors.html" with invitation=invitation %}
-
     {% if form %}
         <h1 class="h1-hero-c1">Bienvenue {{ invitation.first_name }} {{ invitation.last_name }} !</h1>
         <form method="post" action="{{ invitation.acceptance_link }}" role="form" class="js-prevent-multiple-submit">

--- a/itou/users/adapter.py
+++ b/itou/users/adapter.py
@@ -37,10 +37,13 @@ class UserAdapter(DefaultAccountAdapter):
         redirect_url = reverse("home:hp")
         # Inclusion Connect
         ic_session = request.session.get(INCLUSION_CONNECT_SESSION_KEY)
-        if ic_session and ic_session.get("token"):
-            params = {"token": ic_session["token"], "state": ic_session["state"]}
-            ic_base_logout_url = reverse("inclusion_connect:logout")
-            redirect_url = f"{ic_base_logout_url}?{urlencode(params)}"
+        if ic_session:
+            token = ic_session["token"]
+            state = ic_session["state"]
+            if token and state:
+                params = {"token": token, "state": state}
+                ic_base_logout_url = reverse("inclusion_connect:logout")
+                redirect_url = f"{ic_base_logout_url}?{urlencode(params)}"
         # France Connect
         fc_token = request.session.get(FRANCE_CONNECT_SESSION_TOKEN)
         fc_state = request.session.get(FRANCE_CONNECT_SESSION_STATE)

--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -10,6 +10,7 @@ from django.shortcuts import get_object_or_404, redirect, render, reverse
 from django.utils import formats, safestring
 
 from itou.invitations.models import InvitationAbstract, PrescriberWithOrgInvitation, SiaeStaffInvitation
+from itou.openid_connect.inclusion_connect.enums import InclusionConnectChannel
 from itou.users.enums import KIND_PRESCRIBER
 from itou.users.models import User
 from itou.utils.perms.institution import get_current_institution_or_404
@@ -39,6 +40,7 @@ def handle_invited_prescriber_registration(request, invitation):
     params = {
         "user_kind": KIND_PRESCRIBER,
         "login_hint": invitation.email,
+        "channel": InclusionConnectChannel.INVITATION.value,
         "previous_url": request.get_full_path(),
         "next_url": get_safe_url(request, "redirect_to"),
     }

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -45,6 +45,9 @@ class PrescriberLoginView(ItouLoginView):
             "user_kind": KIND_PRESCRIBER,
             "previous_url": self.request.get_full_path(),
         }
+        next_url = get_safe_url(self.request, "next")
+        if next_url:
+            params["next_url"] = next_url
         inclusion_connect_url = f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
         extra_context = {
             "account_type_display_name": "prescripteur",

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -43,7 +43,7 @@ class PrescriberLoginView(ItouLoginView):
         context = super().get_context_data(**kwargs)
         params = {
             "user_kind": KIND_PRESCRIBER,
-            "previous_url": self.request.resolver_match.view_name,
+            "previous_url": self.request.get_full_path(),
         }
         inclusion_connect_url = f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
         extra_context = {

--- a/itou/www/signup/tests/test_prescriber.py
+++ b/itou/www/signup/tests/test_prescriber.py
@@ -78,6 +78,7 @@ class PrescriberSignupTest(TestCase):
         next_url = reverse("signup:prescriber_join_org")
         params = {
             "login_hint": email,
+            "channel": "pole_emploi",
             "user_kind": KIND_PRESCRIBER,
             "previous_url": previous_url,
             "next_url": next_url,
@@ -93,6 +94,7 @@ class PrescriberSignupTest(TestCase):
                 self,
                 assert_redirects=False,
                 login_hint=email,
+                channel="pole_emploi",
                 user_info_email=email,
                 previous_url=previous_url,
                 next_url=next_url,
@@ -1001,6 +1003,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(TestCase):
             response = mock_oauth_dance(
                 self,
                 login_hint=pe_email,
+                channel="pole_emploi",
                 assert_redirects=False,
                 previous_url=previous_url,
                 next_url=next_url,

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -617,7 +617,7 @@ def prescriber_pole_emploi_user(request, template_name="signup/prescriber_pole_e
     params = {
         "login_hint": session_data["email"],
         "user_kind": KIND_PRESCRIBER,
-        "previous_url": request.path_info,
+        "previous_url": request.get_full_path(),
         "next_url": reverse("signup:prescriber_join_org"),
     }
     inclusion_connect_url = f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
@@ -674,7 +674,7 @@ def prescriber_user(request, template_name="signup/prescriber_user.html"):
 
     ic_params = {
         "user_kind": KIND_PRESCRIBER,
-        "previous_url": request.path_info,
+        "previous_url": request.get_full_path(),
     }
     if join_as_orienteur_with_org or join_authorized_org:
         # Redirect to the join organization view after login or signup.

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -19,6 +19,7 @@ from django.utils.http import urlencode
 from django.views.decorators.http import require_GET
 
 from itou.common_apps.address.models import lat_lon_to_coords
+from itou.openid_connect.inclusion_connect.enums import InclusionConnectChannel
 from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
 from itou.siaes.enums import SiaeKind
 from itou.siaes.models import Siae
@@ -616,6 +617,7 @@ def prescriber_pole_emploi_user(request, template_name="signup/prescriber_pole_e
     )
     params = {
         "login_hint": session_data["email"],
+        "channel": InclusionConnectChannel.POLE_EMPLOI.value,
         "user_kind": KIND_PRESCRIBER,
         "previous_url": request.get_full_path(),
         "next_url": reverse("signup:prescriber_join_org"),


### PR DESCRIPTION
### Quoi ?

En tant que prescripteur invité à rejoindre une organisation , je peux m’inscrire /me connecter via Inclusion Connect

### Pourquoi ?

On ne veut plus créer de nouveaux prescripteurs avec un compte Django.

### Comment ?

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran (optionnel)

![Screenshot from 2022-08-09 16-20-19](https://user-images.githubusercontent.com/7632730/183673331-5b187f35-a922-4317-bed6-609db0490fc3.png)

### Autre (optionnel)

A faire : 
- [ ] Ajouter les tests une fois le fonctionnement choisi validé.