### PR TITLE
Permettre au dernier employeur qui a embauché un candidat d’avoir la main pour prolonger ou suspendre

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -747,13 +747,9 @@ class User(AbstractUser, AddressMixin):
         if not self.is_job_seeker:
             return None
 
-        # Last accepted job application is based on creation and hiring dates.
-        # There were cases of identical job application creation dates in production,
-        # leading to bad ordering (listed in DB natural "insertion" order).
-        #
         # Some candidates may not have accepted job applications
         # Assuming its the case can lead to issues downstream
-        return self.job_applications.accepted().order_by("hiring_start_at").last()
+        return self.job_applications.accepted().with_accepted_at().order_by("-accepted_at", "-hiring_start_at").first()
 
     @cached_property
     def jobseeker_hash_id(self):


### PR DESCRIPTION
### Quoi ?

Calcul de la date d'acceptation d'une candidature :
- Pour une candidature classique : on se réfère au log des transitions
- Pour une candidature créée lors d’un import d’agrément : on se réfère à la date de création de la candidature.

### Pourquoi ?

Permettre au dernier employeur qui a embauché un candidat d’avoir la main pour prolonger ou suspendre

### Comment ?

En ne se basant plus sur la date de contrat mais sur la date d’acceptation de la candidature.
