### PR TITLE
Candidatures : ajout nom conseiller pe

### DIFF
--- a/itou/metabase/management/commands/sql/019_candidatures_echelle_locale.sql
+++ b/itou/metabase/management/commands/sql/019_candidatures_echelle_locale.sql
@@ -117,6 +117,7 @@ select
     safir_org_prescripteur,
     id_org_prescripteur,
     nom_org_prescripteur,
+    Nom_prénom_conseiller_pe,
     dept_org,
     injection_ai,
     ville,


### PR DESCRIPTION
A la demande de PE, du nom du conseiller pe ayant effectué la prescription

