### PR TITLE
Amélioration de la résilience du parcours d'inscription prescripteur face aux API indisponibles

### DIFF
--- a/itou/templates/signup/prescriber_check_already_exists.html
+++ b/itou/templates/signup/prescriber_check_already_exists.html
@@ -83,7 +83,7 @@
                 </p>
             {% endif %}
             <a class="btn btn btn-outline-secondary mt-3" href="{{ prev_url }}">Retour</a>
-            <a href="{% url 'signup:prescriber_choose_org' %}" class="btn btn-primary mt-3">Inscrire mon organisation</a>
+            <a href="{% url 'signup:prescriber_choose_org' siret=form.cleaned_data.siret %}" class="btn btn-primary mt-3">Inscrire mon organisation</a>
         </div>
     {% endif %}
 {% endblock %}

--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -58,6 +58,9 @@ def etablissement_get_or_error(siret):
             params={"date": timezone.localdate().isoformat()},
         )
         r.raise_for_status()
+    except httpx.RequestError:
+        logger.exception("A request to the INSEE API failed")
+        return None, "Problème de connexion à la base Sirene. Essayez ultérieurement."
     except httpx.HTTPStatusError as e:
         if e.response.status_code == httpx.codes.BAD_REQUEST:
             error = f"Erreur dans le format du SIRET : « {siret} »."

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -881,6 +881,16 @@ class ApiEntrepriseTest(SimpleTestCase):
         self.assertEqual(result, (None, "Problème de connexion à la base Sirene. Essayez ultérieurement."))
 
     @respx.mock
+    def test_etablissement_get_or_error_with_request_error(self):
+        self.siret_endpoint.mock(side_effect=httpx.RequestError)
+
+        with self.assertLogs(api_entreprise.logger, logging.ERROR) as cm:
+            result = api_entreprise.etablissement_get_or_error("26570134200148")
+
+        self.assertEqual(result, (None, "Problème de connexion à la base Sirene. Essayez ultérieurement."))
+        self.assertTrue(cm.records[0].message.startswith("A request to the INSEE API failed"))
+
+    @respx.mock
     def test_etablissement_get_or_error_with_other_http_bad_request_error(self):
         self.siret_endpoint.respond(400)
 

--- a/itou/www/signup/urls.py
+++ b/itou/www/signup/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import path, re_path
 from django.views.generic import TemplateView
 
 from itou.www.signup import views
@@ -38,8 +38,8 @@ urlpatterns = [
         views.prescriber_request_invitation,
         name="prescriber_request_invitation",
     ),
-    path(
-        "prescriber/choose_org",
+    re_path(
+        r"^prescriber/choose_org/(?P<siret>\d{14})?$",
         views.prescriber_choose_org,
         name="prescriber_choose_org",
     ),


### PR DESCRIPTION
### Quoi ?

L’API entreprise est parfois injoignable pendant plusieurs heures pour des raisons de maintenance. Par exemple, du 31 janvier au 3 février ou le 21 septembre prochain.

Le prescripteur qui souhaite se créer un compte avec une organisation voit alors l’erreur suivante : 
> Problème de connexion à la base Sirene. Essayez ultérieurement.

### Pourquoi ?

L'erreur lié à l'API empêche un prescripteur de s'inscrire et/ou de rejoindre une structure déjà existante alors que l'API ne nous sert pas dans ce cas précis.

### Comment ?

Déplacement des appels API dans le formulaire utilisé lorsqu'on veux créer une nouvelle organisation plutôt que lorsqu'on recherche si elle existe.
