### PR TITLE
En tant que SIAE je veux m'assurer que l'annulation du PASS est justifiée dans mon cas

### DIFF
--- a/itou/templates/apply/process_cancel.html
+++ b/itou/templates/apply/process_cancel.html
@@ -5,9 +5,15 @@
 
     {{ block.super }}
 
-    <div class="alert alert-warning" role="status">
-        <p>En annulant l’embauche, vous renoncez à toute aide au poste pour ce salarié. Si le salarié a travaillé dans votre structure, suspendez le PASS IAE et ne validez pas cette annulation.</p>
-        <p class="mb-0">L’annulation d’embauche ne concerne que les salariés n’ayant jamais travaillé pour vous.</p>
+    <div class="alert alert-warning alert-dismissible fade show" role="status">
+        <div class="row">
+            <div class="col-auto pr-0">
+                <i class="ri-information-line ri-xl text-warning"></i>
+            </div>
+            <div class="col">
+                <p class="mb-0">En validant, <b>vous renoncez aux aides au poste</b> liées à cette candidature pour tous les jours travaillés de ce salarié. Si ce salarié a travaillé dans votre structure, il est préférable de suspendre son PASS IAE ci-dessus.</p>
+            </div>
+        </div>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">
@@ -17,8 +23,9 @@
         <input type="hidden" name="confirm" value="true">
 
         {% buttons %}
-            <a class="btn btn-outline-primary" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Annuler</a>
-            <button type="submit" class="btn btn-danger">Confirmer l'annulation de l'embauche</button>
+
+            <button type="submit" class="btn btn-danger float-right">Confirmer l'annulation de l'embauche</button>
+            <a class="btn btn-link float-right" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Retour</a>
         {% endbuttons %}
 
     </form>

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -685,7 +685,7 @@ class ProcessViewsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Confirmer l'annulation de l'embauche")
         self.assertContains(
-            response, "L’annulation d’embauche ne concerne que les salariés n’ayant jamais travaillé pour vous."
+            response, "En validant, <b>vous renoncez aux aides au poste</b> liées à cette candidature pour tous"
         )
 
         post_data = {

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -687,6 +687,9 @@ class ProcessViewsTest(TestCase):
         self.assertContains(
             response, "En validant, <b>vous renoncez aux aides au poste</b> liées à cette candidature pour tous"
         )
+        self.assertContains(
+            response, reverse("approvals:suspend", kwargs={"approval_id": job_application.approval_id})
+        )
 
         post_data = {
             "confirm": "true",

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -364,6 +364,9 @@ def cancel(request, job_application_id, template_name="apply/process_cancel.html
     queryset = JobApplication.objects.siae_member_required(request.user)
     job_application = get_object_or_404(queryset, id=job_application_id)
     check_waiting_period(job_application)
+    approval_can_be_suspended_by_siae = job_application.approval and job_application.approval.can_be_suspended_by_siae(
+        job_application.to_siae
+    )
     next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
 
     if not job_application.can_be_cancelled:
@@ -381,6 +384,7 @@ def cancel(request, job_application_id, template_name="apply/process_cancel.html
 
     context = {
         "job_application": job_application,
+        "approval_can_be_suspended_by_siae": approval_can_be_suspended_by_siae,
     }
     return render(request, template_name, context)
 


### PR DESCRIPTION
### Quoi ?

Rendre plus explicite l'annulation d'un Pass

### Pourquoi ?

Certains employeurs annulent les PASS : 1-par erreur, 2-à la place d’une suspension, 3-pensant bien faire pour ainsi repartir “au propre” sur le parcours du salarié embauché

### Comment ?

- modification du message d'alerte
- affichage du lien `suspendre` lorsque c'est possible

