### PR TITLE
Utiliser les linters du venv pour pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,23 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
+  - repo: local
     hooks:
       - id: black
-        language_version: python3
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
+        name: Black
+        entry: black
+        types: [python]
+        language: system
       - id: flake8
-        language_version: python3
-  - repo: https://github.com/Riverside-Healthcare/djlint
-    rev: v1.17.2
-    hooks:
+        name: Flake8
+        entry: flake8
+        types: [python]
+        language: system
+      - id: isort
+        name: isort
+        entry: isort
+        types: [python]
+        language: system
       - id: djlint
-        language_version: python3
-
+        name: djlint
+        entry: djlint --reformat
+        types: [html]
+        language: system


### PR DESCRIPTION
### Quoi ?

Utiliser les linters du venv pour [pre-commit](https://pre-commit.com/)

### Pourquoi ?

Éviter les incohérences entre la version déclarée dans la configuration
de pre-commit et celle déclarée dans requirements/dev.txt.

### Comment ?

Ce changement s’attend à ce que les linters soient présents dans le
`PATH`.

---
Une PR ultérieure pourrait harmoniser la construction du venv localement
(e.g. make + [pip-tools](https://pypi.org/project/pip-tools/)) pour
figer (et idéalement `hash`er) les requirements et améliorer la
“reproducibilité” des vens entre les machines de dev (et la prod 🎉), et
utiliser les linters situé à un endroit conventionnel (e.g. `.venv`)
pour éviter de dépendre du `PATH`.