### PR TITLE
Intégration de formulaires Tally (successeur de Typeform) sur les vues stats

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -531,33 +531,35 @@ METABASE_SITE_URL = "https://stats.inclusion.beta.gouv.fr"
 METABASE_SECRET_KEY = os.environ.get("METABASE_SECRET_KEY", "")
 
 # Metabase embedded dashboards
-METABASE_DASHBOARD_IDS = {
+METABASE_DASHBOARDS = {
     # Public stats.
-    "stats_public": 119,
+    "stats_public": {"dashboard_id": 119,},
     # Employer stats.
-    "stats_siae_etp": 128,
-    "stats_siae_hiring": 185,
+    "stats_siae_etp": {"dashboard_id": 128, "tally_form_id": "nrjbRv",},
+    "stats_siae_hiring": {"dashboard_id": 185, "tally_form_id": "waQPkB",},
     # Prescriber stats.
-    "stats_cd": 118,
-    "stats_pe_delay_main": 168,
-    "stats_pe_delay_raw": 180,
-    "stats_pe_conversion_main": 169,
-    "stats_pe_conversion_raw": 182,
-    "stats_pe_state_main": 149,
-    "stats_pe_state_raw": 183,
-    "stats_pe_tension": 162,
+    "stats_cd": {"dashboard_id": 118, "tally_form_id": "wb5Nro",},
+    "stats_pe_delay_main": {"dashboard_id": 168, "tally_form_id": "3lb9XW",},
+    "stats_pe_delay_raw": {"dashboard_id": 180,},
+    "stats_pe_conversion_main": {"dashboard_id": 169, "tally_form_id": "mODeK8",},
+    "stats_pe_conversion_raw": {"dashboard_id": 182,},
+    "stats_pe_state_main": {"dashboard_id": 149, "tally_form_id": "mRG61J",},
+    "stats_pe_state_raw": {"dashboard_id": 183,},
+    "stats_pe_tension": {"dashboard_id": 162, "tally_form_id": "wobaYV",},
     # Institution stats - DDETS - department level.
-    "stats_ddets_iae": 117,
-    "stats_ddets_diagnosis_control": 144,
-    "stats_ddets_hiring": 160,
+    "stats_ddets_iae": {"dashboard_id": 117, "tally_form_id": "nPdWLb",},
+    "stats_ddets_diagnosis_control": {"dashboard_id": 144,},
+    "stats_ddets_hiring": {"dashboard_id": 160, "tally_form_id": "mVLBXv",},
     # Institution stats - DREETS - region level.
-    "stats_dreets_iae": 117,
-    "stats_dreets_hiring": 160,
+    "stats_dreets_iae": {"dashboard_id": 117, "tally_form_id": "nPdWLb",},
+    "stats_dreets_hiring": {"dashboard_id": 160, "tally_form_id": "mVLBXv",},
     # Institution stats - DGEFP - nation level.
-    "stats_dgefp_iae": 117,
-    "stats_dgefp_diagnosis_control": 144,
-    "stats_dgefp_af": 142,
+    "stats_dgefp_iae": {"dashboard_id": 117,},
+    "stats_dgefp_diagnosis_control": {"dashboard_id": 144,},
+    "stats_dgefp_af": {"dashboard_id": 142,},
 }
+
+
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(os.environ.get("PILOTAGE_DASHBOARDS_WHITELIST", "[]"))
 
 # Some experimental stats are progressively being deployed to more and more specific beta users.
@@ -568,6 +570,9 @@ PILOTAGE_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/aide/pilota
 
 # Slack notifications sent by Metabase cronjobs.
 SLACK_CRON_WEBHOOK_URL = os.environ.get("SLACK_CRON_WEBHOOK_URL", None)
+
+# Embed tally forms on stats views.
+ENABLE_TALLY_FORMS = False
 
 # Huey / async
 # Workers are run in prod via `CC_WORKER_COMMAND = django-admin run_huey`.

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -33,6 +33,9 @@ sentry_init(dsn=os.environ["SENTRY_DSN_PROD"])
 
 ALLOW_POPULATING_METABASE = True
 
+# Embed tally forms on stats views.
+ENABLE_TALLY_FORMS = True
+
 # DRF Browseable API renderer is not available in production
 REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] = ["rest_framework.renderers.JSONRenderer"]  # noqa F405
 

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -90,4 +90,24 @@
             </div>
         </div>
     </section>
+
+    {% if enable_tally_form %}
+        <script async src="https://tally.so/widgets/embed.js"></script>
+
+        <script>
+            window.TallyConfig = {
+                "formId": "{{ tally_form_id }}",
+                "popup": {
+                    "emoji": {
+                        "text": "👋",
+                        "animation": "wave"
+                    },
+                    "open": {
+                        "trigger": "exit"
+                    }
+                }
+            };
+        </script>
+    {% endif %}
+
 {% endblock %}

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -19,6 +19,12 @@ def _get_token(payload):
     return jwt.encode(payload, settings.METABASE_SECRET_KEY, algorithm="HS256")
 
 
+def get_view_name(request):
+    full_view_name = request.resolver_match.view_name  # e.g. "stats:stats_public"
+    view_name = full_view_name.split(":")[-1]  # e.g. "stats_public"
+    return view_name
+
+
 def metabase_embedded_url(request=None, dashboard_id=None, params={}, with_title=False):
     """
     Creates an embed/signed URL for embedded Metabase dashboards:
@@ -28,9 +34,8 @@ def metabase_embedded_url(request=None, dashboard_id=None, params={}, with_title
     * optional parameters typically for locked filters (e.g. allow viewing data of one departement only)
     """
     if dashboard_id is None:
-        full_view_name = request.resolver_match.view_name  # e.g. "stats:stats_public"
-        view_name = full_view_name.split(":")[-1]  # e.g. "stats_public"
-        dashboard_id = settings.METABASE_DASHBOARD_IDS.get(view_name)
+        view_name = get_view_name(request)
+        dashboard_id = settings.METABASE_DASHBOARDS[view_name]["dashboard_id"]
 
     payload = {"resource": {"dashboard": dashboard_id}, "params": params, "exp": round(time.time()) + (10 * 60)}
     is_titled = "true" if with_title else "false"

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -32,6 +32,7 @@ from itou.utils.apis.metabase import (
     C1_SIAE_FILTER_KEY,
     DEPARTMENT_FILTER_KEY,
     REGION_FILTER_KEY,
+    get_view_name,
     metabase_embedded_url,
 )
 from itou.utils.perms.institution import get_current_institution_or_404
@@ -99,10 +100,18 @@ def get_params_for_whole_country():
 
 
 def render_stats(request, context, params={}, template_name="stats/stats.html"):
+    view_name = get_view_name(request)
+    tally_form_id = settings.METABASE_DASHBOARDS[view_name].get("tally_form_id")
+    enable_tally_form = settings.ENABLE_TALLY_FORMS and tally_form_id is not None
+
     base_context = {
         "iframeurl": metabase_embedded_url(request=request, params=params),
         "stats_base_url": settings.METABASE_SITE_URL,
+        "enable_tally_form": enable_tally_form,
     }
+
+    if enable_tally_form:
+        base_context["tally_form_id"] = tally_form_id
 
     # Key value pairs in context override preexisting pairs in base_context.
     base_context.update(context)

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -102,7 +102,7 @@ def get_params_for_whole_country():
 def render_stats(request, context, params={}, template_name="stats/stats.html"):
     view_name = get_view_name(request)
     tally_form_id = settings.METABASE_DASHBOARDS[view_name].get("tally_form_id")
-    enable_tally_form = settings.ENABLE_TALLY_FORMS and tally_form_id is not None
+    enable_tally_form = settings.ENABLE_TALLY_FORMS and tally_form_id
 
     base_context = {
         "iframeurl": metabase_embedded_url(request=request, params=params),


### PR DESCRIPTION
### Quoi ?

Intégration de formulaires Tally (successeur de Typeform) sur les vues stats.

### Pourquoi ?

Annie souhaite mesurer la satisfaction utilisateur sur chaque vue stat et a préparé un formulaire spécifique pour chaque vue.

### En images

![image](https://user-images.githubusercontent.com/10533583/189351702-cbd9c0ff-225f-4694-bca1-5f086c53a130.png)
