### PR TITLE
Remplacement de la propriété `EligibilityDiagnosis.expires_at` par un champs

### DIFF
--- a/itou/eligibility/admin.py
+++ b/itou/eligibility/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.template.defaultfilters import date as date_filter
 
 from itou.eligibility import models
 from itou.utils.admin import PkSupportRemarkInline
@@ -77,11 +76,6 @@ class EligibilityDiagnosisAdmin(admin.ModelAdmin):
 
     is_valid.boolean = True
     is_valid.short_description = "En cours de validité"
-
-    def expires_at(self, obj):
-        return date_filter(obj.expires_at, "d F Y H:i")
-
-    expires_at.short_description = "Date d'expiration"
 
     def is_considered_valid(self, obj):
         """

--- a/itou/eligibility/factories.py
+++ b/itou/eligibility/factories.py
@@ -13,6 +13,7 @@ class EligibilityDiagnosisFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.EligibilityDiagnosis
 
+    created_at = factory.LazyAttribute(lambda obj: timezone.now())
     author = factory.LazyAttribute(lambda obj: obj.author_prescriber_organization.members.first())
     author_kind = models.EligibilityDiagnosis.AUTHOR_KIND_PRESCRIBER
     author_prescriber_organization = factory.SubFactory(PrescriberOrganizationWithMembershipFactory, authorized=True)
@@ -25,6 +26,7 @@ class EligibilityDiagnosisMadeBySiaeFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.EligibilityDiagnosis
 
+    created_at = factory.LazyAttribute(lambda obj: timezone.now())
     author = factory.LazyAttribute(lambda obj: obj.author_siae.members.first())
     author_kind = models.EligibilityDiagnosis.AUTHOR_KIND_SIAE_STAFF
     author_siae = factory.SubFactory(SiaeFactory, with_membership=True)
@@ -33,16 +35,12 @@ class EligibilityDiagnosisMadeBySiaeFactory(factory.django.DjangoModelFactory):
 
 class ExpiredEligibilityDiagnosisFactory(EligibilityDiagnosisFactory):
 
-    created_at = factory.LazyAttribute(
-        lambda self: models.EligibilityDiagnosis.get_expiration_dt() - timezone.timedelta(days=1)
-    )
+    expires_at = factory.SelfAttribute("created_at")
 
 
 class ExpiredEligibilityDiagnosisMadeBySiaeFactory(EligibilityDiagnosisMadeBySiaeFactory):
 
-    created_at = factory.LazyAttribute(
-        lambda self: models.EligibilityDiagnosis.get_expiration_dt() - timezone.timedelta(days=1)
-    )
+    expires_at = factory.SelfAttribute("created_at")
 
 
 class AdministrativeCriteriaFactory(factory.django.DjangoModelFactory):

--- a/itou/eligibility/migrations/0010_eligibilitydiagnosis_expires_at.py
+++ b/itou/eligibility/migrations/0010_eligibilitydiagnosis_expires_at.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+from django.db.models import ExpressionWrapper, F, Func
+
+
+def fill_expires_at(apps, _schema_editor):
+    model = apps.get_model("eligibility", "EligibilityDiagnosis")
+    model.objects.update(
+        expires_at=ExpressionWrapper(
+            F("created_at") + Func(template="interval '6 months'"),
+            output_field=models.DateTimeField(),
+        )
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("eligibility", "0009_rename_refugee_administrative_criteria"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="eligibilitydiagnosis",
+            name="expires_at",
+            field=models.DateTimeField(db_index=True, blank=True, null=True, verbose_name="Date d'expiration"),
+        ),
+        migrations.RunPython(fill_expires_at, migrations.RunPython.noop, elidable=True),
+        migrations.AlterField(
+            model_name="eligibilitydiagnosis",
+            name="expires_at",
+            field=models.DateTimeField(db_index=True, verbose_name="Date d'expiration"),
+        ),
+    ]

--- a/itou/eligibility/models.py
+++ b/itou/eligibility/models.py
@@ -3,7 +3,7 @@ import logging
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Exists, OuterRef
 from django.utils import timezone
 
@@ -217,6 +217,7 @@ class EligibilityDiagnosis(models.Model):
         return self.expires_at
 
     @classmethod
+    @transaction.atomic()
     def create_diagnosis(cls, job_seeker, user_info, administrative_criteria=None):
         """
         Arguments:
@@ -233,9 +234,7 @@ class EligibilityDiagnosis(models.Model):
             author_prescriber_organization=user_info.prescriber_organization,
         )
         if administrative_criteria:
-            for criteria in administrative_criteria:
-                diagnosis.administrative_criteria.add(criteria)
-            diagnosis.save()
+            diagnosis.administrative_criteria.add(*administrative_criteria)
         return diagnosis
 
 

--- a/itou/fixtures/django/10_eligibility_diagnoses.json
+++ b/itou/fixtures/django/10_eligibility_diagnoses.json
@@ -9,6 +9,7 @@
       "author_siae": 3850,
       "author_prescriber_organization": null,
       "created_at": "2022-02-08T10:57:46.994Z",
+      "expires_at": "2022-08-08T10:57:46.994Z",
       "updated_at": "2022-02-08T10:57:47.028Z"
    }
 },
@@ -22,6 +23,7 @@
       "author_siae": 3850,
       "author_prescriber_organization": 996,
       "created_at": "2022-02-08T10:59:58.777Z",
+      "expires_at": "2022-06-08T10:59:58.777Z",
       "updated_at": "2022-02-08T10:59:58.818Z"
    }
 },
@@ -35,6 +37,7 @@
       "author_siae": 3850,
       "author_prescriber_organization": 903,
       "created_at": "2022-02-08T11:00:49.078Z",
+      "expires_at": "2022-06-08T11:00:49.078Z",
       "updated_at": "2022-02-08T11:00:49.108Z"
    }
 },
@@ -48,6 +51,7 @@
       "author_siae": 3850,
       "author_prescriber_organization": 996,
       "created_at": "2022-02-08T11:01:48.331Z",
+      "expires_at": "2022-06-08T11:01:48.331Z",
       "updated_at": "2022-02-08T11:01:48.364Z"
    }
 },
@@ -61,6 +65,7 @@
       "author_siae": 3850,
       "author_prescriber_organization": 952,
       "created_at": "2022-02-08T11:02:28.172Z",
+      "expires_at": "2022-06-08T11:02:28.172Z",
       "updated_at": "2022-02-08T11:02:28.202Z"
    }
 }


### PR DESCRIPTION
### Quoi ?

Création d'un champs persisté en DB pour `EligibilityDiagnosis.expires_at`.

### Pourquoi ?

Dans le nouveau parcours du dépôt de candidature nous donnons la possibilité aux prescripteurs habilités de mettre un jour le diagnostique d’éligibilité, ce changement introduis deux cas : 
1. Lorsqu'un PH met à jour le diagnostique alors on crée un nouvel objet et l'on fait terminer l'actuel en modifiant `expires_at`.
2. Si les critères et la personnes réalisant le diagnostique sont les mêmes alors on modifie `expires_at` pour que l'objet reste valable encore 6 mois.
