### PR TITLE
Ouverture nationale des stats PE+Employeur (MEP le 7 septembre)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -563,7 +563,6 @@ PILOTAGE_DASHBOARDS_WHITELIST = json.loads(os.environ.get("PILOTAGE_DASHBOARDS_W
 # Specific stats are progressively being deployed to more and more departments and specific users.
 STATS_SIAE_DEPARTMENT_WHITELIST = ["38", "62", "67", "93"]
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.environ.get("STATS_SIAE_USER_PK_WHITELIST", "[]"))
-STATS_PE_DEPARTMENT_WHITELIST = ["38", "62", "67", "93"]
 
 PILOTAGE_SITE_URL = "https://pilotage.inclusion.beta.gouv.fr"
 PILOTAGE_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/aide/pilotage"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -560,8 +560,7 @@ METABASE_DASHBOARD_IDS = {
 }
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(os.environ.get("PILOTAGE_DASHBOARDS_WHITELIST", "[]"))
 
-# Specific stats are progressively being deployed to more and more departments and specific users.
-STATS_SIAE_DEPARTMENT_WHITELIST = ["38", "62", "67", "93"]
+# Some experimental stats are progressively being deployed to more and more specific beta users.
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.environ.get("STATS_SIAE_USER_PK_WHITELIST", "[]"))
 
 PILOTAGE_SITE_URL = "https://pilotage.inclusion.beta.gouv.fr"

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -575,10 +575,7 @@ class User(AbstractUser, AddressMixin):
         return self._can_view_stats_siae(current_org) and self.pk in settings.STATS_SIAE_USER_PK_WHITELIST
 
     def can_view_stats_siae_hiring(self, current_org):
-        return self._can_view_stats_siae(current_org) and (
-            current_org.department in settings.STATS_SIAE_DEPARTMENT_WHITELIST
-            or self.pk in settings.STATS_SIAE_USER_PK_WHITELIST
-        )
+        return self._can_view_stats_siae(current_org)
 
     def can_view_stats_cd(self, current_org):
         """

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -619,7 +619,6 @@ class User(AbstractUser, AddressMixin):
             and current_org.kind == PrescriberOrganizationKind.PE
             and current_org.is_authorized
             and current_org.authorization_status == PrescriberAuthorizationStatus.VALIDATED
-            and current_org.department in settings.STATS_PE_DEPARTMENT_WHITELIST
         )
 
     def get_stats_pe_departments(self, current_org):

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -528,7 +528,7 @@ class ModelTest(TestCase):
         self.assertFalse(user.can_view_stats_dashboard_widget(current_org=org))
 
         # Non CD organization does not give access.
-        org = PrescriberOrganizationWithMembershipFactory(authorized=True)
+        org = PrescriberOrganizationWithMembershipFactory(authorized=True, kind=PrescriberOrganizationKind.CHRS)
         user = org.members.get()
         self.assertFalse(user.can_view_stats_cd(current_org=org))
         self.assertFalse(user.can_view_stats_dashboard_widget(current_org=org))


### PR DESCRIPTION
### Quoi ?

Ouverture nationale des stats PE+Employeur.

### Pourquoi ?

Le grand jour du C2 est arrivé !

### En passant

- Fix d'un flaky test `test_can_view_stats_cd` qui se déclenchait 4% du temps (4 départements sur 100).

### TODO post MEP

~Virer `STATS_SIAE_USER_PK_WHITELIST` des instances clever de conf.~ Eh non, on l'utilise encore pour le TDB expérimental des ETP.