### PR TITLE
Homogénéiser la construction de l'url du site

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -20,6 +20,7 @@ from itou.job_applications.enums import RefusalReason, SenderKind
 from itou.job_applications.tasks import huey_notify_pole_emploi
 from itou.siaes.models import Siae
 from itou.utils.emails import get_email_message
+from itou.utils.urls import get_absolute_url
 
 
 logger = logging.getLogger(__name__)
@@ -935,9 +936,9 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         body = "apply/email/new_for_prescriber_body.txt"
         return get_email_message(to, context, subject, body)
 
-    def email_new_for_job_seeker(self, base_url):
+    def email_new_for_job_seeker(self):
         to = [self.job_seeker.email]
-        context = {"job_application": self, "base_url": base_url}
+        context = {"job_application": self, "base_url": get_absolute_url().rstrip("/")}
         subject = "apply/email/new_for_job_seeker_subject.txt"
         body = "apply/email/new_for_job_seeker_body.txt"
         return get_email_message(to, context, subject, body)

--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -588,7 +588,7 @@ class JobApplicationNotificationsTest(TestCase):
         self.assertIn(job_application.to_siae.city, email.body)
 
         # Assert the Job Seeker does not have access to confidential information.
-        email = job_application.email_new_for_job_seeker(base_url="http://testserver")
+        email = job_application.email_new_for_job_seeker()
         self.assertIn(job_application.sender.get_full_name().title(), email.body)
         self.assertIn(job_application.sender_prescriber_organization.display_name, email.body)
         self.assertNotIn(job_application.sender.email, email.body)
@@ -597,7 +597,7 @@ class JobApplicationNotificationsTest(TestCase):
 
     def test_new_for_job_seeker(self, *args, **kwargs):
         job_application = JobApplicationSentByJobSeekerFactory(selected_jobs=Appellation.objects.all())
-        email = job_application.email_new_for_job_seeker(base_url="http://testserver")
+        email = job_application.email_new_for_job_seeker()
         # To.
         self.assertIn(job_application.sender.email, email.to)
         self.assertEqual(len(email.to), 1)

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -15,6 +15,7 @@ from itou.common_apps.organizations.models import MembershipAbstract, Organizati
 from itou.siaes.enums import SIAE_WITH_CONVENTION_CHOICES, SIAE_WITH_CONVENTION_KINDS, ContractType, SiaeKind
 from itou.utils.emails import get_email_message
 from itou.utils.tokens import siae_signup_token_generator
+from itou.utils.urls import get_absolute_url
 from itou.utils.validators import validate_af_number, validate_naf, validate_siret
 
 
@@ -361,14 +362,11 @@ class Siae(AddressMixin, OrganizationAbstract):
     def new_signup_activation_email_to_official_contact(self, request):
         """
         Send email to siae.auth_email with a magic link to continue signup.
-
-        Request object is needed to build absolute URL for magic link in email body.
-        See https://stackoverflow.com/questions/2345708/how-can-i-get-the-full-absolute-url-with-domain-in-django
         """
         if not self.auth_email:
             raise RuntimeError("Siae cannot be signed up for, this should never happen.")
         to = [self.auth_email]
-        signup_magic_link = request.build_absolute_uri(self.signup_magic_link)
+        signup_magic_link = get_absolute_url(self.signup_magic_link)
         context = {"siae": self, "signup_magic_link": signup_magic_link}
         subject = "siaes/email/new_signup_activation_email_to_official_contact_subject.txt"
         body = "siaes/email/new_signup_activation_email_to_official_contact_body.txt"

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -733,8 +733,7 @@ def step_application(request, siae_pk, template_name="apply/submit_step_applicat
             notification = NewQualifiedJobAppEmployersNotification(job_application=job_application)
 
         notification.send()
-        base_url = request.build_absolute_uri("/")[:-1]
-        job_application.email_new_for_job_seeker(base_url=base_url).send()
+        job_application.email_new_for_job_seeker().send()
 
         if job_application.is_sent_by_proxy:
             job_application.email_new_for_prescriber.send()


### PR DESCRIPTION
### Quoi ?

Je vois qu'on a deux manières de récupérer l'url complète du site :

- une fonction get_absolute_url qui se base sur des settings
- request.build_absolute_uri quand un a un object request valide.

C'est utile pour mettre des liens dans les emails ou pour générer des urls de retour quand on redirige l'utilisateur vers un site partenaire (par exemple les SSO : France Connect, Inclusion Connect ou PE Connect)

Je propose de ne garder que la 1ère qui a l'avantage de fonctionner aussi dans les management commands (où aucun objet request n'est disponible)

### Pourquoi ?


### Comment ?


### Captures d'écran (optionnel)


### Autre (optionnel)

- si des tests manquent, indiquer la raison, la probabilité, et les risques associés à ce manque
- être explicite sur le délai attendu pour une revue de code
- être explicite sur la qualité attendue pour la revue de code
- etc.
