### PR TITLE
settings: Augmenter le timeout HSTS

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -56,5 +56,5 @@ ELASTIC_APM = {
 
 # Enable HTTP Strict Transport Security
 # see https://docs.djangoproject.com/en/4.0/ref/middleware/#http-strict-transport-security
-SECURE_HSTS_SECONDS = 3600  # We set this to a small value initially
+SECURE_HSTS_SECONDS = 31536000
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True


### PR DESCRIPTION
### Quoi ?

Dans le titre.

### Pourquoi ?

Pour suivre les recommandations de Django et de l'audit de sécurité.

### Comment ?
Mettant la valeur du setting à 1 an.