### PR TITLE
Utiliser Inclusion Connect en tant qu'employeur

### DIFF
--- a/itou/invitations/models.py
+++ b/itou/invitations/models.py
@@ -8,7 +8,7 @@ from django.shortcuts import get_object_or_404, reverse
 from django.utils import timezone
 from django.utils.http import urlencode
 
-from itou.users.enums import KIND_JOB_SEEKER, KIND_LABOR_INSPECTOR, KIND_PRESCRIBER, KIND_SIAE_STAFF
+from itou.users.enums import KIND_LABOR_INSPECTOR, KIND_PRESCRIBER, KIND_SIAE_STAFF
 from itou.users.models import User
 from itou.utils.emails import get_email_message
 from itou.utils.urls import get_absolute_url
@@ -38,18 +38,6 @@ class InvitationAbstract(models.Model):
     # reverse(f"login:{account_type}")
     SIGNIN_ACCOUNT_TYPE = ""
     EXPIRATION_DAYS = 14
-    GUEST_TYPE_JOB_SEEKER = KIND_JOB_SEEKER
-    GUEST_TYPE_PRESCRIBER = KIND_PRESCRIBER
-    GUEST_TYPE_PRESCRIBER_WITH_ORG = KIND_PRESCRIBER
-    GUEST_TYPE_SIAE_STAFF = KIND_SIAE_STAFF
-    GUEST_TYPE_LABOR_INSPECTOR = KIND_LABOR_INSPECTOR
-    GUEST_TYPES = [
-        (GUEST_TYPE_JOB_SEEKER, "Candidat"),
-        (GUEST_TYPE_PRESCRIBER, "Prescripteur sans organisation"),
-        (GUEST_TYPE_PRESCRIBER_WITH_ORG, "Prescripteur membre d'une organisation"),
-        (GUEST_TYPE_SIAE_STAFF, "Employeur"),
-        (GUEST_TYPE_LABOR_INSPECTOR, "Inspecteur du travail (DGEFP, DDETS, DREETS)"),
-    ]
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     email = models.EmailField(verbose_name="E-mail")
@@ -76,11 +64,11 @@ class InvitationAbstract(models.Model):
         invitation_model = Invitation.get_model_from_string("siae_staff")
         invitation_model.objects.count()
         """
-        if model_string == cls.GUEST_TYPE_SIAE_STAFF:
+        if model_string == KIND_SIAE_STAFF:
             return SiaeStaffInvitation
-        elif model_string == cls.GUEST_TYPE_PRESCRIBER_WITH_ORG:
+        elif model_string == KIND_PRESCRIBER:
             return PrescriberWithOrgInvitation
-        elif model_string == cls.GUEST_TYPE_LABOR_INSPECTOR:
+        elif model_string == KIND_LABOR_INSPECTOR:
             return LaborInspectorInvitation
         raise TypeError
 
@@ -163,7 +151,7 @@ class PrescriberWithOrgInvitation(InvitationAbstract):
     @property
     def acceptance_link(self):
         kwargs = {"invitation_id": self.pk}
-        signup_kwargs = {"invitation_type": self.GUEST_TYPE_PRESCRIBER_WITH_ORG, **kwargs}
+        signup_kwargs = {"invitation_type": KIND_PRESCRIBER, **kwargs}
         args = {"redirect_to": reverse("invitations_views:join_prescriber_organization", kwargs=kwargs)}
         acceptance_path = "{}?{}".format(
             reverse("invitations_views:new_user", kwargs=signup_kwargs), urlencode(args, True)
@@ -237,7 +225,7 @@ class SiaeStaffInvitation(InvitationAbstract):
     @property
     def acceptance_link(self):
         kwargs = {"invitation_id": self.pk}
-        signup_kwargs = {"invitation_type": self.GUEST_TYPE_SIAE_STAFF, **kwargs}
+        signup_kwargs = {"invitation_type": KIND_SIAE_STAFF, **kwargs}
         args = {"redirect_to": reverse("invitations_views:join_siae", kwargs=kwargs)}
         acceptance_path = "{}?{}".format(
             reverse("invitations_views:new_user", kwargs=signup_kwargs), urlencode(args, True)
@@ -312,8 +300,8 @@ class LaborInspectorInvitation(InvitationAbstract):
 
     @property
     def acceptance_link(self):
-        kwargs = {"invitation_id": self.pk, "invitation_type": self.GUEST_TYPE_LABOR_INSPECTOR}
-        signup_kwargs = {"invitation_type": self.GUEST_TYPE_LABOR_INSPECTOR, **kwargs}
+        kwargs = {"invitation_id": self.pk}
+        signup_kwargs = {"invitation_type": KIND_LABOR_INSPECTOR, **kwargs}
         args = {"redirect_to": reverse("invitations_views:join_institution", kwargs=kwargs)}
         acceptance_path = "{}?{}".format(
             reverse("invitations_views:new_user", kwargs=signup_kwargs), urlencode(args, True)

--- a/itou/openid_connect/inclusion_connect/models.py
+++ b/itou/openid_connect/inclusion_connect/models.py
@@ -11,6 +11,12 @@ class InclusionConnectState(OIDConnectState):
 
 
 @dataclasses.dataclass
-class InclusionConnectUserData(OIDConnectUserData):
+class InclusionConnectPrescriberData(OIDConnectUserData):
     is_prescriber: bool = True
+    identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
+
+
+@dataclasses.dataclass
+class InclusionConnectSiaeStaffData(OIDConnectUserData):
+    is_siae_staff: bool = True
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -350,7 +350,7 @@ class Siae(AddressMixin, OrganizationAbstract):
     @property
     def signup_magic_link(self):
         return reverse(
-            "signup:siae", kwargs={"encoded_siae_id": self.get_encoded_siae_id(), "token": self.get_token()}
+            "signup:siae_user", kwargs={"encoded_siae_id": self.get_encoded_siae_id(), "token": self.get_token()}
         )
 
     def get_encoded_siae_id(self):

--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -12,15 +12,17 @@
     <div class="py-5 py-lg-7">
         <h1 class="h1-hero-c1 text-center">Se connecter</h1>
 
-        {% if inclusion_connect_url %}
-            <p class="text-center mb-1">
-                Se connecter avec
-            </p>
-            {% include "inclusion_connect/includes/button.html" with authentication_type=account_type_display_name %}
+        {% if uses_inclusion_connect %}
+            {% if inclusion_connect_url %}
+                <p class="text-center mb-1">
+                    Se connecter avec
+                </p>
+                {% include "inclusion_connect/includes/button.html" with authentication_type=account_type_display_name %}
 
-            <hr class="my-5" data-text="ou">
-        {% else %}
-            <p class="font-italic text-center mt-3">Inclusion Connect est momentanément désactivé.</p>
+                <hr class="my-5" data-text="ou">
+            {% else %}
+                <p class="font-italic text-center mt-3">Inclusion Connect est momentanément désactivé.</p>
+            {% endif %}
         {% endif %}
 
         <form method="post" action="{{ login_url }}" class="js-prevent-multiple-submit">

--- a/itou/templates/invitations_views/new_ic_user.html
+++ b/itou/templates/invitations_views/new_ic_user.html
@@ -7,7 +7,7 @@
 
     <h1 class="h1-hero-c1">Bienvenue {{ invitation.first_name }} {{ invitation.last_name }} !</h1>
     <div class="">
-        Vous allez rejoindre le tableau de bord de <span class="font-weight-bold">{{ invitation.organization.name }}</span>
+        Vous allez rejoindre le tableau de bord de <span class="font-weight-bold">{{ invitation.organization.name }}{{ invitation.siae.display_name }}</span>
     </div>
 
     {% include "inclusion_connect/includes/description.html" %}

--- a/itou/templates/signup/siae_user.html
+++ b/itou/templates/signup/siae_user.html
@@ -1,0 +1,28 @@
+{% extends "layout/content_small.html" %}
+{% load bootstrap4 %}
+{% load format_filters %}
+
+{% block title %}Employeur solidaire - Inscription{{ block.super }}{% endblock %}
+
+{% block content %}
+
+    <h1 class="h1-hero-c1">
+        Inscription
+        <small class="text-muted">Employeur solidaire</small>
+    </h1>
+
+    <div class="alert alert-emploi">
+        <p class="lead mb-0">
+            Vous allez rejoindre <b>{{ siae.display_name }}</b>
+        </p>
+        <p class="mb-0">
+            {{ siae.siret|format_siret }} - {{ siae.kind }} {{ siae.get_kind_display }}<br>
+            {% if siae.address_line_1 %}{{ siae.address_line_1 }}<br>{% endif %}
+            {% if siae.address_line_2 %}{{ siae.address_line_2 }}<br>{% endif %}
+            {{ siae.post_code }} {{ siae.city }}
+        </p>
+    </div>
+
+    {% include "inclusion_connect/includes/description.html" %}
+
+{% endblock %}

--- a/itou/users/enums.py
+++ b/itou/users/enums.py
@@ -11,6 +11,14 @@ KIND_SIAE_STAFF = "siae_staff"
 KIND_LABOR_INSPECTOR = "labor_inspector"
 
 
+# TODO(alaurent) Replace all uses of KIND_XXX with this new enum
+class Kind(models.TextChoices):
+    JOB_SEEKER = KIND_JOB_SEEKER, "candidat"
+    PRESCREIBER = KIND_PRESCRIBER, "prescripteur"
+    SIAE_STAFF = KIND_SIAE_STAFF, "employeur"
+    LABOR_INSPECTOR = KIND_LABOR_INSPECTOR, "inspecteur du travail"
+
+
 class Title(models.TextChoices):
     M = "M", "Monsieur"
     MME = "MME", "Madame"

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -36,7 +36,7 @@ from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae
 from itou.utils.validators import validate_birthdate, validate_nir, validate_pole_emploi_id
 
-from .enums import IdentityProvider, Title
+from .enums import IdentityProvider, Kind, Title
 
 
 class ApprovalAlreadyExistsError(Exception):
@@ -855,6 +855,23 @@ class User(AbstractUser, AddressMixin):
             # Take advantage of the fact that `cleaned_data` is passed by sharing:
             # the object is shared between the caller and the called routine.
             cleaned_data["lack_of_pole_emploi_id_reason"] = ""
+
+    # TODO(alaurent) Maybe replace with a field in db
+    @property
+    def kind(self):
+        if self.is_job_seeker:
+            return Kind.JOB_SEEKER
+        elif self.is_prescriber:
+            return Kind.PRESCREIBER
+        elif self.is_siae_staff:
+            return Kind.SIAE_STAFF
+        elif self.is_labor_inspector:
+            return Kind.LABOR_INSPECTOR
+        else:
+            raise ValueError("User has no valid kind")
+
+    def get_kind_display(self):
+        return self.kind.label
 
 
 def get_allauth_account_user_display(user):

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -28,7 +28,14 @@ from itou.prescribers.factories import (
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import SiaeFactory
 from itou.users.enums import IdentityProvider, Title
-from itou.users.factories import JobSeekerFactory, JobSeekerProfileFactory, PrescriberFactory, UserFactory
+from itou.users.factories import (
+    JobSeekerFactory,
+    JobSeekerProfileFactory,
+    LaborInspectorFactory,
+    PrescriberFactory,
+    SiaeStaffFactory,
+    UserFactory,
+)
 from itou.users.models import User
 from itou.utils.mocks.address_format import BAN_GEOCODING_API_RESULTS_MOCK, RESULTS_BY_ADDRESS
 
@@ -732,6 +739,32 @@ class ModelTest(TestCase):
             for fields in itertools.combinations(unique_fields, n):
                 with self.assertRaises(ValidationError):
                     UserFactory(**dict(zip(fields, itertools.repeat(True))))
+
+    def test_kind(self):
+        job_seeker = JobSeekerFactory()
+        self.assertEqual("job_seeker", job_seeker.kind)
+
+        prescriber = PrescriberFactory()
+        self.assertEqual("prescriber", prescriber.kind)
+
+        siae_staff = SiaeStaffFactory()
+        self.assertEqual("siae_staff", siae_staff.kind)
+
+        labor_inspector = LaborInspectorFactory()
+        self.assertEqual("labor_inspector", labor_inspector.kind)
+
+    def test_get_kind_display(self):
+        job_seeker = JobSeekerFactory()
+        self.assertEqual("candidat", job_seeker.get_kind_display())
+
+        prescriber = PrescriberFactory()
+        self.assertEqual("prescripteur", prescriber.get_kind_display())
+
+        siae_staff = SiaeStaffFactory()
+        self.assertEqual("employeur", siae_staff.get_kind_display())
+
+        labor_inspector = LaborInspectorFactory()
+        self.assertEqual("inspecteur du travail", labor_inspector.get_kind_display())
 
 
 def mock_get_geocoding_data(address, post_code=None, limit=1):

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -28,10 +28,12 @@ class ItouCurrentOrganizationMiddleware:
         # but he does not belong to any group.
         # This raises an error so we skip the middleware only in this case.
         login_routes = [reverse(f"login:{url.name}") for url in login_urls.urlpatterns] + [reverse("account_login")]
-        skip_middleware = request.path in [reverse("account_logout"), *login_routes] or (
-            request.path.startswith("/invitations/") and not request.path.startswith("/invitations/invite")
-        )
-        if skip_middleware:
+        skip_middleware_conditions = [
+            request.path in [reverse("account_logout"), *login_routes],
+            request.path.startswith("/invitations/") and not request.path.startswith("/invitations/invite"),
+            request.path.startswith("/signup/siae/join"),  # siae staff about to join an siae
+        ]
+        if any(skip_middleware_conditions):
             return self.get_response(request)
 
         if user.is_authenticated:

--- a/itou/www/invitations_views/forms.py
+++ b/itou/www/invitations_views/forms.py
@@ -269,11 +269,6 @@ class NewUserInvitationForm(SignupForm):
         self.fields["first_name"].initial = invitation.first_name
         self.fields["last_name"].initial = invitation.last_name
 
-    def clean(self):
-        if isinstance(self.invitation, SiaeStaffInvitation) and not self.invitation.siae.is_active:
-            raise forms.ValidationError("La structure que vous souhaitez rejoindre n'est plus active.")
-        super().clean()
-
     def save(self, request):
         self.cleaned_data["email"] = self.email
         # Avoid django-allauth to call its own often failing `generate_unique_username`

--- a/itou/www/invitations_views/tests/tests_prescriber_organization.py
+++ b/itou/www/invitations_views/tests/tests_prescriber_organization.py
@@ -236,6 +236,7 @@ class TestAcceptPrescriberWithOrgInvitation(TestCase):
         # Singup fails on Inclusion Connect with email different than the one from the invitation
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             login_hint=invitation.email,
             channel="invitation",
@@ -256,6 +257,7 @@ class TestAcceptPrescriberWithOrgInvitation(TestCase):
         invitation.save()
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             login_hint=invitation.email,
             channel="invitation",
@@ -326,6 +328,7 @@ class TestAcceptPrescriberWithOrgInvitation(TestCase):
 
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             login_hint=user.email,
             channel="invitation",

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -72,9 +72,9 @@ class TestAcceptInvitation(TestCase):
             next_url=next_url,
         )
         response = self.client.get(response.url, follow=True)
-        # Check user is redirected to the dashboard
+        # Check user is redirected to the welcoming tour
         last_url, _status_code = response.redirect_chain[-1]
-        self.assertEqual(last_url, reverse("dashboard:index"))
+        self.assertEqual(last_url, reverse("welcoming_tour:index"))
 
         total_users_after = User.objects.count()
         self.assertEqual((total_users_before + 1), total_users_after)
@@ -184,7 +184,7 @@ class TestAcceptInvitation(TestCase):
         )
         self.client.login(email=user.email, password=DEFAULT_PASSWORD)
         response = self.client.get(invitation.acceptance_link, follow=True)
-        self.assertRedirects(response, reverse("dashboard:index"))
+        self.assertRedirects(response, reverse("welcoming_tour:index"))
 
         current_siae = get_current_siae_or_404(response.wsgi_request)
         self.assertEqual(siae.pk, current_siae.pk)

--- a/itou/www/invitations_views/urls.py
+++ b/itou/www/invitations_views/urls.py
@@ -11,9 +11,7 @@ urlpatterns = [
     path("invite_prescriber_with_org", views.invite_prescriber_with_org, name="invite_prescriber_with_org"),
     path("invite_siae_staff", views.invite_siae_staff, name="invite_siae_staff"),
     path("<str:invitation_type>/<uuid:invitation_id>/new_user", views.new_user, name="new_user"),
-    path(
-        "<str:invitation_type>/<uuid:invitation_id>/join_institution", views.join_institution, name="join_institution"
-    ),
+    path("<uuid:invitation_id>/join_institution", views.join_institution, name="join_institution"),
     path(
         "<uuid:invitation_id>/join_prescriber_organization",
         views.join_prescriber_organization,

--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -240,7 +240,8 @@ def join_siae(request, invitation_id):
         messages.error(request, "Cette invitation n'est plus valide.")
 
     request.session[settings.ITOU_SESSION_CURRENT_SIAE_KEY] = invitation.siae.pk
-    return redirect("dashboard:index")
+    url = get_adapter(request).get_login_redirect_url(request)
+    return HttpResponseRedirect(url)
 
 
 @login_required

--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -10,7 +10,12 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render, reverse
 from django.utils import formats, safestring
 
-from itou.invitations.models import InvitationAbstract, PrescriberWithOrgInvitation, SiaeStaffInvitation
+from itou.invitations.models import (
+    InvitationAbstract,
+    LaborInspectorInvitation,
+    PrescriberWithOrgInvitation,
+    SiaeStaffInvitation,
+)
 from itou.openid_connect.inclusion_connect.enums import InclusionConnectChannel
 from itou.users.enums import KIND_LABOR_INSPECTOR, KIND_PRESCRIBER, KIND_SIAE_STAFF
 from itou.users.models import User
@@ -286,9 +291,8 @@ def invite_labor_inspector(request, template_name="invitations_views/create.html
 
 
 @login_required
-def join_institution(request, invitation_type, invitation_id):
-    invitation_type = InvitationAbstract.get_model_from_string(invitation_type)
-    invitation = get_object_or_404(invitation_type, pk=invitation_id)
+def join_institution(request, invitation_id):
+    invitation = get_object_or_404(LaborInspectorInvitation, pk=invitation_id)
     if not invitation.guest_can_join_institution(request):
         raise PermissionDenied()
 

--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -6,6 +6,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
+from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render, reverse
 from django.utils import formats, safestring
 
@@ -170,7 +171,8 @@ def join_prescriber_organization(request, invitation_id):
         messages.error(request, "Cette invitation n'est plus valide.")
 
     request.session[settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY] = invitation.organization.pk
-    return redirect("dashboard:index")
+    url = get_adapter(request).get_login_redirect_url(request)
+    return HttpResponseRedirect(url)
 
 
 @login_required

--- a/itou/www/login/forms.py
+++ b/itou/www/login/forms.py
@@ -1,6 +1,8 @@
 from allauth.account.forms import LoginForm
 from django import forms
 
+from itou.users.models import User
+
 
 class ItouLoginForm(LoginForm):
     def __init__(self, *args, **kwargs):
@@ -11,9 +13,9 @@ class ItouLoginForm(LoginForm):
 
     def clean(self):
         # Parent method performs authentication on form success.
-        super().clean()
-        if self.user and self.user.has_sso_provider:
-            identity_provider = self.user.get_identity_provider_display()
+        user = User.objects.filter(email=self.data["login"]).first()
+        if user and user.has_sso_provider:
+            identity_provider = user.get_identity_provider_display()
             error_message = f"Votre compte est relié à {identity_provider}. Merci de vous connecter avec ce service."
             raise forms.ValidationError(error_message)
-        return self.cleaned_data
+        return super().clean()

--- a/itou/www/login/tests.py
+++ b/itou/www/login/tests.py
@@ -95,11 +95,12 @@ class SiaeStaffLoginTest(TestCase):
         url = reverse("login:siae_staff")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "S'identifier avec Inclusion Connect")
+        self.assertContains(response, "S'identifier avec Inclusion Connect")
+        self.assertContains(response, reverse("inclusion_connect:authorize"))
         self.assertContains(response, "Adresse e-mail")
         self.assertContains(response, "Mot de passe")
 
-    def test_login(self):
+    def test_login_using_django(self):
         user = SiaeStaffFactory()
         url = reverse("login:siae_staff")
         response = self.client.get(url)
@@ -111,6 +112,22 @@ class SiaeStaffLoginTest(TestCase):
         }
         response = self.client.post(url, data=form_data)
         self.assertRedirects(response, reverse("account_email_verification_sent"))
+
+    def test_login_using_django_but_has_sso_provider(self):
+        user = SiaeStaffFactory(identity_provider=users_enums.IdentityProvider.INCLUSION_CONNECT)
+        url = reverse("login:siae_staff")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        form_data = {
+            "login": user.email,
+            "password": DEFAULT_PASSWORD,
+        }
+        response = self.client.post(url, data=form_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "Votre compte est relié à Inclusion Connect. Merci de vous connecter avec ce service."
+        )
 
 
 class LaborInspectorLoginTest(TestCase):

--- a/itou/www/login/tests.py
+++ b/itou/www/login/tests.py
@@ -81,7 +81,7 @@ class PrescriberLoginTest(TestCase):
 
         form_data = {
             "login": user.email,
-            "password": DEFAULT_PASSWORD,
+            "password": "a",
         }
         response = self.client.post(url, data=form_data)
         self.assertEqual(response.status_code, 200)
@@ -121,7 +121,7 @@ class SiaeStaffLoginTest(TestCase):
 
         form_data = {
             "login": user.email,
-            "password": DEFAULT_PASSWORD,
+            "password": "a",
         }
         response = self.client.post(url, data=form_data)
         self.assertEqual(response.status_code, 200)

--- a/itou/www/login/tests.py
+++ b/itou/www/login/tests.py
@@ -91,6 +91,14 @@ class PrescriberLoginTest(TestCase):
 
 
 class SiaeStaffLoginTest(TestCase):
+    def test_login_options(self):
+        url = reverse("login:siae_staff")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "S'identifier avec Inclusion Connect")
+        self.assertContains(response, "Adresse e-mail")
+        self.assertContains(response, "Mot de passe")
+
     def test_login(self):
         user = SiaeStaffFactory()
         url = reverse("login:siae_staff")
@@ -106,6 +114,14 @@ class SiaeStaffLoginTest(TestCase):
 
 
 class LaborInspectorLoginTest(TestCase):
+    def test_login_options(self):
+        url = reverse("login:labor_inspector")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "S'identifier avec Inclusion Connect")
+        self.assertContains(response, "Adresse e-mail")
+        self.assertContains(response, "Mot de passe")
+
     def test_login(self):
         user = LaborInspectorFactory()
         url = reverse("login:labor_inspector")

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -58,6 +58,7 @@ class PrescriberLoginView(ItouLoginView):
             "login_url": reverse("login:prescriber"),
             "signup_url": reverse("signup:prescriber_check_already_exists"),
             "signup_allowed": True,
+            "uses_inclusion_connect": True,
             "inclusion_connect_url": inclusion_connect_url,
         }
         return context | extra_context

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.urls import reverse
 from django.utils.http import urlencode
 
-from itou.users.enums import KIND_PRESCRIBER
+from itou.users.enums import KIND_PRESCRIBER, KIND_SIAE_STAFF
 from itou.utils.urls import get_safe_url
 from itou.www.login.forms import ItouLoginForm
 
@@ -69,11 +69,25 @@ class SiaeStaffLoginView(ItouLoginView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        params = {
+            "user_kind": KIND_SIAE_STAFF,
+            "previous_url": self.request.get_full_path(),
+        }
+        next_url = get_safe_url(self.request, "next")
+        if next_url:
+            params["next_url"] = next_url
+        inclusion_connect_url = (
+            f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
+            if settings.INCLUSION_CONNECT_BASE_URL
+            else None
+        )
         extra_context = {
             "account_type_display_name": "employeur solidaire",
             "login_url": reverse("login:siae_staff"),
             "signup_url": reverse("signup:siae_select"),
             "signup_allowed": True,
+            "uses_inclusion_connect": True,
+            "inclusion_connect_url": inclusion_connect_url,
         }
         return context | extra_context
 

--- a/itou/www/signup/tests/test_prescriber.py
+++ b/itou/www/signup/tests/test_prescriber.py
@@ -91,26 +91,22 @@ class PrescriberSignupTest(TestCase):
         self.assertContains(response, url + '"')
 
         # Connect with Inclusion Connect.
-        # Skip the welcoming tour to test dashboard content.
-        url = reverse("dashboard:index")
-        with mock.patch("itou.users.adapter.UserAdapter.get_login_redirect_url", return_value=url):
-            response = mock_oauth_dance(
-                self,
-                assert_redirects=False,
-                login_hint=email,
-                channel="pole_emploi",
-                user_info_email=email,
-                previous_url=previous_url,
-                next_url=next_url,
-            )
-            # Follow the redirection.
-            response = self.client.get(response.url, follow=True)
-
-        # Response should contain links available only to prescribers.
-        self.assertContains(response, reverse("apply:list_for_prescriber"))
+        response = mock_oauth_dance(
+            self,
+            assert_redirects=False,
+            login_hint=email,
+            channel="pole_emploi",
+            user_info_email=email,
+            previous_url=previous_url,
+            next_url=next_url,
+        )
+        # Follow the redirection.
+        response = self.client.get(response.url, follow=True)
+        self.assertTemplateUsed(response, "welcoming_tour/prescriber.html")
 
         # Organization
         self.assertEqual(self.client.session.get(settings.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY), organization.pk)
+        response = self.client.get(reverse("dashboard:index"))
         self.assertContains(response, f"Code SAFIR {organization.code_safir_pole_emploi}")
 
         user = User.objects.get(email=email)
@@ -175,19 +171,15 @@ class PrescriberSignupTest(TestCase):
         url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
         self.assertContains(response, url + '"')
 
-        url = reverse("dashboard:index")
-        with mock.patch("itou.users.adapter.UserAdapter.get_login_redirect_url", return_value=url):
-            response = mock_oauth_dance(
-                self,
-                assert_redirects=False,
-                previous_url=previous_url,
-                next_url=next_url,
-            )
-            # Follow the redirection.
-            response = self.client.get(response.url, follow=True)
-
-        # Response should contain links available only to prescribers.
-        self.assertContains(response, reverse("apply:list_for_prescriber"))
+        response = mock_oauth_dance(
+            self,
+            assert_redirects=False,
+            previous_url=previous_url,
+            next_url=next_url,
+        )
+        # Follow the redirection.
+        response = self.client.get(response.url, follow=True)
+        self.assertTemplateUsed(response, "welcoming_tour/prescriber.html")
 
         # Check `User` state.
         user = User.objects.get(email=OIDC_USERINFO["email"])
@@ -270,20 +262,16 @@ class PrescriberSignupTest(TestCase):
         url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
         self.assertContains(response, url + '"')
 
-        url = reverse("dashboard:index")
-        with mock.patch("itou.users.adapter.UserAdapter.get_login_redirect_url", return_value=url):
-            previous_url = reverse("signup:prescriber_user")
-            response = mock_oauth_dance(
-                self,
-                assert_redirects=False,
-                previous_url=previous_url,
-                next_url=next_url,
-            )
-            # Follow the redirection.
-            response = self.client.get(response.url, follow=True)
-
-        # Response should contain links available only to prescribers.
-        self.assertContains(response, reverse("apply:list_for_prescriber"))
+        previous_url = reverse("signup:prescriber_user")
+        response = mock_oauth_dance(
+            self,
+            assert_redirects=False,
+            previous_url=previous_url,
+            next_url=next_url,
+        )
+        # Follow the redirection.
+        response = self.client.get(response.url, follow=True)
+        self.assertTemplateUsed(response, "welcoming_tour/prescriber.html")
 
         # Check `User` state.
         user = User.objects.get(email=OIDC_USERINFO["email"])
@@ -363,19 +351,15 @@ class PrescriberSignupTest(TestCase):
         url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
         self.assertContains(response, url + '"')
 
-        url = reverse("dashboard:index")
-        with mock.patch("itou.users.adapter.UserAdapter.get_login_redirect_url", return_value=url):
-            response = mock_oauth_dance(
-                self,
-                assert_redirects=False,
-                previous_url=previous_url,
-                next_url=next_url,
-            )
-            # Follow the redirection.
-            response = self.client.get(response.url, follow=True)
-
-        # Response should contain links available only to prescribers.
-        self.assertContains(response, reverse("apply:list_for_prescriber"))
+        response = mock_oauth_dance(
+            self,
+            assert_redirects=False,
+            previous_url=previous_url,
+            next_url=next_url,
+        )
+        # Follow the redirection.
+        response = self.client.get(response.url, follow=True)
+        self.assertTemplateUsed(response, "welcoming_tour/prescriber.html")
 
         # Check `User` state.
         user = User.objects.get(email=OIDC_USERINFO["email"])
@@ -510,18 +494,14 @@ class PrescriberSignupTest(TestCase):
         url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
         self.assertContains(response, url + '"')
 
-        url = reverse("dashboard:index")
-        with mock.patch("itou.users.adapter.UserAdapter.get_login_redirect_url", return_value=url):
-            response = mock_oauth_dance(
-                self,
-                assert_redirects=False,
-                previous_url=previous_url,
-            )
-            # Follow the redirection.
-            response = self.client.get(response.url, follow=True)
-
-        # Response should contain links available only to prescribers.
-        self.assertContains(response, reverse("apply:list_for_prescriber"))
+        response = mock_oauth_dance(
+            self,
+            assert_redirects=False,
+            previous_url=previous_url,
+        )
+        # Follow the redirection.
+        response = self.client.get(response.url, follow=True)
+        self.assertTemplateUsed(response, "welcoming_tour/prescriber.html")
 
         # Check `User` state.
         user = User.objects.get(email=OIDC_USERINFO["email"])
@@ -593,16 +573,15 @@ class PrescriberSignupTest(TestCase):
         url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
         self.assertContains(response, url + '"')
 
-        url = reverse("dashboard:index")
-        with mock.patch("itou.users.adapter.UserAdapter.get_login_redirect_url", return_value=url):
-            response = mock_oauth_dance(
-                self,
-                assert_redirects=False,
-                previous_url=previous_url,
-                next_url=next_url,
-            )
-            # Follow the redirection.
-            response = self.client.get(response.url, follow=True)
+        response = mock_oauth_dance(
+            self,
+            assert_redirects=False,
+            previous_url=previous_url,
+            next_url=next_url,
+        )
+        # Follow the redirection.
+        response = self.client.get(response.url, follow=True)
+        self.assertTemplateUsed(response, "welcoming_tour/prescriber.html")
 
         # Check new org is OK.
         same_siret_orgs = PrescriberOrganization.objects.filter(siret=siret).order_by("kind").all()
@@ -701,18 +680,14 @@ class PrescriberSignupTest(TestCase):
         self.assertContains(response, url + '"')
 
         # Connect with Inclusion Connect.
-        # Skip the welcoming tour to test dashboard content.
-        url = reverse("dashboard:index")
-        with mock.patch("itou.users.adapter.UserAdapter.get_login_redirect_url", return_value=url):
-            response = mock_oauth_dance(
-                self,
-                assert_redirects=False,
-                previous_url=previous_url,
-            )
-            # Follow the redirection.
-            response = self.client.get(response.url, follow=True)
-
-        self.assertContains(response, reverse("apply:list_for_prescriber"))
+        response = mock_oauth_dance(
+            self,
+            assert_redirects=False,
+            previous_url=previous_url,
+        )
+        # Follow the redirection.
+        response = self.client.get(response.url, follow=True)
+        self.assertTemplateUsed(response, "welcoming_tour/prescriber.html")
 
         user = User.objects.get(email=OIDC_USERINFO["email"])
         self.assertTrue(user.has_sso_provider)
@@ -773,19 +748,15 @@ class PrescriberSignupTest(TestCase):
         self.assertContains(response, url + '"')
 
         # Connect with Inclusion Connect.
-        url = reverse("dashboard:index")
-        with mock.patch("itou.users.adapter.UserAdapter.get_login_redirect_url", return_value=url):
-            response = mock_oauth_dance(
-                self,
-                assert_redirects=False,
-                previous_url=previous_url,
-                next_url=next_url,
-            )
-            # Follow the redirection.
-            response = self.client.get(response.url, follow=True)
-
-        # Response should contain links available only to prescribers.
-        self.assertContains(response, reverse("apply:list_for_prescriber"))
+        response = mock_oauth_dance(
+            self,
+            assert_redirects=False,
+            previous_url=previous_url,
+            next_url=next_url,
+        )
+        # Follow the redirection.
+        response = self.client.get(response.url, follow=True)
+        self.assertTemplateUsed(response, "welcoming_tour/prescriber.html")
 
         # Check organization
         org = PrescriberOrganization.objects.get(siret=org.siret)
@@ -851,18 +822,17 @@ class InclusionConnectPrescribersViewsExceptionsTest(TestCase):
         self.assertContains(response, "inclusion_connect_button.svg")
 
         # Connect with Inclusion Connect.
-        url = reverse("dashboard:index")
-        with mock.patch("itou.users.adapter.UserAdapter.get_login_redirect_url", return_value=url):
-            previous_url = reverse("signup:prescriber_user")
-            next_url = reverse("signup:prescriber_join_org")
-            response = mock_oauth_dance(
-                self,
-                assert_redirects=False,
-                previous_url=previous_url,
-                next_url=next_url,
-            )
-            # Follow the redirection.
-            response = self.client.get(response.url, follow=True)
+        previous_url = reverse("signup:prescriber_user")
+        next_url = reverse("signup:prescriber_join_org")
+        response = mock_oauth_dance(
+            self,
+            assert_redirects=False,
+            previous_url=previous_url,
+            next_url=next_url,
+        )
+        # Follow the redirection.
+        response = self.client.get(response.url, follow=True)
+        self.assertTemplateNotUsed(response, "welcoming_tour/prescriber.html")
 
         # The user should be logged out and redirected to the home page.
         self.assertFalse(self.client.session.get(INCLUSION_CONNECT_SESSION_KEY))
@@ -920,13 +890,18 @@ class InclusionConnectPrescribersViewsExceptionsTest(TestCase):
         # Connect with Inclusion Connect.
         previous_url = reverse("signup:prescriber_user")
         next_url = reverse("signup:prescriber_join_org")
-        response = mock_oauth_dance(self, assert_redirects=False, previous_url=previous_url, next_url=next_url)
+        response = mock_oauth_dance(
+            self,
+            assert_redirects=False,
+            previous_url=previous_url,
+            next_url=next_url,
+        )
         # Follow the redirection.
         response = self.client.get(response.url, follow=True)
 
         # Show an error and don't create an organization.
         self.assertEqual(response.wsgi_request.path, signup_url)
-        self.assertNotContains(response, reverse("apply:list_for_prescriber"))
+        self.assertTemplateNotUsed(response, "welcoming_tour/prescriber.html")
         self.assertContains(response, "inclusion_connect_button.svg")
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
@@ -966,24 +941,23 @@ class InclusionConnectPrescribersViewsExceptionsTest(TestCase):
         self.assertContains(response, "inclusion_connect_button.svg")
 
         # Connect with Inclusion Connect but, this time, don't use a PE email.
-        url = reverse("dashboard:index")
-        with mock.patch("itou.users.adapter.UserAdapter.get_login_redirect_url", return_value=url):
-            previous_url = reverse("signup:prescriber_pole_emploi_user")
-            next_url = reverse("signup:prescriber_join_org")
-            wrong_email = "athos@touspourun.com"
-            response = mock_oauth_dance(
-                self,
-                login_hint=pe_email,
-                channel="pole_emploi",
-                assert_redirects=False,
-                previous_url=previous_url,
-                next_url=next_url,
-                user_info_email=wrong_email,
-            )
-            # Follow the redirection.
-            response = self.client.get(response.url, follow=True)
+        previous_url = reverse("signup:prescriber_pole_emploi_user")
+        next_url = reverse("signup:prescriber_join_org")
+        wrong_email = "athos@touspourun.com"
+        response = mock_oauth_dance(
+            self,
+            login_hint=pe_email,
+            channel="pole_emploi",
+            assert_redirects=False,
+            previous_url=previous_url,
+            next_url=next_url,
+            user_info_email=wrong_email,
+        )
+        # Follow the redirection.
+        response = self.client.get(response.url, follow=True)
 
-        self.assertNotContains(response, reverse("apply:list_for_prescriber"))
+        # Response should contain elements available only to prescribers on the welcoming tour.
+        self.assertTemplateNotUsed(response, "welcoming_tour/prescriber.html")
         self.assertContains(response, "inclusion_connect_button.svg")
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)

--- a/itou/www/signup/tests/test_prescriber.py
+++ b/itou/www/signup/tests/test_prescriber.py
@@ -93,6 +93,7 @@ class PrescriberSignupTest(TestCase):
         # Connect with Inclusion Connect.
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             login_hint=email,
             channel="pole_emploi",
@@ -173,6 +174,7 @@ class PrescriberSignupTest(TestCase):
 
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             previous_url=previous_url,
             next_url=next_url,
@@ -265,6 +267,7 @@ class PrescriberSignupTest(TestCase):
         previous_url = reverse("signup:prescriber_user")
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             previous_url=previous_url,
             next_url=next_url,
@@ -353,6 +356,7 @@ class PrescriberSignupTest(TestCase):
 
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             previous_url=previous_url,
             next_url=next_url,
@@ -496,6 +500,7 @@ class PrescriberSignupTest(TestCase):
 
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             previous_url=previous_url,
         )
@@ -575,6 +580,7 @@ class PrescriberSignupTest(TestCase):
 
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             previous_url=previous_url,
             next_url=next_url,
@@ -682,6 +688,7 @@ class PrescriberSignupTest(TestCase):
         # Connect with Inclusion Connect.
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             previous_url=previous_url,
         )
@@ -750,6 +757,7 @@ class PrescriberSignupTest(TestCase):
         # Connect with Inclusion Connect.
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             previous_url=previous_url,
             next_url=next_url,
@@ -826,6 +834,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(TestCase):
         next_url = reverse("signup:prescriber_join_org")
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             previous_url=previous_url,
             next_url=next_url,
@@ -892,6 +901,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(TestCase):
         next_url = reverse("signup:prescriber_join_org")
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             assert_redirects=False,
             previous_url=previous_url,
             next_url=next_url,
@@ -905,7 +915,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(TestCase):
         self.assertContains(response, "inclusion_connect_button.svg")
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
-        error_message = "Un compte non prescripteur existe déjà avec cette adresse e-mail"
+        error_message = "Un compte employeur existe déjà avec cette adresse e-mail"
         self.assertIn(error_message, str(messages[0]))
 
         user = User.objects.get(email=OIDC_USERINFO["email"])
@@ -946,6 +956,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(TestCase):
         wrong_email = "athos@touspourun.com"
         response = mock_oauth_dance(
             self,
+            KIND_PRESCRIBER,
             login_hint=pe_email,
             channel="pole_emploi",
             assert_redirects=False,

--- a/itou/www/signup/tests/test_siae.py
+++ b/itou/www/signup/tests/test_siae.py
@@ -9,135 +9,150 @@ from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.html import escape
+from django.utils.http import urlencode
+from freezegun import freeze_time
 
+from itou.openid_connect.inclusion_connect.tests import OIDC_USERINFO, mock_oauth_dance
 from itou.siaes.enums import SiaeKind
-from itou.siaes.factories import SiaeFactory, SiaeWithMembershipAndJobsFactory
-from itou.users.factories import DEFAULT_PASSWORD
+from itou.siaes.factories import SiaeFactory, SiaeMembershipFactory, SiaeWithMembershipAndJobsFactory
+from itou.users.enums import KIND_SIAE_STAFF
+from itou.users.factories import DEFAULT_PASSWORD, SiaeStaffFactory
 from itou.users.models import User
 from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK, INSEE_API_RESULT_MOCK
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
 
 
 class SiaeSignupTest(TestCase):
+    @freeze_time("2022-09-15 15:53:54")
+    @respx.mock
     def test_join_an_siae_without_members(self):
         """
         A user joins an SIAE without members.
-
-        The full "email confirmation process" is tested here.
-        Further Siae's signup tests doesn't have to fully test it again.
         """
-
-        user_first_name = "Jacques"
-        user_email = "jacques.doe@siae.com"
-        user_secondary_email = "jacques.doe@hotmail.com"
-
         siae = SiaeFactory(kind=SiaeKind.ETTI)
         self.assertEqual(0, siae.members.count())
 
+        url = reverse("signup:siae_select")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # Find an SIAE by SIREN.
+        response = self.client.get(url, {"siren": siae.siret[:9]})
+        self.assertEqual(response.status_code, 200)
+
+        # Choose an SIAE between results.
+        post_data = {"siaes": siae.pk}
+        # Pass `siren` in request.GET
+        response = self.client.post(f"{url}?siren={siae.siret[:9]}", data=post_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, "/")
+
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertIn("Un nouvel utilisateur souhaite rejoindre votre structure", email.subject)
+
+        magic_link = siae.signup_magic_link
+        response = self.client.get(magic_link)
+        self.assertEqual(response.status_code, 200)
+
+        # No error when opening magic link a second time.
+        response = self.client.get(magic_link)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "inclusion_connect_button.svg")
+
+        # Check IC will redirect to the correct url
+        encoded_siae_id = siae.get_encoded_siae_id()
         token = siae.get_token()
-        with mock.patch("itou.utils.tokens.SiaeSignupTokenGenerator.make_token", return_value=token):
+        previous_url = reverse("signup:siae_user", args=(encoded_siae_id, token))
+        next_url = reverse("signup:siae_join", args=(encoded_siae_id, token))
+        params = {
+            "user_kind": KIND_SIAE_STAFF,
+            "previous_url": previous_url,
+            "next_url": next_url,
+        }
+        url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
+        self.assertContains(response, url + '"')
 
-            url = reverse("signup:siae_select")
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, 200)
+        response = mock_oauth_dance(
+            self,
+            KIND_SIAE_STAFF,
+            assert_redirects=False,
+            previous_url=previous_url,
+            next_url=next_url,
+        )
+        response = self.client.get(response.url)
+        # Check user is redirected to the welcoming tour
+        self.assertRedirects(response, reverse("welcoming_tour:index"))
+        # Check user sees the siae staff tour
+        response = self.client.get(response.url)
+        self.assertContains(response, "Publiez vos offres, augmentez votre visibilité")
 
-            # Find an SIAE by SIREN.
-            response = self.client.get(url, {"siren": siae.siret[:9]})
-            self.assertEqual(response.status_code, 200)
+        user = User.objects.get(email=OIDC_USERINFO["email"])
 
-            # Choose an SIAE between results.
-            post_data = {"siaes": siae.pk}
-            # Pass `siren` in request.GET
-            response = self.client.post(f"{url}?siren={siae.siret[:9]}", data=post_data)
-            self.assertEqual(response.status_code, 302)
-            self.assertRedirects(response, "/")
+        # Check `User` state.
+        self.assertFalse(user.is_job_seeker)
+        self.assertFalse(user.is_prescriber)
+        self.assertTrue(user.is_siae_staff)
+        self.assertTrue(user.is_active)
+        self.assertTrue(siae.has_admin(user))
+        self.assertEqual(1, siae.members.count())
 
-            self.assertEqual(len(mail.outbox), 1)
-            email = mail.outbox[0]
-            self.assertIn("Un nouvel utilisateur souhaite rejoindre votre structure", email.subject)
+        # No new sent email.
+        self.assertEqual(len(mail.outbox), 1)
 
-            magic_link = siae.signup_magic_link
-            response = self.client.get(magic_link)
-            self.assertEqual(response.status_code, 200)
+        # Magic link is no longer valid because siae.members.count() has changed.
+        response = self.client.get(magic_link, follow=True)
+        self.assertRedirects(response, reverse("signup:siae_select"))
+        expected_message = (
+            "Ce lien d'inscription est invalide ou a expiré. Veuillez procéder à une nouvelle inscription."
+        )
+        self.assertContains(response, escape(expected_message))
 
-            # No error when opening magic link a second time.
-            response = self.client.get(magic_link)
-            self.assertEqual(response.status_code, 200)
+    @freeze_time("2022-09-15 15:53:54")
+    @respx.mock
+    def test_join_an_siae_without_members_as_an_existing_siae_staff(self):
+        """
+        A user joins an SIAE without members.
+        """
+        siae = SiaeFactory(kind=SiaeKind.ETTI)
+        self.assertEqual(0, siae.members.count())
 
-            # Create user.
-            url = siae.signup_magic_link
-            post_data = {
-                # Hidden fields
-                "encoded_siae_id": siae.get_encoded_siae_id(),
-                "token": siae.get_token(),
-                # Readonly fields
-                "siret": siae.siret,
-                "kind": siae.kind,
-                "siae_name": siae.display_name,
-                # Regular fields
-                "first_name": user_first_name,
-                "last_name": "Doe",
-                "email": user_secondary_email,
-                "password1": DEFAULT_PASSWORD,
-                "password2": DEFAULT_PASSWORD,
-            }
-            response = self.client.post(url, data=post_data)
-            self.assertEqual(response.status_code, 302)
-            self.assertRedirects(response, reverse("account_email_verification_sent"))
+        user = SiaeStaffFactory(email=OIDC_USERINFO["email"], has_completed_welcoming_tour=True)
+        SiaeMembershipFactory(user=user)
+        self.assertEqual(1, user.siae_set.count())
 
-            self.assertFalse(User.objects.filter(email=user_email).exists())
-            user = User.objects.get(email=user_secondary_email)
+        magic_link = siae.signup_magic_link
+        response = self.client.get(magic_link)
+        self.assertContains(response, "inclusion_connect_button.svg")
 
-            # Check `User` state.
-            self.assertFalse(user.is_job_seeker)
-            self.assertFalse(user.is_prescriber)
-            self.assertTrue(user.is_siae_staff)
-            self.assertTrue(user.is_active)
-            self.assertTrue(siae.has_admin(user))
-            self.assertEqual(1, siae.members.count())
-            # `username` should be a valid UUID, see `User.generate_unique_username()`.
-            self.assertEqual(user.username, uuid.UUID(user.username, version=4).hex)
-            self.assertEqual(user.first_name, user_first_name)
-            self.assertEqual(user.last_name, post_data["last_name"])
-            self.assertEqual(user.email, user_secondary_email)
-            # Check `EmailAddress` state.
-            self.assertEqual(user.emailaddress_set.count(), 1)
-            user_email = user.emailaddress_set.first()
-            self.assertFalse(user_email.verified)
+        # Check IC will redirect to the correct url
+        encoded_siae_id = siae.get_encoded_siae_id()
+        token = siae.get_token()
+        previous_url = reverse("signup:siae_user", args=(encoded_siae_id, token))
+        next_url = reverse("signup:siae_join", args=(encoded_siae_id, token))
+        params = {
+            "user_kind": KIND_SIAE_STAFF,
+            "previous_url": previous_url,
+            "next_url": next_url,
+        }
+        url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
+        self.assertContains(response, url + '"')
 
-            # Check sent email.
-            self.assertEqual(len(mail.outbox), 2)
-            subjects = [email.subject for email in mail.outbox]
-            self.assertIn("[Action requise] Un nouvel utilisateur souhaite rejoindre votre structure !", subjects)
-            self.assertIn("Confirmez votre adresse e-mail", subjects)
+        response = mock_oauth_dance(
+            self,
+            KIND_SIAE_STAFF,
+            assert_redirects=False,
+            previous_url=previous_url,
+            next_url=next_url,
+        )
+        response = self.client.get(response.url)
+        # Check user is redirected to the welcoming tour
+        self.assertRedirects(response, reverse("dashboard:index"))
 
-            # Magic link is no longer valid because siae.members.count() has changed.
-            response = self.client.get(magic_link, follow=True)
-            redirect_url, status_code = response.redirect_chain[-1]
-            self.assertEqual(status_code, 302)
-            next_url = reverse("signup:siae_select")
-            self.assertEqual(redirect_url, next_url)
-            self.assertEqual(response.status_code, 200)
-            expected_message = (
-                "Ce lien d'inscription est invalide ou a expiré. Veuillez procéder à une nouvelle inscription."
-            )
-            self.assertContains(response, escape(expected_message))
-
-            # User cannot log in until confirmation.
-            post_data = {"login": user.email, "password": DEFAULT_PASSWORD}
-            url = reverse("login:siae_staff")
-            response = self.client.post(url, data=post_data)
-            self.assertEqual(response.status_code, 302)
-            self.assertEqual(response.url, reverse("account_email_verification_sent"))
-
-            # Confirm email + auto login.
-            confirmation_token = EmailConfirmationHMAC(user_email).key
-            confirm_email_url = reverse("account_confirm_email", kwargs={"key": confirmation_token})
-            response = self.client.post(confirm_email_url)
-            self.assertEqual(response.status_code, 302)
-            self.assertEqual(response.url, reverse("welcoming_tour:index"))
-            user_email = user.emailaddress_set.first()
-            self.assertTrue(user_email.verified)
+        # Check `User` state.
+        self.assertTrue(siae.has_admin(user))
+        self.assertEqual(1, siae.members.count())
+        self.assertEqual(2, user.siae_set.count())
 
     @respx.mock
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)

--- a/itou/www/signup/tests/test_siae.py
+++ b/itou/www/signup/tests/test_siae.py
@@ -5,6 +5,7 @@ import httpx
 import respx
 from allauth.account.models import EmailConfirmationHMAC
 from django.conf import settings
+from django.contrib.messages import get_messages
 from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
@@ -16,7 +17,7 @@ from itou.openid_connect.inclusion_connect.tests import OIDC_USERINFO, mock_oaut
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import SiaeFactory, SiaeMembershipFactory, SiaeWithMembershipAndJobsFactory
 from itou.users.enums import KIND_SIAE_STAFF
-from itou.users.factories import DEFAULT_PASSWORD, SiaeStaffFactory
+from itou.users.factories import DEFAULT_PASSWORD, PrescriberFactory, SiaeStaffFactory
 from itou.users.models import User
 from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK, INSEE_API_RESULT_MOCK
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
@@ -271,3 +272,27 @@ class SiaeSignupTest(TestCase):
         ):
             response = self.client.get(url, {"siren": "402191662"})
         self.assertEqual(response.status_code, 200)
+
+
+class SiaeSignupViewsExceptionsTest(TestCase):
+    def test_non_staff_cant_join_a_siae(self):
+        siae = SiaeFactory(kind=SiaeKind.ETTI)
+        self.assertEqual(0, siae.members.count())
+
+        user = PrescriberFactory(email=OIDC_USERINFO["email"])
+        self.client.login(email=user.email, password=DEFAULT_PASSWORD)
+
+        # Skip IC process and jump to joining the SIAE.
+        encoded_siae_id = siae.get_encoded_siae_id()
+        token = siae.get_token()
+        url = reverse("signup:siae_join", args=(encoded_siae_id, token))
+
+        response = self.client.get(url)
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual("Vous ne pouvez pas rejoindre une SIAE avec ce compte.", str(messages[0]))
+        self.assertRedirects(response, reverse("home:hp"))
+
+        # Check `User` state.
+        self.assertFalse(siae.has_admin(user))
+        self.assertEqual(0, siae.members.count())

--- a/itou/www/signup/urls.py
+++ b/itou/www/signup/urls.py
@@ -80,5 +80,6 @@ urlpatterns = [
     ),
     # SIAE.
     path("siae/select", views.siae_select, name="siae_select"),
-    path("siae/<str:encoded_siae_id>/<str:token>", views.SiaeSignupView.as_view(), name="siae"),
+    path("siae/<str:encoded_siae_id>/<str:token>", views.siae_user, name="siae_user"),
+    path("siae/join/<str:encoded_siae_id>/<str:token>", views.siae_join, name="siae_join"),
 ]

--- a/itou/www/signup/urls.py
+++ b/itou/www/signup/urls.py
@@ -80,6 +80,6 @@ urlpatterns = [
     ),
     # SIAE.
     path("siae/select", views.siae_select, name="siae_select"),
-    path("siae/<str:encoded_siae_id>/<str:token>", views.siae_user, name="siae_user"),
-    path("siae/join/<str:encoded_siae_id>/<str:token>", views.siae_join, name="siae_join"),
+    path("siae/<str:encoded_siae_id>/<str:token>", views.SiaeUserView.as_view(), name="siae_user"),
+    path("siae/join/<str:encoded_siae_id>/<str:token>", views.SiaeJoinView.as_view(), name="siae_join"),
 ]

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -241,6 +241,11 @@ def siae_user(request, encoded_siae_id, token, template_name="signup/siae_user.h
 
 @login_required
 def siae_join(request, encoded_siae_id, token):
+    if not request.user.is_siae_staff:
+        logger.error("A non staff user tried to join a SIAE")
+        messages.error(request, "Vous ne pouvez pas rejoindre une SIAE avec ce compte.")
+        return HttpResponseRedirect(reverse("home:hp"))
+
     # FIXME(alaurent) Move to commun ClassBaseViewMixin
     # Get siae from endoded_siae_id
     siae_id = int(urlsafe_base64_decode(encoded_siae_id))

--- a/itou/www/welcoming_tour/tests.py
+++ b/itou/www/welcoming_tour/tests.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 
 from itou.openid_connect.inclusion_connect.tests import mock_oauth_dance
 from itou.siaes.factories import SiaeFactory
+from itou.users.enums import KIND_PRESCRIBER
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, SiaeStaffFactory
 from itou.users.models import User
 
@@ -64,7 +65,7 @@ class WelcomingTourTest(TestCase):
         session = self.client.session
         session[settings.ITOU_SESSION_PRESCRIBER_SIGNUP_KEY] = {"url_history": []}
         session.save()
-        response = mock_oauth_dance(self, assert_redirects=False)
+        response = mock_oauth_dance(self, KIND_PRESCRIBER, assert_redirects=False)
         response = self.client.get(response.url, follow=True)
 
         # User should be redirected to the welcoming tour as he just signed up
@@ -72,7 +73,7 @@ class WelcomingTourTest(TestCase):
         self.assertTemplateUsed(response, "welcoming_tour/prescriber.html")
 
         self.client.logout()
-        response = mock_oauth_dance(self, assert_redirects=False)
+        response = mock_oauth_dance(self, KIND_PRESCRIBER, assert_redirects=False)
         response = self.client.get(response.url, follow=True)
         self.assertNotEqual(response.wsgi_request.path, reverse("welcoming_tour:index"))
         self.assertContains(response, "Revoir le message")


### PR DESCRIPTION
### Quoi ?

- [x] En tant qu'employeur, je peux me connecter avec Inclusion Connect
- [x] En tant qu’employeur invité à rejoindre une structure, je peux utiliser Inclusion Connect
- [x] En tant qu’employeur je peux rejoindre une entreprise existant en base et sans membre en m’inscrivant sur les emplois avec Inclusion Connect
- [x] Si j'ai déjà un compte prescripteur, un message d'erreur m'indique que je dois utiliser un email différent pour mon compte employeur.
- [x] ajouter / corriger les tests

### Pourquoi ?


### Comment ?


### Captures d'écran (optionnel)

Le lien d'invitation envoie sur la page suivante :
![Screenshot from 2022-09-12 14-51-12](https://user-images.githubusercontent.com/7632730/189658370-f01ae7c4-2638-4fcc-8dd2-4dd0974546bc.png)

### Autre (optionnel)

- si des tests manquent, indiquer la raison, la probabilité, et les risques associés à ce manque
- être explicite sur le délai attendu pour une revue de code
- être explicite sur la qualité attendue pour la revue de code
- etc.
