### PR TITLE
Remove dead code from institution_evaluated_siae_list

### DIFF
--- a/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
@@ -15,15 +15,15 @@
                     <h1 class="h1">Contrôler les pièces justificatives</h1>
                     <h3 class="h3">
                         Liste des Siae
-                        {% if ended_at %}
+                        {% if evaluation_campaign.ended_at %}
                             contrôlées
                         {% else %}
                             à contrôler
                         {% endif %}
                     </h3>
                     <p>
-                        Contrôle initié le {{ evaluations_asked_at|date:"d F Y" }}
-                        {% if ended_at %}, clôturé le {{ ended_at|date:"d F Y" }}{% endif %}
+                        Contrôle initié le {{ evaluation_campaign.evaluations_asked_at|date:"d F Y" }}
+                        {% if evaluation_campaign.ended_at %}, clôturé le {{ evaluation_campaign.ended_at|date:"d F Y" }}{% endif %}
                     </p>
                 </div>
             </div>

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -315,6 +315,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
             1  # django session
             + 1  # fetch user
             + 3  # fetch institution membership & institution x 2 !should be fixed!
+            + 1  # fetch evaluation campaign
             + 3  # fetch evaluated_siae and its prefetch_related eval_job_app & eval_admin_crit
             + 1  # one again institution membership
             + 1  # social account


### PR DESCRIPTION
There must be an evaluated SIAE, otherwise get_list_or_404 would return
a 404 response.

Take that opportunity to simplify the context: pass in the campaign.