### PR TITLE
[TECH] Bump botocore

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -83,6 +83,8 @@ pysftp==0.2.9  # https://bitbucket.org/dundeemt/pysftp/src/master/
 
 # Our S3 provider does not provide a UI to manage the S3 bucket. Use this CLI instead.
 boto3==1.24.32  # https://github.com/boto/boto3
+# boto3 does require botocore which gets compiled in our dependencies. Bump it when bumping boto3.
+botocore==1.27.78
 
 # API
 # ------------------------------------------------------------------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,10 +42,11 @@ boto3==1.24.32 \
     --hash=sha256:021f2a71cbcd75c87724b7dfbf28a691f07899345047f6bc999ef646d97461df \
     --hash=sha256:cb1f1d443672a65e23756cc712d060222e53e68d0700af60b4d904125d9186db
     # via -r requirements/base.in
-botocore==1.27.73 \
-    --hash=sha256:0b94d1e7b1435f8ff108c74a09fe03ec88aadbfafe97e940ea415dc86ba305a3 \
-    --hash=sha256:e281e45e84d2728207d63499a37cea1dc1dde6093167ab238370ece67f6e7316
+botocore==1.27.78 \
+    --hash=sha256:b45ae0680699ce100386ac1478e03fd3f29ef22d6bfb5a19169ffee6e67c5293 \
+    --hash=sha256:fc2ffdafce66c051c69ae6ac50599d6da11e84371c704ae9b7cf9e2742a4dc77
     # via
+    #   -r requirements/base.in
     #   boto3
     #   s3transfer
 certifi==2022.9.14 \

--- a/requirements/demo.txt
+++ b/requirements/demo.txt
@@ -42,10 +42,11 @@ boto3==1.24.32 \
     --hash=sha256:021f2a71cbcd75c87724b7dfbf28a691f07899345047f6bc999ef646d97461df \
     --hash=sha256:cb1f1d443672a65e23756cc712d060222e53e68d0700af60b4d904125d9186db
     # via -r requirements/././base.in
-botocore==1.27.73 \
-    --hash=sha256:0b94d1e7b1435f8ff108c74a09fe03ec88aadbfafe97e940ea415dc86ba305a3 \
-    --hash=sha256:e281e45e84d2728207d63499a37cea1dc1dde6093167ab238370ece67f6e7316
+botocore==1.27.78 \
+    --hash=sha256:b45ae0680699ce100386ac1478e03fd3f29ef22d6bfb5a19169ffee6e67c5293 \
+    --hash=sha256:fc2ffdafce66c051c69ae6ac50599d6da11e84371c704ae9b7cf9e2742a4dc77
     # via
+    #   -r requirements/././base.in
     #   boto3
     #   s3transfer
 certifi==2022.9.14 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -81,10 +81,11 @@ boto3==1.24.32 \
     --hash=sha256:021f2a71cbcd75c87724b7dfbf28a691f07899345047f6bc999ef646d97461df \
     --hash=sha256:cb1f1d443672a65e23756cc712d060222e53e68d0700af60b4d904125d9186db
     # via -r requirements/base.in
-botocore==1.27.73 \
-    --hash=sha256:0b94d1e7b1435f8ff108c74a09fe03ec88aadbfafe97e940ea415dc86ba305a3 \
-    --hash=sha256:e281e45e84d2728207d63499a37cea1dc1dde6093167ab238370ece67f6e7316
+botocore==1.27.78 \
+    --hash=sha256:b45ae0680699ce100386ac1478e03fd3f29ef22d6bfb5a19169ffee6e67c5293 \
+    --hash=sha256:fc2ffdafce66c051c69ae6ac50599d6da11e84371c704ae9b7cf9e2742a4dc77
     # via
+    #   -r requirements/base.in
     #   boto3
     #   s3transfer
 build==0.8.0 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -42,10 +42,11 @@ boto3==1.24.32 \
     --hash=sha256:021f2a71cbcd75c87724b7dfbf28a691f07899345047f6bc999ef646d97461df \
     --hash=sha256:cb1f1d443672a65e23756cc712d060222e53e68d0700af60b4d904125d9186db
     # via -r requirements/././base.in
-botocore==1.27.73 \
-    --hash=sha256:0b94d1e7b1435f8ff108c74a09fe03ec88aadbfafe97e940ea415dc86ba305a3 \
-    --hash=sha256:e281e45e84d2728207d63499a37cea1dc1dde6093167ab238370ece67f6e7316
+botocore==1.27.78 \
+    --hash=sha256:b45ae0680699ce100386ac1478e03fd3f29ef22d6bfb5a19169ffee6e67c5293 \
+    --hash=sha256:fc2ffdafce66c051c69ae6ac50599d6da11e84371c704ae9b7cf9e2742a4dc77
     # via
+    #   -r requirements/././base.in
     #   boto3
     #   s3transfer
 certifi==2022.9.14 \

--- a/requirements/staging.txt
+++ b/requirements/staging.txt
@@ -42,10 +42,11 @@ boto3==1.24.32 \
     --hash=sha256:021f2a71cbcd75c87724b7dfbf28a691f07899345047f6bc999ef646d97461df \
     --hash=sha256:cb1f1d443672a65e23756cc712d060222e53e68d0700af60b4d904125d9186db
     # via -r requirements/././base.in
-botocore==1.27.73 \
-    --hash=sha256:0b94d1e7b1435f8ff108c74a09fe03ec88aadbfafe97e940ea415dc86ba305a3 \
-    --hash=sha256:e281e45e84d2728207d63499a37cea1dc1dde6093167ab238370ece67f6e7316
+botocore==1.27.78 \
+    --hash=sha256:b45ae0680699ce100386ac1478e03fd3f29ef22d6bfb5a19169ffee6e67c5293 \
+    --hash=sha256:fc2ffdafce66c051c69ae6ac50599d6da11e84371c704ae9b7cf9e2742a4dc77
     # via
+    #   -r requirements/././base.in
     #   boto3
     #   s3transfer
 certifi==2022.9.14 \


### PR DESCRIPTION
It is required by boto3 and will be automatically updated on its own every time we bump the dependencies by runnning compile-deps.

With this change, we get rid of this happening randomly which can be annoying.


[non je ne traduis pas tout ça, ça n'a pas a entrer dans le changelog, etc]