### PR TITLE
Nettoyage des fiches salarié sans PASS IAE

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -97,6 +97,9 @@ class EmployeeRecordQuerySet(models.QuerySet):
     def disabled_for_siae(self, siae):
         return self.disabled().filter(job_application__to_siae=siae).select_related("job_application")
 
+    def archived(self):
+        return self.filter(status=Status.ARCHIVED)
+
     # Search queries
 
     def find_by_batch(self, filename, line_number):

--- a/itou/employee_record/tests/tests_management_commands.py
+++ b/itou/employee_record/tests/tests_management_commands.py
@@ -293,3 +293,16 @@ class SanitizeManagementCommandTest(ManagementCommandTestCase):
 
         self.assertIn(" - fixing missing jobseeker profiles: switching status to DISABLED", out)
         self.assertIn(" - done!", out)
+
+    def test_missing_approvals(self):
+        # Check for employee record without approval (through job application)
+
+        employee_record = EmployeeRecordFactory()
+        employee_record.job_application.approval = None
+        employee_record.job_application.save()
+
+        out, _ = self.call_command()
+
+        self.assertEqual(0, EmployeeRecord.objects.filter(job_application__approval__isnull=True).count())
+        self.assertIn(" - fixing missing approvals: DELETING employee records", out)
+        self.assertIn(" - done!", out)


### PR DESCRIPTION
### Quoi ?

Modification de la management command `sanitize_employee_records` avec l'ajout de la vérification des fiches salarié sans PASS IAE associé.

### Pourquoi ?

Au fil du temps, certaines candidatures voient le PASS IAE qui leur est associé être supprimé (pour différentes raisons).

Il n'y a pas de contrainte ou liaison en DB directe entre une fiche salarié et son PASS IAE (ça passe par la candidature).

Si aucun PASS IAE n'est présent, l'API ne peut pas afficher les fiches en question (source d'erreur Sentry).

### Comment ?

**SUPPRESSION** des fiches salarié sans PASS IAE associé.
Il n'y a aucun intérêt à garder des fiches dont le PASS IAE n'existe plus (incohérent).
