### PR TITLE
Correction : Les candidatures ne sont plus toutes enregistrées comme "spontanée"

### DIFF
--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -65,6 +65,7 @@
 {% endblock %}
 
 {% block form_content %}
+    {{ form.selected_jobs.as_hidden }}
     <div class="d-flex flex-column flex-lg-row">
         <div class="col-12 col-lg-7 pl-0">
             {% bootstrap_field form.message %}


### PR DESCRIPTION
### Quoi ?

Ajout des fiches de poste sélectionnées dans le formulaire en tant que champs cachés.

### Pourquoi ?

Depuis la MEP de #1485 toutes les candidatures sont enregistrées sans les fiches de postes sélectionnées en étape 1.
