### PR TITLE
Evolutions mineures des imports SIAE et EA

### DIFF
--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -174,7 +174,7 @@ def check_convention_data_consistency():
         # Additional data consistency checks.
         for siae in convention.siaes.all():
             assert siae.siren == convention.siren_signature
-            if siae.kind == SiaeKind.ACIPHC and convention.kind == SiaeKind.KIND_ACI:
+            if siae.kind == SiaeKind.ACIPHC and convention.kind == SiaeKind.ACI:
                 assert siae.source == Siae.SOURCE_USER_CREATED
                 # Sometimes our staff manually changes an existing ACI antenna's kind from ACI to ACIPHC and forgets
                 # to detach the ACI convention.

--- a/itou/siaes/management/commands/_import_siae/utils.py
+++ b/itou/siaes/management/commands/_import_siae/utils.py
@@ -13,6 +13,7 @@ import pandas as pd
 from django.utils import timezone
 
 from itou.common_apps.address.models import AddressMixin
+from itou.job_applications.models import JobApplicationWorkflow
 from itou.siaes.models import Siae
 from itou.utils.apis.geocoding import GeocodingDataException, get_geocoding_data
 
@@ -125,7 +126,9 @@ def remap_columns(df, column_mapping):
 
 
 def could_siae_be_deleted(siae):
-    if siae.members.count() >= 1 or siae.job_applications_received.count() >= 1:
+    if siae.evaluated_siaes.exists():
+        return False
+    if siae.job_applications_received.exclude(state=JobApplicationWorkflow.STATE_NEW).exists():
         return False
     # An ASP siae can only be deleted when all its antennas have been deleted.
     if siae.source == Siae.SOURCE_ASP:

--- a/itou/siaes/management/commands/import_ea_eatt.py
+++ b/itou/siaes/management/commands/import_ea_eatt.py
@@ -69,6 +69,7 @@ def get_ea_eatt_df():
     # Replace NaN elements with None.
     df = df.replace({np.nan: None})
 
+    df = df[df.kind != "Entreprise Adaptée en Milieu Pénitentiaire"]
     df["kind"] = df.kind.apply(convert_kind)
 
     # Drop rows without siret.

--- a/itou/siaes/tests/tests_import_siae_command.py
+++ b/itou/siaes/tests/tests_import_siae_command.py
@@ -148,6 +148,18 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         )
         self.assertEqual((siae.source, siae.siret, siae.kind), (Siae.SOURCE_ASP, SIRET, SiaeKind.ACI))
 
+    def test_check_convention_data_consistency_aciphc_edge_case(self):
+        SIRET = "41294123900011"
+        user_created_siae = SiaeFactory(
+            siret=SIRET,
+            kind=SiaeKind.ACIPHC,
+            source=Siae.SOURCE_USER_CREATED,
+            convention__siret_signature=SIRET,
+            convention__kind=SiaeKind.ACI,
+        )
+        SiaeFactory(source=Siae.SOURCE_ASP, siret=SIRET, kind=SiaeKind.ACI, convention=user_created_siae.convention)
+        self.mod.check_convention_data_consistency()
+
     def test_check_signup_possible_for_a_siae_without_members_but_with_auth_email(self):
         instance = lazy_import_siae_command()
         SiaeFactory(auth_email="tadaaa")


### PR DESCRIPTION
### Quoi ?

- Fix TDD d'une typo dans le code de l'import SIAE.
- Fix import EA : on ignore le nouveau type exotique EAMP.
- Evolution de la règle qui autorise les imports SIAE/EA/GEIQ à supprimer automatiquement des structures
  - Règle plus sûre (ne jamais jamais supprimer une structure sous contrôle)
  - Règle plus aggressive (supprimer dorénavant les structures n'ayant que des candidatures à l'état nouveau, et peu importe s'il elles ont des membres)
  - Voir ci-dessous le avant/après : changement pas énorme mais tout de même

```
# Before
227 siaes past their grace period cannot be deleted
97 EA_EATT cannot be deleted as they have data.
# After
199 siaes past their grace period cannot be deleted
72 EA_EATT cannot be deleted as they have data
```

### Pourquoi ?

L'import ASP casse cette semaine sur les 2 premiers soucis.