### PR TITLE
Les DR PE peuvent maintenant voir les stats de toute leur région

### DIFF
--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -88,6 +88,29 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
     In case 3, we talk about "prescripteur habilité" in French.
     """
 
+    # DRPE, as in "Direction Régionale Pôle emploi", are special PE agencies which oversee their whole region.
+    # We keep it simple by hardcoding their (short) list here to avoid the complexity of adding a field or a kind.
+    DRPE_SAFIR_CODES = [
+        "13992",
+        "20010",
+        "21069",
+        "31096",
+        "33127",
+        "35076",
+        "44116",
+        "45054",
+        "59212",
+        "67085",
+        "69188",
+        "75980",
+        "76115",
+        "97110",
+        "97210",
+        "97310",
+        "97410",
+        "97600",
+    ]
+
     # Rules:
     # - a SIRET was not mandatory in the past (some entries still have a "blank" siret)
     # - a SIRET is now required for all organizations, except for Pôle emploi agencies
@@ -269,6 +292,13 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
         subject = "prescribers/email/must_validate_prescriber_organization_email_subject.txt"
         body = "prescribers/email/must_validate_prescriber_organization_email_body.txt"
         return get_email_message(to, context, subject, body)
+
+    @property
+    def is_drpe(self):
+        """
+        DRPE, as in "Direction Régionale Pôle emploi", are special PE agencies which oversee their whole region.
+        """
+        return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi in self.DRPE_SAFIR_CODES
 
 
 class PrescriberMembership(MembershipAbstract):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -26,7 +26,7 @@ from itou.asp.models import (
     LaneType,
     RSAAllocation,
 )
-from itou.common_apps.address.departments import department_from_postcode
+from itou.common_apps.address.departments import REGIONS, department_from_postcode
 from itou.common_apps.address.format import format_address
 from itou.common_apps.address.models import AddressMixin
 from itou.institutions.enums import InstitutionKind
@@ -622,10 +622,12 @@ class User(AbstractUser, AddressMixin):
             and current_org.department in settings.STATS_PE_DEPARTMENT_WHITELIST
         )
 
-    def get_stats_pe_department(self, current_org):
+    def get_stats_pe_departments(self, current_org):
         if not self.can_view_stats_pe(current_org=current_org):
             raise PermissionDenied
-        return current_org.department
+        if current_org.is_drpe:
+            return REGIONS[current_org.region]
+        return [current_org.department]
 
     def can_view_stats_ddets(self, current_org):
         """

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -221,9 +221,13 @@ def render_stats_pe(request, page_title):
     params = {
         DEPARTMENT_FILTER_KEY: [DEPARTMENTS[d] for d in departments],
     }
+    if current_org.is_drpe:
+        matomo_custom_url_suffix = f"{format_region_for_matomo(current_org.region)}/drpe"
+    else:
+        matomo_custom_url_suffix = format_region_and_department_for_matomo(current_org.department)
     context = {
         "page_title": page_title,
-        "matomo_custom_url_suffix": format_region_and_department_for_matomo(departments[0]),
+        "matomo_custom_url_suffix": matomo_custom_url_suffix,
     }
     return render_stats(request=request, context=context, params=params)
 

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -217,13 +217,13 @@ def render_stats_pe(request, page_title):
     current_org = get_current_org_or_404(request)
     if not request.user.can_view_stats_pe(current_org=current_org):
         raise PermissionDenied
-    department = request.user.get_stats_pe_department(current_org=current_org)
+    departments = request.user.get_stats_pe_departments(current_org=current_org)
     params = {
-        DEPARTMENT_FILTER_KEY: DEPARTMENTS[department],
+        DEPARTMENT_FILTER_KEY: [DEPARTMENTS[d] for d in departments],
     }
     context = {
         "page_title": page_title,
-        "matomo_custom_url_suffix": format_region_and_department_for_matomo(department),
+        "matomo_custom_url_suffix": format_region_and_department_for_matomo(departments[0]),
     }
     return render_stats(request=request, context=context, params=params)
 


### PR DESCRIPTION
### Quoi ?

Les DR PE (Direction Régionale Pôle emploi) peuvent maintenant voir les stats de toute leur région et non de seulement leur département.

### Pourquoi ?

Dans la db C1 les DR PE sont actuellement des agences PE comme les autres, du coup, comme les agences PE classiques, elles n'avaient accès qu'aux stats de leur département.

Une DR PE a bien sûr vocation à consulter les stats de sa région entière et pas juste son département.

### Comment ?

Vu le nombre très réduit (18) de DRPE et leur stabilité dans le temps, on évite de rajouter un champ ou un type d'organisation prescripteur, et on hardcode leur liste. Cela me parait le plus simple mais c'est ouvert à débat.

### Post MEP avec Yannick

- (Non bloquant) Décider comme faire évoluer le tracking Matomo correspondant pour distinguer proprement DRPE du reste.
- (Non bloquant) Rajouter un filtre département sur chacun des 7 TDB concernés pour que les DRPE puissent filtrer et voir les stats de départements spécifiques de leur région.

```
    "stats_pe_delay_main": 168,
    "stats_pe_delay_raw": 180,
    "stats_pe_conversion_main": 169,
    "stats_pe_conversion_raw": 182,
    "stats_pe_state_main": 149,
    "stats_pe_state_raw": 183,
    "stats_pe_tension": 162,
```