### PR TITLE
dashboard: Restore displaying the PASS IAE for job seekers

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -213,7 +213,7 @@
                     <div class="card-body">
                         <ul class="list-unstyled">
                             <li class="card-text mb-3">
-                                {% include "approvals/includes/status.html" with approval=user.latest_common_approval %}
+                                {% include "approvals/includes/status.html" with common_approval=user.latest_common_approval %}
                             </li>
                             {% if user.has_common_approval_in_waiting_period %}
                                 <li class="card-text mb-3">


### PR DESCRIPTION
### Quoi ?

Restaure l'affichage du PASS IAE pour les candidats sur leur tableau de bord.

### Pourquoi ?
Cela avait disparu suite à cette (un peu trop grosse) [PR](https://github.com/betagouv/itou/pull/1450).

### Comment ?

En rétablissant le bon paramètre pour le gabarit, et en testant la sortie attendue.
