### PR TITLE
Erreur d'affichage dans la liste des nouvelles fiches salarié

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -215,7 +215,10 @@ class EmployeeRecord(models.Model):
         ordering = ["-created_at"]
 
     def __str__(self):
-        return f"PK:{self.pk} PASS:{self.approval_number} SIRET:{self.siret} JOBSEEKER:{self.job_seeker}"
+        return (
+            f"PK:{self.pk} PASS:{self.approval_number} SIRET:{self.siret} "
+            f"JOBSEEKER:{self.job_seeker} STATUS:{self.status}"
+        )
 
     def save(self, *args, **kwargs):
         if self.pk:

--- a/itou/utils/perms/employee_record.py
+++ b/itou/utils/perms/employee_record.py
@@ -45,7 +45,7 @@ def can_create_employee_record(request, job_application_id=None):
 
     # SIAE is eligible to employee record ?
     if not siae.can_use_employee_record:
-        raise PermissionDenied
+        raise PermissionDenied("Cette stucture ne peut pas utiliser la gestion des fiches salarié'.")
 
     if job_application_id:
         # We want to reuse a job application in view, but first check that all is ok
@@ -59,8 +59,11 @@ def can_create_employee_record(request, job_application_id=None):
             pk=job_application_id,
         )
 
-        if not (siae_is_allowed(job_application, siae) and tunnel_step_is_allowed(job_application)):
-            raise PermissionDenied
+        if not siae_is_allowed(job_application, siae):
+            raise PermissionDenied("Cette structure ne peut pas modifier cette fiche salarié.")
+
+        if not tunnel_step_is_allowed(job_application):
+            raise PermissionDenied("Cette fiche salarié ne peut pas être modifiée.")
 
         # Finally, the reusable Holy Grail
         return job_application

--- a/itou/utils/perms/employee_record.py
+++ b/itou/utils/perms/employee_record.py
@@ -57,10 +57,8 @@ def can_create_employee_record(request, job_application_id=None):
                 "job_seeker__jobseeker_profile",
             ),
             pk=job_application_id,
+            to_siae=siae,
         )
-
-        if not siae_is_allowed(job_application, siae):
-            raise PermissionDenied("Cette structure ne peut pas modifier cette fiche salarié.")
 
         if not tunnel_step_is_allowed(job_application):
             raise PermissionDenied("Cette fiche salarié ne peut pas être modifiée.")

--- a/itou/www/employee_record_views/tests/test_create.py
+++ b/itou/www/employee_record_views/tests/test_create.py
@@ -120,7 +120,8 @@ class AbstractCreateEmployeeRecordTest(TestCase):
         self.client.login(username=self.user_without_perms.username, password=DEFAULT_PASSWORD)
 
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 403)
+        # Changed to 404
+        self.assertEqual(response.status_code, 404)
 
     def test_access_denied_bad_siae_kind(self):
         # SIAE can't use employee record (not the correct kind)

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -83,11 +83,12 @@ def list_employee_records(request, template_name="employee_record/list.html"):
         .order_by("-status")
     )
     employee_record_badges = {row["status"]: row["cnt"] for row in employee_record_statuses}
+    eligibible_job_applications = JobApplication.objects.eligible_as_employee_record(siae)
 
     # Set count of each status for badge display
     status_badges = [
         (
-            JobApplication.objects.eligible_as_employee_record(siae).count(),
+            eligibible_job_applications.count(),
             "info",
         ),
         (employee_record_badges.get(Status.READY, 0), "secondary"),
@@ -106,8 +107,8 @@ def list_employee_records(request, template_name="employee_record/list.html"):
     base_query = EmployeeRecord.objects.full_fetch()
 
     if status == Status.NEW:
-        data = JobApplication.objects.eligible_as_employee_record(siae)
         # Browse to get only the linked employee record in "new" state
+        data = eligibible_job_applications
         for item in data:
             for e in item.employee_record.all():
                 if e.status == Status.NEW:


### PR DESCRIPTION
### Quoi ?

La liste des fiches salarié en état `NEW` est incorrecte et affiche des candidatures ayant déjà une fiche salarié associée.
Certaines candidatures ayant déjà une fiche associée sont re-proposées à la complétion / soumission.
Une protection ultérieure empêche l'utilisateur d'aller plus loin, mais l'affichage est définitivement faux.

### Pourquoi ?

Un petit oubli sur le commit https://github.com/betagouv/itou/commit/ecc543a0d70fc716086bbb6f884f5cfe94d649f9

La méthode `is_eligible_for_employee_record` devient trop permissive (L231).

Il est nécessaire de filtrer sur les candidatures n'ayant pas encore de fiches salarié associée.

### Comment ?

Voir code: exclusion des `job_application` ayant une fiche salarié associée.

### Note

Cette PR est un "quick fix" pour améliorer l'expérience utilisateur rapidement. 
Mais elle est aussi un préalable : 
- à la refonte et / ou à une meilleure documentation des règles métiers concernant les conditions de création des fiches salarié.
- a une étude visant à vérifier et valider les règles métiers lorsque l'on effectue un transfert de SIAE / `move_siae` (en cours) 
