### PR TITLE
Ajout de variables d'environnement en dev pour Inclusion Connect

### DIFF
--- a/envs/dev.env.template
+++ b/envs/dev.env.template
@@ -29,3 +29,10 @@ DJANGO_SETTINGS_MODULE=config.settings.dev
 DJANGO_DEBUG=True
 ITOU_LOG_LEVEL=DEBUG
 DJANGO_SECRET_KEY=******************dev_secret_key******************
+
+# Inclusion Connect
+# To run IC locally, see https://github.com/betagouv/itou-inclusion-connect
+INCLUSION_CONNECT_BASE_URL=http://0.0.0.0:8080
+INCLUSION_CONNECT_REALM=local
+INCLUSION_CONNECT_CLIENT_ID=client_id
+INCLUSION_CONNECT_CLIENT_SECRET=client_secret


### PR DESCRIPTION
### Quoi ?

Mise à jour du envs/dev.env.template.

### Pourquoi ?

Inclusion Connect peut désormais tourner en local mais il faut indiquer les bonnes variables d'environnement.
