### PR TITLE
Contrôle a posteriori: Utiliser POST pour modifier les données

### DIFF
--- a/itou/templates/siae_evaluations/includes/criterion_validation.html
+++ b/itou/templates/siae_evaluations/includes/criterion_validation.html
@@ -15,23 +15,29 @@
             {% if evaluated_siae.state == "SUBMITTED" or evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED"%}
                 {% if evaluated_administrative_criteria.review_state == 'PENDING' %}
                     <div class="col-lg-2 col-md-2 col-9">
-                        <a href="{% url 'siae_evaluations_views:institution_evaluated_administrative_criteria' evaluated_administrative_criteria.pk "accept"%}"
-                            class="btn btn-success btn-sm float-right" title="Accepter ce justificatif">
-                            Accepter
-                        </a>
+                        <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_administrative_criteria' evaluated_administrative_criteria.pk 'accept' %}">
+                            {% csrf_token %}
+                            <button class="btn btn-success btn-sm float-right" title="Accepter ce justificatif">
+                                Accepter
+                            </button>
+                        </form>
                     </div>
                     <div class="col-lg-2 col-md-2 col-3">
-                        <a href="{% url 'siae_evaluations_views:institution_evaluated_administrative_criteria' evaluated_administrative_criteria.pk "refuse"%}"
-                            class="btn btn-danger btn-sm float-right" title="Refuser ce justificatif">
-                            Refuser
-                        </a>
+                        <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_administrative_criteria' evaluated_administrative_criteria.pk 'refuse' %}">
+                            {% csrf_token %}
+                            <button class="btn btn-danger btn-sm float-right" title="Refuser ce justificatif">
+                                Refuser
+                            </button>
+                        </form>
                     </div>
                 {% else %}
                     <div class="col-lg-4 col-md-4 col-12">
-                        <a href="{% url 'siae_evaluations_views:institution_evaluated_administrative_criteria' evaluated_administrative_criteria.pk "reinit"%}"
-                            class="btn btn-outline-primary btn-sm float-right" title="Modifier l'état de ce justificatif">
-                            Modifier
-                        </a>
+                        <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_administrative_criteria' evaluated_administrative_criteria.pk 'reinit' %}">
+                            {% csrf_token %}
+                            <button class="btn btn-outline-primary btn-sm float-right" title="Modifier l'état de ce justificatif">
+                                Modifier
+                            </button>
+                        </form>
                     </div>
                 {%endif%}
             {%endif%}

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
@@ -55,10 +55,12 @@
                         </div>
 
                         <div class="col-4">
-                            <a class="btn {% if evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}btn-primary {% else %}btn-outline-primary disabled {% endif %}btn-sm float-right"
-                                href="{% url 'siae_evaluations_views:institution_evaluated_siae_validation' evaluated_siae.pk %}">
-                                Valider
-                            </a>
+                            <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_siae_validation' evaluated_siae.pk %}">
+                                {% csrf_token %}
+                                <button class="btn {% if evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}btn-primary {% else %}btn-outline-primary disabled {% endif %}btn-sm float-right">
+                                    Valider
+                                </button>
+                            </form>
                         </div>
                     </div>
                 </div>
@@ -100,10 +102,12 @@
                     </div>
 
                     <div class="col-4">
-                        <a class="btn btn-primary btn-sm float-right"
-                            href="{% url 'siae_evaluations_views:institution_evaluated_siae_validation' evaluated_siae.pk %}">
-                            Valider
-                        </a>
+                        <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_siae_validation' evaluated_siae.pk %}">
+                            {% csrf_token %}
+                            <button class="btn btn-primary btn-sm float-right">
+                                Valider
+                            </button>
+                        </form>
                     </div>
                 </div>
             {% endif %}
@@ -120,4 +124,3 @@
 
 
 {% endblock %}
-

--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -40,9 +40,12 @@
                 </div>
 
                 <div class="col-md-4">
-                    <a class="btn {% if is_submittable %}btn-primary {% else %}btn-outline-primary disabled {% endif %}float-right" href="{% url 'siae_evaluations_views:siae_submit_proofs' evaluated_siae.pk %}">
-                        Soumettre à validation
-                    </a>
+                    <form method="post" action="{% url 'siae_evaluations_views:siae_submit_proofs' evaluated_siae.pk %}">
+                        {% csrf_token %}
+                        <button class="btn {% if is_submittable %}btn-primary {% else %}btn-outline-primary disabled {% endif %}float-right">
+                            Soumettre à validation
+                        </button>
+                    </form>
                 </div>
             </div>
             <div class="row">
@@ -62,9 +65,12 @@
                     </div>
 
                     <div class="col-4">
-                        <a class="btn btn-primary float-right" href="{% url 'siae_evaluations_views:siae_submit_proofs' evaluated_siae.pk %}">
-                            Soumettre à validation
-                        </a>
+                        <form method="post" action="{% url 'siae_evaluations_views:siae_submit_proofs' evaluated_siae.pk %}">
+                            {% csrf_token %}
+                            <button class="btn {% if is_submittable %}btn-primary {% else %}btn-outline-primary disabled {% endif %}float-right">
+                                Soumettre à validation
+                            </button>
+                        </form>
                     </div>
                 </div>
             {% endif%}

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -539,7 +539,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_siae.save(update_fields=["reviewed_at"])
 
         self.client.force_login(self.user)
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_siae_validation",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
@@ -875,7 +875,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         self.client.force_login(self.user)
 
         # institution without evaluation_campaign
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_administrative_criteria",
                 kwargs={"evaluated_administrative_criteria_pk": 1, "action": "dummy"},
@@ -888,7 +888,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         evaluated_siae = create_evaluated_siae_consistent_datas(evaluation_campaign)
         evaluated_job_application = evaluated_siae.evaluated_job_applications.first()
         evaluated_administrative_criteria = evaluated_job_application.evaluated_administrative_criteria.first()
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_administrative_criteria",
                 kwargs={
@@ -902,7 +902,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         # institution with evaluation_campaign in "siae upload its proofs" phase
         evaluation_campaign.evaluations_asked_at = timezone.now()
         evaluation_campaign.save(update_fields=["evaluations_asked_at"])
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_administrative_criteria",
                 kwargs={
@@ -916,7 +916,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         # institution with ended evaluation_campaign
         evaluation_campaign.ended_at = timezone.now()
         evaluation_campaign.save(update_fields=["ended_at"])
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_administrative_criteria",
                 kwargs={
@@ -937,7 +937,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         )
 
         # action = dummy
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_administrative_criteria",
                 kwargs={
@@ -952,7 +952,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         self.assertEqual(evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED, eval_admin_crit.review_state)
 
         # action reinit
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_administrative_criteria",
                 kwargs={
@@ -967,7 +967,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         self.assertEqual(evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING, eval_admin_crit.review_state)
 
         # action = accept
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_administrative_criteria",
                 kwargs={
@@ -982,7 +982,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         self.assertEqual(evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED, eval_admin_crit.review_state)
 
         # action = refuse
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_administrative_criteria",
                 kwargs={
@@ -1001,7 +1001,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         evsiae.reviewed_at = timezone.now()
         evsiae.save(update_fields=["reviewed_at"])
 
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_administrative_criteria",
                 kwargs={
@@ -1027,7 +1027,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
         self.client.force_login(self.user)
 
         # institution without evaluation_campaign
-        response = self.client.get(
+        response = self.client.post(
             reverse(
                 "siae_evaluations_views:institution_evaluated_siae_validation",
                 kwargs={"evaluated_siae_pk": 1},
@@ -1041,19 +1041,19 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
             kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
         )
 
-        response = self.client.get(url)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 404)
 
         # institution with evaluation_campaign in "siae upload its proofs" phase
         self.evaluation_campaign.evaluations_asked_at = timezone.now()
         self.evaluation_campaign.save(update_fields=["evaluations_asked_at"])
-        response = self.client.get(url)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
 
         # institution with ended evaluation_campaign
         self.evaluation_campaign.ended_at = timezone.now()
         self.evaluation_campaign.save(update_fields=["ended_at"])
-        response = self.client.get(url)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 404)
 
     def test_actions_and_redirection(self):
@@ -1075,7 +1075,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
         )
 
         # before validation
-        response = self.client.get(url)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, redirect_url)
         self.evaluated_siae.refresh_from_db()
@@ -1085,7 +1085,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
         EvaluatedAdministrativeCriteria.objects.filter(
             evaluated_job_application__evaluated_siae=self.evaluated_siae
         ).update(review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED)
-        response = self.client.get(url)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, redirect_url)
         self.evaluated_siae.refresh_from_db()
@@ -1098,7 +1098,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
             evaluated_job_application__evaluated_siae=self.evaluated_siae
         ).update(review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED)
 
-        response = self.client.get(url)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, redirect_url)
         self.evaluated_siae.refresh_from_db()
@@ -1106,7 +1106,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
 
         # cannot validate twice
         timestamp = self.evaluated_siae.reviewed_at
-        response = self.client.get(url)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
         self.evaluated_siae.refresh_from_db()
         self.assertEqual(timestamp, self.evaluated_siae.reviewed_at)

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_list_or_404, get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.safestring import mark_safe
+from django.views.decorators.http import require_POST
 
 from itou.siae_evaluations import enums as evaluation_enums
 from itou.siae_evaluations.models import (
@@ -167,6 +168,7 @@ def institution_evaluated_job_application(
 
 
 @login_required
+@require_POST
 def institution_evaluated_administrative_criteria(request, evaluated_administrative_criteria_pk, action):
     institution = get_current_institution_or_404(request)
     evaluated_administrative_criteria = get_object_or_404(
@@ -198,6 +200,7 @@ def institution_evaluated_administrative_criteria(request, evaluated_administrat
 
 
 @login_required
+@require_POST
 def institution_evaluated_siae_validation(request, evaluated_siae_pk):
     institution = get_current_institution_or_404(request)
     evaluated_siae = get_object_or_404(
@@ -369,6 +372,7 @@ def siae_upload_doc(
 
 
 @login_required
+@require_POST
 def siae_submit_proofs(request, evaluated_siae_pk):
     evaluated_siae = get_object_or_404(
         EvaluatedSiae,


### PR DESCRIPTION
### Quoi ?

Contrôle a posteriori: Utiliser POST pour modifier les données

### Pourquoi ?

Meilleure accessibilité pour les utilisateurs, indique que cliquer sur le bouton soumet un formulaire et modifie des ressources sur le serveur, au lieu d’indiquer une simple navigation.
Facilite l’observation côté serveur des requêtes qui changent les données ou pas.