### PR TITLE
Boost stats

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -542,7 +542,8 @@ METABASE_DASHBOARDS = {
     # Employer stats.
     "stats_siae_etp": {
         "dashboard_id": 128,
-        "tally_form_id": "nrjbRv",
+        # Tally form suspended on 2022/09/30, should be restored soon.
+        # "tally_form_id": "nrjbRv",
     },
     "stats_siae_hiring": {
         "dashboard_id": 185,
@@ -551,7 +552,8 @@ METABASE_DASHBOARDS = {
     # Prescriber stats.
     "stats_cd": {
         "dashboard_id": 118,
-        "tally_form_id": "wb5Nro",
+        # Tally form suspended on 2022/09/30, should be restored soon.
+        # "tally_form_id": "wb5Nro",
     },
     "stats_pe_delay_main": {
         "dashboard_id": 168,
@@ -581,7 +583,8 @@ METABASE_DASHBOARDS = {
     # Institution stats - DDETS - department level.
     "stats_ddets_iae": {
         "dashboard_id": 117,
-        "tally_form_id": "nPdWLb",
+        # Tally form suspended on 2022/09/30, should be restored soon.
+        # "tally_form_id": "nPdWLb",
     },
     "stats_ddets_diagnosis_control": {
         "dashboard_id": 144,
@@ -593,7 +596,8 @@ METABASE_DASHBOARDS = {
     # Institution stats - DREETS - region level.
     "stats_dreets_iae": {
         "dashboard_id": 117,
-        "tally_form_id": "nPdWLb",
+        # Tally form suspended on 2022/09/30, should be restored soon.
+        # "tally_form_id": "nPdWLb",
     },
     "stats_dreets_hiring": {
         "dashboard_id": 160,

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -563,11 +563,6 @@
                                 <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données 2021 du contrôle a posteriori (version bêta)</a>
                                 <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
-                            <li class="card-text mb-3">
-                                <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_dgefp_af' %}">Voir les données des annexes financières actives</a>
-                                <span class="badge badge-accent-03 text-primary">Nouveau</span>
-                            </li>
                         {% endif %}
                         <li class="card-text mb-3">
                             <i class="ri-pulse-line ri-lg mr-1"></i>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -500,7 +500,6 @@
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_siae_hiring' %}">Voir les données de recrutement de mes structures (Plateforme de l'inclusion)</a>
-                                <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
                         {% endif %}
                         {% if can_view_stats_cd %}
@@ -513,22 +512,18 @@
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_pe_delay_main' %}">Voir les données du délai d'entrée en IAE</a>
-                                <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_pe_conversion_main' %}">Voir les données du taux de transformation</a>
-                                <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_pe_state_main' %}">Voir les données de l’état des candidatures orientées</a>
-                                <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_pe_tension' %}">Voir les données des fiches de poste en tension</a>
-                                <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
                         {% endif %}
                         {% if can_view_stats_ddets %}
@@ -539,7 +534,6 @@
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_ddets_hiring' %}">Voir les données facilitation de l'embauche</a>
-                                <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
                         {% endif %}
                         {% if can_view_stats_dreets %}
@@ -550,7 +544,6 @@
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_dreets_hiring' %}">Voir les données facilitation de l'embauche</a>
-                                <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
                         {% endif %}
                         {% if can_view_stats_dgefp %}
@@ -561,7 +554,6 @@
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
                                 <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données 2021 du contrôle a posteriori (version bêta)</a>
-                                <span class="badge badge-accent-03 text-primary">Nouveau</span>
                             </li>
                         {% endif %}
                         <li class="card-text mb-3">

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -61,7 +61,7 @@
                             <h2 class="h2 m-0">Dictionnaire des indicateurs</h2>
                         </div>
                         <div class="card-body">
-                            <p>Liste de tous les indicateurs présentant leurs définitions, formules et sources de données.</p>
+                            <p>Liste de tous les indicateurs présentant leurs définitions, formules et sources de données</p>
                         </div>
                         <div class="card-footer text-right">
                             <a href="https://communaute.inclusion.beta.gouv.fr/doc/pilotage/dictionnaire-des-indicateurs/" target="_blank" class="btn btn-sm btn-ico btn-link stretched-link">
@@ -82,6 +82,40 @@
                         <div class="card-footer text-right">
                             <a href="https://communaute.inclusion.beta.gouv.fr/doc/communaute/glossaire-de-linclusion/" target="_blank" class="btn btn-sm btn-ico btn-link stretched-link">
                                 <span>Accéder au glossaire</span>
+                                <i class="ri-external-link-line ri-lg"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="s-section__row row row-cols-1 row-cols-md-2 row-cols-lg-3">
+                <div class="col mb-3 mb-md-5">
+                    <div class="card c-card c-card--communaute c-card--hovershadow h-100 w-100">
+                        <div class="card-header">
+                            <h2 class="h2 m-0">Suggestions</h2>
+                        </div>
+                        <div class="card-body">
+                            <p>Nos tableaux de bord sont amenés à évoluer pour vous aider au mieux, n’hésitez pas à nous faire vos retours</p>
+                        </div>
+                        <div class="card-footer text-right">
+                            <a href="https://communaute.inclusion.beta.gouv.fr/suggestions-le-pilotage-de-linclusion/" target="_blank" class="btn btn-sm btn-ico btn-link stretched-link">
+                                <span>Accéder aux suggestions</span>
+                                <i class="ri-external-link-line ri-lg"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="col mb-3 mb-md-5">
+                    <div class="card c-card c-card--communaute c-card--hovershadow h-100 w-100">
+                        <div class="card-header">
+                            <h2 class="h2 m-0">Aide et support</h2>
+                        </div>
+                        <div class="card-body">
+                            <p>Si notre documentation ne vous renseigne pas suffisamment, vous pouvez contacter notre support</p>
+                        </div>
+                        <div class="card-footer text-right">
+                            <a href="https://communaute.inclusion.beta.gouv.fr/aide/pilotage/" target="_blank" class="btn btn-sm btn-ico btn-link stretched-link">
+                                <span>Accéder au support</span>
                                 <i class="ri-external-link-line ri-lg"></i>
                             </a>
                         </div>


### PR DESCRIPTION
### Quoi ?

Boost stats avec au menu :
- Ajout de colonnes utiles extraites du NIR (sexe, année et mois de naissance) dans la table `candidats` sur Metabase.
- Ajout de deux blocs informatifs en bas des pages stats exactement comme c'est déjà fait sur le site https://pilotage.inclusion.beta.gouv.fr/
- Désactivation temporaire de certains formulaires Tally à la demande d'Annie. Commentés dans le code donc facilement réactivables. Attention @vperron tu as auras un petit merge conflict sur le setting `METABASE_DASHBOARDS`.
- Débranchage du TDB AF DGEFP qu'on rebranchera début 2023 (donc on le garde prête à rebrancher).
- Retrait plusieurs badges "Nouveaux".

### Notes

J'aurai bien aimé écrire des tests pour `_job_seekers` mais malheureusement pas possible tant que je n'ai pas d'abord résolu un bug cryptique de test qui ne casse qu'en CI et pas en local dev, cf https://github.com/betagouv/itou/pull/1481 je regarde ça à mon retour le 10 octobre, pas eu le temps.

### Captures d'écran (optionnel)

Les 2 nouveaux blocs sont ceux du bas.

![image](https://user-images.githubusercontent.com/10533583/193066896-2097c406-5596-4e5f-8d0b-d8ee875f9ef6.png)

