### PR TITLE
[Standby] Ouverture du module fiches salarié pour les EITI

### DIFF
--- a/itou/api/README-FS-SSII.md
+++ b/itou/api/README-FS-SSII.md
@@ -16,7 +16,7 @@ Ceci est une documentation publique à destination des logiciels SSII pour la r�
 
 - Il y a au plus une FS par couple (SIRET, PASS IAE). Autrement dit, si une même personne est recrutée pour la seconde fois (avec à chaque fois le même PASS IAE) dans la même SIAE (ou deux structures ayant le même SIRET), cela ne donnera pas lieu à une nouvelle FS.
 
-- Les seules mesures concernées ici sont ACI, EI, ETTI et normalement les AI. Donc pas les EITI, GEIQ, EA, EATT.
+- Les seules mesures concernées ici sont ACI, AI, EI, EITI, ETTI. Donc pas les GEIQ, EA, EATT.
 
 ## Exemples techniques complets avec curl
 
@@ -178,6 +178,7 @@ Tous les référentiels utiles mentionnés dans le JSON ci-dessous sont [disponi
         # Doit être rempli si et seulement si inscritPoleEmploi est true.
         "numeroIDE": "3500000A",
         "salarieRQTH": false,
+        # Toujours "false" pour les EITI
         "salarieOETH": false,
         # Dixit Mélanie : Dans la même idée : ATA n'est pas demandée sur ITOU mais l'est sur l'ASP. Cette aide conditionne le true/false de l'aide sociale.
         "salarieAideSociale": false,

--- a/itou/asp/models.py
+++ b/itou/asp/models.py
@@ -498,14 +498,6 @@ class SiaeKind(models.TextChoices):
     EI_MP = "EI_MP", "Milieu Pénitentiaire - Entreprise d'Insertion"
     ACI_MP = "ACI_MP", "Milieu Pénitentiaire - Atelier et Chantier d'Insertion"
 
-    @property
-    def valid_kind_for_employee_record(self):
-        """
-        The ASP SIAE kind ("Mesure") must be one of the following
-        to be eligible for ASP employee record processing
-        """
-        return self.value in ["AI_DC", "ACI_DC", "ETTI_DC", "EI_DC"]
-
     @classmethod
     def from_siae_kind(cls, kind):
         """

--- a/itou/employee_record/mocks/asp_test_siaes.py
+++ b/itou/employee_record/mocks/asp_test_siaes.py
@@ -25,6 +25,7 @@ ASP_ID_TO_SIRET_MAPPING = {
     2062: {"siret": "21590350101445", "mesure": "ACI_DC", "numeroAnnexe": "ACI033207853A0M0"},
     1516: {"siret": "33055039301440", "mesure": "EI_DC", "numeroAnnexe": "ACI023201111A0M0"},
     1060: {"siret": "33055039301440", "mesure": "AI_DC", "numeroAnnexe": "AI59L209512A0M0"},
+    3411: {"siret": "83533318801446", "mesure": "EITI_DC", "numeroAnnexe": ""},
 }
 
 

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -610,6 +610,12 @@ class EmployeeRecord(models.Model):
         return SiaeKind.from_siae_kind(self.job_application.to_siae.kind)
 
     @property
+    def asp_oeth_employee(self):
+        if self.asp_siae_type is SiaeKind.EITI:
+            return False
+        return self.job_seeker_profile.oeth_employee if self.job_seeker_profile else None
+
+    @property
     def batch_line_number(self):
         """
         This transient field is updated at runtime for JSON serialization.

--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -128,7 +128,7 @@ class _SituationSerializer(serializers.Serializer):
     numeroIDE = serializers.CharField(source="job_seeker.pole_emploi_id")
 
     salarieRQTH = serializers.BooleanField(source="job_seeker.jobseeker_profile.rqth_employee")
-    salarieOETH = serializers.BooleanField(source="job_seeker.jobseeker_profile.oeth_employee")
+    salarieOETH = serializers.BooleanField(source="asp_oeth_employee")
     salarieAideSociale = serializers.BooleanField(source="job_seeker.jobseeker_profile.has_social_allowance")
 
     salarieBenefRSA = serializers.CharField(source="job_seeker.jobseeker_profile.has_rsa_allocation")

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -349,7 +349,7 @@ class JobApplicationQuerySet(models.QuerySet):
         Rules of eligibility for a job application:
             - be in 'ACCEPTED' state (valid hiring)
             - to be linked to an approval
-            - hiring SIAE must be one of : AI, EI, ACI, ETTI. EITI will be added as of september 2022
+            - hiring SIAE must be one of : ACI, AI, EI, EITI, ETTI.
             - the hiring date must be greater than 2021.09.27 (feature production date)
             - employee record is not blocked via admin (`create_employee_record` field)
 

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -192,7 +192,7 @@ class Siae(AddressMixin, OrganizationAbstract):
     )
 
     # These kinds of SIAE can use employee record app to send data to ASP
-    ASP_EMPLOYEE_RECORD_KINDS = [SiaeKind.EI, SiaeKind.ACI, SiaeKind.AI, SiaeKind.ETTI]
+    ASP_EMPLOYEE_RECORD_KINDS = [SiaeKind.ACI, SiaeKind.AI, SiaeKind.EI, SiaeKind.EITI, SiaeKind.ETTI]
 
     # SIAE structures have two different SIRET numbers in ASP FluxIAE data ("Vue Structure").
     # The first one is the "SIRET actualisé" which we store as `siae.siret`. It changes rather frequently

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -14,7 +14,7 @@ class ListEmployeeRecordsTest(EmployeeRecordFixtureTest):
             name="Evil Corp.", membership__user__first_name="Elliot", membership__user__is_superuser=True
         )
         self.siae_without_perms = SiaeWithMembershipAndJobsFactory(
-            kind="EITI", name="A-Team", membership__user__first_name="Hannibal"
+            kind="EATT", name="A-Team", membership__user__first_name="Hannibal"
         )
         self.user = self.siae.members.get(first_name="Elliot")
         self.user_without_perms = self.siae_without_perms.members.get(first_name="Hannibal")


### PR DESCRIPTION
Ça me semble un peu trop simple qu'il n'y ai que ça mais je ne trouve/connais pas d'autre chemin donc j'ouvre la PR :grin:

### Quoi ?

Ouverture du module fiches salarié pour les EITI avec règle spécifique concernant le champ “OETH”

### Pourquoi ?

Mise à jour du cahier des charges ASP (Version : 1.05 du 16/08/2022)

### Comment ?

- Ajout de la mesure EITI aux mesures pouvant utiliser les fiches salarié
- Si la mesure de la ligne est EITI, la plateforme doit envoyer à l’ASP le champs OETH à false