### PR TITLE
feat(api): add link to structure page

### DIFF
--- a/itou/api/data_inclusion_api/serializers.py
+++ b/itou/api/data_inclusion_api/serializers.py
@@ -30,6 +30,7 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
     complement_adresse = serializers.CharField(source="address_line_2")
     date_maj = serializers.SerializerMethodField()
     structure_parente = serializers.SerializerMethodField()
+    lien_source = serializers.SerializerMethodField()
 
     class Meta:
         model = Siae
@@ -54,6 +55,7 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
             "source",
             "date_maj",
             "structure_parente",
+            "lien_source",
         ]
         read_only_fields = fields
 
@@ -82,6 +84,9 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
         dt = obj.updated_at or obj.created_at
         return dt.astimezone(timezone.get_current_timezone()).isoformat()
 
+    def get_lien_source(self, obj) -> str:
+        return self.context["request"].build_absolute_uri(obj.get_card_url())
+
 
 class PrescriberOrgStructureSerializer(serializers.ModelSerializer):
     """Serialize Prescriber Organization instance to the data.inclusion structure schema.
@@ -106,6 +111,7 @@ class PrescriberOrgStructureSerializer(serializers.ModelSerializer):
     source = serializers.ReadOnlyField(default="")
     date_maj = serializers.SerializerMethodField()
     structure_parente = serializers.SerializerMethodField()
+    lien_source = serializers.SerializerMethodField()
 
     class Meta:
         model = PrescriberOrganization
@@ -130,6 +136,7 @@ class PrescriberOrgStructureSerializer(serializers.ModelSerializer):
             "source",
             "date_maj",
             "structure_parente",
+            "lien_source",
         ]
         read_only_fields = fields
 
@@ -147,3 +154,7 @@ class PrescriberOrgStructureSerializer(serializers.ModelSerializer):
 
     def get_structure_parente(self, obj) -> Optional[str]:
         return None
+
+    def get_lien_source(self, obj) -> str:
+        url = obj.get_card_url()
+        return self.context["request"].build_absolute_uri(url) if url else None

--- a/itou/api/data_inclusion_api/tests.py
+++ b/itou/api/data_inclusion_api/tests.py
@@ -12,6 +12,19 @@ def _str_with_tz(dt):
     return dt.astimezone(timezone.get_current_timezone()).isoformat()
 
 
+class DataInclusionStructureTest(APITestCase):
+    maxDiff = None
+
+    def test_list_missing_type_query_param(self):
+        user = SiaeStaffFactory()
+        authenticated_client = APIClient()
+        authenticated_client.force_authenticate(user)
+        url = reverse("v1:structures-list")
+
+        response = authenticated_client.get(url, format="json")
+        self.assertEqual(response.status_code, 400)
+
+
 class DataInclusionSiaeStructureTest(APITestCase):
     url = reverse("v1:structures-list")
     maxDiff = None
@@ -60,6 +73,7 @@ class DataInclusionSiaeStructureTest(APITestCase):
                     "source": siae.source,
                     "date_maj": _str_with_tz(siae.updated_at),
                     "structure_parente": None,
+                    "lien_source": f"http://testserver{reverse('siaes_views:card', kwargs={'siae_id': siae.pk})}",
                 },
                 {
                     "id": str(antenne.uid),
@@ -83,6 +97,7 @@ class DataInclusionSiaeStructureTest(APITestCase):
                     "date_maj": _str_with_tz(antenne.updated_at),
                     # Antenne references parent structure
                     "structure_parente": str(siae.uid),
+                    "lien_source": f"http://testserver{reverse('siaes_views:card', kwargs={'siae_id': antenne.pk})}",
                 },
             ],
         )
@@ -130,7 +145,7 @@ class DataInclusionPrescriberStructureTest(APITestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_list_structures(self):
-        orga = PrescriberOrganizationFactory()
+        orga = PrescriberOrganizationFactory(is_authorized=True)
 
         response = self.authenticated_client.get(
             self.url,
@@ -162,6 +177,7 @@ class DataInclusionPrescriberStructureTest(APITestCase):
                     "source": "",
                     "date_maj": _str_with_tz(orga.created_at),
                     "structure_parente": None,
+                    "lien_source": f"http://testserver{reverse('prescribers_views:card', kwargs={'org_id': orga.pk})}",
                 }
             ],
         )


### PR DESCRIPTION
### Quoi ?

Exposition via l'api data.inclusion d'un lien vers la page de la structure sur les emplois

```json
{
    "id": "44b32551-8c00-4b1a-a833-641a98f3bb4d",
    "typologie": "ACI",
    "nom": "ACI Librairie Mille Feuilles",
    "siret": "21780621500547",
    "rna": "",
    "presentation_resume": "Chantier …",
    "presentation_detail": "Chantier d'insertion professionnelle…",
    "site_web": "",
    "telephone": "0130561812",
    "courriel": "librairie.mille-feuilles@mairie-trappes.fr",
    "code_postal": "78190",
    "code_insee": "",
    "commune": "Trappes",
    "adresse": "23 rue Pierre Sémard",
    "complement_adresse": "",
    "longitude": 2.005141,
    "latitude": 48.775355,
    "source": "ASP",
    "date_maj": "2022-09-20T14:56:50.728907+02:00",
    "structure_parente": null,
    "lien_source": "https://emplois.inclusion.beta.gouv.fr/siae/3918/card" <---
}
```

### Pourquoi ?

Pour permettre de rediriger les consommateurs des données d'une structure vers le site des emplois

