### PR TITLE
Transmission de la date de fin pour les PASS IAE sans fiches salariés

### DIFF
--- a/itou/asp/factories.py
+++ b/itou/asp/factories.py
@@ -38,7 +38,7 @@ _sample_communes = [
 class CountryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Country
-        strategy = factory.BUILD_STRATEGY
+        django_get_or_create = ("code",)
 
     code, name, group = random.choice(_sample_europe_countries).values()
 
@@ -73,7 +73,11 @@ class CommuneFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = models.Commune
-        strategy = factory.BUILD_STRATEGY
+        django_get_or_create = (
+            "code",
+            "start_date",
+            "end_date",
+        )
 
     # FIXME: may cause issues in testing validity periods
     start_date = datetime.date(2000, 1, 1)

--- a/itou/siaes/factories.py
+++ b/itou/siaes/factories.py
@@ -82,6 +82,7 @@ class SiaeFactory(factory.django.DjangoModelFactory):
                 [kind for kind in SiaeKind if kind not in models.Siae.ELIGIBILITY_REQUIRED_KINDS]
             ),
         )
+        use_employee_record = factory.Trait(kind=factory.fuzzy.FuzzyChoice(models.Siae.ASP_EMPLOYEE_RECORD_KINDS))
         with_membership = factory.Trait(
             membership=factory.RelatedFactory("itou.siaes.factories.SiaeMembershipFactory", "siae"),
         )

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -12,7 +12,8 @@
                     Début de contrat :&nbsp;<b>{{ item.hiring_start_at|default_if_none:"Non renseigné" }}</b>
                 </p>
                 <p class="m-0">
-                    Fin de contrat :&nbsp;<b>{{ item.hiring_end_at|default_if_none:"Non renseigné" }}</b>
+                    Fin de contrat :&nbsp;<b{% if item.has_outdated_date %} class="text-danger"{% endif %}>{{ item.hiring_end_at|default_if_none:"Non renseigné" }}</b>
+                    {% if item.has_outdated_date %}<i class="ri-error-warning-fill ri-xl text-danger align-text-bottom"></i>{% endif %}
                 </p>
                 <p class="m-0">
                     Numéro de PASS IAE (agrément) :&nbsp;<b>{{ item.approval.number|format_approval_number }}</b>
@@ -98,12 +99,33 @@
 
         {# Actions #}
         {% if form.status.value == "NEW" %}
-            <div class="text-right">
-                {% if item.employee_record_new %}
-                    <a href="{% url "employee_record_views:disable" item.employee_record_new.id %}?status=NEW" class="btn btn-outline-primary mt-2">Désactiver la fiche salarié</a>
-                {% endif %}
-                <a href="{% url "employee_record_views:create" item.id %}" class="btn btn-outline-primary mt-2">Créer la fiche salarié</a>
-            </div>
+            {% if item.has_outdated_date %}
+                <div class="alert alert-danger mt-4" role="status">
+                    <div class="row">
+                        <div class="col-auto pr-0">
+                            <i class="ri-error-warning-fill ri-xl text-danger"></i>
+                        </div>
+                        <div class="col">
+                            <p class="mb-2">
+                                <strong>Attention, une action de votre part est requise</strong>
+                            </p>
+                            <p class="mb-0">
+                                La nouvelle date de fin du PASS IAE n’a pas pu être transmise à l’Extranet IAE 2.0 de l’ASP. Une mise à jour manuelle est nécessaire.
+                            </p>
+                        </div>
+                        <div class="col-auto align-self-center">
+                            <a class="btn btn-primary" href="{% url "employee_record_views:create" item.id %}">Mettre à jour</a>
+                        </div>
+                    </div>
+                </div>
+            {% else %}
+                <div class="text-right">
+                    {% if item.employee_record_new %}
+                        <a href="{% url "employee_record_views:disable" item.employee_record_new.id %}?status=NEW" class="btn btn-outline-primary mt-2">Désactiver la fiche salarié</a>
+                    {% endif %}
+                    <a href="{% url "employee_record_views:create" item.id %}" class="btn btn-outline-primary mt-2">Créer la fiche salarié</a>
+                </div>
+            {% endif %}
         {% elif form.status.value == "READY" %}
             <div class="text-right">
                 <a href="{% url "employee_record_views:summary" employee_record.id %}?status=READY" class="btn btn-outline-primary mt-2">Voir le détail de la fiche salarié</a>
@@ -128,7 +150,5 @@
                 <a href="{% url "employee_record_views:summary" employee_record.id %}?status=DISABLED" class="btn btn-outline-primary mt-2">Voir le détail de la fiche salarié</a>
             </div>
         {% endif %}
-
     </div>
-
 </div>

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -22,15 +22,15 @@
     </h1>
 
     <div class="mt-3">
-        <form method="get" class="form" id="status-filter-form">
-            <div class="row">
-                <div class="col-sm-3">
-                    <div class="card-deck">
-                        <div class="card">
-                            <div class="card-header">
-                                <b>Filtrer les fiches</b>
-                            </div>
-                            <div class="card-body">
+        <div class="row">
+            <div class="col-sm-3">
+                <div class="card-deck">
+                    <div class="card">
+                        <div class="card-header">
+                            <b>Filtrer les fiches</b>
+                        </div>
+                        <div class="card-body">
+                            <form method="get" class="form" id="status-filter-form">
                                 <p class="text-muted">
                                     <b>Par statut</b>
                                 </p>
@@ -46,91 +46,101 @@
                                         </div>
                                     {% endfor %}
                                 </div>
-                            </div>
+                            </form>
                         </div>
                     </div>
                 </div>
-            </form>
+            </div>
 
             <div class="col-sm-9">
                 <div class="container rounded bg-gray-400 p-3 mb-3">
                     <div class="row">
                         <div class="col-sm-10">
                             <h5>Nous transférons vos fiches salarié à l'ASP afin de vous faire gagner du temps</h5>
-                            <p class="mt-3">Une fois envoyées et validées, vous retrouverez directement vos données sur l'extranet de l'ASP.</p>
+                            <p class="mt-3">Une fois envoyées et validées, vous retrouverez directement vos données sur
+                                l'extranet de l'ASP.</p>
                             <ul>
                                 <li>
-                                    Ne sont présentes dans cette liste que les candidatures acceptées (embauches) à partir du <b>{{ feature_availability_date|date }}</b>.
+                                    Ne sont présentes dans cette liste que les candidatures acceptées (embauches) à
+                                    partir du <b>{{ feature_availability_date|date }}</b>.
                                 </li>
                                 <li>
-                                    Vous devez avoir une annexe financière valide dans l'extranet de l'ASP pour pouvoir déclarer une fiche salarié dans les emplois.
+                                    Vous devez avoir une annexe financière valide dans l'extranet de l'ASP pour pouvoir
+                                    déclarer une fiche salarié dans les emplois.
                                 </li>
                             </ul>
                         </div>
                         <div class="col-sm-2 text-right">
-                            <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP" class="img-fluid">
-                        </img>
+                            <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"
+                                 class="img-fluid" />
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            {# Messages #}
-            <div class="alert alert-info mb-4">
-                {% if form.status.value == "NEW" %}
-                    <p class="mb-0">
-                        Vous trouverez ici les candidatures validées à partir desquelles vous devez créér de nouvelles fiches salarié.
-                    </p>
-                {% elif form.status.value == "READY" %}
-                    <p class="mb-0">Vous trouverez ici les fiches salarié complétées et en attente d'envoi à l'ASP.</p>
-                    <p class="mb-0">À ce stade, seule la visualisation des informations de la fiche est possible.</p>
-                {% elif form.status.value == "SENT" %}
-                    <p class="mb-0">Vous trouverez ici les fiches salarié complétées et envoyées à l'ASP.</p>
-                    <p class="mb-0">
-                        À ce stade, et en attendant un retour de l'ASP, seule la visualisation des informations de la fiche est possible.
-                    </p>
-                {% elif form.status.value == "REJECTED" %}
-                    <p class="mb-0">Vous trouverez ici les fiches salarié envoyées à l'ASP et retournées avec une erreur.</p>
-                    <p class="mb-0">Vous pouvez modifier les fiches en erreur et les envoyer à nouveau.</p>
-                {% elif form.status.value == "PROCESSED" %}
-                    <p class="mb-0">Vous trouverez ici les fiches salarié envoyées et validées par l'ASP.</p>
-                    <p class="mb-0">
-                        Aucune action ultérieure n'est possible à ce stade, mais vous pouvez consulter le détail de la fiche salarié.
-                    </p>
-                {% elif form.status.value == "DISABLED" %}
-                    <p class="mb-0">Vous trouverez ici les fiches salarié que vous avez désactivées.</p>
-                    <p class="mb-0">
-                        En cas de besoin vous pouvez réactiver une fiche, elle sera transférée dans la catégorie "Nouvelle".
-                    </p>
-                {% endif %}
-            </div>
-
-            {# "Real" employee records objects #}
-            <div class="employee-records-list">
-                {% if employee_records_list %}
-                    {% for employee_record in navigation_pages %}
-                        {% with item=employee_record.job_application %}
-                            {% include "employee_record/includes/list_item.html" %}
-                        {% endwith %}
-                    {% endfor %}
-                    {# New employee records i.e. job applications #}
-                {% else %}
-                    {% for item in navigation_pages %}
-                        {% include "employee_record/includes/list_item.html" %}
-                    {% endfor %}
-                {% endif %}
-            </div>
-
-            {% if not navigation_pages %}
-                <div class="text-muted text-center">
-                    <i class="ri-forbid-line mr-1"></i>
-                    <span>Aucune fiche salarié avec le statut selectionné ...</span>
+                {# Messages #}
+                <div class="alert alert-info mb-4">
+                    {% if form.status.value == "NEW" %}
+                        <p class="mb-0">
+                            Vous trouverez ici les candidatures validées à partir desquelles vous devez créér de
+                            nouvelles fiches salarié.
+                        </p>
+                    {% elif form.status.value == "READY" %}
+                        <p class="mb-0">Vous trouverez ici les fiches salarié complétées et en attente d'envoi à
+                            l'ASP.</p>
+                        <p class="mb-0">À ce stade, seule la visualisation des informations de la fiche est
+                            possible.</p>
+                    {% elif form.status.value == "SENT" %}
+                        <p class="mb-0">Vous trouverez ici les fiches salarié complétées et envoyées à l'ASP.</p>
+                        <p class="mb-0">
+                            À ce stade, et en attendant un retour de l'ASP, seule la visualisation des informations de
+                            la fiche est possible.
+                        </p>
+                    {% elif form.status.value == "REJECTED" %}
+                        <p class="mb-0">Vous trouverez ici les fiches salarié envoyées à l'ASP et retournées avec une
+                            erreur.</p>
+                        <p class="mb-0">Vous pouvez modifier les fiches en erreur et les envoyer à nouveau.</p>
+                    {% elif form.status.value == "PROCESSED" %}
+                        <p class="mb-0">Vous trouverez ici les fiches salarié envoyées et validées par l'ASP.</p>
+                        <p class="mb-0">
+                            Aucune action ultérieure n'est possible à ce stade, mais vous pouvez consulter le détail de
+                            la fiche salarié.
+                        </p>
+                    {% elif form.status.value == "DISABLED" %}
+                        <p class="mb-0">Vous trouverez ici les fiches salarié que vous avez désactivées.</p>
+                        <p class="mb-0">
+                            En cas de besoin vous pouvez réactiver une fiche, elle sera transférée dans la catégorie
+                            "Nouvelle".
+                        </p>
+                    {% endif %}
                 </div>
-            {% endif %}
 
-            {% include "includes/pagination.html" with page=navigation_pages %}
+                {# "Real" employee records objects #}
+                <div class="employee-records-list">
+                    {% if employee_records_list %}
+                        {% for employee_record in navigation_pages %}
+                            {% with item=employee_record.job_application %}
+                                {% include "employee_record/includes/list_item.html" %}
+                            {% endwith %}
+                        {% endfor %}
+                        {# New employee records i.e. job applications #}
+                    {% else %}
+                        {% for item in navigation_pages %}
+                            {% include "employee_record/includes/list_item.html" %}
+                        {% endfor %}
+                    {% endif %}
+                </div>
 
+                {% if not navigation_pages %}
+                    <div class="text-muted text-center">
+                        <i class="ri-forbid-line mr-1"></i>
+                        <span>Aucune fiche salarié avec le statut selectionné ...</span>
+                    </div>
+                {% endif %}
+
+                {% include "includes/pagination.html" with page=navigation_pages %}
+
+            </div>
         </div>
     </div>
-</div>
 
 {% endblock %}

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -57,8 +57,10 @@
                     <div class="row">
                         <div class="col-sm-10">
                             <h5>Nous transférons vos fiches salarié à l'ASP afin de vous faire gagner du temps</h5>
-                            <p class="mt-3">Une fois envoyées et validées, vous retrouverez directement vos données sur
-                                l'extranet de l'ASP.</p>
+                            <p class="mt-3">
+                                Une fois envoyées et validées, vous retrouverez directement vos données sur
+                                l'extranet de l'ASP.
+                            </p>
                             <ul>
                                 <li>
                                     Ne sont présentes dans cette liste que les candidatures acceptées (embauches) à
@@ -71,24 +73,27 @@
                             </ul>
                         </div>
                         <div class="col-sm-2 text-right">
-                            <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP"
-                                 class="img-fluid" />
+                            <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP" class="img-fluid" />
                         </div>
                     </div>
                 </div>
 
                 {# Messages #}
-                <div class="alert alert-info mb-4">
+                <div class="h5">
                     {% if form.status.value == "NEW" %}
                         <p class="mb-0">
                             Vous trouverez ici les candidatures validées à partir desquelles vous devez créér de
                             nouvelles fiches salarié.
                         </p>
                     {% elif form.status.value == "READY" %}
-                        <p class="mb-0">Vous trouverez ici les fiches salarié complétées et en attente d'envoi à
-                            l'ASP.</p>
-                        <p class="mb-0">À ce stade, seule la visualisation des informations de la fiche est
-                            possible.</p>
+                        <p class="mb-0">
+                            Vous trouverez ici les fiches salarié complétées et en attente d'envoi à
+                            l'ASP.
+                        </p>
+                        <p class="mb-0">
+                            À ce stade, seule la visualisation des informations de la fiche est
+                            possible.
+                        </p>
                     {% elif form.status.value == "SENT" %}
                         <p class="mb-0">Vous trouverez ici les fiches salarié complétées et envoyées à l'ASP.</p>
                         <p class="mb-0">
@@ -96,8 +101,10 @@
                             la fiche est possible.
                         </p>
                     {% elif form.status.value == "REJECTED" %}
-                        <p class="mb-0">Vous trouverez ici les fiches salarié envoyées à l'ASP et retournées avec une
-                            erreur.</p>
+                        <p class="mb-0">
+                            Vous trouverez ici les fiches salarié envoyées à l'ASP et retournées avec une
+                            erreur.
+                        </p>
                         <p class="mb-0">Vous pouvez modifier les fiches en erreur et les envoyer à nouveau.</p>
                     {% elif form.status.value == "PROCESSED" %}
                         <p class="mb-0">Vous trouverez ici les fiches salarié envoyées et validées par l'ASP.</p>
@@ -113,6 +120,20 @@
                         </p>
                     {% endif %}
                 </div>
+                {% if has_outdated_date %}
+                    <div class="alert alert-danger mb-4">
+                        <div class="row">
+                            <div class="col-auto pr-0">
+                                <i class="ri-error-warning-line ri-xl text-danger"></i>
+                            </div>
+                            <div class="col">
+                                <p class="mb-0">
+                                    <strong>Attention, nous avons détecté une ou plusieurs fiches salarié dont la nouvelle date de fin du PASS IAE doit être transmise manuellement à l’ASP  </strong>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
 
                 {# "Real" employee records objects #}
                 <div class="employee-records-list">

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -170,8 +170,9 @@ def create(request, job_application_id, template_name="employee_record/create.ht
         profile, _ = JobSeekerProfile.objects.get_or_create(user=employee)
 
         try:
-            # Try a geo lookup of the address every time we call this form
-            profile.update_hexa_address()
+            if employee.post_code and employee.address_line_1:
+                # Try a geo lookup of the address
+                profile.update_hexa_address()
         except ValidationError:
             # Can occur if employee address is badly formatted and is not found by geoloc API
             profile.clear_hexa_address()


### PR DESCRIPTION
### Quoi ?

Transmettre les notifications d’actualisation de date de PASS IAE lorsqu’on prolonge ou suspend un PASS IAE qui n’est pas concerné par les fiches salariés (import agrément via module PE ou PASS IAE obtenu avant le 27/09/2021)

### Pourquoi ?

Actuellement lorsqu’un utilisateur prolonge ou suspend un PASS IAE qui n’a pas généré de fiche salarié , les nouvelles dates du PASS IAE ne sont jamais transmises dans l’ASP.

### Comment ?

1. Ajout de ces cas à la liste des "nouvelle" FS avec une UI spécifique afin de permettre leur création, le parcours de création reste inchangé.
2. Ajout d'une règle générique au moment de l'ingestion du fichier de retour de l'ASP :
  _Lors du premier envois de la FS, si l'ASP nous dit que c'est un doublon 3436 et que nous avons une suspension ou prolongation alors on demande l'envois d'une notification puisque il est très fortement probable que la date de fin soit erronée coté ASP._

### Captures d'écran

![localhost_8000_employee_record_list_status=NEW](https://user-images.githubusercontent.com/20045330/194262689-5aba3f39-478c-475f-98cd-ab542e92a5d7.png)

### Autre

- Il n'y a (pour le moment) pas de tests pour la commande `transfer_employee_records.py` car rien n'existe pour tester un comportement aussi précis, ils arriveront plus tard.
