### PR TITLE
Utilisation de pytest pour lancer les tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
     - name: 🚧 Check pending migrations
       run: django-admin makemigrations --check --dry-run --noinput
     - name: 🤹‍ Django tests
-      run: django-admin test --noinput --failfast --parallel
+      run: make test
       env:
         DJANGO_DEBUG: True
+        USE_VENV: 1

--- a/Makefile
+++ b/Makefile
@@ -112,19 +112,13 @@ graph_models_itou:
 # Tests.
 # =============================================================================
 
-.PHONY: test test-interactive coverage
+.PHONY: coverage test
 
-TEST_OPTS += --force-color --timing --no-input
-
-test:
-	$(EXEC_CMD) ./manage.py test --settings=config.settings.test $(TEST_OPTS) --parallel $(TARGET)
-
-# Lets you add a debugger.
-test-interactive:
-	$(EXEC_CMD) ./manage.py test --settings=config.settings.test $(TEST_OPTS) --keepdb $(TARGET)
+test: $(VIRTUAL_ENV)
+	$(EXEC_CMD) pytest $(TARGET)
 
 coverage:
-	$(EXEC_CMD) coverage run ./manage.py test itou --settings=config.settings.test --no-input
+	$(EXEC_CMD) coverage run -m pytest
 	$(EXEC_CMD) coverage html
 
 # Docker shell.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = config.settings.test
 python_files = test*.py
-addopts = --reuse-db --verbose --capture=no
+addopts = --numprocesses=logical --reuse-db

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -39,6 +39,7 @@ requests-mock==1.9.3  # https://github.com/jamielennox/requests-mock
 respx==0.19.2  # https://lundberg.github.io/respx/
 pytest==7.1.2  # https://github.com/pytest-dev/pytest
 pytest-django== 4.5.2 # https://github.com/pytest-dev/pytest-django/
+pytest-xdist  # https://pypi.org/project/pytest-xdist/
 
 # Data extracts
 # ------------------------------------------------------------------------------

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -360,6 +360,10 @@ et-xmlfile==1.1.0 \
     --hash=sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c \
     --hash=sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada
     # via openpyxl
+execnet==1.9.0 \
+    --hash=sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
+    --hash=sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142
+    # via pytest-xdist
 executing==1.0.0 \
     --hash=sha256:550d581b497228b572235e633599133eeee67073c65914ca346100ad56775349 \
     --hash=sha256:98daefa9d1916a4f0d944880d5aeaf079e05585689bebd9ff9b32e31dd5e1017
@@ -892,7 +896,9 @@ pure-eval==0.2.2 \
 py==1.11.0 \
     --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
     --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-forked
 pycodestyle==2.8.0 \
     --hash=sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20 \
     --hash=sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f
@@ -978,9 +984,19 @@ pytest==7.1.2 \
     # via
     #   -r requirements/dev.in
     #   pytest-django
+    #   pytest-forked
+    #   pytest-xdist
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
+    # via -r requirements/dev.in
+pytest-forked==1.4.0 \
+    --hash=sha256:8b67587c8f98cbbadfdd804539ed5455b6ed03802203485dd2f53c1422d7440e \
+    --hash=sha256:bbbb6717efc886b9d64537b41fb1497cfaf3c9601276be8da2cccfea5a3c8ad8
+    # via pytest-xdist
+pytest-xdist==2.5.0 \
+    --hash=sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf \
+    --hash=sha256:6fe5c74fec98906deb8f2d2b616b5c782022744978e7bd4695d39c8f42d0ce65
     # via -r requirements/dev.in
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \


### PR DESCRIPTION
### Quoi ?

Utilisation de pytest pour lancer les tests

### Pourquoi ?

- L’utilisation du runner Django est assez verbeuse (pas mal de configuration). Voir https://itou-inclusion.slack.com/archives/C0412CTV63D/p1663851337162789
- L’interface du runner Django est bien moins aboutie, notamment à cause de l’affichage des messages (`print()`) qui empêche de suivre la progression des tests, et les rapports d’échecs et d’erreurs pytest sont beaucoup plus précis, facilitant le diagnostic.

### Autre

- En attendant un débat avec l’équipe, je propose de garder la compatibilité avec unittest. Pour cette raison, la CI continue de tourner avec le test runner django (basé sur unittest). Le runner pytest est simplement plus mis en avant afin d’améliorer la qualité de vie des devs.
- Cheatsheet :
    - `make test` : `pytest`
    - `make test-interactive` : `pytest --pdb`