### PR TITLE
Permettre la correction de l'adresse du candidat lors de la création de la fiche salariée

### DIFF
--- a/itou/utils/apis/geocoding.py
+++ b/itou/utils/apis/geocoding.py
@@ -28,8 +28,9 @@ def call_ban_geocoding_api(address, post_code=None, limit=1):
 
     try:
         r = httpx.get(url)
-    except httpx.RequestError as e:
-        logger.info("Error while fetching `%s`: %s", url, e)
+        r.raise_for_status()
+    except httpx.HTTPError as e:
+        logger.info("Error while requesting `%s`: %s", url, e)
         return None
 
     try:


### PR DESCRIPTION
### Quoi ?

Gérer les retours de l'appel à l'API de Géocoding

### Pourquoi ?

En cas d'anomalie lors du géocoding d'une adresse, le plantage de l'API fait planter nos processus métier au lieu de rendre la main à l'utilisateur pour lui permettre de corriger l'adresse.

Dans le cas de l'anomalie sentry traitée, le plantage empêche la création de la fiche salariée.

### Comment ?

Ajout de la gestion les codes 5xx dans la méthode `call_ban_geocoding_api`

ref https://www.python-httpx.org/exceptions/

remarque : partie de code mockée mais jamais testée ;)
