### PR TITLE
Enlève les espaces lors de la présentation d’identifiants

### DIFF
--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load call_method %}
+{% load format_filters %}
 {% comment %}
 
 Arguments:
@@ -40,7 +41,7 @@ Arguments:
     </p>
 {% else %}
     <p>
-        <b>{{ common_approval.number_with_spaces }}</b>
+        <b>{{ common_approval.number|format_approval_number }}</b>
     </p>
 {% endif %}
 

--- a/itou/templates/approvals/printable_approval.html
+++ b/itou/templates/approvals/printable_approval.html
@@ -1,5 +1,6 @@
 {% extends "layout/base_printable.html" %}
 {% load static %}
+{% load format_filters %}
 
 {% block title %}
     Attestation de délivrance d'agrément pour {{ job_seeker.get_full_name|title }}.
@@ -40,7 +41,7 @@
 
             <span class="d-block font-weight-bold">Références à rappeler :</span>
 
-            <span class="d-block">PASS IAE n° {{ approval.number_with_spaces }}</span>
+            <span class="d-block">PASS IAE n° {{ approval.number|format_approval_number }}</span>
 
             <span class="d-block">
                 du {{ approval.start_at|date:"d/m/Y" }} au {{ approval.end_at|date:"d/m/Y" }}

--- a/itou/templates/employee_record/create.html
+++ b/itou/templates/employee_record/create.html
@@ -19,7 +19,7 @@
                     <div class="col-sm-9 pt-3">
                         <div>Début du contrat : <b>{{ job_application.hiring_start_at|default_if_none:"Non renseigné" }}</b></div>
                         <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default_if_none:"Non renseigné" }}</b></div>
-                        <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
+                        <div>Numéro de PASS IAE : <b>{{ job_application.approval.number|format_approval_number }}</b></div>
                     </div>
                     <div class="col-sm-3 text-right">
                         <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"></img>

--- a/itou/templates/employee_record/disable.html
+++ b/itou/templates/employee_record/disable.html
@@ -21,7 +21,7 @@
                         {% with job_application=employee_record.job_application %}
                             <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
                             <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default:"Non renseigné" }}</b></div>
-                            <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
+                            <div>Numéro de PASS IAE : <b>{{ job_application.approval.number|format_approval_number }}</b></div>
                         {% endwith %}
                         <div>
                             <b>{{ employee_record.get_status_display }}</b> le {{ employee_record.updated_at }}

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -1,3 +1,4 @@
+{% load format_filters %}
 <div class="card my-5">
 
     <div class="card-header">
@@ -9,7 +10,7 @@
             <div class="col-md-7">
                 <p class="m-0">Début de contrat :&nbsp;<b>{{ item.hiring_start_at|default_if_none:"Non renseigné" }}</b></p>
                 <p class="m-0">Fin de contrat :&nbsp;<b>{{ item.hiring_end_at|default_if_none:"Non renseigné" }}</b></p>
-                <p class="m-0">Numéro de PASS IAE (agrément) :&nbsp;<b>{{ item.approval.number_with_spaces }}</b></p>
+                <p class="m-0">Numéro de PASS IAE (agrément) :&nbsp;<b>{{ item.approval.number|format_approval_number }}</b></p>
             </div>
 
             {# Statuses #}

--- a/itou/templates/employee_record/reactivate.html
+++ b/itou/templates/employee_record/reactivate.html
@@ -21,7 +21,7 @@
                         {% with job_application=employee_record.job_application %}
                             <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
                             <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default:"Non renseigné" }}</b></div>
-                            <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
+                            <div>Numéro de PASS IAE : <b>{{ job_application.approval.number|format_approval_number }}</b></div>
                         {% endwith %}
                         <div>
                             <b>{{ employee_record.get_status_display }}</b> le {{ employee_record.updated_at }}

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -18,7 +18,7 @@
                         {% with job_application=employee_record.job_application %}
                             <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
                             <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default:"Non renseigné" }}</b></div>
-                            <div>Numéro de PASS IAE : <b>{{ job_application.approval.number_with_spaces }}</b></div>
+                            <div>Numéro de PASS IAE : <b>{{ job_application.approval.number|format_approval_number }}</b></div>
                         {% endwith %}
                         <div>
                             <b>{{ employee_record.get_status_display }}</b> le {{ employee_record.updated_at }}

--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
@@ -1,3 +1,4 @@
+{% load format_filters %}
 <div class="row">
     <div class="col-md-8">
         <h3 class="h2">Auto-prescription pour
@@ -5,7 +6,7 @@
                 {{job_seeker.get_full_name|title}}
             </span>
         </h3>
-        <p class="m-0">PASS IAE :&nbsp;<b>{{ approval.number_with_spaces }}</b> délivré le {{ approval.start_at|date:"d E Y" }}</p>
+        <p class="m-0">PASS IAE :&nbsp;<b>{{ approval.number|format_approval_number }}</b> délivré le {{ approval.start_at|date:"d E Y" }}</p>
     </div>
     <div class="col-md-4 text-right">
         <p class="small mb-0">

--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
@@ -1,3 +1,4 @@
+{% load format_filters %}
 <div class="row">
     <div class="col-lg-8 col-md-7 col-12">
         <h3 class="h2">Auto-prescription pour
@@ -38,6 +39,6 @@
 </div>
 <div class="row">
     <div class="col-12">
-        <p class="m-0">PASS IAE :&nbsp;<b>{{ approval.number_with_spaces }}</b> délivré le {{ approval.start_at|date:"d E Y" }}</p>
+        <p class="m-0">PASS IAE :&nbsp;<b>{{ approval.number|format_approval_number }}</b> délivré le {{ approval.start_at|date:"d E Y" }}</p>
     </div>
 </div>

--- a/itou/utils/templatetags/format_filters.py
+++ b/itou/utils/templatetags/format_filters.py
@@ -1,6 +1,7 @@
 """
 https://docs.djangoproject.com/en/dev/howto/custom-template-tags/
 """
+import io
 import re
 from textwrap import wrap
 
@@ -51,7 +52,12 @@ def format_nir(nir):
     nir_regex = r"^([12])([0-9]{2})([0-9]{2})(2[AB]|[0-9]{2})([0-9]{3})([0-9]{3})([0-9]{2})$"
     match = re.match(nir_regex, nir_without_spaces)
     if match is not None:
-        return " ".join(match.groups())
+        groups = match.groups()
+        with io.StringIO() as formatted:
+            formatted.write(f"<span>{groups[0]}</span>")
+            for group in groups[1:]:
+                formatted.write(f'<span class="ml-1">{group}</span>')
+            return mark_safe(formatted.getvalue())
     else:
         # Some NIRs do not match the pattern (they can be NTT/NIA) so we can’t format them
         # When this happen, we should not crash but return the initial value

--- a/itou/utils/templatetags/format_filters.py
+++ b/itou/utils/templatetags/format_filters.py
@@ -6,6 +6,8 @@ from textwrap import wrap
 
 from django import template
 from django.template.defaultfilters import stringfilter
+from django.utils.html import conditional_escape
+from django.utils.safestring import mark_safe
 
 
 register = template.Library()
@@ -54,3 +56,16 @@ def format_nir(nir):
         # Some NIRs do not match the pattern (they can be NTT/NIA) so we can’t format them
         # When this happen, we should not crash but return the initial value
         return nir
+
+
+@register.filter(needs_autoescape=True)
+@stringfilter
+def format_approval_number(number, autoescape=True):
+    if not number:
+        return mark_safe("")
+    group_indices = [[0, 5], [5, 7], [7, None]]
+    escape = conditional_escape if autoescape else lambda text: text
+    parts = [escape(number[start:end]) for start, end in group_indices]
+    return mark_safe(
+        f'<span>{parts[0]}</span><span class="ml-1">{parts[1]}</span><span class="ml-1">{parts[2]}</span>'
+    )

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -554,6 +554,17 @@ class UtilsTemplateFiltersTestCase(TestCase):
         self.assertEqual(format_filters.format_nir(""), "")
         self.assertEqual(format_filters.format_nir("12345678910"), "12345678910")
 
+    def test_format_approval_number(self):
+        test_cases = [
+            ("", ""),
+            ("XXXXX3500001", '<span>XXXXX</span><span class="ml-1">35</span><span class="ml-1">00001</span>'),
+            # Actual formatting does not really matter, just verify it does not crash.
+            ("foo", '<span>foo</span><span class="ml-1"></span><span class="ml-1"></span>'),
+        ]
+        for number, expected in test_cases:
+            with self.subTest(number):
+                self.assertEqual(format_filters.format_approval_number(number), expected)
+
 
 class UtilsEmailsTestCase(TestCase):
     def test_get_safe_url(self):

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -549,10 +549,25 @@ class UtilsTemplateFiltersTestCase(TestCase):
         self.assertEqual(format_filters.format_siret("12345678912345"), "123 456 789 12345")
 
     def test_format_nir(self):
-        self.assertEqual(format_filters.format_nir("141068078200557"), "1 41 06 80 782 005 57")
-        self.assertEqual(format_filters.format_nir(" 1 41 06 80 782 005 57"), "1 41 06 80 782 005 57")
-        self.assertEqual(format_filters.format_nir(""), "")
-        self.assertEqual(format_filters.format_nir("12345678910"), "12345678910")
+        test_cases = [
+            (
+                "141068078200557",
+                '<span>1</span><span class="ml-1">41</span><span class="ml-1">06</span>'
+                '<span class="ml-1">80</span><span class="ml-1">782</span><span class="ml-1">005</span>'
+                '<span class="ml-1">57</span>',
+            ),
+            (
+                " 1 41 06 80 782 005 57",
+                '<span>1</span><span class="ml-1">41</span><span class="ml-1">06</span>'
+                '<span class="ml-1">80</span><span class="ml-1">782</span><span class="ml-1">005</span>'
+                '<span class="ml-1">57</span>',
+            ),
+            ("", ""),
+            ("12345678910", "12345678910"),
+        ]
+        for nir, expected in test_cases:
+            with self.subTest(nir):
+                self.assertEqual(format_filters.format_nir(nir), expected)
 
     def test_format_approval_number(self):
         test_cases = [

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -17,6 +17,7 @@ from itou.siaes.factories import SiaeMembershipFactory
 from itou.users.enums import KIND_SIAE_STAFF
 from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
 from itou.utils.perms.user import UserInfo
+from itou.utils.templatetags.format_filters import format_approval_number
 from itou.www.siae_evaluations_views.forms import LaborExplanationForm, SetChosenPercentForm
 
 
@@ -391,7 +392,8 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, evaluated_siae)
-        self.assertContains(response, evaluated_job_application.job_application.approval.number_with_spaces)
+        formatted_number = format_approval_number(evaluated_job_application.job_application.approval.number)
+        self.assertContains(response, formatted_number, html=True, count=1)
         self.assertContains(response, evaluated_job_application.job_application.job_seeker.last_name)
         self.assertEqual(
             response.context["back_url"],


### PR DESCRIPTION
### Quoi ?

Enlève les espaces lors de la présentation d’identifiants

### Pourquoi ?

Le support reçoit régulièrement les numéros copiés/collés, qui contiennent les espaces. La saisie d’un numéro avec les espaces dans un champ de recherche affecte la pertinence des résultats. Le support “nettoie” les données manuellement en enlevant les espaces avant d’effectuer une action.

### Comment ?

Avec un peu de markup et de CSS :
`<span>GROUPE1</span><span class="ml-1">GROUPE2</span>`

### Captures d'écran

![image](https://user-images.githubusercontent.com/2758243/190449702-64298c6d-22a2-438c-8146-9d912a788cc4.png)
