### PR TITLE
[Tech] docker : Quelques simplifications suite à la nouvelle gestion des settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!docker
+!requirements

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 # For Docker Compose
-DJANGO_PORT_ON_DOCKER_HOST=8000
-POSTGRES_PORT_ON_DOCKER_HOST=5433
+#DJANGO_PORT_ON_DOCKER_HOST=8000
+#POSTGRES_PORT_ON_DOCKER_HOST=5432
 
 # Path to the itou-backup project repository.
 PATH_TO_ITOU_BACKUPS=~/sites/itou-backups

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ psql_itou:
 
 # Connect to postgres client as the `root` user.
 psql_root:
-	docker exec -ti -e PGPASSWORD=password itou_postgres psql -U postgres
+	docker exec -ti itou_postgres psql -U postgres
 
 # Write query results to a CSV file.
 # --

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -70,11 +70,11 @@ ASP_ITOU_PREFIX = "XXXXX"  # same as in our fixtures
 ITOU_PROTOCOL = "http"
 ITOU_FQDN = "127.0.0.1:8000"
 
-DATABASES["default"]["HOST"] = "127.0.0.1"
-DATABASES["default"]["PORT"] = 5432
-DATABASES["default"]["NAME"] = "itou"
-DATABASES["default"]["USER"] = "postgres"  # check that with Docker
-DATABASES["default"]["PASSWORD"] = "password"
+DATABASES["default"]["HOST"] = os.getenv("PGHOST", "127.0.0.1")
+DATABASES["default"]["PORT"] = os.getenv("PGPORT", "5432")
+DATABASES["default"]["NAME"] = os.getenv("PGDATABASE", "itou")
+DATABASES["default"]["USER"] = os.getenv("PGUSER", "postgres")
+DATABASES["default"]["PASSWORD"] = os.getenv("PGPASSWORD", "password")
 
 ELASTIC_APM["ENABLED"] = False
 # FIXME(vperron): Remove this as soon as the checks are disabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
   # https://hub.docker.com/r/mdillon/postgis/tags
   postgres:
     container_name: itou_postgres
-    env_file:
-      - ./envs/dev.env
     environment:
+      # Required by the "_/postgres" image used by "postgis/postgis"
+      # https://registry.hub.docker.com/_/postgres/
+      - POSTGRES_PASSWORD=password
       # Avoid a log error when starting the itou_postgres container:
       # > Role "root" does not exist.
       # Without this variable, the default Unix account ('root')
@@ -16,6 +17,8 @@ services:
       # https://www.postgresql.org/docs/current/libpq-envars.html
       - PGUSER=postgres
       - PGPASSWORD=password
+      # Set the name of the database, this used by the scripts we add to the image (ie. psql_init.sh, backup, ...)
+      - ITOU_POSTGRES_DATABASE_NAME=itou
     # The default memory setting (64M) is not enough anymore due to the size of the database we import
     # https://stackoverflow.com/questions/56839975/docker-shm-size-dev-shm-resizing-shared-memory
     shm_size: 1g
@@ -32,13 +35,13 @@ services:
 
   django:
     container_name: itou_django
-    env_file:
-      - ./envs/dev.env
-      - ./envs/secrets.env
     environment:
       - PGHOST=postgres
       - PGUSER=postgres
       - PGPASSWORD=password
+      - PYTHONPATH=.
+      - DJANGO_SETTINGS_MODULE=config.settings.dev
+      - ITOU_LOG_LEVEL=DEBUG
     depends_on:
       - postgres
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,14 @@ services:
     container_name: itou_postgres
     env_file:
       - ./envs/dev.env
+    environment:
+      # Avoid a log error when starting the itou_postgres container:
+      # > Role "root" does not exist.
+      # Without this variable, the default Unix account ('root')
+      # is used automatically when starting postgres.
+      # https://www.postgresql.org/docs/current/libpq-envars.html
+      - PGUSER=postgres
+      - PGPASSWORD=password
     # The default memory setting (64M) is not enough anymore due to the size of the database we import
     # https://stackoverflow.com/questions/56839975/docker-shm-size-dev-shm-resizing-shared-memory
     shm_size: 1g
@@ -27,6 +35,10 @@ services:
     env_file:
       - ./envs/dev.env
       - ./envs/secrets.env
+    environment:
+      - PGHOST=postgres
+      - PGUSER=postgres
+      - PGPASSWORD=password
     depends_on:
       - postgres
     build:

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -67,12 +67,12 @@ RUN pip install --upgrade pip \
 RUN apt-get purge -y --auto-remove build-essential libpq-dev $(! command -v gpg > /dev/null || echo 'gnupg dirmngr') \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --chown=app:app . $APP_DIR
+COPY --chown=app:app ./docker/dev/django/entrypoint.sh /entrypoint.sh
 
-RUN chmod +x $APP_DIR/docker/dev/django/entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 USER app
 
 WORKDIR $APP_DIR
 
-ENTRYPOINT ["./docker/dev/django/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/dev/django/entrypoint.sh
+++ b/docker/dev/django/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-while ! pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT; do
+while ! pg_isready; do
     >&2 echo "Postgres is unavailable - sleeping"
     sleep 1
 done

--- a/docker/dev/django/entrypoint.sh
+++ b/docker/dev/django/entrypoint.sh
@@ -14,10 +14,6 @@ done
 
 django-admin migrate
 
-# --nopin disables for you the annoying PIN security prompt on the web
-# debugger. For local dev only of course!
-# --keep-meta-shutdown is set to avoid this issue : https://github.com/django-extensions/django-extensions/issues/1715
-# This option should be removed when the package Werkzeug is updated with the fix.
-django-admin runserver_plus --keep-meta-shutdown 0.0.0.0:8000 --nopin
+django-admin runserver 0.0.0.0:8000
 
 exec "$@"

--- a/docker/dev/postgres/Dockerfile
+++ b/docker/dev/postgres/Dockerfile
@@ -1,9 +1,9 @@
 # https://registry.hub.docker.com/r/postgis/postgis
 FROM postgis/postgis:14-master
 
-COPY ./docker/dev/postgres/maintenance /usr/local/bin/maintenance
+COPY ./docker/dev/postgres/maintenance /tmp/maintenance
 
-RUN chmod +x /usr/local/bin/maintenance/*
+RUN chmod +x /tmp/maintenance/*
 
-RUN mv /usr/local/bin/maintenance/* /usr/local/bin \
-    && rm -Rf /usr/local/bin/maintenance
+RUN mv /tmp/maintenance/* /usr/local/bin \
+    && rm -Rf /tmp/maintenance

--- a/docker/dev/postgres/maintenance/backup
+++ b/docker/dev/postgres/maintenance/backup
@@ -15,8 +15,6 @@ source "${working_dir}/_sourced/messages.sh"
 
 message_welcome "Backing up the '${ITOU_POSTGRES_DATABASE_NAME}' database..."
 
-export PGUSER="${ITOU_POSTGRES_USER}"
-export PGPASSWORD="${ITOU_POSTGRES_PASSWORD}"
 export PGDATABASE="${ITOU_POSTGRES_DATABASE_NAME}"
 
 backup_filename="${BACKUP_FILE_PREFIX}_custom_format_$(date +'%Y_%m_%dT%H_%M_%S').dump"

--- a/docker/dev/postgres/maintenance/backup
+++ b/docker/dev/postgres/maintenance/backup
@@ -15,8 +15,6 @@ source "${working_dir}/_sourced/messages.sh"
 
 message_welcome "Backing up the '${ITOU_POSTGRES_DATABASE_NAME}' database..."
 
-export PGHOST="${POSTGRES_HOST}"
-export PGPORT="${POSTGRES_PORT}"
 export PGUSER="${ITOU_POSTGRES_USER}"
 export PGPASSWORD="${ITOU_POSTGRES_PASSWORD}"
 export PGDATABASE="${ITOU_POSTGRES_DATABASE_NAME}"

--- a/docker/dev/postgres/maintenance/restore
+++ b/docker/dev/postgres/maintenance/restore
@@ -30,8 +30,6 @@ fi
 
 message_welcome "Restoring the '${ITOU_POSTGRES_DATABASE_NAME}' database from the '${backup_filename}' backup..."
 
-export PGHOST="${POSTGRES_HOST}"
-export PGPORT="${POSTGRES_PORT}"
 export PGUSER="${ITOU_POSTGRES_USER}"
 export PGPASSWORD="${ITOU_POSTGRES_PASSWORD}"
 export PGDATABASE="${ITOU_POSTGRES_DATABASE_NAME}"

--- a/docker/dev/postgres/maintenance/restore
+++ b/docker/dev/postgres/maintenance/restore
@@ -30,15 +30,13 @@ fi
 
 message_welcome "Restoring the '${ITOU_POSTGRES_DATABASE_NAME}' database from the '${backup_filename}' backup..."
 
-export PGUSER="${ITOU_POSTGRES_USER}"
-export PGPASSWORD="${ITOU_POSTGRES_PASSWORD}"
 export PGDATABASE="${ITOU_POSTGRES_DATABASE_NAME}"
 
 message_info "Dropping the database..."
 dropdb "${ITOU_POSTGRES_DATABASE_NAME}"
 
 message_info "Creating a new database..."
-createdb --owner="${ITOU_POSTGRES_USER}"
+createdb
 
 message_info "Applying the backup to the new database..."
 pg_restore --dbname="${ITOU_POSTGRES_DATABASE_NAME}" --format=c --clean --no-owner --verbose "${backup_filename}"

--- a/docker/dev/postgres/psql_init.sh
+++ b/docker/dev/postgres/psql_init.sh
@@ -8,7 +8,7 @@ export BASE_DIR=$(dirname "$BASH_SOURCE")
 
 # The PostgreSQL user should be able to create extensions.
 # Only the PostgreSQL superuser role provides that permission.
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+psql -v ON_ERROR_STOP=1 <<-EOSQL
 
   \c postgres;
 

--- a/docker/dev/postgres/psql_init.sh
+++ b/docker/dev/postgres/psql_init.sh
@@ -4,16 +4,4 @@ set -e
 # Initialization script.
 # https://hub.docker.com/_/postgres/#initialization-scripts
 
-export BASE_DIR=$(dirname "$BASH_SOURCE")
-
-# The PostgreSQL user should be able to create extensions.
-# Only the PostgreSQL superuser role provides that permission.
-psql -v ON_ERROR_STOP=1 <<-EOSQL
-
-  \c postgres;
-
-  CREATE USER $ITOU_POSTGRES_USER WITH ENCRYPTED PASSWORD '$ITOU_POSTGRES_PASSWORD';
-  CREATE DATABASE $ITOU_POSTGRES_DATABASE_NAME OWNER $ITOU_POSTGRES_USER;
-  ALTER USER $ITOU_POSTGRES_USER CREATEDB SUPERUSER;
-
-EOSQL
+psql -v ON_ERROR_STOP=1 --echo-queries --command="CREATE DATABASE \"$ITOU_POSTGRES_DATABASE_NAME\";"


### PR DESCRIPTION
### Quoi ?

- Réduction de nombre de variables d’environnement pour n'utiliser que celle comprises par `libpq`.
- Remplacement du fichier `envs/dev.env` au profit de variables _inline_.
- :warning: Suppression du fichier `envs/secrets.env` au profit de `.env` (chargé automatiquement par les settings).
- Suppression de l'utilisateur `itou` pour n'utiliser que `postgres` pour la BDD.
- Amélioration de la vitesse de création des images docker.
- On ne promeut plus l'utilisation des variables `*_PORT_ON_DOCKER_HOST` mais elles restent documentées.
- :exclamation: Utilisation de `runserver` plutôt que `runserver_plus` car [les templates ne sont plus rechargé automatiquement](https://github.com/django-extensions/django-extensions/issues/1766).

### Pourquoi ?

Problème initial : L'env docker `django` ne fonctionnais plus car la DB n'était plus accessible.

### Autres

Je n'ai pas essayé tout ce qui est lié au backup, repo ou script ajouté dans l'image, mais ça devrait fonctionner :crossed_fingers:.
Si on pense que c'est vraiment gênant de déférer ça j'y jetterais un œil, surtout qu'il me semble que certaine partie n'était plus forcément utiles ou qu'on ne voulais plus les utiliser.