### PR TITLE
Add a venv alias to build the virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ else
 	EXEC_CMD := docker exec -ti itou_django
 endif
 
-.PHONY: run clean cdsitepackages quality fix pylint compile-deps
+.PHONY: run venv clean cdsitepackages quality fix pylint compile-deps
 
 # Run Docker images
 run:
@@ -27,6 +27,8 @@ $(VIRTUAL_ENV): requirements/dev.txt
 	$@/bin/pip install -r $^
 	$@/bin/pip-sync $^
 	touch $@
+
+venv: $(VIRTUAL_ENV)
 
 PIP_COMPILE_FLAGS := --upgrade --allow-unsafe --generate-hashes
 compile-deps: $(VIRTUAL_ENV)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ le développement. Elle peut être exécutée régulièrement pour s’assurer q
 dépendances sont bien à jour.
 
 ```bash
-$ make .venv
+$ make venv
 ```
 
 La variable d’environnement `DJANGO_SECRET_KEY` doit avoir une valeur. Par


### PR DESCRIPTION
Instead of requiring everybody to type the path to their venv, just make
an alias.