### PR TITLE
Évaluation SIAE: Implémentation de la phase contradictoire

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -139,7 +139,7 @@ class EvaluationCampaignAdmin(admin.ModelAdmin):
 class EvaluatedSiaeAdmin(admin.ModelAdmin):
     list_display = ("evaluation_campaign", "siae", "reviewed_at")
     list_display_links = ("siae",)
-    readonly_fields = ("evaluation_campaign", "siae", "reviewed_at", "state")
+    readonly_fields = ("evaluation_campaign", "siae", "reviewed_at", "final_reviewed_at", "state")
     list_filter = (
         "reviewed_at",
         "evaluation_campaign__institution__department",

--- a/itou/siae_evaluations/enums.py
+++ b/itou/siae_evaluations/enums.py
@@ -50,7 +50,6 @@ class EvaluatedSiaeState(models.TextChoices):
     SUBMITTED = "SUBMITTED"
     ACCEPTED = "ACCEPTED"
     REFUSED = "REFUSED"
-    REVIEWED = "REVIEWED"
     ADVERSARIAL_STAGE = "ADVERSARIAL_STAGE"
 
 

--- a/itou/siae_evaluations/migrations/0009_evaluatedsiae_sanctioned_at.py
+++ b/itou/siae_evaluations/migrations/0009_evaluatedsiae_sanctioned_at.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siae_evaluations", "0008_alter_evaluatedadministrativecriteria_review_state"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evaluatedsiae",
+            name="final_reviewed_at",
+            field=models.DateTimeField(blank=True, null=True, verbose_name="Contrôle définitif le"),
+        ),
+    ]

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -304,8 +304,6 @@ class EvaluatedSiae(models.Model):
         on_delete=models.CASCADE,
         related_name="evaluated_siaes",
     )
-    # The timestamp of the first review, which marks the start of the
-    # adversarial phase.
     reviewed_at = models.DateTimeField(verbose_name=("Contrôlée le"), blank=True, null=True)
 
     objects = EvaluatedSiaeManager.from_queryset(EvaluatedSiaeQuerySet)()
@@ -336,10 +334,8 @@ class EvaluatedSiae(models.Model):
                 connection = mail.get_connection()
                 connection.send_messages([email])
 
-                # The first review marks the beginning of the adversarial phase.
-                if self.reviewed_at is None:
-                    self.reviewed_at = timezone.now()
-                    self.save(update_fields=["reviewed_at"])
+                self.reviewed_at = timezone.now()
+                self.save(update_fields=["reviewed_at"])
 
     # fixme vincentporte : to refactor. move all get_email_to_siae_xxx() method to emails.py in siae model
     def get_email_to_siae_selected(self):

--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
@@ -14,7 +14,7 @@
                 <p class="badge badge-pilotage float-right">Nouveaux justificatifs à traiter</p>
             {%elif state == "SUBMITTED" %}
                 <p class="badge badge-pilotage float-right">À traiter</p>
-            {%elif state == "REFUSED" or state == "REFUSED_2" %}
+            {% elif not evaluated_siae.reviewed_at and state == "REFUSED" or state == "REFUSED_2" %}
                 <p class="badge badge-danger float-right">Problème constaté</p>
             {%elif state == "ACCEPTED" %}
                 <p class="badge badge-success float-right">Validé</p>

--- a/itou/templates/siae_evaluations/includes/siae_infos.html
+++ b/itou/templates/siae_evaluations/includes/siae_infos.html
@@ -6,18 +6,27 @@
     </div>
     <div class="col-lg-3 col-md-3 col-4">
         <p class="small mb-0">
-            {% if evaluated_siae.state == "SUBMITTED"%}
-                {# NOTE(vperron): Why do we check reviewed_at here, instead of state == ADVERSARIAL_STATE ? #}
-                <p class="badge badge-pilotage float-right">{%if evaluated_siae.reviewed_at%}Phase contradictoire - {%endif%}À traiter</p>
-            {%elif evaluated_siae.state == "REFUSED" or evaluated_siae.state == "ACCEPTED" %}
-                <p class="badge badge-pilotage float-right">{%if evaluated_siae.reviewed_at%}Phase contradictoire - {%endif%}En cours</p>
-            {%elif evaluated_siae.state == "REVIEWED" %}
-                <p class="badge badge-communaute-light float-right">Résultats transmis</p>
-            {%elif evaluated_siae.state == "ADVERSARIAL_STAGE" %}
-                <p class="badge badge-marche-light float-right">Phase contradictoire</p>
-            {%else%}
-                <p class="badge badge-emploi float-right">{%if evaluated_siae.reviewed_at%}Phase contradictoire - {%endif%}En attente</p>
-            {%endif%}
+            {% if evaluated_siae.final_reviewed_at %}
+                <p class="badge{% if evaluated_siae.state == "ACCEPTED" %} badge-success{% else %} badge-danger{%endif%} float-right">
+                    {% if evaluated_siae.state == "ACCEPTED" %}
+                        Résultat positif
+                    {% elif evaluated_siae.state == "REFUSED" %}
+                        Résultat négatif
+                    {% else %}
+                        Non contrôlée
+                    {% endif %}
+                </p>
+            {% else %}
+                {% if evaluated_siae.state == "SUBMITTED" %}
+                    <p class="badge badge-pilotage float-right">{% if evaluated_siae.reviewed_at %}Phase contradictoire - {% endif %}À traiter</p>
+                {% elif evaluated_siae.state == "REFUSED" or evaluated_siae.state == "ACCEPTED" %}
+                    <p class="badge badge-pilotage float-right">{% if evaluated_siae.reviewed_at %}Phase contradictoire - {% endif %}En cours</p>
+                {% elif evaluated_siae.state == "ADVERSARIAL_STAGE" %}
+                    <p class="badge badge-marche-light float-right">Phase contradictoire</p>
+                {% else %}
+                    <p class="badge badge-emploi float-right">{% if evaluated_siae.reviewed_at %}Phase contradictoire - {% endif %}En attente</p>
+                {% endif %}
+            {% endif %}
         </p>
     </div>
 </div>

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
@@ -17,7 +17,7 @@
                     </h1>
 
                     {# messages #}
-                    {%if evaluated_siae.state == "REVIEWED" or evaluated_siae.state == "ADVERSARIAL_STAGE"%}
+                    {% if show_notified %}
                         <div class="alert alert-communaute alert-dismissible fade show" role="status">
                             <button type="button" class="close" data-dismiss="alert" aria-label="Fermer">
                                 <i class="ri-close-line"></i>
@@ -57,7 +57,7 @@
                         <div class="col-4">
                             <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_siae_validation' evaluated_siae.pk %}">
                                 {% csrf_token %}
-                                <button class="btn {% if evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}btn-primary {% else %}btn-outline-primary disabled {% endif %}btn-sm float-right">
+                                <button class="btn {% if evaluated_siae.can_review %}btn-primary {% else %}btn-outline-primary disabled {% endif %}btn-sm float-right">
                                     Valider
                                 </button>
                             </form>
@@ -81,7 +81,7 @@
                                         class="btn btn-outline-primary btn-sm float-right">
                                         Contrôler cette auto-prescription
                                     </a>
-                                {% elif evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" or evaluated_siae.state == "REVIEWED" or evaluated_siae.state == "ADVERSARIAL_STAGE" %}
+                                {% elif evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" or evaluated_siae.state == "ADVERSARIAL_STAGE" %}
                                     <a href="{% url 'siae_evaluations_views:institution_evaluated_job_application' evaluated_job_application.pk %}"
                                         class="btn btn-outline-primary btn-sm float-right">
                                         Revoir ses justificatifs
@@ -93,7 +93,7 @@
                 </div>
             </div>
 
-            {% if evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}
+            {% if evaluated_siae.can_review %}
                 <div class="row">
                     <div class="col-8">
                         <p>Lorsque vous aurez contrôlé<strong> tous vos justificatifs</strong> pour cette SIAE,

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
@@ -32,12 +32,16 @@
                             <div class="card-body">
                                 <a href="{% url 'siae_evaluations_views:institution_evaluated_siae_detail' evaluated_siae.pk %}"
                                     class="btn btn-outline-primary btn-sm float-right">
-                                    {%if evaluated_siae.state == "SUBMITTED" or evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED"%}
-                                        Contrôler cette SIAE
-                                    {%elif evaluated_siae.state == "REVIEWED" or evaluated_siae.state == "ADVERSARIAL_STAGE"%}
-                                        Revoir ses justificatifs
+                                    {% if evaluated_siae.final_reviewed_at %}
+                                        Voir le résultat
                                     {% else %}
-                                        Voir
+                                        {% if evaluated_siae.state == "SUBMITTED" or evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}
+                                            Contrôler cette SIAE
+                                        {%elif evaluated_siae.state == "ADVERSARIAL_STAGE"%}
+                                            Revoir ses justificatifs
+                                        {% else %}
+                                            Voir
+                                        {%endif%}
                                     {%endif%}
                                 </a>
                             </div>
@@ -55,4 +59,3 @@
 
 
 {% endblock %}
-

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
@@ -16,7 +16,7 @@
                         Contrôler les pièces justificatives
                     </h1>
                     <h3 class="h3">
-                        Liste des Siae à contrôler
+                        Liste des Siae {% if ended_at %}contrôlées{% else %}à contrôler{%endif%}
                     </h3>
                     <p>Contrôle initié le {{evaluations_asked_at|date:"d F Y"}}{% if ended_at %}, clôturé le {{ended_at|date:"d F Y"}}{% endif%}</p>
                 </div>

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -525,37 +525,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, valide)
 
-    def test_second_review_does_not_update_reviewed_at(self):
-        campaign = EvaluationCampaignFactory(
-            institution=self.institution,
-            evaluations_asked_at=timezone.now() - relativedelta(weeks=3),
-        )
-        evaluated_siae = create_evaluated_siae_consistent_datas(campaign)
-        EvaluatedAdministrativeCriteria.objects.filter(
-            evaluated_job_application__evaluated_siae=evaluated_siae
-        ).update(review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED)
-        now = timezone.now()
-        evaluated_siae.reviewed_at = now
-        evaluated_siae.save(update_fields=["reviewed_at"])
-
-        self.client.force_login(self.user)
-        response = self.client.post(
-            reverse(
-                "siae_evaluations_views:institution_evaluated_siae_validation",
-                kwargs={"evaluated_siae_pk": evaluated_siae.pk},
-            )
-        )
-
-        self.assertRedirects(
-            response,
-            reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
-                kwargs={"evaluated_siae_pk": evaluated_siae.pk},
-            ),
-        )
-        evaluated_siae.refresh_from_db()
-        self.assertEqual(evaluated_siae.reviewed_at, now)
-
     def test_num_queries_in_view(self):
         self.client.force_login(self.user)
         evaluation_campaign = EvaluationCampaignFactory(


### PR DESCRIPTION
### Quoi ?

Évaluation SIAE: Implémentation de la phase contradictoire

### Pourquoi ?

Précédemment, une SIAE entrée en phase contradictoire y restait définitivement. Lorsqu’une décision est prise, la DDETS devrait voir le résultat de cette décision.

### Comment ?

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

Un nouveau champ est ajouté au modèle EvaluatedSiae: `final_reviewed_at`. Il permet de distinguer la phase amiable de la phase contradictoire.

Le statut `REVIEWED` est supprimé. Il indiquait auparavant un état transitoire entre la revue d’une SIAE par une DDETS et la prise d’une décision. Une décision positive donne immédiatement lieu à un résultat positif, sans passer par cet état. L’effet d’une décision négative varie :

- dans la phase amiable, il débute la phase contradictoire, offrant à la SIAE contrôlée une chance d’envoyer un nouveau justificatif. La phase contradictoire (ADVERSARIAL_STAGE dans le code) remplace le statut `REVIEWED_AT`.
- dans la phase contradictoire, il définit le résultat du contrôle comme négatif.

### Autre

- Le nouvel utilitaire `can_review` centralise la logique pour afficher ou masquer le bouton “Valider” des DDETS. Il est également utilisé pour contrôler l’accès à la vue institution_evaluated_siae_validation view, qui pouvait auparavant être appelée n’importe quand, au risque de compromettre le processus (ex. double validation).
- La gestion de transaction de `EvaluatedSiae.review()` a été déplacée dans le vue, conformément aux bonnes pratiques du projet.