### PR TITLE
fast-machine: Retirer les accès Redis.

### DIFF
--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -40,7 +40,6 @@ clever service link-addon c1-bucket-config --alias $APP_NAME
 clever service link-addon c1-deployment-config --alias $APP_NAME
 clever service link-addon c1-imports-config --alias $APP_NAME
 clever service link-addon c1-prod-database-encrypted  --alias $APP_NAME
-clever service link-addon c1-itou-redis --alias $APP_NAME
 
 # This has to be enforced at at least deployment time (issue between uwsgi build & Python 3.10 on Clever machines)
 clever env set CPUCOUNT 1 --alias $APP_NAME


### PR DESCRIPTION
We never run `django-admin run_huey` on the fast machines.

They're not supposed to access the redis then.

Stop any confusion !
