### PR TITLE
Correction nouveaux motif de refus

### DIFF
--- a/itou/metabase/management/commands/sql/017_fiches_deposte_en_tension_recrutement.sql
+++ b/itou/metabase/management/commands/sql/017_fiches_deposte_en_tension_recrutement.sql
@@ -114,7 +114,7 @@ id_structures_pas_poste_ouvert as (
     where 
         date_candidature >= date_trunc('month',  current_date) - interval '1 month'
         and 
-        motif_de_refus = 'Pas de poste ouvert en ce moment'
+        motif_de_refus = 'Pas de recrutement en cours'
 ),
 /* Nombre de jours nécessaires pour qu'une fiche de poste reçoit une première candidature */
 delai_1_ere_candidature as (


### PR DESCRIPTION
Remplacement du motif de refus "pas de poste ouvert en ce moment" par "pas de recrutement en cours" suite à MEP C1