### PR TITLE
Ajout de l’ID des SIAE évaluées aux URLs du contrôle a posteriori

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -344,15 +344,16 @@ class EvaluatedSiae(models.Model):
     # fixme vincentporte : to refactor. move all get_email_to_siae_xxx() method to emails.py in siae model
     def get_email_to_siae_selected(self):
         to = self.siae.active_admin_members
+        evaluated_siae_url = reverse(
+            "siae_evaluations_views:siae_job_applications_list",
+            kwargs={"evaluated_siae_pk": self.pk},
+        )
         context = {
             "campaign": self.evaluation_campaign,
             "siae": self.siae,
             # end_date for eligible siaes to return their documents of proofs is 6 weeks after notification
             "end_date": timezone.now() + relativedelta(weeks=6),
-            "url": (
-                f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}"
-                f"{reverse('siae_evaluations_views:siae_job_applications_list')}"
-            ),
+            "url": (f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}" + evaluated_siae_url),
         }
         subject = "siae_evaluations/email/to_siae_selected_subject.txt"
         body = "siae_evaluations/email/to_siae_selected_body.txt"

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -454,12 +454,16 @@
                     <p class="h4 card-header">Contrôle a posteriori <span class="badge badge-accent-03 text-primary">Nouveau</span></p>
                     <div class="card-body">
                         <ul class="list-unstyled">
-                            <li class="card-text mb-3">
-                                <i class="ri-file-copy-2-line ri-lg mr-1"></i>
-                                <a href="{% url 'siae_evaluations_views:siae_job_applications_list' %}">Justifier mes auto-prescriptions</a>
-                                {# note vincentporte: static icon, will be displayed dynamically later.#}
-                                <i class="ri-error-warning-fill ri-lg mr-1 text-danger"></i>
-                            </li>
+                            {% for evaluated_siae in active_campaigns %}
+                                <li class="card-text mb-3">
+                                    <i class="ri-file-copy-2-line ri-lg mr-1"></i>
+                                    <a href="{% url 'siae_evaluations_views:siae_job_applications_list' evaluated_siae.pk %}">
+                                        Justifier mes auto-prescriptions
+                                    </a>
+                                    {# note vincentporte: static icon, will be displayed dynamically later.#}
+                                    <i class="ri-error-warning-fill ri-lg mr-1 text-danger"></i>
+                                </li>
+                            {% endfor %}
                         </ul>
                     </div>
                 </div>

--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -18,62 +18,57 @@
             <h1 class="h1">
                 Justifier mes auto-prescriptions
             </h1>
-            {% if evaluated_job_applications %}
 
-                <div class="alert alert-info" role="status">
-                    <p class="font-weight-bold">Précision</p>
-                    <p>On entend par auto-prescription toutes les embauches pour lesquelles vous avez validé vous-mêmes
-                        les critères administratifs d'éligibilité IAE.
+            <div class="alert alert-info" role="status">
+                <p class="font-weight-bold">Précision</p>
+                <p>On entend par auto-prescription toutes les embauches pour lesquelles vous avez validé vous-mêmes
+                    les critères administratifs d'éligibilité IAE.
+                </p>
+            </div>
+
+            <div class="row mt-3">
+                <div class="col-12">
+                    <p class="h2">Liste de mes auto-prescriptions à justifier</p>
+                    <p>Contrôle initié le {{evaluations_asked_at|date:"d F Y"}}</p>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-8">
+                    <p>Lorsque vous aurez ajouté<strong> tous vos justificatifs</strong>,
+                        veuillez les soumettre à validation, la DDETS effectuera un contrôle de ceux-ci et reviendra vers vous.
                     </p>
                 </div>
 
-                <div class="row mt-3">
-                    <div class="col-12">
-                        <p class="h2">Liste de mes auto-prescriptions à justifier</p>
-                        <p>Contrôle initié le {{evaluations_asked_at|date:"d F Y"}}</p>
-                    </div>
+                <div class="col-md-4">
+                    <a class="btn {% if is_submittable %}btn-primary {% else %}btn-outline-primary disabled {% endif %}float-right" href="{% url 'siae_evaluations_views:siae_submit_proofs' evaluated_siae.pk %}">
+                        Soumettre à validation
+                    </a>
                 </div>
-                <div class="row">
-                    <div class="col-md-8">
+            </div>
+            <div class="row">
+                <div class="col-12">
+                    {% for evaluated_job_application in evaluated_job_applications %}
+                        {% include "siae_evaluations/includes/list_item.html" with item=evaluated_job_application%}
+                    {% endfor %}
+                </div>
+            </div>
+
+            {% if is_submittable %}
+                <div class="row mt-3">
+                    <div class="col-8">
                         <p>Lorsque vous aurez ajouté<strong> tous vos justificatifs</strong>,
                             veuillez les soumettre à validation, la DDETS effectuera un contrôle de ceux-ci et reviendra vers vous.
                         </p>
                     </div>
 
-                    <div class="col-md-4">
-                        <a class="btn {% if is_submittable %}btn-primary {% else %}btn-outline-primary disabled {% endif %}float-right" href="{% url 'siae_evaluations_views:siae_submit_proofs' %}">
+                    <div class="col-4">
+                        <a class="btn btn-primary float-right" href="{% url 'siae_evaluations_views:siae_submit_proofs' evaluated_siae.pk %}">
                             Soumettre à validation
                         </a>
                     </div>
                 </div>
-                <div class="row">
-                    <div class="col-12">
-                        {% for evaluated_job_application in evaluated_job_applications %}
-                            {% include "siae_evaluations/includes/list_item.html" with item=evaluated_job_application%}
-                        {% endfor %}
-                    </div>
-                </div>
+            {% endif%}
 
-                {% if is_submittable %}
-                    <div class="row mt-3">
-                        <div class="col-8">
-                            <p>Lorsque vous aurez ajouté<strong> tous vos justificatifs</strong>,
-                                veuillez les soumettre à validation, la DDETS effectuera un contrôle de ceux-ci et reviendra vers vous.
-                            </p>
-                        </div>
-
-                        <div class="col-4">
-                            <a class="btn btn-primary float-right" href="{% url 'siae_evaluations_views:siae_submit_proofs' %}">
-                                Soumettre à validation
-                            </a>
-                        </div>
-                    </div>
-                {% endif%}
-
-
-            {% else %}
-                <p>Vous n'avez aucun contrôle en cours.</p>
-            {% endif %}
 
             {% if back_url %}
                 <p class="mt-4">

--- a/itou/www/siae_evaluations_views/urls.py
+++ b/itou/www/siae_evaluations_views/urls.py
@@ -33,7 +33,11 @@ urlpatterns = [
         views.institution_evaluated_siae_validation,
         name="institution_evaluated_siae_validation",
     ),
-    path("siae_job_applications_list", views.siae_job_applications_list, name="siae_job_applications_list"),
+    path(
+        "siae_job_applications_list/<int:evaluated_siae_pk>/",
+        views.siae_job_applications_list,
+        name="siae_job_applications_list",
+    ),
     path(
         "siae_select_criteria/<int:evaluated_job_application_pk>/",
         views.siae_select_criteria,
@@ -44,5 +48,5 @@ urlpatterns = [
         views.siae_upload_doc,
         name="siae_upload_doc",
     ),
-    path("siae_submit_proofs", views.siae_submit_proofs, name="siae_submit_proofs"),
+    path("siae_submit_proofs/<int:evaluated_siae_pk>/", views.siae_submit_proofs, name="siae_submit_proofs"),
 ]


### PR DESCRIPTION
### Quoi ?

Ajout de l’ID des SIAE évaluées aux URLs du contrôle a posteriori

### Pourquoi ?

La même SIAE peut être évaluée sur plusieurs campagnes. Au lieu de déduire l’évaluation à partir du statut de la campagne, le système utilise maintenant l’ID passé en paramètre.

### Comment ?

Pour être sélectionnée dans une campagne de contrôle a posteriori, une SIAE doit avoir réalisé des auto-prescriptions et donc avoir au moins une candidature. Le cas d’une SIAE contrôlée sans candidatures ne devrait pas arriver en pratique. Maintenant, le système indique l’erreur avec un code de statut 404 (not found) au lieu d’afficher une page presque vide indiquant qu’aucun contrôle n’est en cours.

SiaeJobApplicationListViewTest.test_access compte les requêtes SQL, mais ce nombre dépend des requêtes HTTP précédentes, qui initialisaient des caches. Comme les requêtes HTTP précédentes ont été supprimées, le nombre de requêtes SQL a un peu augmenté.