### PR TITLE
Envoi des e-mails en synchrone en recette jetable et en fast machine

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -6,6 +6,7 @@ import datetime
 import json
 import os
 
+from django.utils import timezone
 from dotenv import load_dotenv
 
 
@@ -446,12 +447,10 @@ ANYMAIL = {
     "WEBHOOK_SECRET": os.getenv("MAILJET_WEBHOOK_SECRET"),
 }
 
-# EMAIL_BACKEND points to an async wrapper of a "real" email backend
-# The real backend is hardcoded in the wrapper to avoid multiple and
-# confusing parameters in Django settings.
-# Switch to a "standard" Django backend to get the synchronous behaviour back.
-EMAIL_BACKEND = "itou.utils.tasks.AsyncEmailBackend"
-
+if ITOU_ENVIRONMENT in ["DEMO", "PROD", "STAGING"]:
+    EMAIL_BACKEND = "itou.utils.tasks.AsyncEmailBackend"
+elif ITOU_ENVIRONMENT in ["REVIEW-APP", "FAST-MACHINE"]:
+    EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
 
 SEND_EMAIL_DELAY_BETWEEN_RETRIES_IN_SECONDS = 5 * 60
 SEND_EMAIL_RETRY_TOTAL_TIME_IN_SECONDS = 24 * 3600

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -6,7 +6,6 @@ import datetime
 import json
 import os
 
-from django.utils import timezone
 from dotenv import load_dotenv
 
 


### PR DESCRIPTION
### Quoi ?

Utilisation du moteur d'e-mail Anymail, synchrone, en recette jetable et en fast machine car on n'a pas besoin de plus. Je lance le débat !

### Pourquoi ?

Les recettes jetables nous permettent de tester que les fonctionnalités fonctionnent comme en prod. Pour cela, l'environnement doit s'en rapprocher le plus possible fonctionnellement parlant. Concrètement, si je dois tester un nouveau contenu d'e-mail, je veux pouvoir le faire.

Concernant les fast machines, c'est plus discutable. Je m'attends à ce que les scripts envoient effectivement des e-mails car l'environnement est presque celui de la prod.