### PR TITLE
Petites améliorations de l’outil d’intégration continue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     env:
       DJANGO_SETTINGS_MODULE: config.settings.test
       DJANGO_SECRET_KEY: ministryofsillywalks
@@ -47,10 +44,10 @@ jobs:
         psql <<SQL
             CREATE DATABASE itou;
         SQL
-    - name: 💂 Install Python ${{ matrix.python-version }}
+    - name: 💂 Install Python
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.10"
     - name: 📥 Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+        cache: pip
+        cache-dependency-path: requirements/dev.txt
     - name: 📥 Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
### Quoi ?

- Simplification de la configuration
- Ajout d’un cache pour les dépendances

### Pourquoi ?

Une seule version de Python est utilisée, il est inutile de configurer une matrice de versions.

Les dépendances sont systématiquement téléchargées depuis PyPI, ce qui augmente la pression sur PyPI et ralentit les builds.