### PR TITLE
Limiter l'accès aux contract PHC à une liste définie d'ACIs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -565,6 +565,9 @@ PILOTAGE_DASHBOARDS_WHITELIST = json.loads(os.environ.get("PILOTAGE_DASHBOARDS_W
 # Some experimental stats are progressively being deployed to more and more specific beta users.
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.environ.get("STATS_SIAE_USER_PK_WHITELIST", "[]"))
 
+# Only ACIs given by Convergence France may access some contracts
+ACI_CONVERGENCE_PK_WHITELIST = json.loads(os.environ.get("ACI_CONVERGENCE_PK_WHITELIST", "[]"))
+
 PILOTAGE_SITE_URL = "https://pilotage.inclusion.beta.gouv.fr"
 PILOTAGE_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/aide/pilotage"
 

--- a/itou/www/siaes_views/forms.py
+++ b/itou/www/siaes_views/forms.py
@@ -302,7 +302,7 @@ class EditJobDescriptionForm(forms.ModelForm):
                 "",
                 "---------",
             )
-        ] + ContractType.choices_from_siae_kind(kind=current_siae.kind)
+        ] + ContractType.choices_for_siae(siae=current_siae)
 
     class Meta:
         model = SiaeJobDescription


### PR DESCRIPTION
### Quoi ?

Depuis 2 ans une expérimentation permet de faire un parcours préalablement à l’entrée dans un ACI. Il s’agit des dispositif Convergence et Premières Heures en Chantier. Il faut limiter la sélection de ce type de contrat uniquement à une liste d’ACI.

### Pourquoi ?


### Comment ?

Ajout d'une variable d'environnement pour définir la whitelist dans le code.

### Captures d'écran (optionnel)

### Autre (optionnel)
