### PR TITLE
support: Ajouter une fonctionnalité pour prendre temporairement l'identité d'un utilisateur

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -61,6 +61,8 @@ THIRD_PARTY_APPS = [
     "drf_spectacular",
     "django_filters",
     "import_export",
+    "hijack",
+    "hijack.contrib.admin",
 ]
 
 
@@ -120,6 +122,7 @@ DJANGO_MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "hijack.middleware.HijackUserMiddleware",
 ]
 
 ITOU_MIDDLEWARE = [
@@ -793,3 +796,6 @@ EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE = timezone.datetime(2021, 9, 27, tzinf
 # This is disabled by default, overidden in prod settings, and can be set
 # via local dev settings or env vars for a temporary environment.
 EMPLOYEE_RECORD_TRANSFER_ENABLED = bool(os.environ.get("EMPLOYEE_RECORD_TRANSFER_ENABLED", False))
+
+HIJACK_PERMISSION_CHECK = "itou.utils.perms.user.has_hijack_perm"
+HIJACK_ALLOWED_USER_EMAILS = [s.lower() for s in os.getenv("HIJACK_ALLOWED_USER_EMAILS", "").split(",") if s]

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ register_converter(SiretConverter, "siret")
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("hijack/", include("hijack.urls")),
     # --------------------------------------------------------------------------------------
     # allauth URLs. Order is important because some URLs are overriden.
     # --------------------------------------------------------------------------------------

--- a/itou/utils/perms/tests.py
+++ b/itou/utils/perms/tests.py
@@ -1,0 +1,72 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from itou.users.factories import UserFactory
+
+
+class UserHijackPermTestCase(TestCase):
+    def test_user_does_not_exist(self):
+        hijacker = UserFactory(is_active=True, is_superuser=True)
+        self.client.force_login(hijacker)
+        response = self.client.post(reverse("hijack:acquire"), {"user_pk": 0, "next": "/foo/"})
+        self.assertEqual(response.status_code, 404)
+
+    def test_superuser(self):
+        hijacked = UserFactory()
+        hijacker = UserFactory(is_superuser=True)
+        self.client.force_login(hijacker)
+
+        with self.assertLogs() as cm:
+            response = self.client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/foo/")
+        self.assertEqual(cm.records[0].message, f"admin={hijacker} has started impersonation of user={hijacked}")
+
+        with self.assertLogs() as cm:
+            response = self.client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/bar/")
+        self.assertEqual(cm.records[0].message, f"admin={hijacker} has ended impersonation of user={hijacked}")
+
+    def test_disallowed_hijackers(self):
+        hijacked = UserFactory(is_active=True)
+
+        hijacker = UserFactory(is_active=False)
+        self.client.force_login(hijacker)
+        response = self.client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/accounts/login/?next=/hijack/acquire/")
+
+        hijacker = UserFactory(is_active=True, is_staff=False, is_superuser=False)
+        self.client.force_login(hijacker)
+        response = self.client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        self.assertEqual(response.status_code, 403)
+
+        hijacker = UserFactory(is_active=True, is_staff=True, is_superuser=False)
+        self.client.force_login(hijacker)
+        response = self.client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        self.assertEqual(response.status_code, 403)
+
+        with override_settings(HIJACK_ALLOWED_USER_EMAILS=["foo@test.com", "bar@baz.org"]):
+            hijacker = UserFactory(is_active=True, is_staff=True, is_superuser=False, email="not@inthelist.com")
+            self.client.force_login(hijacker)
+            response = self.client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+            self.assertEqual(response.status_code, 403)
+
+    @override_settings(HIJACK_ALLOWED_USER_EMAILS=["foo@test.com", "bar@baz.org"])
+    def test_allowed_staff_hijacker(self):
+        hijacked = UserFactory(is_active=True)
+        hijacker = UserFactory(is_active=True, is_staff=True, email="bar@baz.org")
+        self.client.force_login(hijacker)
+
+        with self.assertLogs() as cm:
+            response = self.client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/foo/")
+        self.assertEqual(cm.records[0].message, f"admin={hijacker} has started impersonation of user={hijacked}")
+
+        with self.assertLogs() as cm:
+            response = self.client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/bar/")
+        self.assertEqual(cm.records[0].message, f"admin={hijacker} has ended impersonation of user={hijacked}")

--- a/itou/utils/perms/user.py
+++ b/itou/utils/perms/user.py
@@ -1,9 +1,15 @@
+import logging
 from collections import namedtuple
+
+from django.conf import settings
+from hijack import signals
 
 from itou.users import enums as users_enums
 from itou.utils.perms.prescriber import get_current_org_or_404
 from itou.utils.perms.siae import get_current_siae_or_404
 
+
+logger = logging.getLogger(__name__)
 
 # FIXME(vperron): This namedtuple seems like an intermediate object that is maybe no longer justified.
 # From afar it looks like a code smell or something we could/should get rid of. Beware.
@@ -34,3 +40,28 @@ def get_user_info(request):
     is_authorized_prescriber = prescriber_organization.is_authorized if prescriber_organization else False
 
     return UserInfo(request.user, kind, prescriber_organization, is_authorized_prescriber, siae)
+
+
+def has_hijack_perm(*, hijacker, hijacked):
+    if not hijacker.is_active or not hijacked.is_active:
+        return False
+
+    if hijacker.is_superuser:
+        return True
+
+    if not hijacker.is_staff:
+        return False
+
+    return hijacker.email.lower() in settings.HIJACK_ALLOWED_USER_EMAILS
+
+
+def hijack_started_signal(sender, hijacker, hijacked, request, **kwargs):  # pylint: disable=unused-argument
+    logger.info("admin=%s has started impersonation of user=%s", hijacker, hijacked)
+
+
+def hijack_ended_signal(sender, hijacker, hijacked, request, **kwargs):  # pylint: disable=unused-argument
+    logger.info("admin=%s has ended impersonation of user=%s", hijacker, hijacked)
+
+
+signals.hijack_started.connect(hijack_started_signal)
+signals.hijack_ended.connect(hijack_ended_signal)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -95,3 +95,6 @@ pyyaml==6.0  # https://github.com/yaml/pyyaml
 
 # For automatic export/import of models in the admin
 django-import-export==2.8.0
+
+# To impersonate users from the admin
+django-hijack==3.2.1  # https://github.com/django-hijack/django-hijack

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -182,6 +182,7 @@ django==4.1.1 \
     #   django-appconf
     #   django-bootstrap4
     #   django-filter
+    #   django-hijack
     #   django-import-export
     #   django-select2
     #   django-xworkflows
@@ -205,6 +206,10 @@ django-bootstrap4==22.1 \
 django-filter==22.1 \
     --hash=sha256:ed429e34760127e3520a67f415bec4c905d4649fbe45d0d6da37e6ff5e0287eb \
     --hash=sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5
+    # via -r requirements/base.in
+django-hijack==3.2.1 \
+    --hash=sha256:8df524fd085a43205a6bb497c53fd94483824b4f3179762fc1c31c1dea58d1ca \
+    --hash=sha256:b0723750b247e5b1f69f600a40b1d512404061f33918e0bffb4aa928314ea1db
     # via -r requirements/base.in
 django-import-export==2.8.0 \
     --hash=sha256:31d7dcfba22251e3ef93accb7da844f58c4d78585db9dd7dae37bb76f939da2c \

--- a/requirements/demo.txt
+++ b/requirements/demo.txt
@@ -184,6 +184,7 @@ django==4.1.1 \
     #   django-appconf
     #   django-bootstrap4
     #   django-filter
+    #   django-hijack
     #   django-import-export
     #   django-select2
     #   django-xworkflows
@@ -207,6 +208,10 @@ django-bootstrap4==22.1 \
 django-filter==22.1 \
     --hash=sha256:ed429e34760127e3520a67f415bec4c905d4649fbe45d0d6da37e6ff5e0287eb \
     --hash=sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5
+    # via -r requirements/././base.in
+django-hijack==3.2.1 \
+    --hash=sha256:8df524fd085a43205a6bb497c53fd94483824b4f3179762fc1c31c1dea58d1ca \
+    --hash=sha256:b0723750b247e5b1f69f600a40b1d512404061f33918e0bffb4aa928314ea1db
     # via -r requirements/././base.in
 django-import-export==2.8.0 \
     --hash=sha256:31d7dcfba22251e3ef93accb7da844f58c4d78585db9dd7dae37bb76f939da2c \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -295,6 +295,7 @@ django==4.1.1 \
     #   django-debug-toolbar
     #   django-extensions
     #   django-filter
+    #   django-hijack
     #   django-import-export
     #   django-select2
     #   django-xworkflows
@@ -330,6 +331,10 @@ django-extensions==3.2.1 \
 django-filter==22.1 \
     --hash=sha256:ed429e34760127e3520a67f415bec4c905d4649fbe45d0d6da37e6ff5e0287eb \
     --hash=sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5
+    # via -r requirements/base.in
+django-hijack==3.2.1 \
+    --hash=sha256:8df524fd085a43205a6bb497c53fd94483824b4f3179762fc1c31c1dea58d1ca \
+    --hash=sha256:b0723750b247e5b1f69f600a40b1d512404061f33918e0bffb4aa928314ea1db
     # via -r requirements/base.in
 django-import-export==2.8.0 \
     --hash=sha256:31d7dcfba22251e3ef93accb7da844f58c4d78585db9dd7dae37bb76f939da2c \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -184,6 +184,7 @@ django==4.1.1 \
     #   django-appconf
     #   django-bootstrap4
     #   django-filter
+    #   django-hijack
     #   django-import-export
     #   django-select2
     #   django-xworkflows
@@ -207,6 +208,10 @@ django-bootstrap4==22.1 \
 django-filter==22.1 \
     --hash=sha256:ed429e34760127e3520a67f415bec4c905d4649fbe45d0d6da37e6ff5e0287eb \
     --hash=sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5
+    # via -r requirements/././base.in
+django-hijack==3.2.1 \
+    --hash=sha256:8df524fd085a43205a6bb497c53fd94483824b4f3179762fc1c31c1dea58d1ca \
+    --hash=sha256:b0723750b247e5b1f69f600a40b1d512404061f33918e0bffb4aa928314ea1db
     # via -r requirements/././base.in
 django-import-export==2.8.0 \
     --hash=sha256:31d7dcfba22251e3ef93accb7da844f58c4d78585db9dd7dae37bb76f939da2c \

--- a/requirements/staging.txt
+++ b/requirements/staging.txt
@@ -184,6 +184,7 @@ django==4.1.1 \
     #   django-appconf
     #   django-bootstrap4
     #   django-filter
+    #   django-hijack
     #   django-import-export
     #   django-select2
     #   django-xworkflows
@@ -207,6 +208,10 @@ django-bootstrap4==22.1 \
 django-filter==22.1 \
     --hash=sha256:ed429e34760127e3520a67f415bec4c905d4649fbe45d0d6da37e6ff5e0287eb \
     --hash=sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5
+    # via -r requirements/././base.in
+django-hijack==3.2.1 \
+    --hash=sha256:8df524fd085a43205a6bb497c53fd94483824b4f3179762fc1c31c1dea58d1ca \
+    --hash=sha256:b0723750b247e5b1f69f600a40b1d512404061f33918e0bffb4aa928314ea1db
     # via -r requirements/././base.in
 django-import-export==2.8.0 \
     --hash=sha256:31d7dcfba22251e3ef93accb7da844f58c4d78585db9dd7dae37bb76f939da2c \


### PR DESCRIPTION
### Quoi ?

Permettre à un groupe d'administrateurs d'aller plus vite sur leurs investigations en permettant de "voir" le site comme un autre utilisateur.

### Pourquoi ?
En particulier le support mais aussi les développeurs peuvent passer du temps à demander à un utilisateur des détails, captures d'écran, URLs, etc qui peuvent prendre du temps, etre imprécises, etc.

Avec cette fonctionnalité les administrateurs seront en mesure de valider eux-memes un problème et avoir tous les indices directement.

### Comment ?
En utilisant django-hijack.


Cf la review app:
![Screenshot from 2022-09-15 18-26-52](https://user-images.githubusercontent.com/88618/190457568-556b5b51-5379-4cc1-a741-31903fe11514.png)

![Screenshot from 2022-09-15 18-27-27](https://user-images.githubusercontent.com/88618/190457663-53faf63b-d67a-4f69-81ce-23ce1e61b8fd.png)

