### PR TITLE
Boost Dev - Sprint 50 - Semaine 37

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -421,11 +421,10 @@ INCLUSION_CONNECT_REALM = os.environ.get("INCLUSION_CONNECT_REALM")
 INCLUSION_CONNECT_CLIENT_ID = os.environ.get("INCLUSION_CONNECT_CLIENT_ID")
 INCLUSION_CONNECT_CLIENT_SECRET = os.environ.get("INCLUSION_CONNECT_CLIENT_SECRET")
 
-# Typeform
+# Tally forms
 # ------------------------------------------------------------------------------
+TALLY_URL = "https://tally.so"
 
-TYPEFORM_SECRET = os.environ.get("TYPEFORM_SECRET")
-TYPEFORM_URL = "https://itou.typeform.com"
 
 # Itou.
 # ------------------------------------------------------------------------------
@@ -534,30 +533,79 @@ METABASE_SECRET_KEY = os.environ.get("METABASE_SECRET_KEY", "")
 # Metabase embedded dashboards
 METABASE_DASHBOARDS = {
     # Public stats.
-    "stats_public": {"dashboard_id": 119,},
+    "stats_public": {
+        "dashboard_id": 119,
+    },
     # Employer stats.
-    "stats_siae_etp": {"dashboard_id": 128, "tally_form_id": "nrjbRv",},
-    "stats_siae_hiring": {"dashboard_id": 185, "tally_form_id": "waQPkB",},
+    "stats_siae_etp": {
+        "dashboard_id": 128,
+        "tally_form_id": "nrjbRv",
+    },
+    "stats_siae_hiring": {
+        "dashboard_id": 185,
+        "tally_form_id": "waQPkB",
+    },
     # Prescriber stats.
-    "stats_cd": {"dashboard_id": 118, "tally_form_id": "wb5Nro",},
-    "stats_pe_delay_main": {"dashboard_id": 168, "tally_form_id": "3lb9XW",},
-    "stats_pe_delay_raw": {"dashboard_id": 180,},
-    "stats_pe_conversion_main": {"dashboard_id": 169, "tally_form_id": "mODeK8",},
-    "stats_pe_conversion_raw": {"dashboard_id": 182,},
-    "stats_pe_state_main": {"dashboard_id": 149, "tally_form_id": "mRG61J",},
-    "stats_pe_state_raw": {"dashboard_id": 183,},
-    "stats_pe_tension": {"dashboard_id": 162, "tally_form_id": "wobaYV",},
+    "stats_cd": {
+        "dashboard_id": 118,
+        "tally_form_id": "wb5Nro",
+    },
+    "stats_pe_delay_main": {
+        "dashboard_id": 168,
+        "tally_form_id": "3lb9XW",
+    },
+    "stats_pe_delay_raw": {
+        "dashboard_id": 180,
+    },
+    "stats_pe_conversion_main": {
+        "dashboard_id": 169,
+        "tally_form_id": "mODeK8",
+    },
+    "stats_pe_conversion_raw": {
+        "dashboard_id": 182,
+    },
+    "stats_pe_state_main": {
+        "dashboard_id": 149,
+        "tally_form_id": "mRG61J",
+    },
+    "stats_pe_state_raw": {
+        "dashboard_id": 183,
+    },
+    "stats_pe_tension": {
+        "dashboard_id": 162,
+        "tally_form_id": "wobaYV",
+    },
     # Institution stats - DDETS - department level.
-    "stats_ddets_iae": {"dashboard_id": 117, "tally_form_id": "nPdWLb",},
-    "stats_ddets_diagnosis_control": {"dashboard_id": 144,},
-    "stats_ddets_hiring": {"dashboard_id": 160, "tally_form_id": "mVLBXv",},
+    "stats_ddets_iae": {
+        "dashboard_id": 117,
+        "tally_form_id": "nPdWLb",
+    },
+    "stats_ddets_diagnosis_control": {
+        "dashboard_id": 144,
+    },
+    "stats_ddets_hiring": {
+        "dashboard_id": 160,
+        "tally_form_id": "mVLBXv",
+    },
     # Institution stats - DREETS - region level.
-    "stats_dreets_iae": {"dashboard_id": 117, "tally_form_id": "nPdWLb",},
-    "stats_dreets_hiring": {"dashboard_id": 160, "tally_form_id": "mVLBXv",},
+    "stats_dreets_iae": {
+        "dashboard_id": 117,
+        "tally_form_id": "nPdWLb",
+    },
+    "stats_dreets_hiring": {
+        "dashboard_id": 160,
+        "tally_form_id": "mVLBXv",
+    },
     # Institution stats - DGEFP - nation level.
-    "stats_dgefp_iae": {"dashboard_id": 117,},
-    "stats_dgefp_diagnosis_control": {"dashboard_id": 144,},
-    "stats_dgefp_af": {"dashboard_id": 142,},
+    "stats_dgefp_iae": {
+        "dashboard_id": 117,
+    },
+    "stats_dgefp_diagnosis_control": {
+        "dashboard_id": 144,
+    },
+    "stats_dgefp_af": {
+        "dashboard_id": 142,
+    },
 }
 
 

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -747,6 +747,8 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         self.transferred_at = timezone.now()
         self.to_siae = target_siae
         self.state = JobApplicationWorkflow.STATE_NEW
+        # Consider job application as new : don't keep answers
+        self.answer = self.answer_to_prescriber = ""
 
         # Delete eligibility diagnosis if not provided by an authorized prescriber
         eligibility_diagnosis = self.eligibility_diagnosis
@@ -764,6 +766,8 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
                 "transferred_at",
                 "transferred_by",
                 "transferred_from",
+                "answer",
+                "answer_to_prescriber",
             ]
         )
 

--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -642,7 +642,8 @@ class JobApplicationNotificationsTest(TestCase):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory()
         email = job_application.email_accept_for_proxy
         # To.
-        self.assertIn(job_application.sender.email, email.to)
+        self.assertNotIn(job_application.to_siae.email, email.to)
+        self.assertEqual(email.to, [job_application.sender.email])
         self.assertEqual(len(email.to), 1)
         self.assertEqual(len(email.bcc), 0)
         # Subject.

--- a/itou/job_applications/tests/tests_transfer.py
+++ b/itou/job_applications/tests/tests_transfer.py
@@ -127,6 +127,8 @@ class JobApplicationTransferModelTest(TestCase):
             state=JobApplicationWorkflow.STATE_PROCESSING,
             to_siae=origin_siae,
             eligibility_diagnosis=EligibilityDiagnosisMadeBySiaeFactory(),
+            answer="Answer to job seeker",
+            answer_to_prescriber="Answer to prescriber",
         )
 
         # Failing to transfer must not update new fields
@@ -147,6 +149,8 @@ class JobApplicationTransferModelTest(TestCase):
         self.assertEqual(job_application.to_siae, target_siae)
         self.assertEqual(job_application.state, JobApplicationWorkflow.STATE_NEW)
         self.assertIsNone(job_application.eligibility_diagnosis)
+        self.assertEqual(job_application.answer, "")
+        self.assertEqual(job_application.answer_to_prescriber, "")
 
     def test_workflow_transitions(self):
         # `source` contains possible entry points of transition

--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -10,7 +10,7 @@ from itou.common_apps.address.models import AddressMixin
 from itou.common_apps.organizations.models import MembershipAbstract, OrganizationAbstract, OrganizationQuerySet
 from itou.prescribers.enums import PrescriberAuthorizationStatus, PrescriberOrganizationKind
 from itou.utils.emails import get_email_message
-from itou.utils.urls import get_absolute_url
+from itou.utils.urls import get_absolute_url, get_tally_form_url
 from itou.utils.validators import validate_code_safir, validate_siret
 
 
@@ -227,14 +227,13 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
         """
         Returns the typeform's satisfaction survey URL to be sent after a successful hiring.
         """
-        args = {
+        kwargs = {
             "idorganisation": self.pk,
             "region": self.region or "",
-            "typeorga": self.get_kind_display(),
             "departement": self.department or "",
         }
-        qs = urlencode(args)
-        return f"{settings.TYPEFORM_URL}/to/EDHZSU7p?{qs}"
+
+        return get_tally_form_url("w2EoDp", **kwargs)
 
     def get_card_url(self):
         if not self.is_authorized:

--- a/itou/prescribers/tests.py
+++ b/itou/prescribers/tests.py
@@ -91,18 +91,16 @@ class PrescriberOrganizationModelTest(TestCase):
 
         org = PrescriberOrganizationFactory(kind=PrescriberOrganizationKind.PE, department="57")
         url = org.accept_survey_url
-        self.assertTrue(url.startswith(f"{settings.TYPEFORM_URL}/to/EDHZSU7p?"))
+        self.assertTrue(url.startswith(f"{settings.TALLY_URL}/r/"))
         self.assertIn(f"idorganisation={org.pk}", url)
-        self.assertIn("typeorga=P%C3%B4le+emploi", url)
         self.assertIn("region=Grand+Est", url)
         self.assertIn("departement=57", url)
 
         # Ensure that the URL does not break when there is no department.
         org = PrescriberOrganizationFactory(kind=PrescriberOrganizationKind.CAP_EMPLOI, department="")
         url = org.accept_survey_url
-        self.assertTrue(url.startswith(f"{settings.TYPEFORM_URL}/to/EDHZSU7p?"))
+        self.assertTrue(url.startswith(f"{settings.TALLY_URL}/r/"))
         self.assertIn(f"idorganisation={org.pk}", url)
-        self.assertIn("typeorga=CAP+emploi", url)
         self.assertIn("region=", url)
         self.assertIn("departement=", url)
 

--- a/itou/siaes/management/commands/_import_siae/utils.py
+++ b/itou/siaes/management/commands/_import_siae/utils.py
@@ -318,6 +318,7 @@ def get_fluxiae_df(
     parse_dates=None,
     skip_first_row=True,
     anonymize_sensitive_data=True,
+    infer_datetime_format=True,
     dry_run=False,
 ):
     """
@@ -363,6 +364,12 @@ def get_fluxiae_df(
 
     if parse_dates:
         kwargs["parse_dates"] = parse_dates
+
+    # Removes warnings when autonatically parsing dates with pandas.read_csv
+    # ex: UserWarning: Parsing '30/04/2023' in DD/MM/YYYY format. Provide format ...
+    #     ... or specify infer_datetime_format=True for consistent parsing.
+    # See: https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
+    kwargs["infer_datetime_format"] = infer_datetime_format
 
     df = pd.read_csv(
         filename,

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -8,14 +8,14 @@ from django.db.models.functions import Cast, Coalesce
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes
-from django.utils.http import urlencode, urlsafe_base64_encode
+from django.utils.http import urlsafe_base64_encode
 
 from itou.common_apps.address.models import AddressMixin
 from itou.common_apps.organizations.models import MembershipAbstract, OrganizationAbstract, OrganizationQuerySet
 from itou.siaes.enums import SIAE_WITH_CONVENTION_CHOICES, SIAE_WITH_CONVENTION_KINDS, ContractType, SiaeKind
 from itou.utils.emails import get_email_message
 from itou.utils.tokens import siae_signup_token_generator
-from itou.utils.urls import get_absolute_url
+from itou.utils.urls import get_absolute_url, get_tally_form_url
 from itou.utils.validators import validate_af_number, validate_naf, validate_siret
 
 
@@ -268,14 +268,13 @@ class Siae(AddressMixin, OrganizationAbstract):
         """
         Returns the typeform's satisfaction survey URL to be sent after a successful hiring.
         """
-        args = {
+        kwargs = {
             "id_siae": self.pk,
-            "region": self.region or "",
             "type_siae": self.get_kind_display(),
+            "region": self.region or "",
             "departement": self.department or "",
         }
-        qs = urlencode(args)
-        return f"{settings.TYPEFORM_URL}/to/nUjfDnrA?{qs}"
+        return get_tally_form_url("mY59xq", **kwargs)
 
     @property
     def display_name(self):

--- a/itou/siaes/tests/tests_models.py
+++ b/itou/siaes/tests/tests_models.py
@@ -59,7 +59,7 @@ class SiaeModelTest(TestCase):
 
         siae = SiaeFactory(kind=SiaeKind.EI, department="57")
         url = siae.accept_survey_url
-        self.assertTrue(url.startswith(f"{settings.TYPEFORM_URL}/to/nUjfDnrA?"))
+        self.assertTrue(url.startswith(f"{settings.TALLY_URL}/r/"))
         self.assertIn(f"id_siae={siae.pk}", url)
         self.assertIn("type_siae=Entreprise+d%27insertion", url)
         self.assertIn("region=Grand+Est", url)
@@ -67,7 +67,7 @@ class SiaeModelTest(TestCase):
 
         # Ensure that the URL does not break when there is no department.
         siae = SiaeFactory(kind=SiaeKind.AI, department="")
-        self.assertTrue(url.startswith(f"{settings.TYPEFORM_URL}/to/nUjfDnrA?"))
+        self.assertTrue(url.startswith(f"{settings.TALLY_URL}/r/"))
         url = siae.accept_survey_url
         self.assertIn(f"id_siae={siae.pk}", url)
         self.assertIn("type_siae=Association+interm%C3%A9diaire", url)

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -88,8 +88,6 @@ Arguments:
                                         </small>
                                     {% endif %}
                                 {% endif %}
-                                <br>
-                                <small>{{ s.get_reason_display }}</small>
                             </li>
                         {% endfor %}
                     </ul>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "layout/content.html" %}
-{% load static %}
+{% load static tally %}
 {% block title %}Tableau de bord{{ block.super }}{% endblock %}
 
 {% block messages %}
@@ -77,7 +77,7 @@
             {% if current_prescriber_organization.has_pending_authorization_proof %}
                 <p class="mb-0">
                     Merci de nous transmettre l'arrêté préfectoral portant mention de cette habilitation :
-                    <a href="{{ TYPEFORM_URL }}/to/mk0GyI67#idprescriber={{ current_prescriber_organization.pk }}&iduser={{ user.pk }}&source={{ ITOU_ENVIRONMENT }}" rel="noopener" target="_blank" title="Cliquez ici pour l'envoyer (ouverture dans un nouvel onglet)">
+                    <a href="{% tally_form_url "wgDzz1" idprescriber=current_prescriber_organization.pk iduser=user.pk source=ITOU_ENVIRONMENT %}" rel="noopener" target="_blank" title="Cliquez ici pour l'envoyer (ouverture dans un nouvel onglet)">
                         cliquez ici pour l'envoyer
                         <i class="ri-external-link-line ri-lg"></i>
                     </a>

--- a/itou/templates/includes/test_accounts.html
+++ b/itou/templates/includes/test_accounts.html
@@ -8,7 +8,7 @@
     <div class="sticky-top shadow bg-danger text-white text-center layout" style="z-index:2;">
         <div class="layout-content py-0">
             <div class="d-flex align-items-center text-center p-1">
-                <p class="font-weight-bold flex-grow-1 mb-0 p-1 text-white h3">{{ ITOU_ENVIRONMENT }}</p>
+                <p class="font-weight-bold flex-grow-1 mb-0 p-1 text-white h3">{{ ITOU_ENVIRONMENT }}{% if ITOU_ENVIRONMENT == "DEMO" %} - Données fictives{% endif %}</p>
                 {% if not user.is_authenticated %}
                     <div>
                         <button class="btn btn-sm btn-light border" data-toggle="modal" data-target="#testAccountsModal">

--- a/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
+++ b/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
@@ -10,7 +10,7 @@ Si vous êtes bien un prescripteur habilité, nous avons besoin d'une preuve de 
 
 - si vous êtes une organisation habilitée par le préfet : merci de nous communiquer par retour de mail l'arrêté préfectoral portant mention de votre habilitation à valider l'éligibilité IAE des candidats. Pensez à nous communiquer l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
 
-- si votre organisation appartient à la liste des organisations habilitées au national ({{ itou_community_url }}/doc/emplois/liste-des-prescripteurs-habilites/) : merci de nous communiquer par retour de mail le type de structure et l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
+- si votre organisation appartient à la liste des organisations habilitées au national ({{ itou_community_url }}/doc/emplois/liste-des-prescripteurs-habilites/) : merci de nous communiquer un document justifiant la typologie de votre organisation. Vous pouvez transmettre ce document via {{ itou_assistance_url }}, rubrique « Habilitation / Prescripteur »
 
 - si vous êtes une organisation conventionnée par un Conseil départemental pour le suivi des BRSA : vous devez demander au Conseil départemental de nous contacter via {{ itou_assistance_url }}, rubrique « Habilitation / Prescripteur » afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail). Communiquez à cette personne l'ID de votre structure en lui demandant de le mentionner dans l'e-mail attestant de votre habilitation pour que nous fassions le rapprochement
 

--- a/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
+++ b/itou/templates/prescribers/email/refused_prescriber_organization_email_body.txt
@@ -10,7 +10,7 @@ Si vous êtes bien un prescripteur habilité, nous avons besoin d'une preuve de 
 
 - si vous êtes une organisation habilitée par le préfet : merci de nous communiquer par retour de mail l'arrêté préfectoral portant mention de votre habilitation à valider l'éligibilité IAE des candidats. Pensez à nous communiquer l'ID de votre organisation (ce numéro est affiché dans votre tableau de bord)
 
-- si votre organisation appartient à la liste des organisations habilitées au national ({{ itou_community_url }}/doc/emplois/liste-des-prescripteurs-habilites/) : merci de nous communiquer un document justifiant la typologie de votre organisation. Vous pouvez transmettre ce document via {{ itou_assistance_url }}, rubrique « Habilitation / Prescripteur »
+- si votre organisation appartient à la liste des organisations habilitées au national ({{ itou_community_url }}/doc/emplois/liste-des-prescripteurs-habilites/) : merci de nous communiquer un document justifiant la typologie de votre organisation, vous pouvez transmettre ce document via {{ itou_assistance_url }}, rubrique « Habilitation / Prescripteur
 
 - si vous êtes une organisation conventionnée par un Conseil départemental pour le suivi des BRSA : vous devez demander au Conseil départemental de nous contacter via {{ itou_assistance_url }}, rubrique « Habilitation / Prescripteur » afin de nous confirmer votre conventionnement (nous n'acceptons pas les transferts de mail). Communiquez à cette personne l'ID de votre structure en lui demandant de le mentionner dans l'e-mail attestant de votre habilitation pour que nous fassions le rapprochement
 

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -1,5 +1,5 @@
 {% extends "layout/content_small.html" %}
-{% load bootstrap4 %}
+{% load bootstrap4 tally %}
 
 {% block title %}Employeur solidaire - Inscription{{ block.super }}{% endblock %}
 
@@ -42,7 +42,7 @@
 
             <p>
                 <strong>Si vous tentez d'inscrire une Entreprise Adaptée ou un GEIQ</strong> :
-                Utilisez <a href="{{ TYPEFORM_URL }}/to/RYfNLR79" target="_blank" rel="noopener" title="lien pour une Entreprise Adaptée ou un GEIQ (ouverture dans un nouvel onglet)">ce formulaire</a>.
+                Utilisez <a href="{% tally_form_url "wA799W" %}" target="_blank" rel="noopener" title="lien pour une Entreprise Adaptée ou un GEIQ (ouverture dans un nouvel onglet)">ce formulaire</a>.
             </p>
 
             <p class="mb-0">

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -28,5 +28,4 @@ def expose_settings(request):
         "ITOU_PILOTAGE_URL": settings.PILOTAGE_SITE_URL,
         "ITOU_PROTOCOL": settings.ITOU_PROTOCOL,
         "SHOW_TEST_ACCOUNTS_BANNER": settings.SHOW_TEST_ACCOUNTS_BANNER,
-        "TYPEFORM_URL": settings.TYPEFORM_URL,
     }

--- a/itou/utils/templatetags/tally.py
+++ b/itou/utils/templatetags/tally.py
@@ -1,0 +1,17 @@
+from django import template
+
+from itou.utils.urls import get_tally_form_url
+
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def tally_form_url(context, form_id, **kwargs):
+    """
+    Wraps `itou.utils.urls.get_tally_form_url` for template usage.
+    Can use context variables.
+
+    Usage in template  : {% tally_form_url "tally_form_id" my_param=some_context_var ... %}
+    """
+    return get_tally_form_url(form_id, **kwargs)

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -61,7 +61,7 @@ from itou.utils.perms.context_processors import get_current_organization_and_per
 from itou.utils.perms.user import get_user_info
 from itou.utils.templatetags import dict_filters, format_filters
 from itou.utils.tokens import SIAE_SIGNUP_MAGIC_LINK_TIMEOUT, SiaeSignupTokenGenerator
-from itou.utils.urls import get_absolute_url, get_external_link_markup, get_safe_url
+from itou.utils.urls import get_absolute_url, get_external_link_markup, get_safe_url, get_tally_form_url
 from itou.utils.validators import (
     alphanumeric,
     validate_af_number,
@@ -525,6 +525,17 @@ class UtilsTemplateTagsTestCase(TestCase):
             template.render(Context({"value": "Firstname Lastname", "predicate": False})),
             "F… L…",
         )
+
+    @override_settings(TALLY_URL="https://foobar")
+    def test_tally_url_custom_template_tag(self):
+        test_id = 1234
+        context = {
+            "test_id": test_id,
+        }
+        template = Template("{% load tally %}url:{% tally_form_url 'abcde' pk=test_id hard='coded'%}")
+        out = template.render(Context(context))
+
+        self.assertEqual(f"url:{get_tally_form_url('abcde', pk=test_id, hard='coded')}", out)
 
 
 class UtilsTemplateFiltersTestCase(TestCase):

--- a/itou/utils/urls.py
+++ b/itou/utils/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.http import url_has_allowed_host_and_scheme, urlencode
 from django.utils.safestring import mark_safe
 
 
@@ -64,3 +64,12 @@ class SiretConverter:
 
     def to_url(self, value):
         return f"{value}"
+
+
+def get_tally_form_url(form_id, **kwargs):
+    url = f"{settings.TALLY_URL}/r/{form_id}"
+
+    if kwargs:
+        url += "?" + urlencode(kwargs)
+
+    return mark_safe(url)

--- a/itou/www/approvals_views/tests/test_suspend.py
+++ b/itou/www/approvals_views/tests/test_suspend.py
@@ -75,6 +75,11 @@ class ApprovalSuspendViewTest(TestCase):
         suspension = approval.suspension_set.first()
         self.assertEqual(suspension.created_by, siae_user)
 
+        # Ensure suspension reason is not displayed in details page
+        detail_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
+        response = self.client.get(detail_url)
+        self.assertNotContains(response, suspension.get_reason_display())
+
     def test_create_suspension_without_end_date(self):
         # Only test form validation (faster)
 

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 
-from itou.common_apps.address.forms import OptionalAddressFormMixin
+from itou.common_apps.address.forms import MandatoryAddressFormMixin
 from itou.job_applications.notifications import (
     NewQualifiedJobAppEmployersNotification,
     NewSpontaneousJobAppEmployersNotification,
@@ -11,7 +11,7 @@ from itou.users.models import User
 from itou.utils.widgets import DuetDatePickerWidget, MultipleSwitchCheckboxWidget, SwitchCheckboxWidget
 
 
-class EditUserInfoForm(OptionalAddressFormMixin, forms.ModelForm):
+class EditUserInfoForm(MandatoryAddressFormMixin, forms.ModelForm):
     """
     Edit a user profile.
     """
@@ -27,7 +27,6 @@ class EditUserInfoForm(OptionalAddressFormMixin, forms.ModelForm):
             del self.fields["pole_emploi_id"]
             del self.fields["lack_of_pole_emploi_id_reason"]
         else:
-            self.fields["phone"].required = True
             self.fields["birthdate"].required = True
             self.fields["birthdate"].widget = DuetDatePickerWidget(
                 attrs={

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -304,6 +304,10 @@ class EditUserInfoViewTest(TestCase):
             "birthdate": "20/12/1978",
             "phone": "0610203050",
             "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "address_line_1": "10, rue du Gué",
+            "address_line_2": "Sous l'escalier",
+            "post_code": "35400",
+            "city": "Saint-Malo",
         }
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
@@ -313,6 +317,10 @@ class EditUserInfoViewTest(TestCase):
         self.assertEqual(user.last_name, post_data["last_name"])
         self.assertEqual(user.phone, post_data["phone"])
         self.assertEqual(user.birthdate.strftime("%d/%m/%Y"), post_data["birthdate"])
+        self.assertEqual(user.address_line_1, post_data["address_line_1"])
+        self.assertEqual(user.address_line_2, post_data["address_line_2"])
+        self.assertEqual(user.post_code, post_data["post_code"])
+        self.assertEqual(user.city, post_data["city"])
 
         # Ensure that the job seeker cannot edit email here.
         self.assertNotEqual(user.email, post_data["email"])
@@ -332,12 +340,20 @@ class EditUserInfoViewTest(TestCase):
             "birthdate": "20/12/1978",
             "phone": "0610203050",
             "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "address_line_1": "10, rue du Gué",
+            "address_line_2": "Sous l'escalier",
+            "post_code": "35400",
+            "city": "Saint-Malo",
         }
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
         user = User.objects.get(id=user.id)
         self.assertEqual(user.phone, post_data["phone"])
+        self.assertEqual(user.address_line_1, post_data["address_line_1"])
+        self.assertEqual(user.address_line_2, post_data["address_line_2"])
+        self.assertEqual(user.post_code, post_data["post_code"])
+        self.assertEqual(user.city, post_data["city"])
 
         # Ensure that the job seeker cannot update data retreived from the SSO here.
         self.assertNotEqual(user.first_name, post_data["first_name"])
@@ -369,8 +385,10 @@ class EditJobSeekerInfo(TestCase):
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
-            "phone": "0610203050",
             "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "address_line_1": "10, rue du Gué",
+            "post_code": "35400",
+            "city": "Saint-Malo",
         }
         response = self.client.post(url, data=post_data)
 
@@ -381,7 +399,20 @@ class EditJobSeekerInfo(TestCase):
         self.assertEqual(job_seeker.first_name, post_data["first_name"])
         self.assertEqual(job_seeker.last_name, post_data["last_name"])
         self.assertEqual(job_seeker.birthdate.strftime("%d/%m/%Y"), post_data["birthdate"])
+        self.assertEqual(job_seeker.address_line_1, post_data["address_line_1"])
+        self.assertEqual(job_seeker.post_code, post_data["post_code"])
+        self.assertEqual(job_seeker.city, post_data["city"])
+
+        # Optional fields
+        post_data |= {
+            "phone": "0610203050",
+            "address_line_2": "Sous l'escalier",
+        }
+        response = self.client.post(url, data=post_data)
+        job_seeker.refresh_from_db()
+
         self.assertEqual(job_seeker.phone, post_data["phone"])
+        self.assertEqual(job_seeker.address_line_2, post_data["address_line_2"])
 
     def test_edit_by_prescriber(self):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory()
@@ -458,8 +489,10 @@ class EditJobSeekerInfo(TestCase):
         post_data = {
             "email": new_email,
             "birthdate": "20/12/1978",
-            "phone": "0610203050",
             "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "address_line_1": "10, rue du Gué",
+            "post_code": "35400",
+            "city": "Saint-Malo",
         }
         response = self.client.post(url, data=post_data)
 
@@ -468,6 +501,17 @@ class EditJobSeekerInfo(TestCase):
 
         job_seeker = User.objects.get(id=job_application.job_seeker.id)
         self.assertEqual(job_seeker.email, new_email)
+
+        # Optional fields
+        post_data |= {
+            "phone": "0610203050",
+            "address_line_2": "Sous l'escalier",
+        }
+        response = self.client.post(url, data=post_data)
+        job_seeker.refresh_from_db()
+
+        self.assertEqual(job_seeker.phone, post_data["phone"])
+        self.assertEqual(job_seeker.address_line_2, post_data["address_line_2"])
 
     def test_edit_email_when_confirmed(self):
         new_email = "bidou@yopmail.com"
@@ -495,8 +539,10 @@ class EditJobSeekerInfo(TestCase):
         post_data = {
             "email": new_email,
             "birthdate": "20/12/1978",
-            "phone": "0610203050",
             "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "address_line_1": "10, rue du Gué",
+            "post_code": "35400",
+            "city": "Saint-Malo",
         }
         response = self.client.post(url, data=post_data)
 
@@ -506,8 +552,21 @@ class EditJobSeekerInfo(TestCase):
         job_seeker = User.objects.get(id=job_application.job_seeker.id)
         # The email is not changed, but other fields are taken into account
         self.assertNotEqual(job_seeker.email, new_email)
-        self.assertEqual(job_seeker.phone, post_data["phone"])
         self.assertEqual(job_seeker.birthdate.strftime("%d/%m/%Y"), post_data["birthdate"])
+        self.assertEqual(job_seeker.address_line_1, post_data["address_line_1"])
+        self.assertEqual(job_seeker.post_code, post_data["post_code"])
+        self.assertEqual(job_seeker.city, post_data["city"])
+
+        # Optional fields
+        post_data |= {
+            "phone": "0610203050",
+            "address_line_2": "Sous l'escalier",
+        }
+        response = self.client.post(url, data=post_data)
+        job_seeker.refresh_from_db()
+
+        self.assertEqual(job_seeker.phone, post_data["phone"])
+        self.assertEqual(job_seeker.address_line_2, post_data["address_line_2"])
 
 
 class ChangeEmailViewTest(TestCase):

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -286,6 +286,24 @@ class DashboardViewTest(TestCase):
         self.assertContains(response, "Valide du 21/06/2022 au 06/12/2022")
         self.assertContains(response, "Délivrance : le 21/06/2022")
 
+    def test_prescriber_with_authorization_pending_dashboard_must_contain_tally_link(self):
+        prescriber_org = prescribers_factories.PrescriberOrganizationWithMembershipFactory(
+            kind=PrescriberOrganizationKind.OTHER,
+            with_pending_authorization=True,
+        )
+
+        prescriber = prescriber_org.members.first()
+        self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
+        response = self.client.get(reverse("dashboard:index"))
+
+        self.assertContains(
+            response,
+            f"https://tally.so/r/wgDzz1?"
+            f"idprescriber={prescriber_org.pk}"
+            f"&iduser={prescriber.pk}"
+            f"&source={settings.ITOU_ENVIRONMENT}",
+        )
+
 
 class EditUserInfoViewTest(TestCase):
     def test_edit(self):

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -161,7 +161,7 @@ class NewEmployeeRecordStep2Form(forms.ModelForm):
 
         address_re_validator = RegexValidator(
             "^[a-zA-Z0-9@ ]{,32}$",
-            message="Le champ ne doit pas contenir de caractères spéciaux et ne pas excéder 32 caractères",
+            message="Le champ ne doit contenir ni caractères spéciaux, ni accents et ne pas excéder 32 caractères",
         )
         self.fields["hexa_lane_name"].validators = [address_re_validator]
         self.fields["hexa_additional_address"].validators = [address_re_validator]

--- a/itou/www/signup/tests/test_siae.py
+++ b/itou/www/signup/tests/test_siae.py
@@ -16,6 +16,7 @@ from itou.users.factories import DEFAULT_PASSWORD
 from itou.users.models import User
 from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK, INSEE_API_RESULT_MOCK
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
+from itou.utils.urls import get_tally_form_url
 
 
 class SiaeSignupTest(TestCase):
@@ -235,7 +236,7 @@ class SiaeSignupTest(TestCase):
         url = reverse("signup:siae_select")
         response = self.client.get(url, {"siren": "111111111"})  # not existing SIREN
         self.assertContains(response, "https://communaute.inclusion.beta.gouv.fr/aide/emplois/#support")
-        self.assertContains(response, f"{settings.TYPEFORM_URL}/to/RYfNLR79")
+        self.assertContains(response, get_tally_form_url("wA799W"))
         self.assertContains(response, reverse("signup:facilitator_search"))
 
     def test_siae_select_does_not_die_under_requests(self):


### PR DESCRIPTION
### Quoi ?

Les modifications suivantes effectuées pour les différentes cartes Notion de boost dev : 
- les réponses données aux candidatures sont supprimées lors d'un transfert entre SIAE
- notification des données factices sur l'environnement de démo
- correction d'un avertissement concernant le format de date lors de l'import des SIAE
- vérification de la suppression de l'e-mail de notification d'une nouvelle embauche pour les SIAE
- suppression de l'affichage de la raison d'une suspension
- lors de la saisie des informations d'un utilisateur, le téléphone devient optionnel et les informations de l'adresse obligatoires
- modification de l'e-mail envoyé aux prescripteurs lors d'un refus d'habilitation
- suppression de Typeform et remplacement par Tally

### Pourquoi ?

Dans le cadre de la session Supportix.

### Comment ?

Avec bienveillance (toujours).
