### PR TITLE
Fix typo in “S’inscrire” nav option

### DIFF
--- a/itou/templates/layout/_header.html
+++ b/itou/templates/layout/_header.html
@@ -182,8 +182,7 @@
                                 <i class="ri-arrow-right-up-line ri-lg"></i>
                             </a>
                         </li>
-                        {% include 'layout/_nav_btn_items.html' with
-                        button_size='btn-sm' %}
+                        {% include 'layout/_nav_btn_items.html' with button_size='btn-sm' %}
                     </ul>
                 </nav>
                 <div>{% include 'layout/_nav_preheader_items.html' %}</div>


### PR DESCRIPTION
The button appears as “{% include 'layout/_nav_btn_items.html' with
button_size='btn-sm' %}” in the template.


### Quoi ?

Correction d’une typo sur le bouton “S’inscrire | Se connecter”.

### Pourquoi ?

Un extrait de code incompréhensible apparait actuellement pour les utilisateurs.