### PR TITLE
Exécute les tests avec Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9"]
     env:
       DJANGO_SETTINGS_MODULE: config.settings.test
       DJANGO_SECRET_KEY: ministryofsillywalks


### PR DESCRIPTION
### Quoi ?

Exécute les tests avec Python 3.9

### Pourquoi ?

L’environnement de production utilise Python 3.9, les tests sont plus pertinents s’ils utilisent la même version.