### PR TITLE
Replace deprecated assertEquals → assertEqual

### DIFF
--- a/itou/employee_record/tests/tests_models.py
+++ b/itou/employee_record/tests/tests_models.py
@@ -484,8 +484,8 @@ class EmployeeRecordLifeCycleTest(TestCase):
         )
         employee_record_code_3436.update_as_processed_as_duplicate()
         self.assertTrue(employee_record_code_3436.processed_as_duplicate)
-        self.assertEquals(Status.PROCESSED, employee_record_code_3436.status)
-        self.assertEquals("Statut forcé suite à doublon ASP", employee_record_code_3436.asp_processing_label)
+        self.assertEqual(Status.PROCESSED, employee_record_code_3436.status)
+        self.assertEqual("Statut forcé suite à doublon ASP", employee_record_code_3436.asp_processing_label)
         self.assertIsNone(employee_record_code_3436.archived_json)
 
         with self.assertRaises(InvalidStatusError):

--- a/itou/prescribers/tests.py
+++ b/itou/prescribers/tests.py
@@ -594,20 +594,20 @@ class UpdateRefusedPrescriberOrganizationKindManagementCommandsTest(TestCase):
         )
 
         # Controls before execution
-        self.assertEquals(len(PrescriberAuthorizationStatus) + 2, PrescriberOrganization.objects.all().count())
-        self.assertEquals(
+        self.assertEqual(len(PrescriberAuthorizationStatus) + 2, PrescriberOrganization.objects.all().count())
+        self.assertEqual(
             3,
             PrescriberOrganization.objects.filter(authorization_status=PrescriberAuthorizationStatus.REFUSED).count(),
         )
-        self.assertEquals(0, PrescriberOrganization.objects.filter(kind=PrescriberOrganizationKind.OTHER).count())
+        self.assertEqual(0, PrescriberOrganization.objects.filter(kind=PrescriberOrganizationKind.OTHER).count())
 
         # Update refused prescriber organizations without duplicated siret
         call_command("update_refused_prescriber_organizations_kind")
 
         # Controls after execution
-        self.assertEquals(len(PrescriberAuthorizationStatus) + 2, PrescriberOrganization.objects.all().count())
-        self.assertEquals(
+        self.assertEqual(len(PrescriberAuthorizationStatus) + 2, PrescriberOrganization.objects.all().count())
+        self.assertEqual(
             3,
             PrescriberOrganization.objects.filter(authorization_status=PrescriberAuthorizationStatus.REFUSED).count(),
         )
-        self.assertEquals(1, PrescriberOrganization.objects.filter(kind=PrescriberOrganizationKind.OTHER).count())
+        self.assertEqual(1, PrescriberOrganization.objects.filter(kind=PrescriberOrganizationKind.OTHER).count())

--- a/itou/www/eligibility_views/tests.py
+++ b/itou/www/eligibility_views/tests.py
@@ -59,7 +59,7 @@ class AdministrativeCriteriaFormTest(TestCase):
         user = siae.members.first()
 
         form = AdministrativeCriteriaForm(user, siae)
-        self.assertEquals(AdministrativeCriteria.objects.all().count(), len(form.fields))
+        self.assertEqual(AdministrativeCriteria.objects.all().count(), len(form.fields))
 
     def test_error_criteria_number_for_siae(self):
         """


### PR DESCRIPTION
assertEquals is deprecated.
https://docs.python.org/3/library/unittest.html#deprecated-aliases