### PR TITLE
Meilleure gestion des erreurs de session pour les pages du dépôt de candidature

### DIFF
--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -34,6 +34,24 @@ from itou.utils.storage.s3 import S3Upload
 fake = faker.Faker(locale="fr_FR")
 
 
+class ApplyTest(TestCase):
+    def test_we_redirect_to_siae_on_missing_session_for_fbv(self):
+        routes = {
+            "apply:step_check_job_seeker_info",
+            "apply:step_check_prev_applications",
+            "apply:step_eligibility",
+            "apply:step_application",
+        }
+        user = JobSeekerFactory()
+        siae = SiaeFactory(with_jobs=True)
+
+        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        for route in routes:
+            with self.subTest(route=route):
+                response = self.client.get(reverse(route, kwargs={"siae_pk": siae.pk}))
+                self.assertRedirects(response, reverse("siaes_views:card", kwargs={"siae_id": siae.pk}))
+
+
 class ApplyAsJobSeekerTest(TestCase):
     @property
     def default_session_data(self):

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -46,8 +46,8 @@ def valid_session_required(required_keys=None):
         @functools.wraps(function)
         def decorated(request, *args, **kwargs):
             session_ns = SessionNamespace(request.session, f"job_application-{kwargs['siae_pk']}")
-            if not session_ns:
-                raise PermissionDenied("no opened session")
+            if not session_ns.exists():
+                return HttpResponseRedirect(reverse("siaes_views:card", kwargs={"siae_id": kwargs["siae_pk"]}))
             if required_keys:
                 for key in required_keys:
                     if session_ns.get(key) != kwargs[key]:

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -764,6 +764,7 @@ def step_application(request, siae_pk, template_name="apply/submit_step_applicat
 
 class ApplicationSentView(ApplyStepBaseView):
     template_name = "apply/submit_step_application_sent.html"
+    required_session_namespaces = ["apply_session"]
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
### Quoi ?

Ne plus générer une erreur 500 lambda mais, soit une erreur ciblé, soit une redirection vers la page de départ.

### Pourquoi ?

Le parcours de dépôt de candidature s'appuis fortement sur les sessions, pour éviter des problèmes nous supprimons ces sessions dès que nous le pouvons mais les utilisateurs utilisent régulièrement le retour navigateur ce qui finis en général par une erreur 500 (car `KeyError`).

### Comment ?

Les protections étaient déjà là, mais pas forcément fonctionnelles (:confounded:) ou activées.

### Autre

Je suis rester superficiel dans les corrections car ces parties vont être supprimées/modifiées avec la dernière étape de la refonte du dépôt de candidature, qui d'ailleurs corrige déjà en partie ces problèmes ;).