### PR TITLE
Accélère la base de données pour les tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,23 +23,22 @@ jobs:
       CELLAR_ADDON_KEY_ID: TheMeaningOfLife
       CELLAR_ADDON_KEY_SECRET: "42"
       CELLAR_ADDON_HOST: domain.com
-    services:
-      postgres:
-        # Docker Hub image
-        image: postgis/postgis:14-master
-        env:
-          POSTGRES_PASSWORD: password
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
     steps:
     - uses: actions/checkout@v3
+    - name: 💾 Start database
+      run: >-
+        docker run
+        --detach
+        --rm
+        --env POSTGRES_PASSWORD=password
+        --volume "${{ github.workspace }}/.github/workflows/postgres-test-settings.sh":/docker-entrypoint-initdb.d/postgres-test-settings.sh:ro
+        --publish 5432:5432
+        --health-cmd pg_isready
+        --health-interval 10s
+        --health-timeout 5s
+        --health-retries 5
+        postgis/postgis:14-master
     - name: 🌍 Install spatial libraries
       run: sudo apt-get update && sudo apt-get install binutils build-essential libproj-dev gdal-bin
     - name: 💾 Create a database to check migrations

--- a/.github/workflows/postgres-test-settings.sh
+++ b/.github/workflows/postgres-test-settings.sh
@@ -1,0 +1,12 @@
+echo <<EOF >>/var/lib/postgresql/data/postgresql.conf
+# Non-durable settings
+# https://www.postgresql.org/docs/current/non-durability.html
+fsync=off
+synchronous_commit=off
+full_pages_write=off
+max_wal_size=1GB
+checkpoint_timeout=1d
+EOF
+# Used by the pg_isready health check.
+createuser -s root
+createdb root


### PR DESCRIPTION
### Quoi ?

Accélère la base de données pour les tests

### Pourquoi ?

Un environnement de test n’a pas besoin d’une garantie de persistance, et ce changement devrait apporter une amélioration visible du temps d’exécution des tests.

https://www.postgresql.org/docs/current/non-durability.html

### Comment ?

Paramètre PostgreSQL de manière non durable, ce qui améliore nettement sa vitesse, au détriment de la durabilité des données (risque de perte plus important en cas d’arrêt brutal de la base, par exemple).