### PR TITLE
Blocage du parcours des fiches salarié en cas d'absence de type de voie dans l'adresse du salarié

### DIFF
--- a/itou/asp/factories.py
+++ b/itou/asp/factories.py
@@ -30,6 +30,7 @@ _sample_communes = [
     {"code": "37273", "name": "VILLE-AUX-DAMES"},
     {"code": "13200", "name": "MARSEILLE"},
     {"code": "67152", "name": "GEISPOLSHEIM"},
+    {"code": "85146", "name": "MONTAIGU-VENDEE"},
 ]
 
 
@@ -74,6 +75,7 @@ class CommuneFactory(factory.django.DjangoModelFactory):
     code, name = random.choice(_sample_communes).values()
 
 
+# FIXME: unreliable and confusing
 class MockedCommuneFactory(CommuneFactory):
     """
     A factory with a specific code for mock testing

--- a/itou/common_apps/address/format.py
+++ b/itou/common_apps/address/format.py
@@ -109,15 +109,17 @@ def format_address(obj):
         # so we use an aliases table as a last change to get the type
         # example: got "R" or "r" instead of "Rue"
         or find_lane_type_aliases(lane)
+        # If all previous options have failed, fallback to "lieu-dit" as lane type.
+        # This will fix some geolocation errors, f.i. when
+        # lane types are not in french and not referenced by ASP.
+        # (in Brittany or Basque country ...)
+        or LaneType.LD
     )
 
-    if lt:
-        result["lane_type"] = lt.name
-        # If split is successful, then we can strip the lane type
-        # from the lane name for a better result
-        result["lane"] = rest[0] if rest else lane_type
-    else:
-        return None, f"Impossible de trouver le type de voie : {lane_type} pour l'adresse : {address}"
+    result["lane_type"] = lt.name
+    # If split is successful, then we can strip the lane type
+    # from the lane name for a better result
+    result["lane"] = rest[0] if rest else lane_type
 
     # INSEE code: must double check with ASP ref file
     result["insee_code"] = address.get("insee_code")

--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -45,7 +45,11 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
         "asp_processing_code",
         "status",
     )
-    list_filter = ("status",)
+
+    list_filter = (
+        "status",
+        "processed_as_duplicate",
+    )
 
     search_fields = (
         "pk",
@@ -72,6 +76,7 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
         "siret",
         "financial_annex",
         "asp_id",
+        "asp_processing_type",
         "asp_batch_file",
         "asp_batch_line_number",
         "asp_processing_code",
@@ -106,6 +111,7 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
                     "asp_batch_line_number",
                     "asp_processing_code",
                     "asp_processing_label",
+                    "asp_processing_type",
                     "archived_json",
                 )
             },
@@ -123,6 +129,14 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
         url = reverse(f"admin:{app_label}_{model_name}_change", args=[job_seeker.id])
         return mark_safe(f'<a href="{url}">{job_seeker.id}</a>')
 
+    def asp_processing_type(self, obj):
+        return (
+            "Intégrée automatiquement par script (doublon ASP)"
+            if obj.processed_as_duplicate
+            else "Intégration ASP normale"
+        )
+
+    asp_processing_type.short_description = "Type d'intégration"
     job_seeker.short_description = "Salarié"
     job_seeker_profile_link.short_description = "Profil du salarié"
 

--- a/itou/utils/mocks/address_format.py
+++ b/itou/utils/mocks/address_format.py
@@ -275,6 +275,18 @@ BAN_GEOCODING_API_RESULTS_MOCK = [
         "longitude": 4.925175,
         "latitude": 45.749174,
     },
+    {
+        "score": 0.6832486776859503,
+        "address_line_1": "8 la boutrie - caillot",
+        "number": "8",
+        "lane": "la boutrie - caillot",
+        "address": "8 la boutrie - caillot",
+        "post_code": "85600",
+        "insee_code": "85146",
+        "city": "Montaigu-Vendée",
+        "longitude": -1.297749,
+        "latitude": 47.012473,
+    },
 ]
 
 RESULTS_BY_ADDRESS = {elt["address_line_1"]: elt for elt in BAN_GEOCODING_API_RESULTS_MOCK}


### PR DESCRIPTION
### Quoi ?

- réparation d'un problème de formatage d'adresse dans le parcours des fiches salarié
- au passage ajout de l'information de forçage de l'intégration d'une fiche salarié dans l'admin

### Pourquoi ?

Affichage bloquant d'une erreur à la première étape de la saisie des fiches salarié lorsque l'adresse du salarié comporte un type de voie "exotique" (en Basque ou Breizh) non-référencé par l'ASP ou pas de type de voie du tout.

### Comment ?

Si le type de voie n'arrive pas a être correctement déterminé, on se replie sur "Lieu-Dit" (LD).
De toute façon, ces informations ne sont pas impactantes pour l'ASP (et peuvent si besoin être modifié sur l'extranet).

### Autre 

Il faudra effectuer une refonte de `format_address` et le border correctement de tests. 
Et refondre aussi l'utilisation des mocks de géoloc (tout pourris, mais j'assume).