### PR TITLE
Deploiement recette: limite le nom de l’app à 63 caractères

### DIFF
--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -45,7 +45,10 @@ jobs:
 
     - name: 🏷 Set deploy url
       run:
-        echo "DEPLOY_URL=`echo \"$REVIEW_APP_NAME.cleverapps.io\"`" >> $GITHUB_ENV
+        # The maximum length of a domain label (part of domain name separated
+        # by dot) is 63 characters.
+        # https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4
+        echo "DEPLOY_URL=`echo \"${REVIEW_APP_NAME::63}.cleverapps.io\"`" >> $GITHUB_ENV
     # End of environment variables
 
     - name: 🧫 Create a review app on Clever Cloud


### PR DESCRIPTION
### Quoi ?

Deploiement recette: limite le nom de l’app à 63 caractères

### Pourquoi ?

Enlever le warning sur le nom des branches de la documentation.

### Comment ?

La taille maximal d’un `label` dans un nom de domaine est 63 caractères
(partie du domaine entre les points).
https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4