### PR TITLE
Utilise requirements/dev.in pour MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ run:
 $(VIRTUAL_ENV): $(REQUIREMENTS_PATH)
 	$(PYTHON_VERSION) -m venv $@
 	$@/bin/pip install -r $^
-	$@/bin/pip-sync $^
+	$@/bin/pip-sync --force $^
 	touch $@
 
 venv: $(VIRTUAL_ENV)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@
 # Global tasks.
 # =============================================================================
 PYTHON_VERSION := python3.10
+ifeq ($(shell uname -s),Linux)
+	REQUIREMENTS_PATH := requirements/dev.txt
+else
+	REQUIREMENTS_PATH := requirements/dev.in
+endif
+
 VIRTUAL_ENV ?= .venv
 export PATH := $(VIRTUAL_ENV)/bin:$(PATH)
 
@@ -22,7 +28,7 @@ endif
 run:
 	docker-compose up
 
-$(VIRTUAL_ENV): requirements/dev.txt
+$(VIRTUAL_ENV): $(REQUIREMENTS_PATH)
 	$(PYTHON_VERSION) -m venv $@
 	$@/bin/pip install -r $^
 	$@/bin/pip-sync $^


### PR DESCRIPTION
### Quoi ?

Utilise requirements/dev.in pour MacOS

### Pourquoi ?

L’application est déployée uniquement sous Linux. MacOS n’est actuellement pas compatible avec la version pinnée, avec contrôle d’intégrité des dépendances. Pour MacOS et les plateformes non supportées, une spécification moins précise des dépendances est utilisée.