### PR TITLE
BOOST Sprint 47 ("week" 2)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -252,7 +252,7 @@ SESSION_COOKIE_SECURE = True
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
-SESSION_SERIALIZER = 'itou.utils.session.JSONSerializer'
+SESSION_SERIALIZER = "itou.utils.session.JSONSerializer"
 
 X_FRAME_OPTIONS = "DENY"
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -18,9 +18,8 @@ ROOT_DIR = os.path.abspath(os.path.join(CURRENT_DIR, "../.."))
 
 APPS_DIR = os.path.abspath(os.path.join(ROOT_DIR, "itou"))
 
-EXPORT_DIR = f"{ROOT_DIR}/exports"
-
-IMPORT_DIR = f"{ROOT_DIR}/imports"
+EXPORT_DIR = os.environ.get("SCRIPT_EXPORT_PATH", f"{ROOT_DIR}/exports")
+IMPORT_DIR = os.environ.get("SCRIPT_IMPORT_PATH", f"{ROOT_DIR}/imports")
 
 # General.
 # ------------------------------------------------------------------------------

--- a/itou/job_applications/management/commands/display_missing_eligibility_diagnoses.py
+++ b/itou/job_applications/management/commands/display_missing_eligibility_diagnoses.py
@@ -1,0 +1,55 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from itou.approvals.models import Approval
+from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.siaes.models import Siae
+
+
+# The support team sometimes fixes issues by generating a PASS, filling out the necessary information,
+# setting a Job Application as accepted, etc... all in the admin.
+#
+# One of the common "mistakes" made during this process is to forget to fill the "eligibility diagnosis"
+# cell of the job application. We can't blame them, it's a kind of loose denormalization anyway.
+#
+# But it can be many, many other very specific cases. This command is there to help printing a summary
+# of the problematic cases from time to time.
+
+
+class Command(BaseCommand):
+
+    help = "Prints the accepted job applications that do not have eligibility diagnoses for no obvious reason"
+
+    def handle(self, **options):
+        queryset = (
+            JobApplication.objects.filter(
+                state=JobApplicationWorkflow.STATE_ACCEPTED,
+                eligibility_diagnosis=None,
+                approval__number__startswith=Approval.ASP_ITOU_PREFIX,
+                to_siae__kind__in=Siae.ELIGIBILITY_REQUIRED_KINDS,
+            )
+            .exclude(
+                Q(approval__created_by__isnull=True)
+                | Q(approval__created_by__email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL)
+            )
+            .order_by("approval__created_at")
+        )
+        if queryset.count() == 0:
+            return
+
+        self.stdout.write("number,created_at,started_at,end_at,created_by,job_seeker\n")
+        for ja in queryset:
+            self.stdout.write(
+                ",".join(
+                    [
+                        ja.approval.number,
+                        ja.approval.created_at.isoformat(),
+                        ja.approval.start_at.isoformat(),
+                        ja.approval.end_at.isoformat(),
+                        str(ja.approval.created_by),
+                        str(ja.approval.user),
+                    ]
+                )
+                + "\n"
+            )

--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -174,7 +174,7 @@ def check_convention_data_consistency():
         # Additional data consistency checks.
         for siae in convention.siaes.all():
             assert siae.siren == convention.siren_signature
-            if siae.kind == SiaeKind.ACIPHC and convention.kind == SiaeConvention.KIND_ACI:
+            if siae.kind == SiaeKind.ACIPHC and convention.kind == SiaeKind.KIND_ACI:
                 assert siae.source == Siae.SOURCE_USER_CREATED
                 # Sometimes our staff manually changes an existing ACI antenna's kind from ACI to ACIPHC and forgets
                 # to detach the ACI convention.

--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -1,5 +1,6 @@
+# pylint: disable=consider-using-f-string
+
 import argparse
-import logging
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
@@ -13,8 +14,6 @@ from itou.job_applications import models as job_applications_models
 from itou.siaes import models as siaes_models
 from itou.users import models as users_models
 
-
-logger = logging.getLogger(__name__)
 
 HELP_TEXT = """
     Move all data from siae A to siae B (or only the job applications if `only-job-applications` option is set).
@@ -37,177 +36,7 @@ HELP_TEXT = """
 
     And in production:
     $ cd && cd app_* && django-admin move_siae_data --from 3243 --to 9612 --wet-run
-
 """
-
-
-def move_siae_data(from_id, to_id, wet_run=False, only_job_applications=False):
-    if from_id == to_id:
-        logger.error("Unable to use the same siae as source and destination (ID %s)", from_id)
-        return
-
-    from_siae_qs = siaes_models.Siae.objects.filter(pk=from_id)
-    try:
-        from_siae = from_siae_qs.get()
-    except siaes_models.Siae.DoesNotExist:
-        logger.error("Unable to find the siae ID %s", from_id)
-        return
-
-    to_siae_qs = siaes_models.Siae.objects.filter(pk=to_id)
-    try:
-        to_siae = to_siae_qs.get()
-    except siaes_models.Siae.DoesNotExist:
-        logger.error("Unable to find the siae ID %s", to_id)
-        return
-
-    # Intermediate variable for better readability
-    move_all_data = not only_job_applications
-
-    logger.info(
-        "MOVE %s OF siae.id=%s - %s %s - %s",
-        "DATA" if move_all_data else "JOB APPLICATIONS",
-        from_siae.pk,
-        from_siae.kind,
-        from_siae.siret,
-        from_siae.display_name,
-    )
-
-    job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=from_id)
-    logger.info("| Job applications sent: %s", job_applications_sent.count())
-
-    job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=from_id)
-    logger.info("| Job applications received: %s", job_applications_received.count())
-
-    if move_all_data:
-        # Move Job Description not already present in siae destination, Job Applications related will be attached to
-        # Job Description present in siae destination
-        appellation_subquery = Subquery(
-            siaes_models.SiaeJobDescription.objects.filter(siae_id=to_id, appellation_id=OuterRef("appellation_id"))
-        )
-        job_descriptions = siaes_models.SiaeJobDescription.objects.filter(siae_id=from_id).exclude(
-            Exists(appellation_subquery)
-        )
-        logger.info("| Job descriptions: %s", job_descriptions.count())
-
-        # Move users not already present in siae destination
-        members = siaes_models.SiaeMembership.objects.filter(siae_id=from_id).exclude(
-            user__in=users_models.User.objects.filter(siaemembership__siae_id=to_id)
-        )
-        logger.info("| Members: %s", members.count())
-
-        diagnoses = eligibility_models.EligibilityDiagnosis.objects.filter(author_siae_id=from_id)
-        logger.info("| Diagnoses: %s", diagnoses.count())
-
-        prolongations = approvals_models.Prolongation.objects.filter(declared_by_siae_id=from_id)
-        logger.info("| Prolongations: %s", prolongations.count())
-
-        suspensions = approvals_models.Suspension.objects.filter(siae_id=from_id)
-        logger.info("| Suspensions: %s", suspensions.count())
-
-        # Don't move invitations for existing members
-        # The goal is to keep information about the original information
-        invitations = invitations_models.SiaeStaffInvitation.objects.filter(siae_id=from_id).exclude(
-            email__in=users_models.User.objects.filter(siaemembership__siae_id=to_id).values_list("email", flat=True)
-        )
-        logger.info("| Invitations: %s", invitations.count())
-
-    logger.info(
-        "INTO siae.id=%s - %s %s - %s",
-        to_siae.pk,
-        to_siae.kind,
-        to_siae.siret,
-        to_siae.display_name,
-    )
-
-    dest_siae_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=to_id)
-    logger.info("| Job applications sent: %s", dest_siae_job_applications_sent.count())
-
-    dest_siae_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=to_id)
-    logger.info("| Job applications received: %s", dest_siae_job_applications_received.count())
-
-    if move_all_data:
-        logger.info(f"| Brand '{to_siae.brand}' will be updated with '{from_siae.display_name}'")
-        logger.info(f"| Description \n{to_siae.description}\nwill be updated with\n{from_siae.description}")
-        logger.info(f"| Phone '{to_siae.phone}' will be updated with '{from_siae.phone}'")
-        logger.info(f"| Coords '{to_siae.coords}' will be updated with '{from_siae.coords}'")
-        logger.info(f"| Geoscore '{to_siae.geocoding_score}' will be updated with '{from_siae.geocoding_score}'")
-
-    if not wet_run:
-        logger.info("Nothing to do in dry run mode.")
-        return
-
-    with transaction.atomic():
-
-        # If we move the job applications without moving the job descriptions as well, we need to unlink them,
-        # as job applications will be attached to siae B but job descriptions will stay attached to siae A.
-        if only_job_applications:
-            for job_application in job_applications_sent:
-                job_application.selected_jobs.clear()
-            for job_application in job_applications_received:
-                job_application.selected_jobs.clear()
-
-        # If we move job_description, we have to take care of existant job_description linked to siae B (destination),
-        # because we can't have 2 job_applications with the same Appellation for one siae. Job applications linked to
-        # these kind of job_description have to be unlinked to be transfered. Job_description can be different enough
-        # to be irrelevant.
-        if move_all_data:
-            # find Appellation linked to job_description siae B
-            to_siae_appellation_id = siaes_models.SiaeJobDescription.objects.filter(siae_id=to_id).values_list(
-                "appellation_id", flat=True
-            )
-
-            # find job_applications in siae A, linked with job_description which Appellation is found in siae B
-            job_applications_to_clear = job_applications_models.JobApplication.objects.filter(
-                to_siae_id=from_id,
-                selected_jobs__in=siaes_models.SiaeJobDescription.objects.filter(
-                    siae_id=from_id, appellation_id__in=to_siae_appellation_id
-                ),
-            )
-
-            # clean job_applications to let them be transfered in siae B
-            for job_application in job_applications_to_clear:
-                job_application.selected_jobs.clear()
-
-        job_applications_sent.update(sender_siae_id=to_id)
-        job_applications_received.update(to_siae_id=to_id)
-
-        if move_all_data:
-            # do not move duplicated job_descriptions
-            job_descriptions.exclude(appellation_id__in=to_siae_appellation_id).update(siae_id=to_id)
-            members.update(siae_id=to_id)
-            diagnoses.update(author_siae_id=to_id)
-            prolongations.update(declared_by_siae_id=to_id)
-            suspensions.update(siae_id=to_id)
-            invitations.update(siae_id=to_id)
-            to_siae_qs.update(
-                brand=from_siae.display_name,
-                description=from_siae.description,
-                phone=from_siae.phone,
-                coords=from_siae.coords,
-                geocoding_score=from_siae.geocoding_score,
-            )
-            from_siae_qs.update(
-                block_job_applications=True,
-                job_applications_blocked_at=timezone.now(),
-                # Make sure the old siae no longer appears in results
-                coords=None,
-                geocoding_score=None,
-            )
-
-    logger.info("MOVE %s OF siae.id=%s FINISHED", "DATA" if move_all_data else "JOB APPLICATIONS", from_siae.pk)
-    orig_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=from_id)
-    logger.info("| Job applications sent: %s", orig_job_applications_sent.count())
-
-    orig_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=from_id)
-    logger.info("| Job applications received: %s", orig_job_applications_received.count())
-
-    logger.info("INTO siae.id=%s", to_siae.pk)
-
-    dest_siae_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=to_id)
-    logger.info("| Job applications sent: %s", dest_siae_job_applications_sent.count())
-
-    dest_siae_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=to_id)
-    logger.info("| Job applications received: %s", dest_siae_job_applications_received.count())
 
 
 class Command(BaseCommand):
@@ -238,5 +67,178 @@ class Command(BaseCommand):
         )
         parser.add_argument("--wet-run", action=argparse.BooleanOptionalAction, default=False)
 
-    def handle(self, *args, **options):
-        move_siae_data(options["from_id"], options["to_id"], options["wet_run"], options["only_job_applications"])
+    def handle(self, from_id, to_id, wet_run=False, only_job_applications=False, **options):
+        if from_id == to_id:
+            self.stderr.write("Unable to use the same siae as source and destination (ID %s)\n" % from_id)
+            return
+
+        from_siae_qs = siaes_models.Siae.objects.filter(pk=from_id)
+        try:
+            from_siae = from_siae_qs.get()
+        except siaes_models.Siae.DoesNotExist:
+            self.stderr.write("Unable to find the siae ID %s\n" % from_id)
+            return
+
+        to_siae_qs = siaes_models.Siae.objects.filter(pk=to_id)
+        try:
+            to_siae = to_siae_qs.get()
+        except siaes_models.Siae.DoesNotExist:
+            self.stderr.write("Unable to find the siae ID %s\n" % to_id)
+            return
+
+        # Intermediate variable for better readability
+        move_all_data = not only_job_applications
+
+        self.stdout.write(
+            "MOVE %s OF siae.id=%s - %s %s - %s\n"
+            % (
+                "DATA" if move_all_data else "JOB APPLICATIONS",
+                from_siae.pk,
+                from_siae.kind,
+                from_siae.siret,
+                from_siae.display_name,
+            )
+        )
+
+        job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=from_id)
+        self.stdout.write("| Job applications sent: %s" % job_applications_sent.count())
+
+        job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=from_id)
+        self.stdout.write("| Job applications received: %s" % job_applications_received.count())
+
+        if move_all_data:
+            # Move Job Description not already present in siae destination, Job Applications
+            # related will be attached to Job Description present in siae destination
+            appellation_subquery = Subquery(
+                siaes_models.SiaeJobDescription.objects.filter(
+                    siae_id=to_id, appellation_id=OuterRef("appellation_id")
+                )
+            )
+            job_descriptions = siaes_models.SiaeJobDescription.objects.filter(siae_id=from_id).exclude(
+                Exists(appellation_subquery)
+            )
+            self.stdout.write("| Job descriptions: %s\n" % job_descriptions.count())
+
+            # Move users not already present in siae destination
+            members = siaes_models.SiaeMembership.objects.filter(siae_id=from_id).exclude(
+                user__in=users_models.User.objects.filter(siaemembership__siae_id=to_id)
+            )
+            self.stdout.write("| Members: %s\n" % members.count())
+
+            diagnoses = eligibility_models.EligibilityDiagnosis.objects.filter(author_siae_id=from_id)
+            self.stdout.write("| Diagnoses: %s\n" % diagnoses.count())
+
+            prolongations = approvals_models.Prolongation.objects.filter(declared_by_siae_id=from_id)
+            self.stdout.write("| Prolongations: %s\n" % prolongations.count())
+
+            suspensions = approvals_models.Suspension.objects.filter(siae_id=from_id)
+            self.stdout.write("| Suspensions: %s\n" % suspensions.count())
+
+            # Don't move invitations for existing members
+            # The goal is to keep information about the original information
+            invitations = invitations_models.SiaeStaffInvitation.objects.filter(siae_id=from_id).exclude(
+                email__in=users_models.User.objects.filter(siaemembership__siae_id=to_id).values_list(
+                    "email", flat=True
+                )
+            )
+            self.stdout.write("| Invitations: %s\n" % invitations.count())
+
+        self.stdout.write(
+            "INTO siae.id=%s - %s %s - %s\n" % (to_siae.pk, to_siae.kind, to_siae.siret, to_siae.display_name)
+        )
+
+        dest_siae_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=to_id)
+        self.stdout.write("| Job applications sent: %s\n" % dest_siae_job_applications_sent.count())
+
+        dest_siae_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=to_id)
+        self.stdout.write("| Job applications received: %s\n" % dest_siae_job_applications_received.count())
+
+        if move_all_data:
+            self.stdout.write(f"| Brand '{to_siae.brand}' will be updated with '{from_siae.display_name}'\n")
+            self.stdout.write(
+                f"| Description \n{to_siae.description}\nwill be updated with\n{from_siae.description}\n"
+            )
+            self.stdout.write(f"| Phone '{to_siae.phone}' will be updated with '{from_siae.phone}'\n")
+            self.stdout.write(f"| Coords '{to_siae.coords}' will be updated with '{from_siae.coords}'\n")
+            self.stdout.write(
+                f"| Geoscore '{to_siae.geocoding_score}' will be updated with '{from_siae.geocoding_score}'\n"
+            )
+
+        if not wet_run:
+            self.stdout.write("Nothing to do in dry run mode.\n")
+            return
+
+        with transaction.atomic():
+
+            # If we move the job applications without moving the job descriptions as well, we need to unlink them,
+            # as job applications will be attached to siae B but job descriptions will stay attached to siae A.
+            if only_job_applications:
+                for job_application in job_applications_sent:
+                    job_application.selected_jobs.clear()
+                for job_application in job_applications_received:
+                    job_application.selected_jobs.clear()
+
+            # If we move job_description, we have to take care of existant job_description linked
+            # to siae B (destination), because we can't have 2 job_applications with the same Appellation
+            # for one siae. Job applications linked to these kind of job_description have to be
+            # unlinked to be transfered. Job_description can be different enough to be irrelevant.
+            if move_all_data:
+                # find Appellation linked to job_description siae B
+                to_siae_appellation_id = siaes_models.SiaeJobDescription.objects.filter(siae_id=to_id).values_list(
+                    "appellation_id", flat=True
+                )
+
+                # find job_applications in siae A, linked with job_description which Appellation is found in siae B
+                job_applications_to_clear = job_applications_models.JobApplication.objects.filter(
+                    to_siae_id=from_id,
+                    selected_jobs__in=siaes_models.SiaeJobDescription.objects.filter(
+                        siae_id=from_id, appellation_id__in=to_siae_appellation_id
+                    ),
+                )
+
+                # clean job_applications to let them be transfered in siae B
+                for job_application in job_applications_to_clear:
+                    job_application.selected_jobs.clear()
+
+            job_applications_sent.update(sender_siae_id=to_id)
+            job_applications_received.update(to_siae_id=to_id)
+
+            if move_all_data:
+                # do not move duplicated job_descriptions
+                job_descriptions.exclude(appellation_id__in=to_siae_appellation_id).update(siae_id=to_id)
+                members.update(siae_id=to_id)
+                diagnoses.update(author_siae_id=to_id)
+                prolongations.update(declared_by_siae_id=to_id)
+                suspensions.update(siae_id=to_id)
+                invitations.update(siae_id=to_id)
+                to_siae_qs.update(
+                    brand=from_siae.display_name,
+                    description=from_siae.description,
+                    phone=from_siae.phone,
+                    coords=from_siae.coords,
+                    geocoding_score=from_siae.geocoding_score,
+                )
+                from_siae_qs.update(
+                    block_job_applications=True,
+                    job_applications_blocked_at=timezone.now(),
+                    # Make sure the old siae no longer appears in results
+                    coords=None,
+                    geocoding_score=None,
+                )
+
+        self.stdout.write(
+            "MOVE %s OF siae.id=%s FINISHED\n" % ("DATA" if move_all_data else "JOB APPLICATIONS", from_siae.pk)
+        )
+        orig_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=from_id)
+        self.stdout.write("| Job applications sent: %s\n" % orig_job_applications_sent.count())
+
+        orig_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=from_id)
+        self.stdout.write("| Job applications received: %s\n" % orig_job_applications_received.count())
+
+        self.stdout.write("INTO siae.id=%s\n" % to_siae.pk)
+
+        dest_siae_job_applications_sent = job_applications_models.JobApplication.objects.filter(sender_siae_id=to_id)
+        self.stdout.write("| Job applications sent: %s\n" % dest_siae_job_applications_sent.count())
+
+        dest_siae_job_applications_received = job_applications_models.JobApplication.objects.filter(to_siae_id=to_id)
+        self.stdout.write("| Job applications received: %s\n" % dest_siae_job_applications_received.count())

--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -11,6 +11,7 @@ from itou.approvals import models as approvals_models
 from itou.eligibility import models as eligibility_models
 from itou.invitations import models as invitations_models
 from itou.job_applications import models as job_applications_models
+from itou.siae_evaluations.models import EvaluatedSiae
 from itou.siaes import models as siaes_models
 from itou.users import models as users_models
 
@@ -84,6 +85,13 @@ class Command(BaseCommand):
             to_siae = to_siae_qs.get()
         except siaes_models.Siae.DoesNotExist:
             self.stderr.write("Unable to find the siae ID %s\n" % to_id)
+            return
+
+        if EvaluatedSiae.objects.filter(siae=from_siae).exists():
+            self.stderr.write(
+                "Moving the SIAE with id=%s would cause inconsistencies with the DDETS evaluation campaigns !"
+                % from_id
+            )
             return
 
         # Intermediate variable for better readability

--- a/itou/siaes/tests/test_management_commands.py
+++ b/itou/siaes/tests/test_management_commands.py
@@ -1,6 +1,9 @@
+import io
+
 from django.core import management
 from django.test import TestCase
 
+from itou.siae_evaluations.factories import EvaluatedSiaeFactory
 from itou.siaes import factories as siaes_factories
 from itou.siaes.enums import SiaeKind
 
@@ -29,3 +32,20 @@ class MoveSiaeDataTest(TestCase):
         self.assertEqual(siae1.members.count(), 0)
         self.assertEqual(siae2.jobs.count(), 4)
         self.assertEqual(siae2.members.count(), 1)
+
+    def test_stop_if_evaluation_in_place(self):
+        stderr = io.StringIO()
+        siae1 = siaes_factories.SiaeWithMembershipAndJobsFactory()
+        siae2 = siaes_factories.SiaeFactory()
+        EvaluatedSiaeFactory(siae=siae1)
+        management.call_command(
+            "move_siae_data", from_id=siae1.pk, to_id=siae2.pk, stdout=io.StringIO(), stderr=stderr
+        )
+        self.assertEqual(siae1.jobs.count(), 4)
+        self.assertEqual(siae1.members.count(), 1)
+        self.assertEqual(siae2.jobs.count(), 0)
+        self.assertEqual(siae2.members.count(), 0)
+        self.assertEqual(
+            stderr.getvalue(),
+            f"Moving the SIAE with id={siae1.pk} would cause inconsistencies with the DDETS evaluation campaigns !\n",
+        )

--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
@@ -17,6 +17,8 @@
                 <p class="badge badge-danger float-right">Problème constaté</p>
             {%elif state == "ACCEPTED" %}
                 <p class="badge badge-success float-right">Validé</p>
+            {%elif state == "UPLOADED" %}
+                <p class="badge badge-pilotage float-right">Justificatifs téléversés</p>
             {% else %}
                 <p class="badge badge-emploi float-right">{%if evaluated_siae.reviewed_at%}Phase contradictoire - {%endif%}En attente</p>
             {%endif%}

--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -1,5 +1,6 @@
 import csv
 import datetime
+import os
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -283,6 +284,7 @@ class Command(DeprecatedLoggerMixin, BaseCommand):
     def to_csv(self, filename, fieldnames, data):
         log_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
         path = f"{settings.EXPORT_DIR}/{log_datetime}-{filename}-{settings.ITOU_ENVIRONMENT.lower()}.csv"
+        os.makedirs(settings.EXPORT_DIR, exist_ok=True)
         with open(path, "w") as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames, quoting=csv.QUOTE_ALL)
             writer.writeheader()

--- a/itou/users/management/commands/extract_c2_users.py
+++ b/itou/users/management/commands/extract_c2_users.py
@@ -1,5 +1,6 @@
 import csv
 import datetime
+import os
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -40,6 +41,7 @@ class Command(BaseCommand):
 
         fieldnames = data[0].keys()
         log_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        os.makedirs(settings.EXPORT_DIR, exist_ok=True)
         path = f"{settings.EXPORT_DIR}/{log_datetime}-{filename}-{settings.ITOU_ENVIRONMENT.lower()}.csv"
         with open(path, "w") as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames, quoting=csv.QUOTE_ALL)

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -102,7 +102,7 @@ class DeduplicateJobSeekersManagementCommandsTest(TestCase):
         self.assertEqual(1, user3.eligibility_diagnoses.count())
 
         # Merge all users into `user1`.
-        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True)
+        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True, wet_run=True)
 
         # If only one NIR exists for all the duplicates, it should
         # be reassigned to the target account.
@@ -163,7 +163,7 @@ class DeduplicateJobSeekersManagementCommandsTest(TestCase):
         ApprovalFactory(user=user1)
 
         # Merge all users into `user1`.
-        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True)
+        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True, wet_run=True)
 
         self.assertEqual(3, user1.job_applications.count())
 

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -405,16 +405,25 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.assertContains(response, validation_url)
         self.assertNotContains(response, message)
 
-        # EvaluatedAdministrativeCriteria submitted
+        # EvaluatedAdministrativeCriteria uploaded
         evaluated_administrative_criteria = evaluated_job_application.evaluated_administrative_criteria.first()
-        evaluated_administrative_criteria.submitted_at = timezone.now()
         evaluated_administrative_criteria.proof_url = "https://server.com/rocky-balboa.pdf"
-        evaluated_administrative_criteria.save(update_fields=["submitted_at", "proof_url"])
+        evaluated_administrative_criteria.save(update_fields=["proof_url"])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, back_url)
+        self.assertContains(response, "Justificatifs téléversés")
 
+        # EvaluatedAdministrativeCriteria submitted
+        evaluated_administrative_criteria.submitted_at = timezone.now()
+        evaluated_administrative_criteria.save(update_fields=["submitted_at"])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
+        self.assertNotContains(response, "Documents téléversés")
+        self.assertNotContains(response, "En attente")
+        self.assertNotContains(response, "Nouveaux justificatifs à traiter")
         self.assertContains(response, validation_url)
         self.assertNotContains(response, message)
 

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -379,14 +379,14 @@ def siae_submit_proofs(request):
         evaluated_siae=evaluated_siae
     ).prefetch_related("evaluated_administrative_criteria")
 
-    if evaluated_job_applications and all(
+    # if at least one of those job applications is uploaded but not yet transmitted, or accepted, let's submit.
+    if evaluated_job_applications and any(
         (
             evaluated_job_application.state == evaluation_enums.EvaluatedJobApplicationsState.UPLOADED
             or evaluated_job_application.state == evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
         )
         for evaluated_job_application in evaluated_job_applications
     ):
-
         EvaluatedAdministrativeCriteria.objects.filter(
             evaluated_job_application__in=evaluated_job_applications,
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING,


### PR DESCRIPTION
### Quoi ?

La semaine dernière (3J) a été dédiée à la correction des boost sur le controle a posteriori.
Cette "semaine" (1.5J) corrige un certain nombre de boost dev qui trainaient depuis longtemps.
A noter que le ticket concernant l'[erreur de sécurité sur l'envoi de mails](https://www.notion.so/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=a21b982d589f4743bdc9e34ee0e2dbb0&pm=s) n'a pas de correction.

Les premiers commits sont  de la mise au propre pour servir des commits suivants,
et quelques erreurs ou choses dommages corrigées en chemin.

Les derniers commits concernent des tickets Notion.

### Pourquoi ?
Cf Notion pour les derniers commits.
- [Justificatif téléversé](https://www.notion.so/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=b86625e9f9d441c181e05e27ca47effe&pm=s)
- [Erreur Sentry /approvals/display](https://www.notion.so/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=1761e72edaa34d53b41adbaa7b622f21&pm=s)
- [Garde fou move_siae_data](https://www.notion.so/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=5a1fd1cac0eb4fd1b7e1b94dd5c51dd4&pm=s)
- [Evaluation a posteriori : Impossible de transmettre les pièces ](https://www.notion.so/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=7f236b3a620343c8bd3e8159cff99319&pm=s)

### Comment ?
A voir dans chaque commit, mais a priori il n'y a pas de technique de haut vol.
