### PR TITLE
Retrait des dates de la campagne de contrôle a posteriori 2021

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -557,7 +557,7 @@
                             </li>
                             <li class="card-text mb-3">
                                 <i class="ri-pulse-line ri-lg mr-1"></i>
-                                <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données 2021 du contrôle a posteriori (version bêta)</a>
+                                <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données du contrôle a posteriori (version bêta)</a>
                             </li>
                         {% endif %}
                         <li class="card-text mb-3">

--- a/itou/templates/siae_evaluations/samples_selection.html
+++ b/itou/templates/siae_evaluations/samples_selection.html
@@ -8,16 +8,13 @@
 {% block content %}
     <div class="card c-card mt-4 p-3">
         <div class="card-body">
-
-            <p class="h1">
-                Sélectionner l'échantillon
-            </p>
-            <p class="h2">
-                Contrôle a posteriori des auto-prescriptions faites par les SIAE
-            </p>
-            <p class="h3">
-                Sélection des structures à contrôler
-            </p>
+            <h1>
+                Campagne du {{ evaluation_campaign.evaluated_period_start_at|date:"j F Y" }}
+                au {{ evaluation_campaign.evaluated_period_end_at|date:"j F Y" }}
+            </h1>
+            <h2>Sélectionner l'échantillon</h2>
+            <h3>Contrôle a posteriori des auto-prescriptions faites par les SIAE</h3>
+            <h4>Sélection des structures à contrôler</h4>
             <p>
                 Par défaut, un contrôle de 30% des SIAE ayant auto-prescrit a été défini au niveau national.
                 Ce ratio est adaptable au niveau local entre {{ min }}% et {{ max }}%.
@@ -34,7 +31,7 @@
                 faites par les SIAE de votre territoire:
             </p>
             <p class="font-weight-bold">
-                Données du contrôle a posteriori pour la période du {{evaluation_campaign.evaluated_period_start_at|date:"d F Y"}} au {{evaluation_campaign.evaluated_period_end_at|date:"d F Y"}}
+                Données du contrôle a posteriori cette campagne
             </p>
             <p>
                 <a class="btn btn-outline-primary" href="{% url 'stats:stats_ddets_diagnosis_control' %}{% if back_url %}?back_url={{ back_url }}{% endif %}" title="Voir les données">
@@ -42,9 +39,7 @@
                 </a>
             </p>
 
-            <p class="h3">
-                Sélection des salariés à contrôler
-            </p>
+            <h4>Sélection des salariés à contrôler</h4>
             <p>
                 Pour chacune des SIAE à contrôler, nous effectuerons une sélection aléatoire de 20% des recrutements en auto-prescription
                 (entre 2 et 20 dossiers maximum).
@@ -55,11 +50,9 @@
                     <p>Si une ETTI de votre territoire a fait 270 auto-prescriptions, vous devrez en contrôler seulement 20 au lieu de 54 (20% de 270)</p>
                 </div>
             </p>
-            <p class="h2">
-                Validation de l'échantillon des SIAE
-            </p>
+            <h3>Validation de l'échantillon des SIAE</h3>
 
-            {% if evaluation_campaign and evaluation_campaign.percent_set_at%}
+            {% if evaluation_campaign.percent_set_at%}
                 <p>
                     <div class="alert alert-success" role="status">
                         <p>Votre contrôle a posteriori sur la période du {{evaluation_campaign.evaluated_period_start_at|date:"d F Y"}}
@@ -69,7 +62,7 @@
                         </p>
                     </div>
                 </p>
-            {% elif evaluation_campaign %}
+            {% else %}
                 <p>
                     Pour initier le contrôle a posteriori des auto-prescriptions, nous avons besoin de connaître le pourcentage
                     de SIAE que vous souhaitez contrôler. Vous ne pourrez choisir qu'une fois, ensuite, nous effectuerons une sélection
@@ -91,20 +84,7 @@
                     {% endbuttons %}
 
                 </form>
-
-
-
-            {% else %}
-                <p>
-                    <div class="alert alert-info" role="status">
-                        <p class="font-weight-bold">Vous n'avez pas de contrôle en cours.</p>
-                    </div>
-                </p>
-
-
             {% endif %}
-
-
         </div>
     </div>
 

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -8,7 +8,7 @@
 
     {% if show_diagnosis_control_message %}
         <p>
-            Le tableau ci-dessous comprend 100% des auto-prescriptions faites en 2021, vous y avez accès pour prendre connaissance de ces caractéristiques.
+            Le tableau ci-dessous comprend 100% des auto-prescriptions faites sur la période de cette campagne, vous y avez accès pour prendre connaissance de ces caractéristiques.
         </p>
     {% endif %}
 

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -80,8 +80,7 @@ class SamplesSelectionViewTest(TestCase):
         # institution without active campaign
         self.client.force_login(self.user)
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Vous n'avez pas de contrôle en cours.")
+        assert response.status_code == 404
 
         # institution with active campaign to select
         evaluation_campaign = EvaluationCampaignFactory(institution=self.institution)
@@ -101,7 +100,7 @@ class SamplesSelectionViewTest(TestCase):
         evaluation_campaign.ended_at = timezone.now()
         evaluation_campaign.save(update_fields=["percent_set_at", "ended_at"])
         response = self.client.get(self.url)
-        self.assertContains(response, "Vous n'avez pas de contrôle en cours.")
+        assert response.status_code == 404
 
     def test_content(self):
         evaluation_campaign = EvaluationCampaignFactory(institution=self.institution)

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -32,7 +32,9 @@ from itou.www.siae_evaluations_views.forms import (
 @login_required
 def samples_selection(request, template_name="siae_evaluations/samples_selection.html"):
     institution = get_current_institution_or_404(request)
-    evaluation_campaign = EvaluationCampaign.objects.first_active_campaign(institution)
+    evaluation_campaign = get_object_or_404(
+        EvaluationCampaign.objects.for_institution(institution).in_progress(),
+    )
 
     back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
 

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -323,7 +323,7 @@ def stats_ddets_diagnosis_control(request):
     department = get_stats_ddets_department(request)
     params = get_params_for_departement(department)
     context = {
-        "page_title": "Données 2021 du contrôle a posteriori",
+        "page_title": "Données du contrôle a posteriori",
         "back_url": reverse("siae_evaluations_views:samples_selection"),
         "show_diagnosis_control_message": True,
         "matomo_custom_url_suffix": format_region_and_department_for_matomo(department),
@@ -404,7 +404,7 @@ def stats_dgefp_diagnosis_control(request):
     ensure_stats_dgefp_permission(request)
     params = get_params_for_whole_country()
     context = {
-        "page_title": "Données 2021 (version bêta) du contrôle a posteriori",
+        "page_title": "Données (version bêta) du contrôle a posteriori",
         "show_diagnosis_control_message": True,
     }
     return render_stats(request=request, context=context, params=params)


### PR DESCRIPTION
### Quoi ?

Retrait des dates de la campagne de contrôle a posteriori 2021

### Pourquoi ?

La campagne 2022 commence le 10 octobre. Évitons la confusion.

### Comment ?

#### Sélection de l’échantillon

L’accès à la page de sélection du échantillon de contrôle requiert maintenant une campagne de contrôle en cours. Cette page n’est accessible que depuis le tableau de bord, et seulement lorsque l’échantillon n’a pas été selectionné. Une fois l’échantillon sélectionné, la page n’est plus accessible que :

1. pour l’utilisateur qui vient de définir l’échantillon (redirection après la soumission du formulaire)
2. directement via l’URL

L’accès à la page sans campagne de contrôle a posteriori n’a pas besoin d’être géré.

#### Accessibilité

Les titres de la page de sélection de l’échantillon ont été mis à jour pour utiliser des /headings/ (`h1`, `h2`, …) au lieu de paragraphes dont le style est un /heading/. L’utilisation des /headings/ offre une table des matières aux utilisateurs des outils d’accessibilité numérique.

### Captures d’écran
#### Sélection de l’échantillon
![Screenshot 2022-10-06 at 08-43-01 Les emplois de l'inclusion](https://user-images.githubusercontent.com/2758243/194265407-620f6a8d-4392-4a6e-b3d0-bdd781a75022.png)

#### Stats
![Screenshot from 2022-10-06 10-39-36](https://user-images.githubusercontent.com/2758243/194265006-ba2664e5-da23-40ce-9395-01a013a9d57f.png)
