### PR TITLE
Accélération des tests

### DIFF
--- a/itou/allauth_adapters/peamu/tests.py
+++ b/itou/allauth_adapters/peamu/tests.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 
 from itou.allauth_adapters.peamu.provider import PEAMUProvider
 from itou.users import enums as users_enums
-from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
+from itou.users.factories import JobSeekerFactory
 from itou.users.models import User
 
 
@@ -144,7 +144,7 @@ class PEAMUTests(OAuth2TestsMixin, TestCase):
         The most secure option was to simply redirect the default path to our own.
         """
         user = JobSeekerFactory(has_completed_welcoming_tour=True)
-        self.client.login(username=user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get("/accounts/profile/")
         self.assertRedirects(response, reverse("dashboard:index"))
 

--- a/itou/api/employee_record_api/tests/tests.py
+++ b/itou/api/employee_record_api/tests/tests.py
@@ -103,13 +103,13 @@ class EmployeeRecordAPIPermissionsTest(APITestCase):
         A session authentication is valid to use the API (same security level as token)
         => Allows testing in DEV context
         """
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         response = self.client.get(ENDPOINT_URL, format="json")
         self.assertEqual(response.status_code, 200)
 
     def test_permission_ko_with_session(self):
-        self.client.login(username=self.unauthorized_user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.unauthorized_user)
 
         response = self.client.get(ENDPOINT_URL, format="json")
         self.assertRedirects(response, reverse("account_logout"), status_code=302, target_status_code=200)
@@ -146,7 +146,7 @@ class EmployeeRecordAPIFetchListTest(APITestCase):
         Fetch list of employee records with and without `status` query param
         """
         # Using session auth (same as token but less steps)
-        self.client.login(username=self.siae_member.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_member)
 
         # Get list without filtering by status (PROCESSED)
         # note: there is no way to create a processed employee record
@@ -231,7 +231,7 @@ class EmployeeRecordAPIFetchListTest(APITestCase):
         # BUGFIX:
         # Test that employee phone number and email address are passed
         # to API serializer.
-        self.client.login(username=self.siae_member.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_member)
 
         response = self.client.get(ENDPOINT_URL + "?status=READY", format="json")
 
@@ -268,7 +268,7 @@ class EmployeeRecordAPIParametersTest(APITestCase):
         employee_record.update_as_ready()
 
         member = employee_record.job_application.to_siae.members.first()
-        self.client.login(username=member.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(member)
 
         response = self.client.get(ENDPOINT_URL + "?status=READY", format="json")
 
@@ -301,7 +301,7 @@ class EmployeeRecordAPIParametersTest(APITestCase):
         employee_record.update_as_sent("RIAE_FS_20220101000000.json", 1)
 
         member = employee_record.job_application.to_siae.members.first()
-        self.client.login(username=member.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(member)
         response = self.client.get(ENDPOINT_URL + "?status=READY", format="json")
 
         self.assertEqual(response.status_code, 200)
@@ -340,7 +340,7 @@ class EmployeeRecordAPIParametersTest(APITestCase):
         yesterday_param = f"{today - relativedelta(days=1):%Y-%m-%d}"
 
         member = employee_record.job_application.to_siae.members.first()
-        self.client.login(username=member.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(member)
         response = self.client.get(ENDPOINT_URL + f"?created={today_param}", format="json")
 
         self.assertEqual(response.status_code, 200)
@@ -383,7 +383,7 @@ class EmployeeRecordAPIParametersTest(APITestCase):
 
         member = employee_record_1.job_application.to_siae.members.first()
 
-        self.client.login(username=member.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(member)
         response = self.client.get(ENDPOINT_URL + f"?since={today}", format="json")
 
         self.assertEqual(response.status_code, 200)
@@ -431,7 +431,7 @@ class EmployeeRecordAPIParametersTest(APITestCase):
 
         member = employee_record_1.job_application.to_siae.members.first()
 
-        self.client.login(username=member.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(member)
         response = self.client.get(ENDPOINT_URL + "?status=NEW", format="json")
 
         self.assertEqual(response.status_code, 200)

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -32,7 +32,7 @@ from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import Siae
-from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, UserFactory
+from itou.users.factories import JobSeekerFactory, UserFactory
 
 
 class CommonApprovalQuerySetTest(TestCase):
@@ -618,7 +618,7 @@ class AutomaticApprovalAdminViewsTest(TestCase):
         permission = Permission.objects.get(content_type=content_type, codename="change_approval")
         user.user_permissions.add(permission)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         job_app = JobApplicationWithApprovalFactory(state=JobApplicationWorkflow.STATE_ACCEPTED)
         approval = job_app.approval
@@ -644,7 +644,7 @@ class AutomaticApprovalAdminViewsTest(TestCase):
 class CustomApprovalAdminViewsTest(TestCase):
     def test_manually_add_approval(self):
         user = UserFactory()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # When a Pôle emploi ID has been forgotten and the user has no NIR, an approval must be delivered
         # with a manual verification.

--- a/itou/openid_connect/inclusion_connect/tests.py
+++ b/itou/openid_connect/inclusion_connect/tests.py
@@ -465,7 +465,7 @@ class InclusionConnectLogoutTest(TestCase):
         he should be logged out without inclusion connect.
         """
         user = UserFactory()
-        self.client.login(email=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.post(reverse("account_logout"))
         expected_redirection = reverse("home:hp")
         self.assertRedirects(response, expected_redirection)

--- a/itou/prescribers/tests.py
+++ b/itou/prescribers/tests.py
@@ -21,7 +21,7 @@ from itou.prescribers.factories import (
 )
 from itou.prescribers.management.commands.merge_organizations import organization_merge_into
 from itou.prescribers.models import PrescriberOrganization
-from itou.users.factories import DEFAULT_PASSWORD, UserFactory
+from itou.users.factories import UserFactory
 from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK, INSEE_API_RESULT_MOCK
 
 
@@ -254,7 +254,7 @@ class PrescriberOrganizationAdminTest(TestCase):
         ]
 
     def test_refuse_prescriber_habilitation_by_superuser(self):
-        self.client.login(username=self.superuser.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.superuser)
 
         prescriberorganization = PrescriberOrganizationFactory(
             authorized=True,
@@ -299,7 +299,7 @@ class PrescriberOrganizationAdminTest(TestCase):
                 )
 
     def test_refuse_prescriber_habilitation_pending_status(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         prescriberorganization = PrescriberOrganizationFactory(
             authorized=True,
@@ -340,7 +340,7 @@ class PrescriberOrganizationAdminTest(TestCase):
         self.assertEqual(updated_prescriberorganization.authorization_status, PrescriberAuthorizationStatus.REFUSED)
 
     def test_refuse_prescriber_habilitation_not_pending_status(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         prescriberorganization = PrescriberOrganizationFactory(
             authorized=True,
@@ -384,7 +384,7 @@ class PrescriberOrganizationAdminTest(TestCase):
                 )
 
     def test_accept_prescriber_habilitation_by_superuser(self):
-        self.client.login(username=self.superuser.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.superuser)
 
         prescriberorganization = PrescriberOrganizationFactory(
             authorized=True,
@@ -429,7 +429,7 @@ class PrescriberOrganizationAdminTest(TestCase):
                 )
 
     def test_accept_prescriber_habilitation_pending_status(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         prescriberorganization = PrescriberOrganizationFactory(
             authorized=True,
@@ -470,7 +470,7 @@ class PrescriberOrganizationAdminTest(TestCase):
         self.assertEqual(updated_prescriberorganization.authorization_status, PrescriberAuthorizationStatus.VALIDATED)
 
     def test_accept_prescriber_habilitation_refused_status(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         prescriberorganization = PrescriberOrganizationFactory(
             authorized=True,
@@ -511,7 +511,7 @@ class PrescriberOrganizationAdminTest(TestCase):
         self.assertEqual(updated_prescriberorganization.authorization_status, PrescriberAuthorizationStatus.VALIDATED)
 
     def test_accept_prescriber_habilitation_other_status(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         prescriberorganization = PrescriberOrganizationFactory(
             authorized=True,

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -41,7 +41,7 @@ from itou.prescribers.factories import PrescriberOrganizationWithMembershipFacto
 from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import Siae, SiaeMembership
 from itou.users.enums import KIND_JOB_SEEKER, KIND_PRESCRIBER, KIND_SIAE_STAFF
-from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory, UserFactory
+from itou.users.factories import JobSeekerFactory, PrescriberFactory, UserFactory
 from itou.users.models import User
 from itou.utils.apis import api_entreprise
 from itou.utils.apis.geocoding import GeocodingDataException, get_geocoding_data
@@ -1197,7 +1197,7 @@ class ResumeFormMixinTest(TestCase):
 class SupportRemarkAdminViewsTest(TestCase):
     def test_add_support_remark_to_suspension(self):
         user = UserFactory()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         today = timezone.now().date()
         job_app = JobApplicationWithApprovalFactory(state=JobApplicationWorkflow.STATE_ACCEPTED)

--- a/itou/www/apply/tests/test_edit.py
+++ b/itou/www/apply/tests/test_edit.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication
 from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
-from itou.users.factories import DEFAULT_PASSWORD
 from itou.utils.widgets import DuetDatePickerWidget
 
 
@@ -55,7 +54,7 @@ class EditContractTest(TestCase):
         """
         Checks possibility of changing hiring start date to a future date.
         """
-        self.client.login(username=self.user1.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user1)
 
         response = self.client.get(self.url)
 
@@ -87,7 +86,7 @@ class EditContractTest(TestCase):
         """
         Checks possibility of changing hiring start date to a future date, with no hiring_end_at date.
         """
-        self.client.login(username=self.user1.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user1)
 
         response = self.client.get(self.url)
 
@@ -134,7 +133,7 @@ class EditContractTest(TestCase):
         """
         Past contract start date are not allowed
         """
-        self.client.login(username=self.user1.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user1)
 
         response = self.client.get(self.url)
 
@@ -155,7 +154,7 @@ class EditContractTest(TestCase):
         The contract start date can only be postponed of 30 days
         """
 
-        self.client.login(username=self.user1.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user1)
 
         url = reverse("apply:edit_contract_start_date", kwargs={"job_application_id": self.job_application_1.id})
         response = self.client.get(url)
@@ -177,7 +176,7 @@ class EditContractTest(TestCase):
         If hiring date is postponed,
         approval start date must be updated accordingly (if there is an approval)
         """
-        self.client.login(username=self.user1.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user1)
         response = self.client.get(self.url)
 
         future_start_date = (timezone.now() + relativedelta(days=20)).date()
@@ -202,7 +201,7 @@ class EditContractTest(TestCase):
         When the job application is linked to a previous approval,
         check that approval dates are not updated if the hiring date change
         """
-        self.client.login(username=self.user2.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user2)
         response = self.client.get(self.old_url)
 
         future_start_date = (timezone.now() + relativedelta(days=5)).date()
@@ -223,7 +222,7 @@ class EditContractTest(TestCase):
         Previously running approval start date must not be updated
         when postponing contract dates
         """
-        self.client.login(username=self.user2.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user2)
         response = self.client.get(self.old_url)
 
         approval = self.job_application_2.approval

--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -16,7 +16,6 @@ from itou.jobs.factories import create_test_romes_and_appellations
 from itou.jobs.models import Appellation
 from itou.prescribers.factories import PrescriberMembershipFactory, PrescriberOrganizationWithMembershipFactory
 from itou.siaes.factories import SiaeFactory
-from itou.users.factories import DEFAULT_PASSWORD
 from itou.utils.widgets import DuetDatePickerWidget
 
 
@@ -101,7 +100,7 @@ class ProcessListJobSeekerTest(ProcessListTest):
         """
         Maggie wants to see job applications sent for her.
         """
-        self.client.login(username=self.maggie.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.maggie)
         response = self.client.get(self.job_seeker_base_url)
 
         # Count job applications used by the template
@@ -115,7 +114,7 @@ class ProcessListJobSeekerTest(ProcessListTest):
         Provide a list of job applications sent by a job seeker
         and filtered by a state.
         """
-        self.client.login(username=self.maggie.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.maggie)
         expected_state = self.maggie.job_applications.last().state
         params = urlencode({"states": [expected_state]}, True)
         url = f"{self.job_seeker_base_url}?{params}"
@@ -141,7 +140,7 @@ class ProcessListJobSeekerTest(ProcessListTest):
                 created_at=now - timezone.timedelta(days=diff_day), job_seeker=self.maggie
             )
 
-        self.client.login(username=self.maggie.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.maggie)
 
         date_format = DuetDatePickerWidget.INPUT_DATE_FORMAT
 
@@ -172,7 +171,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         Eddie wants to see a list of job applications sent to his SIAE.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         response = self.client.get(self.siae_base_url)
 
         total_applications = len(response.context["job_applications_page"].object_list)
@@ -184,7 +183,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         Eddie wants to see only accepted job applications.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         state_accepted = JobApplicationWorkflow.STATE_ACCEPTED
         params = urlencode({"states": [state_accepted]}, True)
         url = f"{self.siae_base_url}?{params}"
@@ -199,7 +198,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         Eddie wants to see NEW and PROCESSING job applications.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         job_applications_states = [JobApplicationWorkflow.STATE_NEW, JobApplicationWorkflow.STATE_PROCESSING]
         params = urlencode({"states": job_applications_states}, True)
         url = f"{self.siae_base_url}?{params}"
@@ -214,7 +213,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         Eddie wants to see job applications sent at a specific date.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         date_format = DuetDatePickerWidget.INPUT_DATE_FORMAT
         job_applications = self.hit_pit.job_applications_received.not_archived().order_by("created_at")
         jobs_in_range = job_applications[3:]
@@ -242,7 +241,7 @@ class ProcessListSiaeTest(ProcessListTest):
         in the HTTP query if they are not filled in by the user.
         Make sure the template loads all available job applications if fields are empty.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         url = f"{self.siae_base_url}?start_date=&end_date="
         response = self.client.get(url)
         total_applications = len(response.context["job_applications_page"].object_list)
@@ -253,7 +252,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         Eddie wants to see applications sent by Pôle emploi.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         sender_organization = self.pole_emploi
         params = urlencode({"sender_organizations": [sender_organization.id]}, True)
         url = f"{self.siae_base_url}?{params}"
@@ -268,7 +267,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         Eddie wants to see applications sent by a member of Pôle emploi.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         sender = self.thibault_pe
         params = urlencode({"senders": [sender.id]}, True)
         url = f"{self.siae_base_url}?{params}"
@@ -283,7 +282,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         Eddie wants to see Maggie's job applications.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         job_seekers_ids = [self.maggie.id]
         params = urlencode({"job_seekers": job_seekers_ids}, True)
         url = f"{self.siae_base_url}?{params}"
@@ -298,7 +297,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         Eddie wants to see applications sent by Pôle emploi and L'Envol.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         senders_ids = [self.pole_emploi.id, self.l_envol.id]
         params = urlencode({"sender_organizations": [self.thibault_pe.id, self.audrey_envol.id]}, True)
         url = f"{self.siae_base_url}?{params}"
@@ -315,7 +314,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         now = timezone.now()
         yesterday = (now - timezone.timedelta(days=1)).date()
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
 
         params = urlencode(
             {
@@ -364,7 +363,7 @@ class ProcessListSiaeTest(ProcessListTest):
         Eddie wants to see applications of job seeker for whom
         the diagnosis of eligibility has been validated.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
 
         params = urlencode({"eligibility_validated": True})
         url = f"{self.siae_base_url}?{params}"
@@ -383,7 +382,7 @@ class ProcessListSiaeTest(ProcessListTest):
         Eddie wants to see applications of job seeker for whom
         the diagnosis of eligibility has been validated with specific criteria.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
 
         diagnosis = EligibilityDiagnosisFactory(job_seeker=self.maggie)
 
@@ -429,7 +428,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         Eddie wants to see applications of job seeker who live in given department.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
 
         # Maggie moves to Department 37
         self.maggie.post_code = "37000"
@@ -447,7 +446,7 @@ class ProcessListSiaeTest(ProcessListTest):
         """
         Eddie wants to see applications with a given job appellation.
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
 
         create_test_romes_and_appellations(["M1805", "N1101"], appellations_per_rome=2)
         (appellation1, appellation2) = Appellation.objects.all().order_by("?")[:2]
@@ -474,7 +473,7 @@ class ProcessListPrescriberTest(ProcessListTest):
         Connect as Thibault to see a list of job applications
         sent by his organization (Pôle emploi).
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
         response = self.client.get(self.prescriber_base_url)
 
         # Count job applications used by the template
@@ -486,7 +485,7 @@ class ProcessListPrescriberTest(ProcessListTest):
         """
         Connect as Thibault to see a list of available job applications exports
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
         response = self.client.get(self.prescriber_exports_url)
 
         self.assertEqual(200, response.status_code)
@@ -495,7 +494,7 @@ class ProcessListPrescriberTest(ProcessListTest):
         """
         Connect as Thibault to see a list of available job applications exports
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
 
         response = self.client.get(self.prescriber_exports_url)
         sample_date = response.context["job_applications_by_month"][0]["month"]
@@ -514,7 +513,7 @@ class ProcessListPrescriberTest(ProcessListTest):
         Thibault wants to filter a list of job applications
         by the default initial state.
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
         expected_state = JobApplicationWorkflow.initial_state
         params = urlencode({"states": [expected_state]}, True)
         url = f"{self.prescriber_base_url}?{params}"
@@ -529,7 +528,7 @@ class ProcessListPrescriberTest(ProcessListTest):
         Thibault wants to see job applications sent by his colleague Laurie.
         He filters results using her full name.
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
         sender_id = self.laurie_pe.id
         params = urlencode({"senders": sender_id})
         url = f"{self.prescriber_base_url}?{params}"
@@ -543,7 +542,7 @@ class ProcessListPrescriberTest(ProcessListTest):
         """
         Thibault wants to see Maggie's job applications.
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
         job_seekers_ids = [self.maggie.id]
         params = urlencode({"job_seekers": job_seekers_ids}, True)
         url = f"{self.prescriber_base_url}?{params}"
@@ -557,7 +556,7 @@ class ProcessListPrescriberTest(ProcessListTest):
         """
         Thibault wants to see applications sent to Hit Pit.
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
         to_siaes_ids = [self.hit_pit.pk]
         params = urlencode({"to_siaes": to_siaes_ids}, True)
         url = f"{self.prescriber_base_url}?{params}"
@@ -578,7 +577,7 @@ class ProcessListExportsPrescriberTest(ProcessListTest):
         """
         Connect as Thibault to see a list of available job applications exports
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
         response = self.client.get(self.prescriber_exports_url)
 
         self.assertEqual(200, response.status_code)
@@ -587,7 +586,7 @@ class ProcessListExportsPrescriberTest(ProcessListTest):
         """
         Connect as a SIAE and try to see the prescriber export -> redirected
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         response = self.client.get(self.prescriber_exports_url)
 
         self.assertEqual(302, response.status_code)
@@ -603,7 +602,7 @@ class ProcessListExportsSiaeTest(ProcessListTest):
         """
         Connect as a SIAE to see a list of available job applications exports
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
         response = self.client.get(self.siae_exports_url)
 
         self.assertEqual(200, response.status_code)
@@ -612,7 +611,7 @@ class ProcessListExportsSiaeTest(ProcessListTest):
         """
         Connect as Thibault and try to see the siae export -> redirected
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
         response = self.client.get(self.siae_exports_url)
 
         self.assertEqual(404, response.status_code)
@@ -628,7 +627,7 @@ class ProcessListExportsDownloadPrescriberTest(ProcessListTest):
         """
         Connect as Thibault to download a CSV export of available job applications
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
 
         response = self.client.get(self.prescriber_exports_url)
         sample_date = response.context["job_applications_by_month"][0]["month"]
@@ -646,7 +645,7 @@ class ProcessListExportsDownloadPrescriberTest(ProcessListTest):
         """
         Connect as Thibault and attempt to download a CSV export of available job applications from SIAE
         """
-        self.client.login(username=self.thibault_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.thibault_pe)
 
         response = self.client.get(self.prescriber_exports_url)
         sample_date = response.context["job_applications_by_month"][0]["month"]
@@ -668,7 +667,7 @@ class ProcessListExportsDownloadSiaeTest(ProcessListTest):
         """
         Connect as Thibault to download a CSV export of available job applications
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
 
         response = self.client.get(self.siae_exports_url)
         sample_date = response.context["job_applications_by_month"][0]["month"]
@@ -684,7 +683,7 @@ class ProcessListExportsDownloadSiaeTest(ProcessListTest):
         """
         Connect as SIAE and attempt to download a CSV export of available job applications from prescribers
         """
-        self.client.login(username=self.eddie_hit_pit.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.eddie_hit_pit)
 
         response = self.client.get(self.siae_exports_url)
         sample_date = response.context["job_applications_by_month"][0]["month"]

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -24,7 +24,7 @@ from itou.job_applications.factories import (
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import SiaeFactory
-from itou.users.factories import DEFAULT_PASSWORD, JobSeekerWithAddressFactory
+from itou.users.factories import JobSeekerWithAddressFactory
 from itou.users.models import User
 from itou.utils.widgets import DuetDatePickerWidget
 
@@ -40,7 +40,7 @@ class ProcessViewsTest(TestCase):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory()
         siae = job_application.to_siae
         siae_user = siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
@@ -79,7 +79,7 @@ class ProcessViewsTest(TestCase):
             job_seeker__is_job_seeker=True, hidden_for_siae=True
         )
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
@@ -91,7 +91,7 @@ class ProcessViewsTest(TestCase):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory()
         prescriber = job_application.sender_prescriber_organization.members.first()
 
-        self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(prescriber)
 
         url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
@@ -103,7 +103,7 @@ class ProcessViewsTest(TestCase):
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory()
         prescriber = job_application.sender_prescriber_organization.members.first()
 
-        self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(prescriber)
 
         url = reverse("apply:details_for_prescriber", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
@@ -114,7 +114,7 @@ class ProcessViewsTest(TestCase):
 
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory()
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         url = reverse("apply:details_for_prescriber", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
@@ -125,7 +125,7 @@ class ProcessViewsTest(TestCase):
 
         job_application = JobApplicationSentByAuthorizedPrescriberOrganizationFactory()
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         url = reverse("apply:process", kwargs={"job_application_id": job_application.pk})
         response = self.client.post(url)
@@ -143,7 +143,7 @@ class ProcessViewsTest(TestCase):
         )
         self.assertTrue(job_application.state.is_processing)
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         url = reverse("apply:refuse", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
@@ -168,7 +168,7 @@ class ProcessViewsTest(TestCase):
         )
         self.assertTrue(job_application.state.is_processing)
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         url = reverse("apply:postpone", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
@@ -209,7 +209,7 @@ class ProcessViewsTest(TestCase):
                 job_application = JobApplicationSentByJobSeekerFactory(
                     state=state, job_seeker=job_seeker, to_siae=siae
                 )
-                self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+                self.client.force_login(siae_user)
 
                 url = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
                 response = self.client.get(url)
@@ -338,7 +338,7 @@ class ProcessViewsTest(TestCase):
         other_siae_user = job_application.to_siae.members.first()
 
         # login with other siae
-        self.client.login(username=other_siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(other_siae_user)
         url = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
 
         hiring_start_at = today + relativedelta(days=20)
@@ -385,7 +385,7 @@ class ProcessViewsTest(TestCase):
         )
 
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         url = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
@@ -444,7 +444,7 @@ class ProcessViewsTest(TestCase):
         # SIAE 1 logs in and accepts the first job application.
         # The delivered approval should start at the same time as the contract.
         user = job_application.to_siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
         post_data = {
             "hiring_start_at": hiring_start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -472,7 +472,7 @@ class ProcessViewsTest(TestCase):
         job_app_starting_earlier.refresh_from_db()
         self.assertTrue(job_app_starting_earlier.state.is_obsolete)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_app_starting_earlier.pk})
         post_data = {
             "hiring_start_at": hiring_start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -499,7 +499,7 @@ class ProcessViewsTest(TestCase):
         job_app_starting_later.refresh_from_db()
         self.assertTrue(job_app_starting_later.state.is_obsolete)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_app_starting_later.pk})
         post_data = {
             "hiring_start_at": hiring_start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -550,7 +550,7 @@ class ProcessViewsTest(TestCase):
         )
 
         # Accept the job application for the first job seeker.
-        self.client.login(username=siae.members.first().email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae.members.first())
         response = accept_job_application(job_application, city)
         self.assertEqual(response.status_code, 200)
         self.assertNotIn(
@@ -586,7 +586,7 @@ class ProcessViewsTest(TestCase):
         )
         self.assertTrue(job_application.state.is_processing)
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         has_considered_valid_diagnoses = EligibilityDiagnosis.objects.has_considered_valid(
             job_application.job_seeker, for_siae=job_application.to_siae
@@ -643,7 +643,7 @@ class ProcessViewsTest(TestCase):
             state=JobApplicationWorkflow.STATE_PROCESSING, to_siae__kind=SiaeKind.GEIQ
         )
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         url = reverse("apply:eligibility", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
@@ -660,7 +660,7 @@ class ProcessViewsTest(TestCase):
         for state in JobApplicationWorkflow.CAN_BE_ACCEPTED_STATES:
             job_application.state = state
             job_application.save()
-            self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+            self.client.force_login(siae_user)
             url = reverse("apply:eligibility", kwargs={"job_application_id": job_application.pk})
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
@@ -669,7 +669,7 @@ class ProcessViewsTest(TestCase):
         # Wrong state
         job_application.state = JobApplicationWorkflow.STATE_ACCEPTED
         job_application.save()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
         url = reverse("apply:eligibility", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
@@ -679,7 +679,7 @@ class ProcessViewsTest(TestCase):
         # Hiring date is today: cancellation should be possible.
         job_application = JobApplicationWithApprovalFactory(state=JobApplicationWorkflow.STATE_ACCEPTED)
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
         url = reverse("apply:cancel", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -710,7 +710,7 @@ class ProcessViewsTest(TestCase):
         # Add a blocking employee record
         EmployeeRecordFactory(job_application=job_application, status=Status.PROCESSED)
 
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
         url = reverse("apply:cancel", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
         next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
@@ -729,7 +729,7 @@ class ProcessViewsTest(TestCase):
             state=JobApplicationWorkflow.STATE_CANCELLED, job_seeker=job_seeker
         )
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
         hiring_start_at = timezone.localdate()
@@ -763,7 +763,7 @@ class ProcessViewsTest(TestCase):
         )
         self.assertTrue(job_application.state.is_cancelled)
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         url = reverse("apply:archive", kwargs={"job_application_id": job_application.pk})
 
@@ -807,7 +807,7 @@ class ProcessTemplatesTest(TestCase):
 
     def test_details_template_for_state_new(self):
         """Test actions available when the state is new."""
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         response = self.client.get(self.url_details)
         # Test template content.
         self.assertContains(response, self.url_process)
@@ -818,7 +818,7 @@ class ProcessTemplatesTest(TestCase):
 
     def test_details_template_for_state_processing(self):
         """Test actions available when the state is processing."""
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         self.job_application.state = JobApplicationWorkflow.STATE_PROCESSING
         self.job_application.save()
         response = self.client.get(self.url_details)
@@ -831,7 +831,7 @@ class ProcessTemplatesTest(TestCase):
 
     def test_details_template_for_state_postponed(self):
         """Test actions available when the state is postponed."""
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         self.job_application.state = JobApplicationWorkflow.STATE_POSTPONED
         self.job_application.save()
         response = self.client.get(self.url_details)
@@ -844,7 +844,7 @@ class ProcessTemplatesTest(TestCase):
 
     def test_details_template_for_state_postponed_valid_diagnosis(self):
         """Test actions available when the state is postponed."""
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         EligibilityDiagnosisFactory(job_seeker=self.job_application.job_seeker)
         self.job_application.state = JobApplicationWorkflow.STATE_POSTPONED
         self.job_application.save()
@@ -857,7 +857,7 @@ class ProcessTemplatesTest(TestCase):
         self.assertContains(response, self.url_accept)
 
     def test_details_template_for_state_obsolete(self):
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         self.job_application.state = JobApplicationWorkflow.STATE_OBSOLETE
         self.job_application.save()
 
@@ -871,7 +871,7 @@ class ProcessTemplatesTest(TestCase):
         self.assertNotContains(response, self.url_accept)
 
     def test_details_template_for_state_obsolete_valid_diagnosis(self):
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         EligibilityDiagnosisFactory(job_seeker=self.job_application.job_seeker)
         self.job_application.state = JobApplicationWorkflow.STATE_OBSOLETE
         self.job_application.save()
@@ -887,7 +887,7 @@ class ProcessTemplatesTest(TestCase):
 
     def test_details_template_for_state_refused(self):
         """Test actions available for other states."""
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         self.job_application.state = JobApplicationWorkflow.STATE_REFUSED
         self.job_application.save()
         response = self.client.get(self.url_details)
@@ -900,7 +900,7 @@ class ProcessTemplatesTest(TestCase):
 
     def test_details_template_for_state_refused_valid_diagnosis(self):
         """Test actions available for other states."""
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         EligibilityDiagnosisFactory(job_seeker=self.job_application.job_seeker)
         self.job_application.state = JobApplicationWorkflow.STATE_REFUSED
         self.job_application.save()
@@ -914,7 +914,7 @@ class ProcessTemplatesTest(TestCase):
 
     def test_details_template_for_state_canceled(self):
         """Test actions available for other states."""
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         self.job_application.state = JobApplicationWorkflow.STATE_CANCELLED
         self.job_application.save()
         response = self.client.get(self.url_details)
@@ -927,7 +927,7 @@ class ProcessTemplatesTest(TestCase):
 
     def test_details_template_for_state_canceled_valid_diagnosis(self):
         """Test actions available for other states."""
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         EligibilityDiagnosisFactory(job_seeker=self.job_application.job_seeker)
         self.job_application.state = JobApplicationWorkflow.STATE_CANCELLED
         self.job_application.save()
@@ -941,7 +941,7 @@ class ProcessTemplatesTest(TestCase):
 
     def test_details_template_for_state_accepted(self):
         """Test actions available for other states."""
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
         self.job_application.state = JobApplicationWorkflow.STATE_ACCEPTED
         self.job_application.save()
         response = self.client.get(self.url_details)
@@ -966,7 +966,7 @@ class ProcessTransferJobApplicationTest(TestCase):
             to_siae=siae, state=JobApplicationWorkflow.STATE_PROCESSING
         )
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(
             reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
         )
@@ -985,7 +985,7 @@ class ProcessTransferJobApplicationTest(TestCase):
             to_siae=siae, state=JobApplicationWorkflow.STATE_ACCEPTED
         )
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(
             reverse("apply:details_for_siae", kwargs={"job_application_id": job_application_1.pk})
         )
@@ -1009,7 +1009,7 @@ class ProcessTransferJobApplicationTest(TestCase):
 
         self.assertEqual(2, user.siaemembership_set.count())
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(
             reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
         )
@@ -1028,7 +1028,7 @@ class ProcessTransferJobApplicationTest(TestCase):
         )
         transfer_url = reverse("apply:transfer", kwargs={"job_application_id": job_application.pk})
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(
             reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})
         )

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -20,13 +20,7 @@ from itou.job_applications.enums import SenderKind
 from itou.job_applications.models import JobApplication
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.factories import SiaeFactory, SiaeWithMembershipAndJobsFactory
-from itou.users.factories import (
-    DEFAULT_PASSWORD,
-    JobSeekerFactory,
-    JobSeekerProfileFactory,
-    PrescriberFactory,
-    UserFactory,
-)
+from itou.users.factories import JobSeekerFactory, JobSeekerProfileFactory, PrescriberFactory, UserFactory
 from itou.users.models import User
 from itou.utils.session import SessionNamespace
 from itou.utils.storage.s3 import S3Upload
@@ -50,7 +44,7 @@ class ApplyTest(TestCase):
         user = JobSeekerFactory()
         siae = SiaeFactory(with_jobs=True)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         for route in routes:
             with self.subTest(route=route):
                 response = self.client.get(reverse(route, kwargs={"siae_pk": siae.pk}))
@@ -67,7 +61,7 @@ class ApplyTest(TestCase):
         user = JobSeekerFactory()
         siae = SiaeFactory(with_jobs=True)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         for route in routes:
             with self.subTest(route=route):
                 response = self.client.get(reverse(route, kwargs={"siae_pk": siae.pk, "session_uuid": uuid.uuid4()}))
@@ -76,7 +70,7 @@ class ApplyTest(TestCase):
 
     def test_start_coalesce_back_url(self):
         siae = SiaeFactory(with_membership=True)
-        self.client.login(username=siae.members.first().email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae.members.first())
 
         # Default / Fallback
         self.client.get(reverse("apply:start", kwargs={"siae_pk": siae.pk}))
@@ -128,7 +122,7 @@ class ApplyAsJobSeekerTest(TestCase):
         siae = SiaeWithMembershipAndJobsFactory(romes=("N1101", "N1105"))
 
         user = JobSeekerFactory(birthdate=None, nir="")
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Entry point.
         # ----------------------------------------------------------------------
@@ -288,7 +282,7 @@ class ApplyAsJobSeekerTest(TestCase):
         siae = SiaeWithMembershipAndJobsFactory(romes=("N1101", "N1105"))
 
         user = JobSeekerFactory(nir="")
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Entry point.
         # ----------------------------------------------------------------------
@@ -330,7 +324,7 @@ class ApplyAsJobSeekerTest(TestCase):
             PoleEmploiApprovalFactory(
                 pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate, start_at=start_at, end_at=end_at
             )
-            self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+            self.client.force_login(user)
 
             # Follow all redirections…
             response = self.client.get(
@@ -346,7 +340,7 @@ class ApplyAsJobSeekerTest(TestCase):
     def test_apply_as_job_seeker_on_sender_tunnel(self):
         siae = SiaeFactory()
         user = JobSeekerFactory()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Without a session namespace
         response = self.client.get(reverse("apply:check_nir_for_sender", kwargs={"siae_pk": siae.pk}))
@@ -383,7 +377,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
 
         prescriber_organization = PrescriberOrganizationWithMembershipFactory(with_pending_authorization=True)
         user = prescriber_organization.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         dummy_job_seeker_profile = JobSeekerProfileFactory.build()
 
@@ -643,7 +637,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
 
         prescriber_organization = PrescriberOrganizationWithMembershipFactory(authorized=True)
         user = prescriber_organization.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         dummy_job_seeker_profile = JobSeekerProfileFactory.build()
 
@@ -906,7 +900,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
 
         prescriber_organization = PrescriberOrganizationWithMembershipFactory(authorized=True)
         user = prescriber_organization.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Follow all redirections…
         response = self.client.get(reverse("apply:start", kwargs={"siae_pk": siae.pk}), {"back_url": "/"}, follow=True)
@@ -947,7 +941,7 @@ class ApplyAsPrescriberTest(TestCase):
         siae = SiaeWithMembershipAndJobsFactory(romes=("N1101", "N1105"))
 
         user = PrescriberFactory()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         dummy_job_seeker_profile = JobSeekerProfileFactory.build()
 
@@ -1215,7 +1209,7 @@ class ApplyAsPrescriberTest(TestCase):
         ApprovalFactory(user=job_seeker, start_at=start_at, end_at=end_at)
 
         user = PrescriberFactory()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Follow all redirections…
         response = self.client.get(reverse("apply:start", kwargs={"siae_pk": siae.pk}), {"back_url": "/"}, follow=True)
@@ -1238,7 +1232,7 @@ class ApplyAsPrescriberTest(TestCase):
     def test_apply_as_prescriber_on_job_seeker_tunnel(self):
         siae = SiaeFactory()
         user = PrescriberFactory()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Without a session namespace
         response = self.client.get(reverse("apply:check_nir_for_job_seeker", kwargs={"siae_pk": siae.pk}))
@@ -1284,7 +1278,7 @@ class ApplyAsPrescriberNirExceptionsTest(TestCase):
         # Create an approval to bypass the eligibility diagnosis step.
         PoleEmploiApprovalFactory(birthdate=job_seeker.birthdate, pole_emploi_id=job_seeker.pole_emploi_id)
         siae, user = self.create_test_data()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Follow all redirections…
         response = self.client.get(reverse("apply:start", kwargs={"siae_pk": siae.pk}), {"back_url": "/"}, follow=True)
@@ -1359,7 +1353,7 @@ class ApplyAsSiaeTest(TestCase):
         siae2 = SiaeFactory(with_membership=True)
 
         user = siae1.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         response = self.client.get(reverse("apply:start", kwargs={"siae_pk": siae2.pk}), {"back_url": "/"})
         self.assertEqual(response.status_code, 403)
@@ -1370,7 +1364,7 @@ class ApplyAsSiaeTest(TestCase):
         siae = SiaeWithMembershipAndJobsFactory(romes=("N1101", "N1105"))
 
         user = siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         dummy_job_seeker_profile = JobSeekerProfileFactory.build()
 
@@ -1625,7 +1619,7 @@ class ApplyAsSiaeTest(TestCase):
         ApprovalFactory(user=job_seeker, start_at=start_at, end_at=end_at)
 
         user = siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Follow all redirections…
         response = self.client.get(reverse("apply:start", kwargs={"siae_pk": siae.pk}), {"back_url": "/"}, follow=True)
@@ -1660,7 +1654,7 @@ class ApplyAsOtherTest(TestCase):
         siae = SiaeFactory()
         institution = InstitutionWithMembershipFactory()
 
-        self.client.login(username=institution.members.first().email, password=DEFAULT_PASSWORD)
+        self.client.force_login(institution.members.first())
 
         for route in self.ROUTES:
             with self.subTest(route=route):
@@ -1671,7 +1665,7 @@ class ApplyAsOtherTest(TestCase):
         siae = SiaeFactory()
         user = UserFactory(is_job_seeker=False, is_prescriber=False, is_siae_staff=False, is_labor_inspector=False)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         for route in self.ROUTES:
             with self.subTest(route=route):
@@ -1683,7 +1677,7 @@ class ApplicationViewTest(TestCase):
     def test_application_jobs_use_previously_selected_jobs(self):
         siae = SiaeFactory(subject_to_eligibility=True, with_membership=True, with_jobs=True)
 
-        self.client.login(username=siae.members.first().email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae.members.first())
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
         apply_session.init(
             {
@@ -1703,7 +1697,7 @@ class ApplicationViewTest(TestCase):
     def test_application_resume_hidden_fields(self):
         siae = SiaeFactory(with_membership=True, with_jobs=True)
 
-        self.client.login(username=siae.members.first().email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae.members.first())
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
         apply_session.init(
             {
@@ -1721,7 +1715,7 @@ class ApplicationViewTest(TestCase):
     def test_application_eligibility_is_bypassed_for_siae_not_subject_to_eligibility_rules(self):
         siae = SiaeFactory(not_subject_to_eligibility=True, with_membership=True)
 
-        self.client.login(username=siae.members.first().email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae.members.first())
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
         apply_session.init({"job_seeker_pk": JobSeekerFactory()})
         apply_session.save()
@@ -1735,7 +1729,7 @@ class ApplicationViewTest(TestCase):
         siae = SiaeFactory(not_subject_to_eligibility=True, with_membership=True)
         prescriber = PrescriberOrganizationWithMembershipFactory().members.first()
 
-        self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(prescriber)
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
         apply_session.init({"job_seeker_pk": JobSeekerFactory()})
         apply_session.save()
@@ -1749,7 +1743,7 @@ class ApplicationViewTest(TestCase):
         siae = SiaeFactory(not_subject_to_eligibility=True, with_membership=True)
         eligibility_diagnosis = EligibilityDiagnosisFactory()
 
-        self.client.login(username=siae.members.first().email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae.members.first())
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
         apply_session.init({"job_seeker_pk": eligibility_diagnosis.job_seeker})
         apply_session.save()
@@ -1764,7 +1758,7 @@ class ApplicationViewTest(TestCase):
         prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.first()
         eligibility_diagnosis = EligibilityDiagnosisFactory()
 
-        self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(prescriber)
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
         apply_session.init({"job_seeker_pk": eligibility_diagnosis.job_seeker})
         apply_session.save()

--- a/itou/www/approvals_views/tests/test_display.py
+++ b/itou/www/approvals_views/tests/test_display.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 
 from itou.job_applications.factories import JobApplicationFactory, JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication
-from itou.users.factories import DEFAULT_PASSWORD, UserFactory
+from itou.users.factories import UserFactory
 
 
 @patch.object(JobApplication, "can_be_cancelled", new_callable=PropertyMock, return_value=False)
@@ -15,7 +15,7 @@ class TestDisplayApproval(TestCase):
         job_application = JobApplicationWithApprovalFactory()
 
         siae_member = job_application.to_siae.members.first()
-        self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_member)
 
         response = self.client.get(
             reverse("approvals:display_printable_approval", kwargs={"job_application_id": job_application.pk})
@@ -33,7 +33,7 @@ class TestDisplayApproval(TestCase):
         job_application = JobApplicationFactory()
 
         siae_member = job_application.to_siae.members.first()
-        self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_member)
 
         response = self.client.get(
             reverse("approvals:display_printable_approval", kwargs={"job_application_id": job_application.pk})
@@ -49,7 +49,7 @@ class TestDisplayApproval(TestCase):
         )
 
         siae_member = job_application.to_siae.members.first()
-        self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_member)
 
         response = self.client.get(
             reverse("approvals:display_printable_approval", kwargs={"job_application_id": job_application.pk})
@@ -75,7 +75,7 @@ class TestDisplayApproval(TestCase):
         )
 
         siae_member = job_application.to_siae.members.first()
-        self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_member)
 
         response = self.client.get(
             reverse("approvals:display_printable_approval", kwargs={"job_application_id": job_application.pk})
@@ -97,7 +97,7 @@ class TestDisplayApproval(TestCase):
         job_application = JobApplicationWithApprovalFactory(eligibility_diagnosis=None)
 
         siae_member = job_application.to_siae.members.first()
-        self.client.login(username=siae_member.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_member)
 
         with self.assertRaisesRegex(Exception, "had no eligibility diagnosis and also was not mass-imported"):
             self.client.get(

--- a/itou/www/approvals_views/tests/test_prolongation.py
+++ b/itou/www/approvals_views/tests/test_prolongation.py
@@ -10,7 +10,6 @@ from itou.approvals.models import Approval, Prolongation
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
-from itou.users.factories import DEFAULT_PASSWORD
 from itou.utils.widgets import DuetDatePickerWidget
 from itou.www.approvals_views.forms import DeclareProlongationForm
 
@@ -60,7 +59,7 @@ class ApprovalProlongationTest(TestCase):
         Test the creation of a prolongation.
         """
 
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
 
         back_url = "/"
         params = urlencode({"back_url": back_url})
@@ -132,7 +131,7 @@ class ApprovalProlongationTest(TestCase):
         Test the creation of a prolongation without prescriber.
         """
 
-        self.client.login(username=self.siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.siae_user)
 
         back_url = "/"
         params = urlencode({"back_url": back_url})

--- a/itou/www/approvals_views/tests/test_suspend.py
+++ b/itou/www/approvals_views/tests/test_suspend.py
@@ -10,7 +10,6 @@ from itou.employee_record.enums import Status
 from itou.employee_record.factories import EmployeeRecordFactory
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplicationWorkflow
-from itou.users.factories import DEFAULT_PASSWORD
 from itou.utils.widgets import DuetDatePickerWidget
 from itou.www.approvals_views.forms import SuspensionForm
 
@@ -35,7 +34,7 @@ class ApprovalSuspendViewTest(TestCase):
         self.assertEqual(0, approval.suspension_set.count())
 
         siae_user = job_application.to_siae.members.first()
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         back_url = "/"
         params = urlencode({"back_url": back_url})
@@ -157,7 +156,7 @@ class ApprovalSuspendViewTest(TestCase):
 
         suspension = SuspensionFactory(approval=approval, start_at=start_at, end_at=end_at, created_by=siae_user)
 
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         back_url = "/"
         params = urlencode({"back_url": back_url})
@@ -205,7 +204,7 @@ class ApprovalSuspendViewTest(TestCase):
 
         suspension = SuspensionFactory(approval=approval, start_at=start_at, end_at=end_at, created_by=siae_user)
 
-        self.client.login(username=siae_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(siae_user)
 
         back_url = "/"
         params = urlencode({"back_url": back_url})

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -42,7 +42,7 @@ class DashboardViewTest(TestCase):
     def test_dashboard(self):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("dashboard:index")
         response = self.client.get(url)
@@ -52,7 +52,7 @@ class DashboardViewTest(TestCase):
         siae = SiaePendingGracePeriodFactory()
         user = SiaeStaffFactory()
         siae.members.add(user)
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("dashboard:index")
         response = self.client.get(url)
@@ -62,7 +62,7 @@ class DashboardViewTest(TestCase):
         siae = SiaeAfterGracePeriodFactory()
         user = SiaeStaffFactory()
         siae.members.add(user)
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("dashboard:index")
         response = self.client.get(url, follow=True)
@@ -76,7 +76,7 @@ class DashboardViewTest(TestCase):
     def test_dashboard_eiti(self):
         siae = SiaeFactory(kind=SiaeKind.EITI, with_membership=True)
         user = siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("dashboard:index")
         response = self.client.get(url)
@@ -91,7 +91,7 @@ class DashboardViewTest(TestCase):
         user.siae_set.add(other_siae)
         user.siae_set.add(last_siae)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("dashboard:index")
         response = self.client.get(url)
@@ -148,7 +148,7 @@ class DashboardViewTest(TestCase):
             with self.subTest(f"should display when siae_kind={kind}"):
                 siae = SiaeFactory(kind=kind, with_membership=True)
                 user = siae.members.first()
-                self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+                self.client.force_login(user)
 
                 response = self.client.get(reverse("dashboard:index"))
                 self.assertContains(response, "Prolonger ou suspendre un agrément émis par Pôle emploi")
@@ -158,7 +158,7 @@ class DashboardViewTest(TestCase):
             with self.subTest(f"should not display when siae_kind={kind}"):
                 siae = SiaeFactory(kind=kind, with_membership=True)
                 user = siae.members.first()
-                self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+                self.client.force_login(user)
 
                 response = self.client.get(reverse("dashboard:index"))
                 self.assertNotContains(response, "Prolonger ou suspendre un agrément émis par Pôle emploi")
@@ -170,7 +170,7 @@ class DashboardViewTest(TestCase):
                 siae = SiaeFactory(kind=kind, with_membership=True, membership__is_admin=True)
                 user = siae.members.get()
 
-                self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+                self.client.force_login(user)
                 response = self.client.get(reverse("dashboard:index"))
 
                 if user.can_create_siae_antenna(siae):
@@ -182,7 +182,7 @@ class DashboardViewTest(TestCase):
         membershipfactory = InstitutionMembershipFactory()
         user = membershipfactory.user
         institution = membershipfactory.institution
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Contrôle a posteriori")
@@ -230,7 +230,7 @@ class DashboardViewTest(TestCase):
         # preset for incoming new pages
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Contrôle a posteriori")
@@ -243,19 +243,19 @@ class DashboardViewTest(TestCase):
     def test_dashboard_prescriber_suspend_link(self):
 
         user = JobSeekerFactory()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Suspendre un PASS IAE")
 
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Suspendre un PASS IAE")
 
         membershipfactory = InstitutionMembershipFactory()
         user = membershipfactory.user
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Suspendre un PASS IAE")
 
@@ -263,7 +263,7 @@ class DashboardViewTest(TestCase):
             kind=PrescriberOrganizationKind.CAP_EMPLOI
         )
         prescriber = prescriber_org.members.first()
-        self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(prescriber)
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Suspendre un PASS IAE")
 
@@ -271,14 +271,14 @@ class DashboardViewTest(TestCase):
             kind=PrescriberOrganizationKind.PE
         )
         prescriber_pe = prescriber_org_pe.members.first()
-        self.client.login(username=prescriber_pe.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(prescriber_pe)
         response = self.client.get(reverse("dashboard:index"))
         self.assertContains(response, "Suspendre un PASS IAE")
 
     @freeze_time("2022-09-15")
     def test_dashboard_access_by_a_jobseeker(self):
         approval = ApprovalFactory(start_at=datetime(2022, 6, 21), end_at=datetime(2022, 12, 6))
-        self.client.login(username=approval.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(approval.user)
         url = reverse("dashboard:index")
         response = self.client.get(url)
         self.assertContains(response, "PASS IAE (agrément) disponible :")
@@ -293,7 +293,7 @@ class DashboardViewTest(TestCase):
         )
 
         prescriber = prescriber_org.members.first()
-        self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(prescriber)
         response = self.client.get(reverse("dashboard:index"))
 
         self.assertContains(
@@ -308,7 +308,7 @@ class DashboardViewTest(TestCase):
 class EditUserInfoViewTest(TestCase):
     def test_edit(self):
         user = JobSeekerFactory()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("dashboard:edit_user_info")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -345,7 +345,7 @@ class EditUserInfoViewTest(TestCase):
 
     def test_edit_sso(self):
         user = JobSeekerFactory(identity_provider=IdentityProvider.FRANCE_CONNECT)
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("dashboard:edit_user_info")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -389,7 +389,7 @@ class EditJobSeekerInfo(TestCase):
         job_application.job_seeker.created_by = user
         job_application.job_seeker.save()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
@@ -440,7 +440,7 @@ class EditJobSeekerInfo(TestCase):
         job_application.job_seeker.created_by = user
         job_application.job_seeker.save()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -458,7 +458,7 @@ class EditJobSeekerInfo(TestCase):
         prescribers_factories.PrescriberMembershipFactory(
             user=other_prescriber, organization=job_application.sender_prescriber_organization
         )
-        self.client.login(username=other_prescriber.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(other_prescriber)
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -467,7 +467,7 @@ class EditJobSeekerInfo(TestCase):
         job_application = JobApplicationSentByPrescriberFactory()
         # The job seeker manages his own personal information (autonomous)
         user = job_application.sender
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
 
@@ -480,7 +480,7 @@ class EditJobSeekerInfo(TestCase):
 
         # Lambda prescriber not member of the sender organization
         prescriber = PrescriberFactory()
-        self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(prescriber)
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
 
         response = self.client.get(url)
@@ -495,7 +495,7 @@ class EditJobSeekerInfo(TestCase):
         user = siae.members.first()
         job_application = JobApplicationSentByPrescriberFactory(to_siae=siae, job_seeker__created_by=user)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
@@ -545,7 +545,7 @@ class EditJobSeekerInfo(TestCase):
         EmailAddress.objects.create(user=job_seeker, email=job_seeker.email, verified=True)
 
         # Now the SIAE wants to edit the jobseeker email. The field is not available, and it cannot be bypassed
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
@@ -593,7 +593,7 @@ class ChangeEmailViewTest(TestCase):
         old_email = user.email
         new_email = "jean@gabin.fr"
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("dashboard:edit_user_email")
         response = self.client.get(url)
 
@@ -654,12 +654,12 @@ class ChangeEmailViewTest(TestCase):
         url = reverse("dashboard:edit_user_email")
 
         job_seeker = JobSeekerFactory(identity_provider=IdentityProvider.FRANCE_CONNECT)
-        self.client.login(username=job_seeker.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(job_seeker)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
         prescriber = PrescriberFactory(identity_provider=IdentityProvider.INCLUSION_CONNECT)
-        self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(prescriber)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
@@ -698,7 +698,7 @@ class SwitchSiaeTest(TestCase):
     def test_switch_siae(self):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         related_siae = SiaeFactory()
         related_siae.members.add(user)
@@ -742,7 +742,7 @@ class SwitchSiaeTest(TestCase):
     def test_can_still_switch_to_inactive_siae_during_grace_period(self):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         related_siae = SiaePendingGracePeriodFactory()
         related_siae.members.add(user)
@@ -765,7 +765,7 @@ class SwitchSiaeTest(TestCase):
     def test_cannot_switch_to_inactive_siae_after_grace_period(self):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         related_siae = SiaeAfterGracePeriodFactory()
         related_siae.members.add(user)
@@ -795,7 +795,7 @@ class EditUserPreferencesTest(TestCase):
         recipient = user.siaemembership_set.get(siae=siae)
         form_name = "new_job_app_notification_form"
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Recipient's notifications are empty for the moment.
         self.assertFalse(recipient.notifications)
@@ -823,7 +823,7 @@ class EditUserPreferencesTest(TestCase):
         job_descriptions_pks = list(siae.job_description_through.values_list("pk", flat=True))
         recipient = user.siaemembership_set.get(siae=siae)
         form_name = "new_job_app_notification_form"
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Recipient's notifications are empty for the moment.
         self.assertFalse(recipient.notifications)
@@ -853,7 +853,7 @@ class EditUserPreferencesTest(TestCase):
         user = siae.members.first()
         recipient = user.siaemembership_set.get(siae=siae)
         form_name = "new_job_app_notification_form"
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Recipient's notifications are empty for the moment.
         self.assertFalse(recipient.notifications)
@@ -881,7 +881,7 @@ class EditUserPreferencesTest(TestCase):
         job_descriptions_pks = list(siae.job_description_through.values_list("pk", flat=True))
         recipient = user.siaemembership_set.get(siae=siae)
         form_name = "new_job_app_notification_form"
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Recipient's notifications are empty for the moment.
         self.assertFalse(recipient.notifications)
@@ -913,13 +913,13 @@ class EditUserPreferencesExceptionsTest(TestCase):
         # Only employers can currently access the Preferences page.
 
         prescriber = PrescriberFactory()
-        self.client.login(username=prescriber.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(prescriber)
         url = reverse("dashboard:edit_user_notifications")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
         job_seeker = JobSeekerFactory()
-        self.client.login(username=job_seeker.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(job_seeker)
         url = reverse("dashboard:edit_user_notifications")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)

--- a/itou/www/employee_record_views/tests/test_create.py
+++ b/itou/www/employee_record_views/tests/test_create.py
@@ -12,7 +12,7 @@ from itou.job_applications.factories import (
     JobApplicationWithJobSeekerProfileFactory,
 )
 from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
-from itou.users.factories import DEFAULT_PASSWORD, JobSeekerWithMockedAddressFactory
+from itou.users.factories import JobSeekerWithMockedAddressFactory
 from itou.utils.mocks.address_format import mock_get_geocoding_data
 from itou.utils.widgets import DuetDatePickerWidget
 
@@ -59,7 +59,7 @@ class AbstractCreateEmployeeRecordTest(TestCase):
         self.job_seeker = self.job_application.job_seeker
 
     def login_response(self):
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         return self.client.get(self.url)
 
     # Bypass each step with minimum viable data
@@ -69,7 +69,7 @@ class AbstractCreateEmployeeRecordTest(TestCase):
         side_effect=mock_get_geocoding_data,
     )
     def pass_step_1(self, _mock):
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         url = reverse("employee_record_views:create", args=(self.job_application.id,))
         target_url = reverse("employee_record_views:create_step_2", args=(self.job_application.id,))
         response = self.client.post(url, data=get_sample_form_data(self.job_seeker))
@@ -125,7 +125,7 @@ class AbstractCreateEmployeeRecordTest(TestCase):
 
     def test_access_denied_bad_permissions(self):
         # Must not have access
-        self.client.login(username=self.user_without_perms.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user_without_perms)
 
         response = self.client.get(self.url)
         # Changed to 404
@@ -133,7 +133,7 @@ class AbstractCreateEmployeeRecordTest(TestCase):
 
     def test_access_denied_bad_siae_kind(self):
         # SIAE can't use employee record (not the correct kind)
-        self.client.login(username=self.user_siae_bad_kind.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user_siae_bad_kind)
 
         response = self.client.get(self.url)
 
@@ -152,7 +152,7 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
 
     def test_access_granted(self):
         # Must have access
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
@@ -161,7 +161,7 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
 
         hiring_end_at = self.job_application.hiring_end_at
 
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
@@ -171,7 +171,7 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
         self.job_application.hiring_end_at = None
         self.job_application.save()
 
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
@@ -184,7 +184,7 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
     def test_title(self, _mock):
         # Job seeker / employee must have a title
 
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         self.client.get(self.url)
 
         data = {
@@ -215,7 +215,7 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
         # otherwise, only a country is mandatory
 
         # Validation is done by the model
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         self.client.get(self.url)
 
         data = get_sample_form_data(self.job_seeker)

--- a/itou/www/employee_record_views/tests/test_disable.py
+++ b/itou/www/employee_record_views/tests/test_disable.py
@@ -7,7 +7,6 @@ from itou.employee_record.factories import EmployeeRecordWithProfileFactory
 from itou.employee_record.models import EmployeeRecord
 from itou.job_applications.factories import JobApplicationWithCompleteJobSeekerProfileFactory
 from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
-from itou.users.factories import DEFAULT_PASSWORD
 
 
 class DisableEmployeeRecordsTest(TestCase):
@@ -23,14 +22,14 @@ class DisableEmployeeRecordsTest(TestCase):
         self.next_url = reverse("employee_record_views:list")
 
     def test_access_granted(self):
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_disable_employee_record_new(self):
         self.assertEqual(self.employee_record.status, Status.NEW)
 
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(f"{self.url}?status=NEW")
         self.assertContains(response, "Confirmer la désactivation")
 
@@ -45,7 +44,7 @@ class DisableEmployeeRecordsTest(TestCase):
         self.employee_record.refresh_from_db()
         self.assertEqual(self.employee_record.status, Status.READY)
 
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(f"{self.url}?status=READY", follow=True)
         self.assertRedirects(response, f"{self.next_url}?status=READY")
         self.assertContains(response, escape(EmployeeRecord.ERROR_EMPLOYEE_RECORD_INVALID_STATE))
@@ -61,7 +60,7 @@ class DisableEmployeeRecordsTest(TestCase):
         self.employee_record.refresh_from_db()
         self.assertEqual(self.employee_record.status, Status.SENT)
 
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(f"{self.url}?status=SENT", follow=True)
         self.assertRedirects(response, f"{self.next_url}?status=SENT")
         self.assertContains(response, escape(EmployeeRecord.ERROR_EMPLOYEE_RECORD_INVALID_STATE))
@@ -79,7 +78,7 @@ class DisableEmployeeRecordsTest(TestCase):
         self.employee_record.refresh_from_db()
         self.assertEqual(self.employee_record.status, Status.REJECTED)
 
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(f"{self.url}?status=REJECTED")
         self.assertContains(response, "Confirmer la désactivation")
 
@@ -99,7 +98,7 @@ class DisableEmployeeRecordsTest(TestCase):
         self.employee_record.refresh_from_db()
         self.assertEqual(self.employee_record.status, Status.PROCESSED)
 
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(f"{self.url}?status=PROCESSED")
         self.assertContains(response, "Confirmer la désactivation")
 

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -5,7 +5,6 @@ from itou.employee_record import factories as employee_record_factories
 from itou.employee_record.enums import Status
 from itou.job_applications.factories import JobApplicationWithApprovalNotCancellableFactory
 from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
-from itou.users.factories import DEFAULT_PASSWORD
 
 
 class ListEmployeeRecordsTest(TestCase):
@@ -29,7 +28,7 @@ class ListEmployeeRecordsTest(TestCase):
         """
         Non-eligible SIAE should not be able to access this list
         """
-        self.client.login(username=self.user_without_perms.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user_without_perms)
 
         response = self.client.get(self.url)
 
@@ -39,7 +38,7 @@ class ListEmployeeRecordsTest(TestCase):
         """
         Check if new employee records / job applications are displayed in the list
         """
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         response = self.client.get(self.url)
 
@@ -51,7 +50,7 @@ class ListEmployeeRecordsTest(TestCase):
         Check status filter
         """
         # No status defined
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
 
         job_seeker_name = self.job_seeker.get_full_name().title()
@@ -68,7 +67,7 @@ class ListEmployeeRecordsTest(TestCase):
             self.assertNotContains(response, job_seeker_name)
 
     def test_employee_records_with_hiring_end_at(self):
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         hiring_end_at = self.job_application.hiring_end_at
 
         response = self.client.get(self.url)
@@ -77,7 +76,7 @@ class ListEmployeeRecordsTest(TestCase):
         self.assertContains(response, f"Fin de contrat :&nbsp;<b>{hiring_end_at.strftime('%e').lstrip()}")
 
     def test_employee_records_without_hiring_end_at(self):
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         self.job_application.hiring_end_at = None
         self.job_application.save()
 
@@ -87,7 +86,7 @@ class ListEmployeeRecordsTest(TestCase):
         self.assertContains(response, "Fin de contrat :&nbsp;<b>Non renseigné")
 
     def test_rejected_without_custom_message(self):
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         record = employee_record_factories.EmployeeRecordWithProfileFactory(job_application__to_siae=self.siae)
         record.update_as_ready()
@@ -100,7 +99,7 @@ class ListEmployeeRecordsTest(TestCase):
         self.assertContains(response, "JSON Invalide")
 
     def test_rejected_custom_messages(self):
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         record = employee_record_factories.EmployeeRecordWithProfileFactory(job_application__to_siae=self.siae)
 

--- a/itou/www/employee_record_views/tests/test_reactivate.py
+++ b/itou/www/employee_record_views/tests/test_reactivate.py
@@ -5,7 +5,6 @@ from itou.employee_record.enums import Status
 from itou.employee_record.factories import EmployeeRecordWithProfileFactory
 from itou.job_applications.factories import JobApplicationWithCompleteJobSeekerProfileFactory
 from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
-from itou.users.factories import DEFAULT_PASSWORD
 
 
 class ReactivateEmployeeRecordsTest(TestCase):
@@ -28,7 +27,7 @@ class ReactivateEmployeeRecordsTest(TestCase):
         self.employee_record.update_as_processed(process_code, process_message, "{}")
         self.employee_record.update_as_disabled()
 
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(f"{self.url}?status=DISABLED")
         self.assertContains(response, "Confirmer la réactivation")
 

--- a/itou/www/employee_record_views/tests/test_summary.py
+++ b/itou/www/employee_record_views/tests/test_summary.py
@@ -4,7 +4,6 @@ from django.urls import reverse
 from itou.employee_record.factories import EmployeeRecordWithProfileFactory
 from itou.job_applications.factories import JobApplicationWithCompleteJobSeekerProfileFactory
 from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
-from itou.users.factories import DEFAULT_PASSWORD
 
 
 class SummaryEmployeeRecordsTest(TestCase):
@@ -20,13 +19,13 @@ class SummaryEmployeeRecordsTest(TestCase):
 
     def test_access_granted(self):
         # Must have access
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_hiring_end_at_date_in_header(self):
         hiring_end_at = self.job_application.hiring_end_at
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, f"Fin du contrat : <b>{hiring_end_at.strftime('%e').lstrip()}")
@@ -34,7 +33,7 @@ class SummaryEmployeeRecordsTest(TestCase):
     def test_no_hiring_end_at_in_header(self):
         self.job_application.hiring_end_at = None
         self.job_application.save()
-        self.client.login(username=self.user.username, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Fin du contrat : <b>Non renseigné")

--- a/itou/www/invitations_views/tests/tests_prescriber_organization.py
+++ b/itou/www/invitations_views/tests/tests_prescriber_organization.py
@@ -43,7 +43,7 @@ class TestSendPrescriberWithOrgInvitation(TestCase):
             "form-0-last_name": self.guest_data["last_name"],
             "form-0-email": self.guest_data["email"],
         }
-        self.client.login(email=self.sender.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.sender)
 
     def assert_created_invitation(self):
         invitation = PrescriberWithOrgInvitation.objects.get(organization=self.organization)
@@ -113,7 +113,7 @@ class TestSendPrescriberWithOrgInvitationExceptions(TestCase):
 
     def test_invite_existing_user_is_employer(self):
         guest = SiaeFactory(with_membership=True).members.first()
-        self.client.login(email=self.sender.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.sender)
         self.post_data.update(
             {"form-0-first_name": guest.first_name, "form-0-last_name": guest.last_name, "form-0-email": guest.email}
         )
@@ -123,7 +123,7 @@ class TestSendPrescriberWithOrgInvitationExceptions(TestCase):
 
     def test_invite_existing_user_is_job_seeker(self):
         guest = JobSeekerFactory()
-        self.client.login(email=self.sender.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.sender)
         self.post_data.update(
             {"form-0-first_name": guest.first_name, "form-0-last_name": guest.last_name, "form-0-email": guest.email}
         )
@@ -135,7 +135,7 @@ class TestSendPrescriberWithOrgInvitationExceptions(TestCase):
         # The invited user is already a member
         self.organization.members.add(PrescriberFactory())
         guest = self.organization.members.exclude(email=self.sender.email).first()
-        self.client.login(email=self.sender.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.sender)
         self.post_data.update(
             {"form-0-first_name": guest.first_name, "form-0-last_name": guest.last_name, "form-0-email": guest.email}
         )
@@ -157,12 +157,12 @@ class TestPEOrganizationInvitation(TestCase):
             "form-0-last_name": guest.last_name,
             "form-0-email": guest.email,
         }
-        self.client.login(email=self.sender.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.sender)
         response = self.client.post(INVITATION_URL, data=post_data, follow=True)
         self.assertRedirects(response, INVITATION_URL)
 
     def test_pe_organization_invitation_unsuccessful(self):
-        self.client.login(email=self.sender.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.sender)
         post_data = POST_DATA | {
             "form-0-first_name": "René",
             "form-0-last_name": "Boucher",
@@ -281,7 +281,7 @@ class TestAcceptPrescriberWithOrgInvitation(TestCase):
             last_name=user.last_name,
             email=user.email,
         )
-        self.client.login(email=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(invitation.acceptance_link, follow=True)
         self.assert_invitation_is_accepted(response, user, invitation)
 
@@ -294,7 +294,7 @@ class TestAcceptPrescriberWithOrgInvitation(TestCase):
             last_name=user.last_name,
             email=user.email,
         )
-        self.client.login(email=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(invitation.acceptance_link, follow=True)
         self.assert_invitation_is_accepted(response, user, invitation)
 
@@ -381,7 +381,7 @@ class TestAcceptPrescriberWithOrgInvitationExceptions(TestCase):
             email=user.email,
         )
 
-        self.client.login(email=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(invitation.acceptance_link, follow=True)
         self.assertEqual(response.status_code, 403)
         invitation.refresh_from_db()
@@ -389,7 +389,7 @@ class TestAcceptPrescriberWithOrgInvitationExceptions(TestCase):
 
     def test_connected_user_is_not_the_invited_user(self):
         invitation = PrescriberWithOrgSentInvitationFactory(sender=self.sender, organization=self.organization)
-        self.client.login(email=self.sender.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.sender)
         response = self.client.get(invitation.acceptance_link, follow=True)
         self.assertRedirects(response, reverse("account_logout"))
         invitation.refresh_from_db()
@@ -428,7 +428,7 @@ class TestAcceptPrescriberWithOrgInvitationExceptions(TestCase):
         response = self.client.get(invitation.acceptance_link, follow=True)
         self.assertContains(response, escape("Cette invitation n'est plus valide."))
 
-        self.client.login(email=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         # Try to bypass the first check by directly reaching the join endpoint
         join_url = reverse("invitations_views:join_prescriber_organization", kwargs={"invitation_id": invitation.id})
         response = self.client.get(join_url, follow=True)

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -65,7 +65,7 @@ class TestAcceptInvitation(TestCase):
     def test_accept_invitation_logged_in_user(self):
         # A logged in user should log out before accepting an invitation.
         logged_in_user = UserFactory()
-        self.client.login(email=logged_in_user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(logged_in_user)
         # Invitation for another user
         invitation = SentSiaeStaffInvitationFactory(email="loutre@example.com")
         response = self.client.get(invitation.acceptance_link, follow=True)
@@ -104,7 +104,7 @@ class TestAcceptInvitation(TestCase):
         self.assertContains(response, "expirée")
 
         user = SiaeStaffFactory(email=invitation.email)
-        self.client.login(email=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         join_url = reverse("invitations_views:join_siae", kwargs={"invitation_id": invitation.id})
         response = self.client.get(join_url, follow=True)
         self.assertContains(response, escape("Cette invitation n'est plus valide."))
@@ -113,7 +113,7 @@ class TestAcceptInvitation(TestCase):
         siae = SiaeFactory(convention__is_active=False)
         invitation = SentSiaeStaffInvitationFactory(siae=siae)
         user = SiaeStaffFactory(email=invitation.email)
-        self.client.login(email=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         join_url = reverse("invitations_views:join_siae", kwargs={"invitation_id": invitation.id})
         response = self.client.get(join_url, follow=True)
         self.assertContains(response, escape("Cette structure n'est plus active."))
@@ -146,7 +146,7 @@ class TestAcceptInvitation(TestCase):
             last_name=user.last_name,
             email=user.email,
         )
-        self.client.login(email=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(invitation.acceptance_link, follow=True)
         self.assertRedirects(response, reverse("dashboard:index"))
 
@@ -179,7 +179,7 @@ class TestAcceptInvitation(TestCase):
             email=user.email,
         )
 
-        self.client.login(email=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         response = self.client.get(invitation.acceptance_link, follow=True)
 
         self.assertEqual(response.status_code, 403)
@@ -187,7 +187,7 @@ class TestAcceptInvitation(TestCase):
 
     def test_accept_connected_user_is_not_the_invited_user(self):
         invitation = SentSiaeStaffInvitationFactory()
-        self.client.login(email=invitation.sender.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(invitation.sender)
         response = self.client.get(invitation.acceptance_link, follow=True)
 
         self.assertEqual(reverse("account_logout"), response.wsgi_request.path)

--- a/itou/www/prescribers_views/tests/test_admins.py
+++ b/itou/www/prescribers_views/tests/test_admins.py
@@ -4,7 +4,6 @@ from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 
 from itou.prescribers.factories import PrescriberOrganizationWith2MembershipFactory
-from itou.users.factories import DEFAULT_PASSWORD
 
 
 class PrescribersOrganizationAdminMembersManagementTest(TestCase):
@@ -16,7 +15,7 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         admin = organization.members.filter(prescribermembership__is_admin=True).first()
         guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("prescribers_views:update_admin_role", kwargs={"action": "add", "user_id": guest.id})
 
         # Redirection to confirm page
@@ -52,7 +51,7 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         membership.save()
         self.assertTrue(guest in organization.active_admin_members)
 
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("prescribers_views:update_admin_role", kwargs={"action": "remove", "user_id": guest.id})
 
         # Redirection to confirm page
@@ -86,7 +85,7 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         admin = organization.members.filter(prescribermembership__is_admin=True).first()
         guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
-        self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(guest)
         url = reverse("prescribers_views:update_admin_role", kwargs={"action": "remove", "user_id": admin.id})
 
         # Redirection to confirm page
@@ -115,7 +114,7 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         admin = organization.members.filter(prescribermembership__is_admin=True).first()
         guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
-        self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(guest)
 
         # update: possible actions are now filtered via RE_PATH in urls.py
         with self.assertRaises(NoReverseMatch):

--- a/itou/www/prescribers_views/tests/test_edit.py
+++ b/itou/www/prescribers_views/tests/test_edit.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.factories import PrescriberOrganizationFactory, PrescriberOrganizationWithMembershipFactory
 from itou.prescribers.models import PrescriberOrganization
-from itou.users.factories import DEFAULT_PASSWORD
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
 
 
@@ -29,7 +28,7 @@ class EditOrganizationTest(TestCase):
         )
         user = organization.members.first()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("prescribers_views:edit_organization")
         response = self.client.get(url)
@@ -95,7 +94,7 @@ class EditOrganizationTest(TestCase):
         org2.members.add(user)
         org2.save()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("prescribers_views:edit_organization")
         response = self.client.get(url)

--- a/itou/www/prescribers_views/tests/test_members.py
+++ b/itou/www/prescribers_views/tests/test_members.py
@@ -7,14 +7,13 @@ from itou.prescribers.factories import (
     PrescriberOrganizationWith2MembershipFactory,
     PrescriberOrganizationWithMembershipFactory,
 )
-from itou.users.factories import DEFAULT_PASSWORD
 
 
 class MembersTest(TestCase):
     def test_members(self):
         organization = PrescriberOrganizationWithMembershipFactory()
         user = organization.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("prescribers_views:members")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -31,7 +30,7 @@ class UserMembershipDeactivationTest(TestCase):
         memberships = admin.prescribermembership_set.all()
         membership = memberships.first()
 
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("prescribers_views:deactivate_member", kwargs={"user_id": admin.id})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
@@ -53,7 +52,7 @@ class UserMembershipDeactivationTest(TestCase):
         memberships = guest.prescribermembership_set.all()
         membership = memberships.first()
 
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("prescribers_views:deactivate_member", kwargs={"user_id": guest.id})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
@@ -80,7 +79,7 @@ class UserMembershipDeactivationTest(TestCase):
         guest = PrescriberFactory()
         organization.members.add(guest)
 
-        self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(guest)
         url = reverse("prescribers_views:deactivate_member", kwargs={"user_id": guest.id})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
@@ -95,13 +94,13 @@ class UserMembershipDeactivationTest(TestCase):
         admin = organization.members.filter(prescribermembership__is_admin=True).first()
         guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("prescribers_views:deactivate_member", kwargs={"user_id": guest.id})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
 
         # guest is now an orienter
-        self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(guest)
         url = reverse("dashboard:index")
         response = self.client.post(url)
         self.assertEqual(response.status_code, 200)
@@ -122,14 +121,14 @@ class UserMembershipDeactivationTest(TestCase):
         self.assertEqual(len(memberships), 2)
 
         # Admin remove guest from structure
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("prescribers_views:deactivate_member", kwargs={"user_id": guest.id})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
         self.client.logout()
 
         # guest must be able to login
-        self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(guest)
         url = reverse("dashboard:index")
         response = self.client.get(url)
 

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -15,7 +15,7 @@ from itou.siae_evaluations.factories import (
 from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria, EvaluatedJobApplication, EvaluationCampaign
 from itou.siaes.factories import SiaeMembershipFactory
 from itou.users.enums import KIND_SIAE_STAFF
-from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
+from itou.users.factories import JobSeekerFactory
 from itou.utils.perms.user import UserInfo
 from itou.utils.templatetags.format_filters import format_approval_number
 from itou.www.siae_evaluations_views.forms import LaborExplanationForm, SetChosenPercentForm
@@ -77,7 +77,7 @@ class SamplesSelectionViewTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         # institution without active campaign
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Vous n'avez pas de contrôle en cours.")
@@ -106,7 +106,7 @@ class SamplesSelectionViewTest(TestCase):
         evaluation_campaign = EvaluationCampaignFactory(institution=self.institution)
         back_url = reverse("dashboard:index")
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
 
         self.assertEqual(response.context["institution"], self.institution)
@@ -145,7 +145,7 @@ class SamplesSelectionViewTest(TestCase):
     def test_post_form(self):
         evaluation_campaign = EvaluationCampaignFactory(institution=self.institution)
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
 
         post_data = {"chosen_percent": evaluation_enums.EvaluationChosenPercent.MIN}
@@ -164,7 +164,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         self.institution = membership.institution
 
     def test_access(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         # institution without evaluation_campaign
         response = self.client.get(
@@ -209,7 +209,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_content(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         evaluation_campaign = EvaluationCampaignFactory(
             institution=self.institution, evaluations_asked_at=timezone.now()
         )
@@ -231,7 +231,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         transmis = "Résultats transmis"
         phase_contradictoire = "Phase contradictoire"
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         evaluation_campaign = EvaluationCampaignFactory(
             institution=self.institution, evaluations_asked_at=timezone.now()
         )
@@ -297,7 +297,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         self.assertContains(response, transmis)
 
     def test_num_queries(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         evaluation_campaign = EvaluationCampaignFactory(
             institution=self.institution, evaluations_asked_at=timezone.now()
         )
@@ -328,7 +328,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.institution = membership.institution
 
     def test_access(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         # institution without evaluation_campaign
         response = self.client.get(
@@ -363,7 +363,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_content(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         evaluation_campaign = EvaluationCampaignFactory(
             institution=self.institution, evaluations_asked_at=timezone.now()
         )
@@ -491,7 +491,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         # not yet submitted by Siae
         response = self.client.get(url)
@@ -526,7 +526,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.assertContains(response, valide)
 
     def test_num_queries_in_view(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         evaluation_campaign = EvaluationCampaignFactory(
             institution=self.institution, evaluations_asked_at=timezone.now()
         )
@@ -558,7 +558,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.institution = membership.institution
 
     def test_access(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         # institution without evaluation_campaign
         response = self.client.get(
@@ -604,7 +604,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_content(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         evaluation_campaign = EvaluationCampaignFactory(
             institution=self.institution, evaluations_asked_at=timezone.now()
         )
@@ -630,7 +630,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         )
 
     def test_criterion_validation(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         # fixme vincentporte : use EvaluatedAdministrativeCriteria instead
         evaluated_administrative_criteria = get_evaluated_administrative_criteria(self.institution)
@@ -735,7 +735,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         # to be added : readonly conditionnal field
 
     def test_post_form(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         evaluation_campaign = EvaluationCampaignFactory(
             institution=self.institution, evaluations_asked_at=timezone.now()
         )
@@ -768,7 +768,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         )
 
     def test_num_queries_in_view(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         # fixme vincentporte : use EvaluatedAdministrativeCriteria instead
         evaluated_administrative_criteria = get_evaluated_administrative_criteria(self.institution)
         EvaluatedAdministrativeCriteria.objects.create(
@@ -799,7 +799,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_job_application_state_labels(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         # fixme vincentporte : use EvaluatedAdministrativeCriteria instead
         evaluated_administrative_criteria = get_evaluated_administrative_criteria(self.institution)
         evaluated_administrative_criteria.proof_url = "https://www.test.com"
@@ -841,7 +841,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         self.institution = membership.institution
 
     def test_access(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         # institution without evaluation_campaign
         response = self.client.get(
@@ -897,7 +897,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_actions_and_redirection(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         # fixme vincentporte : use EvaluatedAdministrativeCriteria instead
         evaluated_administrative_criteria = get_evaluated_administrative_criteria(self.institution)
         redirect_url = reverse(
@@ -993,7 +993,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
         self.evaluated_siae = create_evaluated_siae_consistent_datas(self.evaluation_campaign)
 
     def test_access(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         # institution without evaluation_campaign
         response = self.client.get(
@@ -1026,7 +1026,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_actions_and_redirection(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         self.evaluation_campaign.evaluations_asked_at = timezone.now()
         self.evaluation_campaign.save(update_fields=["evaluations_asked_at"])

--- a/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
@@ -18,7 +18,7 @@ from itou.siae_evaluations.factories import (
 from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria
 from itou.siaes.factories import SiaeMembershipFactory
 from itou.users.enums import KIND_SIAE_STAFF
-from itou.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
+from itou.users.factories import JobSeekerFactory
 from itou.utils.perms.user import UserInfo
 from itou.utils.storage.s3 import S3Upload
 
@@ -74,7 +74,7 @@ class SiaeJobApplicationListViewTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
         # siae without active campaign
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context["evaluations_asked_at"])
@@ -124,7 +124,7 @@ class SiaeJobApplicationListViewTest(TestCase):
         evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign__evaluations_asked_at=timezone.now(), siae=self.siae)
         evaluated_job_application = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         # no criterion selected
         response = self.client.get(self.url)
@@ -157,7 +157,7 @@ class SiaeJobApplicationListViewTest(TestCase):
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteriaFactory(
             evaluated_job_application=evaluated_job_application, proof_url=""
         )
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(
@@ -195,7 +195,7 @@ class SiaeJobApplicationListViewTest(TestCase):
             kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
         )
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         # no criterion selected
         response = self.client.get(self.url)
@@ -239,7 +239,7 @@ class SiaeSelectCriteriaViewTest(TestCase):
         self.siae = membership.siae
 
     def test_access_without_activ_campaign(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         evaluated_job_application = EvaluatedJobApplicationFactory()
         response = self.client.get(
@@ -252,7 +252,7 @@ class SiaeSelectCriteriaViewTest(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_access_on_ended_campaign(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         evaluated_job_application = EvaluatedJobApplicationFactory(
             evaluated_siae__evaluation_campaign__ended_at=timezone.now()
@@ -267,7 +267,7 @@ class SiaeSelectCriteriaViewTest(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_access(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign__evaluations_asked_at=timezone.now(), siae=self.siae)
         evaluated_job_application = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
@@ -303,7 +303,7 @@ class SiaeSelectCriteriaViewTest(TestCase):
         )
 
     def test_context_fields_list(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         # Combinations :
         # (True, False) = eligibility diagnosis with level 1 administrative criteria
@@ -337,7 +337,7 @@ class SiaeSelectCriteriaViewTest(TestCase):
             kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
         )
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -360,7 +360,7 @@ class SiaeSelectCriteriaViewTest(TestCase):
             kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
         )
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -400,7 +400,7 @@ class SiaeUploadDocsViewTest(TestCase):
         self.siae = membership.siae
 
     def test_access_on_unknown_evaluated_job_application(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(
             reverse(
                 "siae_evaluations_views:siae_upload_doc",
@@ -422,7 +422,7 @@ class SiaeUploadDocsViewTest(TestCase):
             administrative_criteria=criterion.administrative_criteria,
         )
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(
             reverse(
                 "siae_evaluations_views:siae_upload_doc",
@@ -432,7 +432,7 @@ class SiaeUploadDocsViewTest(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_access_on_ended_campaign(self):
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteriaFactory(
@@ -452,7 +452,7 @@ class SiaeUploadDocsViewTest(TestCase):
     @freeze_time("2022-09-14 11:11:11")
     def test_access(self):
         self.maxDiff = None
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)
         criterion = (
@@ -492,7 +492,7 @@ class SiaeUploadDocsViewTest(TestCase):
 
     def test_post(self):
         fake_now = timezone.now()
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)
         criterion = (
@@ -554,7 +554,7 @@ class SiaeSubmitProofsViewTest(TestCase):
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteriaFactory(
             evaluated_job_application=evaluated_job_application
         )
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         with self.assertNumQueries(
             1  # fetch django session
@@ -577,7 +577,7 @@ class SiaeSubmitProofsViewTest(TestCase):
     def test_is_not_submittable(self):
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)
         EvaluatedAdministrativeCriteriaFactory(evaluated_job_application=evaluated_job_application, proof_url="")
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
 
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 302)
@@ -596,7 +596,7 @@ class SiaeSubmitProofsViewTest(TestCase):
             submitted_at=fake_now - relativedelta(days=1),
         )
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 302)
 
@@ -633,7 +633,7 @@ class SiaeSubmitProofsViewTest(TestCase):
             submitted_at=fake_now,
         )
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/dashboard/")
@@ -644,7 +644,7 @@ class SiaeSubmitProofsViewTest(TestCase):
             self.siae, self.user, institution=institution_membership.institution
         )
         EvaluatedAdministrativeCriteriaFactory(evaluated_job_application=evaluated_job_application)
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 302)
 
@@ -682,7 +682,7 @@ class SiaeSubmitProofsViewTest(TestCase):
         evaluation_campaign.ended_at = timezone.now()
         evaluation_campaign.save(update_fields=["ended_at"])
 
-        self.client.login(username=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 404)

--- a/itou/www/siaes_views/tests/tests_job_description_views.py
+++ b/itou/www/siaes_views/tests/tests_job_description_views.py
@@ -11,7 +11,6 @@ from itou.prescribers.factories import PrescriberOrganizationWithMembershipFacto
 from itou.siaes.enums import ContractType, SiaeKind
 from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import SiaeJobDescription
-from itou.users.factories import DEFAULT_PASSWORD
 
 
 class JobDescriptionAbstractTest(TestCase):
@@ -49,7 +48,7 @@ class JobDescriptionAbstractTest(TestCase):
         self.edit_preview_url = reverse("siaes_views:edit_job_description_preview")
 
     def _login(self, user):
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         response = self.client.get(self.url)
 

--- a/itou/www/siaes_views/tests/tests_views.py
+++ b/itou/www/siaes_views/tests/tests_views.py
@@ -17,7 +17,6 @@ from itou.siaes.factories import (
     SiaeWithMembershipAndJobsFactory,
 )
 from itou.siaes.models import Siae
-from itou.users.factories import DEFAULT_PASSWORD
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_NO_RESULT_MOCK, BAN_GEOCODING_API_RESULT_MOCK
 
 
@@ -57,7 +56,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertTrue(siae.should_have_convention)
         self.assertTrue(siae.source == Siae.SOURCE_ASP)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("dashboard:index")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -82,7 +81,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertTrue(siae.should_have_convention)
         self.assertTrue(siae.source == Siae.SOURCE_USER_CREATED)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("dashboard:index")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -113,7 +112,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertTrue(siae.should_have_convention)
         self.assertTrue(siae.source == Siae.SOURCE_STAFF_CREATED)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("dashboard:index")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -131,7 +130,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertTrue(siae.should_have_convention)
         self.assertTrue(siae.source == Siae.SOURCE_ASP)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("dashboard:index")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -149,7 +148,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertFalse(siae.should_have_convention)
         self.assertTrue(siae.source == Siae.SOURCE_GEIQ)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("dashboard:index")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -167,7 +166,7 @@ class ShowAndSelectFinancialAnnexTest(TestCase):
         self.assertFalse(siae.should_have_convention)
         self.assertTrue(siae.source == Siae.SOURCE_USER_CREATED)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("dashboard:index")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -185,7 +184,7 @@ class CreateSiaeViewTest(TestCase):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("siaes_views:create_siae")
         response = self.client.get(url)
@@ -225,7 +224,7 @@ class CreateSiaeViewTest(TestCase):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("siaes_views:create_siae")
         response = self.client.get(url)
@@ -265,7 +264,7 @@ class CreateSiaeViewTest(TestCase):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("siaes_views:create_siae")
         response = self.client.get(url)
@@ -303,7 +302,7 @@ class CreateSiaeViewTest(TestCase):
         siae.save()
         user = siae.members.first()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("siaes_views:create_siae")
         response = self.client.get(url)
@@ -338,7 +337,7 @@ class CreateSiaeViewTest(TestCase):
         new_siret = siae.siren + "12345"
         self.assertNotEqual(siae.siret, new_siret)
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("siaes_views:create_siae")
         response = self.client.get(url)
@@ -369,7 +368,7 @@ class CreateSiaeViewTest(TestCase):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("siaes_views:create_siae")
         response = self.client.get(url)
@@ -432,7 +431,7 @@ class EditSiaeViewTest(TestCase):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("siaes_views:edit_siae_step_contact_infos")
         response = self.client.get(url)
@@ -534,7 +533,7 @@ class EditSiaeViewTest(TestCase):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         # Only admin members should be allowed to edit SIAE's details
         membership = user.siaemembership_set.first()
@@ -552,7 +551,7 @@ class EditSiaeViewWithWrongAddressTest(TestCase):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
 
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
 
         url = reverse("siaes_views:edit_siae_step_contact_infos")
         response = self.client.get(url)
@@ -592,7 +591,7 @@ class MembersTest(TestCase):
     def test_members(self):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
-        self.client.login(username=user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(user)
         url = reverse("siaes_views:members")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -609,7 +608,7 @@ class UserMembershipDeactivationTest(TestCase):
         memberships = admin.siaemembership_set.all()
         membership = memberships.first()
 
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("siaes_views:deactivate_member", kwargs={"user_id": admin.id})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
@@ -632,7 +631,7 @@ class UserMembershipDeactivationTest(TestCase):
         self.assertFalse(guest in siae.active_admin_members)
         self.assertTrue(admin in siae.active_admin_members)
 
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("siaes_views:deactivate_member", kwargs={"user_id": guest.id})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
@@ -657,7 +656,7 @@ class UserMembershipDeactivationTest(TestCase):
         """
         siae = SiaeWith2MembershipsFactory()
         guest = siae.members.filter(siaemembership__is_admin=False).first()
-        self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(guest)
         url = reverse("siaes_views:deactivate_member", kwargs={"user_id": guest.id})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
@@ -673,13 +672,13 @@ class UserMembershipDeactivationTest(TestCase):
         admin = siae.members.filter(siaemembership__is_admin=True).first()
         guest = siae.members.filter(siaemembership__is_admin=False).first()
 
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("siaes_views:deactivate_member", kwargs={"user_id": guest.id})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
         self.client.logout()
 
-        self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(guest)
         url = reverse("dashboard:index")
         response = self.client.get(url)
 
@@ -703,14 +702,14 @@ class UserMembershipDeactivationTest(TestCase):
         self.assertEqual(len(memberships), 2)
 
         # Admin remove guest from structure
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("siaes_views:deactivate_member", kwargs={"user_id": guest.id})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
         self.client.logout()
 
         # guest must be able to login
-        self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(guest)
         url = reverse("dashboard:index")
         response = self.client.get(url)
 
@@ -730,7 +729,7 @@ class SIAEAdminMembersManagementTest(TestCase):
         admin = siae.members.filter(siaemembership__is_admin=True).first()
         guest = siae.members.filter(siaemembership__is_admin=False).first()
 
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("siaes_views:update_admin_role", kwargs={"action": "add", "user_id": guest.id})
 
         # Redirection to confirm page
@@ -764,7 +763,7 @@ class SIAEAdminMembersManagementTest(TestCase):
         membership.save()
         self.assertTrue(guest in siae.active_admin_members)
 
-        self.client.login(username=admin.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(admin)
         url = reverse("siaes_views:update_admin_role", kwargs={"action": "remove", "user_id": guest.id})
 
         # Redirection to confirm page
@@ -796,7 +795,7 @@ class SIAEAdminMembersManagementTest(TestCase):
         admin = siae.members.filter(siaemembership__is_admin=True).first()
         guest = siae.members.filter(siaemembership__is_admin=False).first()
 
-        self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(guest)
         url = reverse("siaes_views:update_admin_role", kwargs={"action": "remove", "user_id": admin.id})
 
         # Redirection to confirm page
@@ -825,7 +824,7 @@ class SIAEAdminMembersManagementTest(TestCase):
         admin = siae.members.filter(siaemembership__is_admin=True).first()
         guest = siae.members.filter(siaemembership__is_admin=False).first()
 
-        self.client.login(username=guest.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(guest)
         # update: less test with RE_PATH
         with self.assertRaises(NoReverseMatch):
             reverse("siaes_views:update_admin_role", kwargs={"action": suspicious_action, "user_id": admin.id})


### PR DESCRIPTION
### Quoi ?

Utilisation de la méthode `force_login()` du client de test au lieu de `login()`.

### Pourquoi ?

`login()` vérifie sérieusement les identifiants de l’utilisateur, ce qui est coûteux en terme de calcul. `force_login()` “hack” le système pour que l’utilisateur soit directement connecté.

### Comment ?

Même si certains tests vérifient le comportement du *backend d’authentification*, la plupart des tests veulent simplement simuler un utilisateur identifié sur le site. Les quelques tests pour qui le comportement du backend d’authentification est important ont été préservés, les autres utilisent maintenant `force_login()`.

Un petit point d’attention : `force_login()` ne vérifie pas que `User.active is True`. Les tests modifiés ne vérifient pas l’accès avec un utilisateur inactif.