### PR TITLE
Le motif de suspension “contrat de travail suspendu depuis plus de 15 jours” d'un pass IAE n’empêche plus de postuler à d'autres offres

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -325,7 +325,7 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     @cached_property
     def can_be_unsuspended(self):
         if self.is_suspended:
-            return self.last_in_progress_suspension.reason in Suspension.REASONS_TO_UNSUSPEND
+            return self.last_in_progress_suspension.reason in Suspension.REASONS_ALLOWING_UNSUSPEND
         return False
 
     def unsuspend(self, hiring_start_at):
@@ -612,11 +612,12 @@ class Suspension(models.Model):
                 reasons.append(Suspension.Reason.CONTRAT_PASSERELLE)
             return [(reason.value, reason.label) for reason in reasons]
 
-    REASONS_TO_UNSUSPEND = [
+    REASONS_ALLOWING_UNSUSPEND = [
         Reason.BROKEN_CONTRACT.value,
         Reason.FINISHED_CONTRACT.value,
         Reason.APPROVAL_BETWEEN_CTA_MEMBERS.value,
         Reason.CONTRAT_PASSERELLE.value,
+        Reason.SUSPENDED_CONTRACT.value,
     ]
 
     approval = models.ForeignKey(Approval, verbose_name="PASS IAE", on_delete=models.CASCADE)

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -124,7 +124,7 @@ class SuspensionForm(forms.ModelForm):
         self.fields["reason"].choices = Suspension.Reason.displayed_choices_for_siae(self.siae)
 
         self.reasons_can_be_unsuspend = [
-            choice for choice, _ in self.fields["reason"].choices if choice in Suspension.REASONS_TO_UNSUSPEND
+            choice for choice, _ in self.fields["reason"].choices if choice in Suspension.REASONS_ALLOWING_UNSUSPEND
         ]
 
         # End date is not strictly required because it can be set


### PR DESCRIPTION
### Quoi ?

Le motif de suspension d'un pass IAE "contrat de travail suspendu depuis plus de 15 jours" est un motif de suspension comme les autres et permet à un candidat de postuler à d'autres offres.

### Pourquoi ?

Actuellement le motif “contrat de travail suspendu depuis plus de 15 jours” implique qu’il n’est pas possible de travailler dans une  autre SIAE par conséquent l’orientation est bloquée.
Cependant les candidatures créées avant la suspension peuvent encore être validées mais la suspension du PASS n’est pas levée. On constate également que ce motif est mal utilisé par les employeurs . Ces 2 problématiques génèrent des tickets au support
Plutôt que de réaliser 2 développements pour résoudre ces 2 problèmes, nous proposons d’aller vers + de simplification en assumant le fait que certains employeurs continueront surement d’utiliser ce motif à tort. Le bénéfice de la simplification est plus important que la règle “métier”

### Comment ?

Ajout du motif de suspension "Contrat de travail suspendu depuis plus de 15 jours" à la liste des raisons permettent de retirer la suspension d'un pass

### Autre (optionnel)

- Tous les motifs de suspension sont à présent des motifs «désuspendable», le test sur cette section à été mis à jours pour utiliser un motif historique afin de le conserver et de le mettre à jours si une raison sort de cette liste.
