### PR TITLE
Débute la phase contradictoire avec EvaluatedSiae.reviewed_at

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -304,6 +304,8 @@ class EvaluatedSiae(models.Model):
         on_delete=models.CASCADE,
         related_name="evaluated_siaes",
     )
+    # The timestamp of the first review, which marks the start of the
+    # adversarial phase.
     reviewed_at = models.DateTimeField(verbose_name=("Contrôlée le"), blank=True, null=True)
 
     objects = EvaluatedSiaeManager.from_queryset(EvaluatedSiaeQuerySet)()
@@ -334,8 +336,10 @@ class EvaluatedSiae(models.Model):
                 connection = mail.get_connection()
                 connection.send_messages([email])
 
-                self.reviewed_at = timezone.now()
-                self.save(update_fields=["reviewed_at"])
+                # The first review marks the beginning of the adversarial phase.
+                if self.reviewed_at is None:
+                    self.reviewed_at = timezone.now()
+                    self.save(update_fields=["reviewed_at"])
 
     # fixme vincentporte : to refactor. move all get_email_to_siae_xxx() method to emails.py in siae model
     def get_email_to_siae_selected(self):


### PR DESCRIPTION
### Quoi ?

Débute la phase contradictoire avec EvaluatedSiae.reviewed_at

### Pourquoi ?

La revue des justificatifs d’auto-prescription des SIAE par les DDETS s’effectue en deux phases. Premièrement, une phase amiable durant laquelle les SIAE peuvent envoyer les justificatifs, pour qu’ils soient traitées par la DDETS. Une fois la phase amiable terminée, les SIAE dont les justificatifs ont été refusées entrent dans une phase contradictoire, d’une durée de 6 semaines, leur offrant la possibilité de se conformer aux remarques de la DDETS. La DDETS va alors à nouveau traiter les documents, et cette fois un refus est définitif.
La date d’intérêt est la première revue, qui a démarré la phase contradictoire. La seconde revue est définitive, sa date importe peu et n’est pas enregistrée pour le moment.