### PR TITLE
Déplacement des données de contrôle a posteriori pendant un move_siae_data

### DIFF
--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -87,13 +87,6 @@ class Command(BaseCommand):
             self.stderr.write("Unable to find the siae ID %s\n" % to_id)
             return
 
-        if EvaluatedSiae.objects.filter(siae=from_siae).exists():
-            self.stderr.write(
-                "Moving the SIAE with id=%s would cause inconsistencies with the DDETS evaluation campaigns !"
-                % from_id
-            )
-            return
-
         # Intermediate variable for better readability
         move_all_data = not only_job_applications
 
@@ -150,6 +143,9 @@ class Command(BaseCommand):
                 )
             )
             self.stdout.write("| Invitations: %s\n" % invitations.count())
+
+            evaluated_siaes = EvaluatedSiae.objects.filter(siae_id=from_id)
+            self.stdout.write("| Evaluated siaes: %s\n" % evaluated_siaes.count())
 
         self.stdout.write(
             "INTO siae.id=%s - %s %s - %s\n" % (to_siae.pk, to_siae.kind, to_siae.siret, to_siae.display_name)
@@ -219,6 +215,7 @@ class Command(BaseCommand):
                 prolongations.update(declared_by_siae_id=to_id)
                 suspensions.update(siae_id=to_id)
                 invitations.update(siae_id=to_id)
+                evaluated_siaes.update(siae_id=to_id)
                 to_siae_qs.update(
                     brand=from_siae.display_name,
                     description=from_siae.description,

--- a/itou/siaes/tests/test_management_commands.py
+++ b/itou/siaes/tests/test_management_commands.py
@@ -33,19 +33,13 @@ class MoveSiaeDataTest(TestCase):
         self.assertEqual(siae2.jobs.count(), 4)
         self.assertEqual(siae2.members.count(), 1)
 
-    def test_stop_if_evaluation_in_place(self):
+    def test_evaluation_data_is_moved(self):
         stderr = io.StringIO()
-        siae1 = siaes_factories.SiaeWithMembershipAndJobsFactory()
+        siae1 = siaes_factories.SiaeFactory()
         siae2 = siaes_factories.SiaeFactory()
         EvaluatedSiaeFactory(siae=siae1)
         management.call_command(
-            "move_siae_data", from_id=siae1.pk, to_id=siae2.pk, stdout=io.StringIO(), stderr=stderr
+            "move_siae_data", from_id=siae1.pk, to_id=siae2.pk, stdout=io.StringIO(), stderr=stderr, wet_run=True
         )
-        self.assertEqual(siae1.jobs.count(), 4)
-        self.assertEqual(siae1.members.count(), 1)
-        self.assertEqual(siae2.jobs.count(), 0)
-        self.assertEqual(siae2.members.count(), 0)
-        self.assertEqual(
-            stderr.getvalue(),
-            f"Moving the SIAE with id={siae1.pk} would cause inconsistencies with the DDETS evaluation campaigns !\n",
-        )
+        self.assertEqual(siae1.evaluated_siaes.count(), 0)
+        self.assertEqual(siae2.evaluated_siaes.count(), 1)


### PR DESCRIPTION
### Quoi ?

Déplacement des données de contrôle a posteriori pendant un move_siae_data.

### Pourquoi ?

Sans cela, ces données restaient sur l'ancienne SIAE, et cette dernière étant souvent supprimée au final, les données en question disparaissaient mystérieusement.  Un garde fou a été placé mais le cas se reproduit donc pas le choix, il faut implémenter le transfert de ces données.

### Comment ?

Comme pour toutes les autres données déplacées par move_siae_data.