### PR TITLE
[Refonte Dépôt de candidature 3/3] Améliorer le parcours de prescription

### DIFF
--- a/itou/common_apps/resume/forms.py
+++ b/itou/common_apps/resume/forms.py
@@ -4,7 +4,7 @@ from django.conf import settings
 
 class ResumeFormMixin(forms.Form):
     resume_link = forms.URLField(
-        label="CV (optionnel)",
+        label="Curriculum Vitae (CV)",
         required=False,
     )
 

--- a/itou/eligibility/models.py
+++ b/itou/eligibility/models.py
@@ -200,6 +200,10 @@ class EligibilityDiagnosis(models.Model):
     def is_valid(self):
         return self.expires_at > timezone.now()
 
+    @property
+    def author_organization(self):
+        return self.author_prescriber_organization or self.author_siae
+
     # A diagnosis is considered valid for the whole duration of an approval.
     # Methods below (whose name contain `considered`) take into account
     # the existence of an ongoing approval.

--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -208,6 +208,25 @@ _:-ms-fullscreen,
     display: none;
 }
 
+/* CSS for js-shroud.
+---------------------------------------------------------------------------- */
+
+.js-shroud {
+    position: relative;
+    opacity: 50%;
+}
+
+.js-shroud::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    /* Bootstrap components scale from 0 to 3: https://getbootstrap.com/docs/4.6/extend/approach/#z-index-scales */
+    z-index: 4;
+}
+
 /* Responsive Multi-Step Progress Bar.
 https://codepen.io/athimannil/pen/wWPYkQ
 

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -47,4 +47,16 @@ $(document).ready(() => {
       $(this).click(swapElements)
     })
   })
+
+  /**
+   * JS to manage shroud
+   */
+  $("[data-shroud-input]").prop("disabled", true)
+  $(".js-shroud").find("[data-shroud-input]").prop("disabled", false)
+  $("[data-shroud-clear]").each(function () {
+    $(this).click(function() {
+      $(".js-shroud").removeClass("js-shroud")
+      $("[data-shroud-input]").prop("disabled", true)
+    })
+  })
 });

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -28,4 +28,23 @@ $(document).ready(() => {
         // Check immediately
         checkValidity({"currentTarget": this})
     });
+
+  /**
+   * JS to swap elements based on CSS selectors
+   */
+  function swapElements(e) {
+    let box = $(e.currentTarget).parents(".js-swap-elements")
+    let swap_elements = $(box).find($(e.currentTarget).data("swap-element"))
+    let swap_element_with = swap_elements
+      .get()  // Convert the jQuery object to an Array
+      .flatMap(item => $(box).find($(item).data("swap-element-with")))  // Make a flat list of elements to swap with
+      .reduce($.merge)  // Convert the Array to a jQuery object
+    swap_elements.hide()
+    swap_element_with.show()
+  }
+  $(".js-swap-elements").each(function () {
+    $(this).find("[data-swap-element]").each(function () {
+      $(this).click(swapElements)
+    })
+  })
 });

--- a/itou/templates/apply/email/new_for_job_seeker_body.txt
+++ b/itou/templates/apply/email/new_for_job_seeker_body.txt
@@ -9,7 +9,6 @@ Vous et {{ job_application.sender.get_full_name|title }} serez tous les deux inf
 
 {% else %}
 Candidature chez {{ job_application.to_siae.display_name }} envoyée avec succès !
-Vous et votre candidat serez tous les deux informés de l'avancement de cette candidature.
 
 {% endif %}
 

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -1,0 +1,83 @@
+{% extends "layout/base.html" %}
+{% load bootstrap4 %}
+{% load str_filters %}
+
+{% block title %}Postuler{{ block.super }}{% endblock %}
+{% block main_css_classes %}bg-emploi-lightest{% endblock %}
+{% block content_full_viewport %}
+    <section class="s-section-twocolumns">
+        <div class="container">
+            <div class="row">
+                <div class="col-12 col-lg-7">
+                    <div class="d-flex flex-column flex-md-row align-items-center">
+                        <h1 class="my-5 flex-grow-1">
+                            {% if request.user.is_job_seeker %}
+                                Postuler
+                            {% elif request.user.is_siae_staff %}
+                                Auto-prescription pour {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}
+                            {% else %}
+                                Postuler pour {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}
+                            {% endif %}
+                        </h1>
+                        {% if is_subject_to_eligibility_rules %}
+                            {% if job_seeker.has_valid_common_approval %}
+                                <span class="badge badge-base badge-pill badge-success"><i class="ri-check-fill"></i>Pass IAE valide</span>
+                            {% elif eligibility_diagnosis %}
+                                <span class="badge badge-base badge-pill badge-success"><i class="ri-check-fill"></i>Éligible à l’IAE</span>
+                            {% else %}
+                                <span class="badge badge-base badge-pill badge-warning"><i class="ri-error-warning-line"></i>Éligibilité IAE à valider</span>
+                            {% endif %}
+                        {% endif %}
+                    </div>
+                    <div class="c-stepper my-5">
+                        <div class="progress progress--emploi mb-2">
+                            <div class="progress-bar" role="progressbar" style="width: {{ progress }}%" aria-valuenow="{{ progress }}" aria-valuemin="0" aria-valuemax="100"></div>
+                        </div>
+                        <span>
+                            {% block progress_title %}
+                                {% if request.user.is_siae_staff %}
+                                    Auto-prescription
+                                {% else %}
+                                    Postuler
+                                {% endif %}
+                            {% endblock %}
+                        </span>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-12{% if not full_content_width %} col-lg-7{% endif %}">
+                    <div class="c-form">
+                        <div class="col-12 p-0 {% if full_content_width %}col-lg-7 pr-lg-5{% endif %}">
+                            <div class="card c-card c-card--emploi c-card--noshadow mb-3 mb-lg-5">
+                                <div class="card-body">
+                                    <p><i class="ri-home-7-line ri-xl mr-2"></i>{{ siae.kind }} - {{ siae.get_kind_display }} </p>
+                                    <hr>
+                                    <p class="h2">{{ siae.display_name }}</p>
+                                    <address class="card-subtitle fs-lg font-weight-bold text-secondary">{{ siae.address_on_one_line }}</address>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 p-0 {% if full_content_width %}col-lg-7 pr-lg-5{% endif %}">{% block pre_step_title %}{% endblock %}</div>
+                        <h2>{% block step_title %}{% endblock %}</h2>
+                        <hr class="mt-5">
+                        {% bootstrap_form_errors form type="all" %}
+                        <form method="post">
+                            {% csrf_token %}
+
+                            {% block form_content %}{% endblock %}
+
+                            <hr class="my-5">
+                            {% buttons %}
+                                <div class="text-right">
+                                    {% if back_url %}<a class="btn btn-link" href="{{ back_url }}">Retour</a>{% endif %}
+                                    <button type="submit" class="btn btn-primary">Suivant</button>
+                                </div>
+                            {% endbuttons %}
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/itou/templates/apply/submit/application/eligibility.html
+++ b/itou/templates/apply/submit/application/eligibility.html
@@ -1,0 +1,49 @@
+{% extends "apply/submit/application/base.html" %}
+{% load bootstrap4 %}
+
+
+{% block progress_title %}{{ block.super }} - Éligibilité IAE{% endblock %}
+{% block step_title %}Préciser la situation administrative du candidat (facultatif){% endblock %}
+{% block pre_step_title %}
+    {% if is_subject_to_eligibility_rules and eligibility_diagnosis %}
+        {% if eligibility_diagnosis.author_organization %}
+            <div class="mb-5">
+                <p>L’éligibilité à l'IAE du candidat a été validée par :</p>
+                <p class="text-tertiary font-weight-bold">{{ eligibility_diagnosis.author_organization.display_name }}</p>
+            </div>
+        {% endif %}
+        <div class="alert alert-info mb-5" role="status">
+            <div class="row">
+                <div class="col-auto pr-0">
+                    <i class="ri-information-line ri-xl"></i>
+                </div>
+                <div class="col">
+                    <p class="mb-2"><strong>Date de fin de validité du diagnostic : {{ eligibility_diagnosis.expires_at|date:"d/m/Y" }}</strong></p>
+                    <p class="mb-2">Tant que l’éligibilité IAE est valide, vous n’avez rien à faire. Si vous souhaitez la mettre à jour, sa validité sera prolongée jusqu'au {{ new_expires_at_if_updated|date:"d/m/Y" }}.</p>
+                    <span class="btn btn-link text-left p-0 js-display-if-javascript-enabled" data-shroud-clear>Mettre à jour l’éligibilité</span>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block form_content %}
+    <div{% if eligibility_diagnosis and not form.is_bound %} class="js-shroud"{% endif %}>
+        <h3 class="h5">Critères administratifs de niveau 1</h3>
+
+        {% for field in form %}
+            {% if form.LEVEL_1_PREFIX in field.name %}
+                {% bootstrap_field field %}
+            {% endif %}
+        {% endfor %}
+
+        <h3 class="h5">Critères administratifs de niveau 2</h3>
+
+        {% for field in form %}
+            {% if form.LEVEL_2_PREFIX in field.name %}
+                {% bootstrap_field field %}
+            {% endif %}
+        {% endfor %}
+        <input type="hidden" name="shrouded" value="1" data-shroud-input />
+    </div>
+{% endblock %}

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -1,0 +1,99 @@
+{% extends "layout/base.html" %}
+{% load bootstrap4 %}
+{% load format_filters %}
+{% load str_filters %}
+
+{% block title %}Création du compte candidat{{ block.super }}{% endblock %}
+{% block main_css_classes %}bg-emploi-lightest{% endblock %}
+{% block content_full_viewport %}
+    <section class="s-section-twocolumns">
+        <div class="container">
+            <div class="row">
+                <div class="col-12 col-lg-7 js-swap-elements">
+                    <h1 class="my-5">{{ request.user.is_siae_staff|yesno:"Auto-prescription enregistrée !,Candidature envoyée !" }}</h1>
+                    <p>
+                        {% if request.user.is_job_seeker %}
+                            Votre candidature
+                        {% else %}
+                            La candidature de {{  job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}
+                        {% endif %}
+                        <b>a bien été envoyée chez {{ job_application.to_siae.display_name }}</b>.
+                    </p>
+                    {% if can_view_personal_information %}
+                        <p><b>
+                            {% if can_edit_personal_information %}
+                                Veuillez vous assurer que {{ request.user.is_job_seeker|yesno:"vos coordonnées,les coordonnées de votre candidat" }} sont bien à jour :
+                            {% else %}
+                                Le candidat a la possibilité de mettre à jour ses coordonnées en se connectant sur son espace.
+                            {% endif %}
+                        </b></p>
+                        <div id="informations" {% if form.is_bound %}style="display: none;"{% endif %} data-swap-element-with=".c-form">
+                            <div class="card c-card c-card--noshadow border-bottom p-3">
+                                <div class="card-header d-flex flex-row align-items-center">
+                                    <h2 class="mb-0 flex-grow-1">{{ job_application.job_seeker.get_full_name }}</h2>
+                                    {% if request.user.is_job_seeker %}
+                                        <a class="btn btn-outline-primary btn-ico btn-sm" href="{% url 'dashboard:edit_user_info' %}">
+                                            <i class="ri-pencil-line mr-2"></i>Modifier
+                                        </a>
+                                    {% elif can_edit_personal_information %}
+                                        <span class="btn btn-outline-primary btn-ico btn-sm js-display-if-javascript-enabled" data-swap-element="#informations">
+                                            <i class="ri-pencil-line mr-2"></i>Modifier
+                                        </span>
+                                    {% endif %}
+                                </div>
+                                <div class="card-body">
+                                    <hr>
+                                    <p>
+                                        <span class="text-muted">Adresse</span><br />
+                                        <b>{{ job_application.job_seeker.address_on_one_line|default:"Non renseigné" }}</b><br />
+                                    </p>
+                                    <hr>
+                                    <p>
+                                        <span class="text-muted">N&deg; de téléphone</span><br />
+                                        <b>{{ job_application.job_seeker.phone|format_phone|default:"Non renseigné" }}</b>
+                                    </p>
+                                </div>
+                            </div>
+                            <div class="text-right pt-5">
+                                <a class="btn btn-link mr-3" href="{% url "home:hp" %}">Revenir à la recherche</a>
+                                <a class="btn btn-primary" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                            </div>
+                        </div>
+                        {% if not request.user.is_job_seeker %}
+                            <div class="c-form c-card--noshadow border-bottom" {% if not form.is_bound %}style="display: none;"{% endif %} data-swap-element-with="#informations">
+                                <h2 class="mb-5">{{ job_application.job_seeker.get_full_name }}</h2>
+
+                                <form method="post" class="js-enable-submit-when-valid">
+                                    {% csrf_token %}
+
+                                    {% bootstrap_field form.address_line_1 %}
+                                    {% bootstrap_field form.address_line_2 %}
+                                    <div class="form-row">
+                                        {% bootstrap_field form.post_code form_group_class='form-group col-md-3' %}
+                                        {% bootstrap_field form.city form_group_class='form-group col-md-9' %}
+                                        {% bootstrap_field form.city_slug %}
+                                    </div>
+                                    {% bootstrap_field form.phone %}
+
+                                    <hr class="my-5">
+                                    {% buttons %}
+                                        <div class="text-right">
+                                            <button type="reset" class="btn btn-link" data-swap-element=".c-form">Annuler</button>
+                                            <button type="submit" class="btn btn-primary">Enregistrer</button>
+                                        </div>
+                                    {% endbuttons %}
+                                </form>
+                            </div>
+                        {% endif %}
+                    {% else %}
+                        <div class="text-right pt-5">
+                            <a class="btn btn-link mr-3" href="{% url "home:hp" %}">Revenir à la recherche</a>
+                            <a class="btn btn-primary" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+    </section>
+{% endblock %}

--- a/itou/templates/apply/submit/application/jobs.html
+++ b/itou/templates/apply/submit/application/jobs.html
@@ -1,0 +1,51 @@
+{% extends "apply/submit/application/base.html" %}
+{% load bootstrap4 %}
+{% load dict_filters %}
+
+{% block progress_title %}{{ block.super }} - Métier(s) recherché(s){% endblock %}
+{% block step_title %}Sélectionner les métiers recherchés{% endblock %}
+
+{% block form_content %}
+    <ul class="list-group list-group-flush">
+        {% for choice in form.selected_jobs %}
+            {% with job_description=job_descriptions_by_pk|get_dict_item:choice.data.value %}
+                <li class="list-group-item list-group-item-action">
+                    <div class="d-flex align-items-start">
+                        <div class="d-inline-flex mt-1 mr-2">{{ choice.tag }}</div>
+                        <div>
+                            <div class="d-flex flex-column flex-lg-row align-items-lg-center">
+                                <label class="font-weight-bold stretched-link order-2 order-md-1 m-0" for="{{ choice.id_for_label }}">{{ choice.choice_label }}</label>
+                                {% if job_description.is_popular %}
+                                    <div class="order-1 order-md-2">
+                                        <span class="badge badge-sm badge-pill badge-accent-03 text-primary ml-0 ml-lg-2 mt-1 mt-lg-0"><i class="ri-group-line"></i>20+ candidatures</span>
+                                    </div>
+                                {% endif %}
+                            </div>
+                            <span class="fs-sm mt-1 d-flex align-items-center">
+                                <i class="ri-map-pin-2-line ri-sm mr-1"></i>{{ job_description.display_location }}
+                            </span>
+                        </div>
+                        <div class="mt-lg-0 ml-auto d-flex flex-column align-items-end justify-content-center">
+                            {% if job_description.display_contract_type %}
+                                <span class="badge badge-xs badge-pill badge-accent-02-light text-primary">{{ job_description.display_contract_type }}</span>
+                            {% endif %}
+                            {% if job_description.hours_per_week %}
+                                <span class="badge badge-xs badge-pill badge-accent-02-light text-primary mt-1">{{ job_description.hours_per_week }}h/semaine</span>
+                            {% endif %}
+                        </div>
+                    </div>
+                </li>
+            {% endwith %}
+        {% endfor %}
+        <li class="list-group-item list-group-item-action">
+            <div class="d-flex align-items-start">
+                <div class="d-inline-flex mt-1 mr-2">{{ form.spontaneous_application }}</div>
+                <div>
+                    <div class="d-flex flex-column flex-lg-row align-items-lg-center">
+                        <label class="font-weight-bold stretched-link m-0" for="{{ form.spontaneous_application.id_for_label }}">{{ form.spontaneous_application.label }}</label>
+                    </div>
+                </div>
+            </div>
+        </li>
+    </ul>
+{% endblock %}

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -1,0 +1,151 @@
+{% extends "apply/submit/application/base.html" %}
+{% load bootstrap4 %}
+{% load static %}
+
+{% block extra_head %}
+    {{ block.super }}
+    <!-- Dropzone -->
+    <link rel="stylesheet" type="text/css" href='{% static "vendor/dropzone/dropzone.min.css" %}'>
+{% endblock extra_head %}
+
+{% block progress_title %}{{ block.super }} - Message & CV{% endblock %}
+{% block step_title %}Finaliser la candidature{% endblock %}
+{% block pre_step_title %}
+    {% if is_subject_to_eligibility_rules %}
+        {% if not request.user.is_job_seeker and eligibility_diagnosis.author_organization %}
+            <div class="mb-5">
+                <p>L’éligibilité à l'IAE du candidat a été validée par :</p>
+                <p class="text-tertiary font-weight-bold">{{ eligibility_diagnosis.author_organization.display_name }}</p>
+            </div>
+        {% endif %}
+        {# Nothing is displayed to SIAE members when the job seeker is not eligible to the IAE #}
+        {% if not request.user.is_siae_staff or job_seeker.has_valid_common_approval or eligibility_diagnosis %}
+            <div class="alert alert-info mb-5" role="status">
+                <div class="row">
+                    <div class="col-auto pr-0">
+                        <i class="ri-information-line ri-xl"></i>
+                    </div>
+                    <div class="col">
+                        {% if job_seeker.has_valid_common_approval %}
+                            <p class="mb-2"><strong>Date de fin de validité du pass IAE : {{ job_seeker.latest_common_approval.end_at|date:"d/m/Y" }}</strong></p>
+                            <p class="mb-0">
+                                {% if request.user.is_prescriber_with_authorized_org or request.user.is_siae_staff %}
+                                    Tant que le Pass IAE est valide, vous n’avez pas à valider la situation administrative du candidat.
+                                {% elif request.user.is_prescriber %}
+                                    Tant que le pass IAE est valide, l’employeur n’aura pas à vérifier l’éligibilité IAE du candidat.
+                                {% elif request.user.is_job_seeker %}
+                                    Tant que le pass IAE est valide, l’employeur n’aura pas à vérifier votre éligibilité à l’IAE.
+                                {% endif %}
+                            </p>
+                        {% elif eligibility_diagnosis %}
+                            <p class="mb-2"><strong>Date de fin de validité du diagnostic : {{ eligibility_diagnosis.expires_at|date:"d/m/Y" }}</strong></p>
+                            <p class="mb-0">
+                                {% if request.user.is_prescriber %}
+                                    Tant que l’éligibilité IAE est valide, l’employeur n’aura pas à vérifier les critères administratifs du candidat.
+                                {% elif request.user.is_siae_staff %}
+                                    Tant que l’éligibilité IAE est valide, vous n’aurez pas à vérifier les critères administratifs du candidat.
+                                {% elif request.user.is_job_seeker %}
+                                    Tant que votre éligibilité IAE est valide, l’employeur n’aura pas à vérifier vos critères administratifs.
+                                {% endif %}
+                            </p>
+                        {% else %}
+                            {% if request.user.is_prescriber %}
+                                <p class="mb-2"><strong>Information</strong></p>
+                                <p class="mb-0">En cas d’embauche, l’employeur se chargera de vérifier et valider l’éligibilité IAE du candidat.</p>
+                            {% elif request.user.is_job_seeker %}
+                                <p class="mb-2"><strong>Information</strong></p>
+                                <p class="mb-0">En cas d’embauche, l’employeur se chargera de vérifier et valider votre éligibilité à l’IAE.</p>
+                            {% endif %}
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
+{% block form_content %}
+    <div class="d-flex flex-column flex-lg-row">
+        <div class="col-12 col-lg-7 pl-0">
+            {% bootstrap_field form.message %}
+        </div>
+        <div>
+            <div class="alert alert-primary bg-white mt-5 py-0" role="status">
+                <div class="row">
+                    <div class="col-auto pr-0">
+                        <i class="ri-lightbulb-line ri-xl"></i>
+                    </div>
+                    <div class="col">
+                        <p class="mb-2"><strong>Bon à savoir</strong></p>
+                        {% if request.user.is_siae_staff %}
+                            <p class="mb-0">Précisez dans le message :</p>
+                            <ul class="mb-0">
+                                <li>les motivations du candidat,</li>
+                                <li>ses compétences,</li>
+                                <li>ses disponibilités</li>
+                            </ul>
+                        {% else %}
+                            <p class="mb-0">
+                                {% if request.user.is_job_seeker %}
+                                    Pour retenir l’attention du recruteur, décrivez votre situation,
+                                    votre parcours, vos compétences et expliquez les freins socio-professionnels rencontrés.<br />
+                                    Vous pouvez vous appuyer sur le document
+                                    <a class="text-important" href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/diagnostic-socio-professionnel/" target="_blank" rel="noreferrer noopener" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.<br />
+                                    Précisez également dans le message, vos motivations, vos compétences, ainsi que vos disponibilités.
+                                {% else %}
+                                    Pour retenir l’attention du recruteur, décrivez la situation actuelle du candidat,
+                                    son parcours, ses compétences et expliquez les freins socio-professionnels rencontrés.<br />
+                                    Vous pouvez vous appuyer sur le document
+                                    <a class="text-important" href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/diagnostic-socio-professionnel/" target="_blank" rel="noreferrer noopener" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.<br />
+                                    Précisez également dans le message, ses motivations, ses compétences, ainsi que ses disponibilités.
+                                {% endif %}
+                            </p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-12 col-lg-7 pl-0">
+        <div class="form-group">
+            <label for="resume_form" class="js-display-if-javascript-enabled">{{ form.resume_link.label }}</label>
+            {{ form.resume_link.as_hidden }}
+            {% include "storage/s3_upload_form.html" with dropzone_form_id="resume_form" %}
+            {% if resume_is_recommended %}
+                <div class="alert alert-warning" role="status">
+                    <div class="row">
+                        <div class="col-auto pr-0">
+                            <i class="ri-information-line ri-xl text-warning"></i>
+                        </div>
+                        <div class="col">
+                            <p class="mb-2"><strong>Le CV est fortement recommandé</strong></p>
+                            <p class="mb-0">L’ajout du Curriculum Vitae (CV) est fortement recommandé pour que la candidature soit étudiée par ce recruteur.</p>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}
+
+
+{% block script %}
+    {{ block.super }}
+    <!-- Dropzone -->
+    <script src='{% static "vendor/dropzone/dropzone.min.js" %}'></script>
+    <script src='{% static "js/s3_upload.js" %}'></script>
+    {{ s3_upload.form_values|json_script:"s3-form-values" }}
+    {{ s3_upload.config|json_script:"s3-upload-config" }}
+    <script>
+        s3UploadInit({
+            dropzoneSelector: "#resume_form",
+            callbackLocationSelector: "#{{ form.resume_link.id_for_label }}",
+            s3FormValuesId: "s3-form-values",
+            s3UploadConfigId: "s3-upload-config",
+            // Not really nice
+            sentryInternalUrl: "{% url 'home:sentry_debug' %}",
+            sentryCsrfToken: "{{ csrf_token }}"
+        });
+    </script>
+{% endblock %}

--- a/itou/templates/apply/submit_base.html
+++ b/itou/templates/apply/submit_base.html
@@ -1,4 +1,5 @@
 {% extends "layout/content_small.html" %}
+{% load str_filters %}
 
 {% block title %}Postuler{{ block.super }}{% endblock %}
 
@@ -9,7 +10,7 @@
             Déclarer une embauche
         {% else %}
             Postuler
-            {% if request.user.is_prescriber and job_seeker %}pour <span class="text-muted">{{ job_seeker.get_full_name|title }}</span>{% endif %}
+            {% if request.user.is_prescriber and job_seeker %}pour <span class="text-muted">{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</span>{% endif %}
             chez <span class="text-muted">{{ siae.display_name }}</span>
         {% endif %}
     </h1>

--- a/itou/templates/apply/submit_step_application_sent.html
+++ b/itou/templates/apply/submit_step_application_sent.html
@@ -1,4 +1,5 @@
 {% extends "layout/content_small.html" %}
+{% load str_filters %}
 
 {% block content %}
 
@@ -7,7 +8,7 @@
     {# This template is shown only to prescribers. #}
     <h1 class="h1-hero-c1">Candidature envoyée</h1>
 
-    <p>La candidature pour <b>{{ job_seeker.get_full_name }}</b> a bien été envoyée
+    <p>La candidature pour <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b> a bien été envoyée
         chez <b>{{ siae.display_name }}</b>.</p>
 
     {% if back_url %}

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -1,6 +1,7 @@
 {% extends "apply/submit_base_two_columns.html" %}
 {% load bootstrap4 %}
 {% load format_filters %}
+{% load str_filters %}
 {% load redirection_fields %}
 {% load static %}
 
@@ -82,9 +83,9 @@
                             </button>
                         </div>
                         <div class="modal-body">
-                            <p>Le numéro {{ form.nir.value|format_nir }} est associé au compte de <b>{{ job_seeker_name }}</b>.</p>
+                            <p>Le numéro {{ form.nir.value|format_nir }} est associé au compte de <b>{{  job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>.</p>
                             <p>
-                                Si cette candidature n'est pas pour <b>{{ job_seeker_name }}</b>, cliquez sur « Ce n'est pas mon candidat » afin de modifier le numéro de sécurité sociale.
+                                Si cette candidature n'est pas pour <b>{{  job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>, cliquez sur « Ce n'est pas mon candidat » afin de modifier le numéro de sécurité sociale.
                             </p>
                         </div>
                         <div class="modal-footer">

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -315,6 +315,35 @@ class User(AbstractUser, AddressMixin):
     def can_edit_email(self, user):
         return user.is_handled_by_proxy and user.is_created_by(self) and not user.has_verified_email
 
+    def can_edit_personal_information(self, user):
+        if self.pk == user.pk:  # I am me
+            return True
+
+        if self.is_prescriber:
+            if self.is_prescriber_with_authorized_org:
+                return user.is_handled_by_proxy
+            else:
+                return user.is_handled_by_proxy and user.is_created_by(self)
+        elif self.is_siae_staff:
+            return user.is_handled_by_proxy
+
+        return False
+
+    def can_view_personal_information(self, user):
+        if self.can_edit_personal_information(user):  # If we can edit them then we can view them
+            return True
+
+        if user.is_job_seeker:  # Restrict display of personal information to job seeker
+            if self.is_prescriber:
+                if self.is_prescriber_with_authorized_org:
+                    return True
+                else:
+                    return user.is_handled_by_proxy and user.is_created_by(self)
+            elif self.is_siae_staff:
+                return True
+
+        return False
+
     def can_add_nir(self, job_seeker):
         return (self.is_prescriber_with_authorized_org or self.is_siae_staff) and (job_seeker and not job_seeker.nir)
 

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -354,7 +354,7 @@ class User(AbstractUser, AddressMixin):
     def has_sso_provider(self):
         return self.identity_provider != IdentityProvider.DJANGO or self.is_peamu
 
-    @property
+    @cached_property
     def has_verified_email(self):
         return self.emailaddress_set.filter(email=self.email, verified=True).exists()
 
@@ -485,11 +485,11 @@ class User(AbstractUser, AddressMixin):
             return None
         return self.socialaccount_set.filter(provider="peamu").get().extra_data["id_token"]
 
-    @property
+    @cached_property
     def is_prescriber_with_org(self):
         return self.is_prescriber and self.prescribermembership_set.filter(is_active=True).exists()
 
-    @property
+    @cached_property
     def is_prescriber_with_authorized_org(self):
         return (
             self.is_prescriber
@@ -522,7 +522,7 @@ class User(AbstractUser, AddressMixin):
     def has_pole_emploi_email(self):
         return self.email and self.email.endswith(settings.POLE_EMPLOI_EMAIL_SUFFIX)
 
-    @property
+    @cached_property
     def is_siae_staff_with_siae(self):
         """
         Useful to identify users deactivated as member of a SIAE

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -558,10 +558,12 @@ class ModelTest(TestCase):
 
         self.assertFalse(user.has_verified_email)
         address = user.emailaddress_set.create(email=user.email, verified=False)
+        del user.has_verified_email
         self.assertFalse(user.has_verified_email)
         address.delete()
 
         user.emailaddress_set.create(email=user.email, verified=True)
+        del user.has_verified_email
         self.assertTrue(user.has_verified_email)
 
     def test_siae_admin_can_create_siae_antenna(self):

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -415,6 +415,118 @@ class ModelTest(TestCase):
         job_seeker.emailaddress_set.create(email=job_seeker.email, verified=True)
         self.assertFalse(user.can_edit_email(job_seeker))
 
+    def test_can_edit_personal_information(self):
+        authorized_prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.first()
+        unauthorized_prescriber = PrescriberFactory()
+        siae_member = SiaeFactory(with_membership=True).members.first()
+        job_seeker = JobSeekerFactory()
+        user_created_by_prescriber = JobSeekerFactory(created_by=unauthorized_prescriber, last_login=None)
+        logged_user_created_by_prescriber = JobSeekerFactory(
+            created_by=unauthorized_prescriber, last_login=timezone.now()
+        )
+        user_created_by_siae_staff = JobSeekerFactory(created_by=siae_member, last_login=None)
+        logged_user_created_by_siae_staff = JobSeekerFactory(created_by=siae_member, last_login=timezone.now())
+
+        specs = {
+            "authorized_prescriber": {
+                "authorized_prescriber": True,
+                "unauthorized_prescriber": False,
+                "siae_member": False,
+                "job_seeker": False,
+                "user_created_by_prescriber": True,
+                "logged_user_created_by_prescriber": False,
+                "user_created_by_siae_staff": True,
+                "logged_user_created_by_siae_staff": False,
+            },
+            "unauthorized_prescriber": {
+                "authorized_prescriber": False,
+                "unauthorized_prescriber": True,
+                "siae_member": False,
+                "job_seeker": False,
+                "user_created_by_prescriber": True,
+                "logged_user_created_by_prescriber": False,
+                "user_created_by_siae_staff": False,
+                "logged_user_created_by_siae_staff": False,
+            },
+            "siae_member": {
+                "authorized_prescriber": False,
+                "unauthorized_prescriber": False,
+                "siae_member": True,
+                "job_seeker": False,
+                "user_created_by_prescriber": True,
+                "logged_user_created_by_prescriber": False,
+                "user_created_by_siae_staff": True,
+                "logged_user_created_by_siae_staff": False,
+            },
+            "job_seeker": {
+                "authorized_prescriber": False,
+                "unauthorized_prescriber": False,
+                "siae_member": False,
+                "job_seeker": True,
+                "user_created_by_prescriber": False,
+                "logged_user_created_by_prescriber": False,
+                "user_created_by_siae_staff": False,
+                "logged_user_created_by_siae_staff": False,
+            },
+        }
+        for user_type, user_specs in specs.items():
+            for other_user_type, expected in user_specs.items():
+                self.assertIs(
+                    locals()[user_type].can_edit_personal_information(locals()[other_user_type]),
+                    expected,
+                    f"{user_type}.can_edit_personal_information({other_user_type})",
+                )
+
+    def test_can_view_personal_information(self):
+        authorized_prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.first()
+        unauthorized_prescriber = PrescriberFactory()
+        siae_member = SiaeFactory(with_membership=True).members.first()
+        job_seeker = JobSeekerFactory()
+        user_created_by_prescriber = JobSeekerFactory(created_by=unauthorized_prescriber, last_login=None)
+        user_created_by_siae_staff = JobSeekerFactory(created_by=siae_member, last_login=None)
+
+        specs = {
+            "authorized_prescriber": {
+                "authorized_prescriber": True,
+                "unauthorized_prescriber": False,
+                "siae_member": False,
+                "job_seeker": True,
+                "user_created_by_prescriber": True,
+                "user_created_by_siae_staff": True,
+            },
+            "unauthorized_prescriber": {
+                "authorized_prescriber": False,
+                "unauthorized_prescriber": True,
+                "siae_member": False,
+                "job_seeker": False,
+                "user_created_by_prescriber": True,
+                "user_created_by_siae_staff": False,
+            },
+            "siae_member": {
+                "authorized_prescriber": False,
+                "unauthorized_prescriber": False,
+                "siae_member": True,
+                "job_seeker": True,
+                "user_created_by_prescriber": True,
+                "user_created_by_siae_staff": True,
+            },
+            "job_seeker": {
+                "authorized_prescriber": False,
+                "unauthorized_prescriber": False,
+                "siae_member": False,
+                "job_seeker": True,
+                "user_created_by_prescriber": False,
+                "user_created_by_siae_staff": False,
+            },
+        }
+        for user_type, user_specs in specs.items():
+            for other_user_type, expected in user_specs.items():
+                self.assertIs(
+                    locals()[user_type].can_view_personal_information(locals()[other_user_type]),
+                    expected,
+                    f"{user_type}.can_view_personal_information({other_user_type})",
+                )
+
     def test_can_add_nir(self):
         siae = SiaeFactory(with_membership=True)
         siae_staff = siae.members.first()

--- a/itou/utils/python.py
+++ b/itou/utils/python.py
@@ -1,0 +1,5 @@
+class Sentinel:
+    """Class to be used for sentinel object, but the object will be falsy"""
+
+    def __bool__(self):
+        return False

--- a/itou/utils/session.py
+++ b/itou/utils/session.py
@@ -48,6 +48,9 @@ class SessionNamespace:
         del self._session[self.name]
         self._session.modified = True
 
+    def save(self):
+        self._session.save()
+
     def as_dict(self):
         return dict(self._session[self.name])
 

--- a/itou/utils/session.py
+++ b/itou/utils/session.py
@@ -5,11 +5,13 @@ from django.core.exceptions import PermissionDenied
 
 import itou.utils.json
 
+from . import python
+
 
 class SessionNamespace:
     """Class to facilitate the usage of namespaces inside the session."""
 
-    NOT_SET = object()
+    NOT_SET = python.Sentinel()
 
     def __init__(self, session, namespace):
         self._session = session

--- a/itou/utils/templatetags/str_filters.py
+++ b/itou/utils/templatetags/str_filters.py
@@ -2,6 +2,7 @@
 https://docs.djangoproject.com/en/dev/howto/custom-template-tags/
 """
 from django import template
+from django.template import defaultfilters
 
 
 register = template.Library()
@@ -22,3 +23,12 @@ def pluralizefr(value, arg="s"):
         except TypeError:  # len() of unsized object.
             pass
     return ""
+
+
+@register.filter(is_safe=True)
+@defaultfilters.stringfilter
+def mask_unless(value, predicate):
+    if predicate:
+        return value
+
+    return " ".join(part[0] + "…" for part in value.split(" "))

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -1252,6 +1252,9 @@ class SessionNamespaceTest(TestCase):
 
         # .get()
         self.assertEqual(ns.get("key"), "value")
+        self.assertIs(ns.get("not_existing_key", None), None)
+        self.assertIs(ns.get("not_existing_key"), ns.NOT_SET)
+        self.assertFalse(ns.get("not_existing_key"))
 
         # .set()
         ns.set("key2", "value2")

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -514,6 +514,18 @@ class UtilsTemplateTagsTestCase(TestCase):
         out = template.render(Context({"counter": 10}))
         self.assertEqual(out, "Résultats")
 
+    def test_mask_unless(self):
+        template = Template("""{% load str_filters %}{{ value|mask_unless:predicate }}""")
+
+        self.assertEqual(
+            template.render(Context({"value": "Firstname Lastname", "predicate": True})),
+            "Firstname Lastname",
+        )
+        self.assertEqual(
+            template.render(Context({"value": "Firstname Lastname", "predicate": False})),
+            "F… L…",
+        )
+
 
 class UtilsTemplateFiltersTestCase(TestCase):
     def test_format_phone(self):

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -37,7 +37,6 @@ fake = faker.Faker(locale="fr_FR")
 class ApplyTest(TestCase):
     def test_we_redirect_to_siae_on_missing_session_for_fbv(self):
         routes = {
-            "apply:step_check_job_seeker_info",
             "apply:step_check_prev_applications",
             "apply:step_eligibility",
             "apply:step_application",
@@ -56,6 +55,7 @@ class ApplyTest(TestCase):
             "apply:check_nir_for_sender",
             "apply:check_email_for_sender",
             "apply:check_nir_for_job_seeker",
+            "apply:step_check_job_seeker_info",
             "apply:step_application_sent",
         }
         user = JobSeekerFactory()
@@ -891,7 +891,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         # ----------------------------------------------------------------------
 
         # Follow all redirections…
-        response = self.client.post(next_url, follow=True)
+        response = self.client.get(next_url, follow=True)
         self.assertEqual(response.status_code, 200)
 
         self.assertFalse(EligibilityDiagnosis.objects.has_considered_valid(job_seeker, for_siae=siae))

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -37,7 +37,6 @@ fake = faker.Faker(locale="fr_FR")
 class ApplyTest(TestCase):
     def test_we_redirect_to_siae_on_missing_session_for_fbv(self):
         routes = {
-            "apply:step_check_prev_applications",
             "apply:step_eligibility",
             "apply:step_application",
         }
@@ -56,6 +55,7 @@ class ApplyTest(TestCase):
             "apply:check_email_for_sender",
             "apply:check_nir_for_job_seeker",
             "apply:step_check_job_seeker_info",
+            "apply:step_check_prev_applications",
             "apply:step_application_sent",
         }
         user = JobSeekerFactory()

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -58,6 +58,20 @@ urlpatterns = [
         submit_views.CheckPreviousApplications.as_view(),
         name="step_check_prev_applications",
     ),
+    path("<int:siae_pk>/application/jobs", submit_views.ApplicationJobsView.as_view(), name="application_jobs"),
+    path(
+        "<int:siae_pk>/application/eligibility",
+        submit_views.ApplicationEligibilityView.as_view(),
+        name="application_eligibility",
+    ),
+    path("<int:siae_pk>/application/resume", submit_views.ApplicationResumeView.as_view(), name="application_resume"),
+    path(
+        "<int:siae_pk>/application/<uuid:application_pk>/end",
+        submit_views.ApplicationEndView.as_view(),
+        name="application_end",
+    ),
+    # Submit - legacy
+    # TODO(rsebille): Remove those 3 once we are fairly confident that no one is still inside that path
     path("<int:siae_pk>/step_eligibility", submit_views.step_eligibility, name="step_eligibility"),
     path("<int:siae_pk>/step_application", submit_views.step_application, name="step_application"),
     path(

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -50,7 +50,7 @@ urlpatterns = [
     # Submit - common.
     path(
         "<int:siae_pk>/step_check_job_seeker_info",
-        submit_views.step_check_job_seeker_info,
+        submit_views.CheckJobSeekerInformations.as_view(),
         name="step_check_job_seeker_info",
     ),
     path(

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -55,7 +55,7 @@ urlpatterns = [
     ),
     path(
         "<int:siae_pk>/step_check_prev_applications",
-        submit_views.step_check_prev_applications,
+        submit_views.CheckPreviousApplications.as_view(),
         name="step_check_prev_applications",
     ),
     path("<int:siae_pk>/step_eligibility", submit_views.step_eligibility, name="step_eligibility"),

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -178,6 +178,13 @@ class ApplyStepForSenderBaseView(ApplyStepBaseView):
 
 
 class StartView(ApplyStepBaseView):
+    def _coalesce_back_url(self):
+        if "back_url" in self.request.GET:
+            return get_safe_url(self.request, "back_url")
+        if job_description_id := self.request.GET.get("job_description_id"):
+            return reverse("siaes_views:job_description_card", kwargs={"job_description_id": job_description_id})
+        return reverse("siaes_views:card", kwargs={"siae_id": self.siae.pk})
+
     def get(self, request, *args, **kwargs):
         # SIAE members can only submit a job application to their SIAE
         if request.user.is_siae_staff and not self.siae.has_member(request.user):
@@ -191,7 +198,7 @@ class StartView(ApplyStepBaseView):
         user_info = get_user_info(request)
         self.apply_session.init(
             {
-                "back_url": get_safe_url(request, "back_url"),
+                "back_url": self._coalesce_back_url(),
                 "job_seeker_pk": user_info.user.pk if user_info.user.is_job_seeker else None,
                 "job_seeker_email": None,
                 "nir": None,

--- a/itou/www/eligibility_views/forms.py
+++ b/itou/www/eligibility_views/forms.py
@@ -78,7 +78,7 @@ class AdministrativeCriteriaForm(forms.Form):
             raise forms.ValidationError(self.ERROR_LONG_TERM_JOB_SEEKER)
 
         # No required criterion for authorized prescribers. Stop here.
-        if self.user.is_prescriber or not self.siae:
+        if self.user.is_prescriber_with_authorized_org or not self.siae:
             return selected_objects
 
         level_1 = [obj for obj in selected_objects if obj.level == AdministrativeCriteria.Level.LEVEL_1]

--- a/itou/www/eligibility_views/tests.py
+++ b/itou/www/eligibility_views/tests.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
+from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import SiaeFactory
 from itou.users.enums import KIND_SIAE_STAFF
@@ -166,6 +167,21 @@ class AdministrativeCriteriaFormTest(TestCase):
         form = AdministrativeCriteriaForm(user, siae=None, data=form_data)
         form.is_valid()
         self.assertIn(form.ERROR_LONG_TERM_JOB_SEEKER, form.errors["__all__"])
+
+    def test_no_required_criteria_for_prescriber_with_authorized_organization(self):
+        prescriber = PrescriberFactory()
+        authorized_prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.first()
+        siae = SiaeFactory()
+
+        self.assertFalse(AdministrativeCriteriaForm(prescriber, siae, data={}).is_valid())
+        self.assertTrue(AdministrativeCriteriaForm(authorized_prescriber, siae, data={}).is_valid())
+
+    def test_no_required_criteria_when_no_siae(self):
+        prescriber = PrescriberFactory()
+        siae = SiaeFactory()
+
+        self.assertFalse(AdministrativeCriteriaForm(prescriber, siae, data={}).is_valid())
+        self.assertTrue(AdministrativeCriteriaForm(prescriber, None, data={}).is_valid())
 
 
 class AdministrativeCriteriaOfJobApplicationFormTest(TestCase):


### PR DESCRIPTION
:warning: Il ne faut relire qu'à partir des `js.utils: Add ...` (5ffcc350). Les commits précédents sont ceux des PR #1472 et #1473. :warning:

### Quoi ?

Améliorer le parcours prescripteur de dépôt de candidature.

### Pourquoi ?

- Les prescriptions ne sont pas assez détaillées et donc pas assez qualitatives pour les recruteurs.
- Manque d'accompagnement dans la complétion de la candidature

### Comment ?

Comme à l’accoutumé les premiers commits sont préparatoire :
1. Ajout de nouvelles fonctionnalités JS
  a. `swap-elements`
  Utiliser dans la dernière page du parcours pour passer de l'affichage texte au formulaire lorsqu'on clique sur le bouton "modifier".
  b.`shroud`
  Utiliser sur la page des critères d'éligibilités pour "désactiver" le formulaire.
2. Transformation des 2 FBV `step_check_job_seeker_info()` et `step_check_prev_applications()` en CBV pour ainsi introduire `ApplicationBaseView()` qui va servir de base aux nouvelles vues.
3. Généralisation du masquage (`mask_unless`) du nom et prénom suivant qui regarde (`User.can_view_personal_information()`). `User.can_edit_personal_information()` est utilisé dans le dernier écran pour le bouton "modifier".
4. Le changement de `www.apply: Only authorized prescribers can bypass required criterion` (f43230fc) est normalement une "correction" (d'après ce que je sais et du commentaire ^^) mais il y a peut-être un cas particulier donc _beware_.
5. Notre gestion de `back_url` est assez _spotty_ (voir foireuse ? :eyes:) donc je tente un truc :grin:.
6. Ajout de la possibilité de MAJ un diagnostique d'éligibilité, normalement c'est carré au niveau métier, mais comme pour le point 4 si vous pensez au moindre truc je suis preneur plutôt que de devoir récupérer les conneries dans quelques mois.
7. _sentinel object_ qui est falsy par défaut, c'est assez niche mais ça semble plutôt logique et ça évite de devoir faire des `is SessionNamespace.NOT_SET` lors d'un `.get()`.
8. Les changements du parcours sont dans `www.apply: Remake the last steps when applying to a SIAE` (8bcde99d)
9. ...

### Captures d'écran (optionnel)

Il y a de très nombreuses variations (texte, informations, etc) en fonction du type de d'utilisateur, du type de la SIAE, et d'autre facteurs donc je ne met pas tout les cas possibles mais les 4 screenshots donnent un bon aperçu.

![depot_candidature_application_jobs](https://user-images.githubusercontent.com/20045330/187925910-700dcdc4-abe9-4fcf-aa01-4c6c6f70ad0b.png)
![depot_candidature_application_eligibility](https://user-images.githubusercontent.com/20045330/187925971-f612de43-df4c-4cd8-8083-08fcd8681a6c.png)
![depot_candidature_application_resume](https://user-images.githubusercontent.com/20045330/187926019-39a8ec92-0d20-4d28-a0c8-b9966d6ff0bd.png)
![depot_candidature_application_end](https://user-images.githubusercontent.com/20045330/187926166-50ce0cde-1516-49e4-b52e-94e9a85866a9.png)
