### PR TITLE
API EmployeeRecord - données manquantes

### DIFF
--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -89,7 +89,7 @@ class _AddressSerializer(serializers.Serializer):
     adrLibelleVoie = serializers.SerializerMethodField()
     adrCpltDistribution = serializers.SerializerMethodField()
 
-    codeinseecom = serializers.CharField(source="jobseeker_profile.hexa_commune.code")
+    codeinseecom = serializers.CharField(source="jobseeker_profile.hexa_commune.code", required=False)
     codepostalcedex = serializers.CharField(source="jobseeker_profile.hexa_post_code")
 
     def get_adrCpltDistribution(self, obj: User):

--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -49,8 +49,8 @@ class _PersonSerializer(serializers.Serializer):
     # codeComInsee is only mandatory if birth country is France
     codeComInsee = serializers.SerializerMethodField(required=False)
 
-    passDateDeb = serializers.DateField(format="%d/%m/%Y", source="approval.start_at")
-    passDateFin = serializers.DateField(format="%d/%m/%Y", source="approval.end_at")
+    passDateDeb = serializers.DateField(format="%d/%m/%Y", source="approval.start_at", required=False)
+    passDateFin = serializers.DateField(format="%d/%m/%Y", source="approval.end_at", required=False)
 
     def get_nomUsage(self, obj: EmployeeRecord):
         return unidecode(obj.job_seeker.last_name).upper()

--- a/itou/employee_record/tests/tests_serializers.py
+++ b/itou/employee_record/tests/tests_serializers.py
@@ -68,6 +68,17 @@ class EmployeeRecordAddressSerializerTest(TestCase):
         self.assertIsNotNone(data)
         self.assertEqual(good_lane_name, data["adrLibelleVoie"])
 
+    def test_null_hexa_commune_code(self):
+        employee_record = EmployeeRecordWithProfileFactory(status=Status.PROCESSED)
+        job_seeker = employee_record.job_seeker
+        job_seeker.jobseeker_profile.hexa_commune = None
+        job_seeker.jobseeker_profile.save(update_fields=["hexa_commune"])
+
+        serializer = _AddressSerializer(job_seeker)
+        data = serializer.data
+
+        self.assertNotIn("codeinseecom", data.keys())
+
 
 class EmployeeRecordUpdateNotificationSerializerTest(TestCase):
     def test_notification_serializer(self):


### PR DESCRIPTION
### Quoi ?

Appel au endpoint `/api/v1/employee-records/` en erreur (logs Sentry)

### Pourquoi ?

Eviter le plantage en l'absence : 
- d'un `approval` lié
- adresse encodée en hexa dans le `job_seeker_profil`

### Comment ?

- Rendre optionnel les dates de l'approval dans le serializer
- Rendre optionnel les données d'adresse hexa dans le serializer

