### PR TITLE
Handle assertFormError signature warnings

### DIFF
--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -638,7 +638,9 @@ class AutomaticApprovalAdminViewsTest(TestCase):
         response = self.client.post(url, data=post_data)
         self.assertEqual(response.status_code, 200)
         self.assertFormError(
-            response, "adminform", "number", [ApprovalAdminForm.ERROR_NUMBER_CANNOT_BE_CHANGED % approval.number]
+            response.context["adminform"],
+            "number",
+            [ApprovalAdminForm.ERROR_NUMBER_CANNOT_BE_CHANGED % approval.number],
         )
 
 

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -265,7 +265,7 @@ class ProcessViewsTest(TestCase):
             **address,
         }
         response = self.client.post(url, data=post_data)
-        self.assertFormError(response, "form_accept", "hiring_start_at", JobApplication.ERROR_START_IN_PAST)
+        self.assertFormError(response.context["form_accept"], "hiring_start_at", JobApplication.ERROR_START_IN_PAST)
 
         # Wrong dates: end < start.
         hiring_start_at = today
@@ -277,7 +277,7 @@ class ProcessViewsTest(TestCase):
             **address,
         }
         response = self.client.post(url, data=post_data)
-        self.assertFormError(response, "form_accept", None, JobApplication.ERROR_END_IS_BEFORE_START)
+        self.assertFormError(response.context["form_accept"], None, JobApplication.ERROR_END_IS_BEFORE_START)
 
         # No address provided.
         job_application = JobApplicationSentByJobSeekerFactory(
@@ -296,9 +296,9 @@ class ProcessViewsTest(TestCase):
             "answer": "",
         }
         response = self.client.post(url, data=post_data)
-        self.assertFormError(response, "form_user_address", "address_line_1", "Ce champ est obligatoire.")
-        self.assertFormError(response, "form_user_address", "city", "Ce champ est obligatoire.")
-        self.assertFormError(response, "form_user_address", "post_code", "Ce champ est obligatoire.")
+        self.assertFormError(response.context["form_user_address"], "address_line_1", "Ce champ est obligatoire.")
+        self.assertFormError(response.context["form_user_address"], "city", "Ce champ est obligatoire.")
+        self.assertFormError(response.context["form_user_address"], "post_code", "Ce champ est obligatoire.")
 
     def test_accept_with_active_suspension(self, *args, **kwargs):
         """Test the `accept` transition with active suspension for active user"""

--- a/itou/www/signup/tests/test_job_seeker.py
+++ b/itou/www/signup/tests/test_job_seeker.py
@@ -37,7 +37,7 @@ class JobSeekerSignupTest(TestCase):
         post_data = {"some": "data"}
         response = self.client.post(url, post_data)
         self.assertEqual(response.status_code, 200)
-        self.assertFormError(response, "form", "situation", [JobSeekerSituationForm.ERROR_NOTHING_CHECKED])
+        self.assertFormError(response.context["form"], "situation", [JobSeekerSituationForm.ERROR_NOTHING_CHECKED])
 
         # Check if one of eligibility criterion is checked.
         next_url = reverse("signup:job_seeker_nir")


### PR DESCRIPTION
Example warning:
```
RemovedInDjango50Warning: Passing response to assertFormError() is
deprecated. Use the form object directly:
assertFormError(response.context['form'], 'situation', ...)
```