### PR TITLE
[WIP] Permettre aux structures d'ajouter un salarié non présent dans leur tableau de bord

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -705,6 +705,10 @@ class EmployeeRecord(models.Model):
 
         return fs
 
+    @classmethod
+    def get_for_approval_number_and_asp_id(cls, approval_number, asp_id):
+        return cls.objects.filter(approval_number=approval_number, asp_id=asp_id).exclude(status=Status.DISABLED).get()
+
 
 class EmployeeRecordBatch:
     """

--- a/itou/templates/employee_record/add.html
+++ b/itou/templates/employee_record/add.html
@@ -1,0 +1,41 @@
+{% extends "layout/content_small.html" %}
+{% load bootstrap4 %}
+{% load format_filters %}
+{% load str_filters %}
+
+{% block title %}Ajouter un salarié{{ block.super }}{% endblock %}
+
+{% block content %}
+    <h1 class="h1-hero-c1">Ajouter un salarié</h1>
+
+    <div class="alert alert-info">
+        <p class="mb-0">
+            Cette fonction est destinée à ajouter un salarié déclaré dans l'extranet IAE 2.0 de l'ASP mais non présent
+            dans vos fiches salariés.
+        </p>
+    </div>
+    <div class="c-form">
+        {% if form.approval %}
+            <p>
+                Le PASS IAE <b>{{ form.approval|format_approval_number }}</b> est associé au compte de
+                <b>{{ form.approval.user.get_full_name|mask_unless:can_view_personal_information }}</b>.
+            </p>
+            <div class="text-right">
+                <a class="btn btn-outline-secondary" href="{% url "employee_record_views:add" %}">Annuler</a>
+                <a class="btn btn-primary" href="{% url "employee_record_views:create" job_application_id=form.approval.user.last_accepted_job_application.pk  %}">Ajouter ce salarié</a>
+            </div>
+        {% else %}
+            <form method="post" role="form" class="js-prevent-multiple-submit">
+                {% csrf_token %}
+                {% bootstrap_form form alert_error_type="all" %}
+
+                <hr class="my-5">
+                <div class="text-right">
+                    {% buttons %}
+                        <button type="submit" class="btn btn-outline-primary">Suivant</button>
+                    {% endbuttons %}
+                </div>
+            </form>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/itou/templates/employee_record/includes/create_step_1.html
+++ b/itou/templates/employee_record/includes/create_step_1.html
@@ -16,8 +16,10 @@
     {% bootstrap_field form.insee_commune %}
     {% bootstrap_field form.insee_commune_code %}
 
-    {% buttons %}
-        <a class="btn btn btn-outline-secondary" href="#">Annuler</a>
-        <button type="submit" class="btn btn-primary">Continuer</button>
-    {% endbuttons %}
+    <div class="text-right">
+        {% buttons %}
+            <a class="btn btn-outline-secondary" href="{% url "employee_record_views:list" %}?status=NEW">Annuler</a>
+            <button type="submit" class="btn btn-primary">Continuer</button>
+        {% endbuttons %}
+    </div>
 </form>

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -4,11 +4,7 @@
 
 <div class="alert alert-emploi">
     <h5 class="h4"><b>Adresse saisie sur la plateforme de l'inclusion :</b></h5>
-    <p>{{ job_seeker.address_line_1 }}</p>
-    {% if job_seeker.address_line_2 %}
-        <p>{{ job_seeker.address_line_2 }}</p>
-    {% endif %}
-    <p>{{ job_seeker.post_code}} {{ job_seeker.city}}</p>
+    <p>{{ job_seeker.address_on_one_line|default:"Non renseigné" }}</p>
 
     <h5 class="h4"><b>Adresse
         {% if address_updated_by_user %}

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -36,7 +36,7 @@
         </div>
     {% else %}
         <div>
-            <p><b>L'adresse du salarié n'a pu être determinée automatiquement.</b></p>
+            <p>L'adresse du salarié n'a pu être determinée automatiquement.</p>
         </div>
     {% endif %}
 </div>
@@ -96,18 +96,15 @@
                 {% bootstrap_field form.insee_commune %}
                 {% bootstrap_field form.insee_commune_code %}
             </div>
-
-            <div class="mt-4">
-                {% buttons %}
-                    <button type="submit" class="btn btn-primary">Modifier l'adresse du salarié</button>
-                {% endbuttons %}
-            </div>
         </div>
-    </form>
-
-    <div class="mb-3">
-        <a class="btn btn btn-outline-secondary" href="{% url "employee_record_views:create" job_application.id %}">Précédent</a>
-        {% if profile.hexa_address_filled %}
-            <a class="btn btn btn-outline-primary" href="{% url "employee_record_views:create_step_3" job_application.id %}">Continuer</a>
-        {% endif %}
+        <div class="mt-4 text-right">
+            {% buttons %}
+                <button type="submit" class="btn btn-primary">Modifier l'adresse du salarié</button>
+            {% endbuttons %}
+        </div>
     </div>
+    <div class="mb-3 text-right">
+        <a class="btn btn-outline-secondary" href="{% url "employee_record_views:create" job_application.id %}">Précédent</a>
+        <a class="btn btn-outline-primary{% if not profile.hexa_address_filled %} disabled{% endif %}" href="{% url "employee_record_views:create_step_3" job_application.id %}">Continuer</a>
+    </div>
+</form>

--- a/itou/templates/employee_record/includes/create_step_3.html
+++ b/itou/templates/employee_record/includes/create_step_3.html
@@ -67,9 +67,11 @@
         {% bootstrap_field form.aah_allocation_since %}
     </div>
 
-    {% buttons %}
-        <a class="btn btn btn-outline-secondary" href="{% url "employee_record_views:create_step_2" job_application.id %}">Précédent</a>
-        <button type="submit" class="btn btn-primary">Continuer</button>
-    {% endbuttons %}
+    <div class="text-right">
+        {% buttons %}
+            <a class="btn btn btn-outline-secondary" href="{% url "employee_record_views:create_step_2" job_application.id %}">Précédent</a>
+            <button type="submit" class="btn btn-primary">Continuer</button>
+        {% endbuttons %}
+    </div>
 
 </form>

--- a/itou/templates/employee_record/includes/create_step_4.html
+++ b/itou/templates/employee_record/includes/create_step_4.html
@@ -15,9 +15,11 @@
 
     {% bootstrap_form form alert_error_type="all" %}
 
-    {% buttons %}
-        <a class="btn btn btn-outline-secondary" href="{% url "employee_record_views:create_step_3" job_application.id %}">Précédent</a>
-        <button type="submit" class="btn btn-primary">Continuer</button>
-    {% endbuttons %}
+    <div class="text-right">
+        {% buttons %}
+            <a class="btn btn btn-outline-secondary" href="{% url "employee_record_views:create_step_3" job_application.id %}">Précédent</a>
+            <button type="submit" class="btn btn-primary">Continuer</button>
+        {% endbuttons %}
+    </div>
 
 </form>

--- a/itou/templates/employee_record/includes/create_step_5.html
+++ b/itou/templates/employee_record/includes/create_step_5.html
@@ -19,10 +19,12 @@
 
     <form method="post" action="{% url "employee_record_views:create_step_5" employee_record.job_application.id %}" class="js-prevent-multiple-submit">
         {% csrf_token %}
-        {% buttons %}
-            <a class="btn btn-outline-secondary" href="{% url "employee_record_views:create_step_4" employee_record.job_application.id %}">Précédent</a>
-            <button type="submit" class="btn btn-primary">Valider la fiche salarié</button>
-        {% endbuttons %}
+        <div class="text-right">
+            {% buttons %}
+                <a class="btn btn-outline-secondary" href="{% url "employee_record_views:create_step_4" employee_record.job_application.id %}">Précédent</a>
+                <button type="submit" class="btn btn-primary">Valider la fiche salarié</button>
+            {% endbuttons %}
+        </div>
     </form>
 
 {% else %}
@@ -30,7 +32,7 @@
         <p><b>La création de cette fiche salariée est terminée.</b></p>
         <p class="mb-0">Vous pouvez suivre l'avancement de son traitement par l'ASP via la liste récapitulative accessible depuis le tableau de bord.</p>
     </div>
-    <div class="mb-3">
+    <div class="mb-3 text-right">
         <a href="{% url "employee_record_views:list" %}?status=NEW" class="btn btn-primary">
             Retour à la liste des fiches salarié
         </a>

--- a/itou/templates/employee_record/includes/create_step_5.html
+++ b/itou/templates/employee_record/includes/create_step_5.html
@@ -29,8 +29,11 @@
 
 {% else %}
     <div class="alert alert-success">
-        <p><b>La création de cette fiche salariée est terminée.</b></p>
+        <p><b>La création de cette fiche salarié est terminée.</b></p>
         <p class="mb-0">Vous pouvez suivre l'avancement de son traitement par l'ASP via la liste récapitulative accessible depuis le tableau de bord.</p>
+        {% if job_application.created_from_pe_approval %}
+            <p class="mb-0">Une fois la fiche salarié intégrée vous pourrez prolonger ou suspendre le PASS IAE.</p>
+        {% endif %}
     </div>
     <div class="mb-3 text-right">
         <a href="{% url "employee_record_views:list" %}?status=NEW" class="btn btn-primary">

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -1,15 +1,20 @@
 {% load format_filters %}
 <div class="card my-5">
 
-    <div class="card-header">
+    <div class="card-header d-flex align-items-start">
         <h3 class="h2">{{ item.job_seeker.get_full_name|title }}</h3>
+        {% if item.created_from_pe_approval %}
+            <span class="badge badge-sm badge-pill badge-outline-tertiary ml-2">Ancien agrément ou PASS IAE</span>
+        {% endif %}
     </div>
 
     <div class="card-body">
         <div class="row">
             <div class="col-md-7">
-                <p class="m-0">Début de contrat :&nbsp;<b>{{ item.hiring_start_at|default_if_none:"Non renseigné" }}</b></p>
-                <p class="m-0">Fin de contrat :&nbsp;<b>{{ item.hiring_end_at|default_if_none:"Non renseigné" }}</b></p>
+                {% if not item.created_from_pe_approval %}
+                    <p class="m-0">Début de contrat :&nbsp;<b>{{ item.hiring_start_at|default_if_none:"Non renseigné" }}</b></p>
+                    <p class="m-0">Fin de contrat :&nbsp;<b>{{ item.hiring_end_at|default_if_none:"Non renseigné" }}</b></p>
+                {% endif %}
                 <p class="m-0">Numéro de PASS IAE (agrément) :&nbsp;<b>{{ item.approval.number|format_approval_number }}</b></p>
             </div>
 

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -20,16 +20,16 @@
     <h1 class="h1-hero-c1">Fiches salarié ASP - <span class="text-muted">{{ current_siae.display_name }}</span></h1>
 
     <div class="mt-3">
-        <form method="get" class="form" id="status-filter-form">
-            <div class="row">
-                <div class="col-sm-3">
-                    <div class="card-deck">
-                        <div class="card">
-                            <div class="card-header">
-                                <b>Filtrer les fiches</b>
-                            </div>
-                            <div class="card-body">
-                                <p class="text-muted"><b>Par statut</b></p>
+        <div class="row">
+            <div class="col-sm-3">
+                <div class="card-deck">
+                    <div class="card">
+                        <div class="card-header">
+                            <b>Filtrer les fiches</b>
+                        </div>
+                        <div class="card-body">
+                            <p class="text-muted"><b>Par statut</b></p>
+                            <form method="get" class="form" id="status-filter-form">
                                 <div class="container form-group m-0" id="status-filter-form-group">
                                     {% for status, badge in form.status|zip:badges %}
                                         <div class="row">
@@ -44,11 +44,11 @@
                                         </div>
                                     {% endfor %}
                                 </div>
-                            </div>
+                            </form>
                         </div>
                     </div>
                 </div>
-            </form>
+            </div>
 
             <div class="col-sm-9">
                 <div class="container rounded bg-gray-400 p-3 mb-3">

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -46,6 +46,10 @@
                                 </div>
                             </form>
                         </div>
+                        <div class="card-footer text-center">
+                            <hr>
+                            <a class="btn btn-outline-primary" href="{% url "employee_record_views:add" %}">Ajouter un salarié</a>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -61,6 +65,7 @@
                             <ul>
                                 <li>Ne sont présentes dans cette liste que les candidatures acceptées (embauches) à partir du <b>{{ feature_availability_date|date }}</b>.</li>
                                 <li>Vous devez avoir une annexe financière valide dans l'extranet de l'ASP pour pouvoir déclarer une fiche salarié dans les emplois.</li>
+                                <li>Les fiches salarié créées afin de prolonger ou suspendre un agrément Pôle emploi, ou un PASS IAE délivré avant le {{ feature_availability_date|date }}, sont identifiés par la mention <b>Ancien agrément ou PASS IAE</b>.</li>
                             </ul>
                         </div>
                         <div class="col-sm-2 text-right">

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -16,7 +16,7 @@
                 <div class="row">
                     <div class="col-sm-9 pt-3">
                         {% with job_application=employee_record.job_application %}
-                            <div>Début du contrat : <b>{{ job_application.hiring_start_at }}</b></div>
+                            <div>Début du contrat : <b>{{ job_application.hiring_start_at|default:"Non renseigné" }}</b></div>
                             <div>Fin du contrat : <b>{{ job_application.hiring_end_at|default:"Non renseigné" }}</b></div>
                             <div>Numéro de PASS IAE : <b>{{ job_application.approval.number|format_approval_number }}</b></div>
                         {% endwith %}
@@ -33,7 +33,7 @@
 
         {% include "employee_record/includes/employee_record_summary.html" %}
 
-        <a href="{% url "employee_record_views:list" %}?status={{ status }}" class="btn btn-primary">Retour à la liste</a>
+        <a href="{% url "employee_record_views:list" %}?status={{ status|default:employee_record.status }}" class="btn btn-primary">Retour à la liste</a>
 
     </div>
 

--- a/itou/www/employee_record_views/urls.py
+++ b/itou/www/employee_record_views/urls.py
@@ -6,6 +6,7 @@ from itou.www.employee_record_views import views
 app_name = "employee_record_views"
 
 urlpatterns = [
+    path("add", views.add_employee_records, name="add"),
     path("list", views.list_employee_records, name="list"),
     path("create/<uuid:job_application_id>", views.create, name="create"),
     path("create_step_2/<uuid:job_application_id>", views.create_step_2, name="create_step_2"),


### PR DESCRIPTION
### Quoi ?

Transmettre les notifications d’actualisation de date de PASS IAE lorsqu’on prolonge ou suspend un PASS IAE qui n’est pas concerné par les fiches salariés (import agrément via module PE ou PASS IAE obtenu avant le 27/09/2021)

### Pourquoi ?

Actuellement lorsqu’un utilisateur prolonge ou suspend un PASS IAE qui n’a pas généré de fiche salarié , les nouvelles dates du PASS IAE ne sont jamais transmises dans l’ASP.

### Comment ?

On force la création d'une fiche salariée pour ce genre de cas :
- [x] Ajout du chemin "Ajouter un salarié"
  - [x] On demande le numéro de PASS IAE afin de récupérer et vérifier les informations basiques.
  - [x] La structure peux créer une fiches salariée depuis un objet quasi-vide.
- [x] On rend la prolongation ou suspension possibles que si une fiche salarié est déjà intégrée.
- [x] Rediriger vers le tunnel de fiche salarié après "Prolonger ou suspendre un agrément émis par Pôle emploi".
- [x] Ajouter un marqueur sur les FS créées de cette manière.

### Captures d'écran (optionnel)

TODO
