### PR TITLE
ci: Correction du build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
         cache-dependency-path: requirements/dev.txt
     - name: 📥 Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements/dev.txt
+        make venv
+        echo ".venv/bin" >> $GITHUB_PATH
       env:
         CPUCOUNT: 1
     - name: ✨ Black, isort, flake8 & djhtml


### PR DESCRIPTION
Les changements concernant la façon d'installer les dépendances font que `make test` lance désormais une installation de dépendances en sous-main dans un dossier `.venv` bien particulier.

Or, le build CI actuel réalisait déjà une installation de dépendances juste avant, mais sans le faire dans ce dossier `.venv`. On avait donc deux installations de dépendances, une "globale" puis une locale (qui fail, car le CPUCOUNT n'est plus mis en place).

 Par ailleurs, si l'on passe à une installation de dépendances via la Makefile (`make venv`), les commandes qui ne passent pas par ce dernier vont échouer car elles vont chercher à résoudre les binaires dans l'environnement global elles aussi; il faut leur donner le chemin vers le `.venv` pour assurer le fonctionnement.

