### PR TITLE
Technique : retirer les utilisations de la plupart des secrets Github.

### DIFF
--- a/.github/workflows/build-metabase-final-tables.yml
+++ b/.github/workflows/build-metabase-final-tables.yml
@@ -23,7 +23,6 @@ env:
   CLEVER_CLI: clever-tools-latest_linux/clever
   CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
   CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
-  CRON_APPS_ORGANIZATION_NAME: ${{ secrets.CLEVER_CRON_APPS_ORGANIZATION_NAME }}
   DEPLOY_BRANCH: master_clever
   PYTHON_VERSION: "3.10"
 
@@ -56,14 +55,14 @@ jobs:
         tar -xvf $CLEVER_TAR_FILE
         $CLEVER_CLI login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
         $CLEVER_CLI create $CRON_TASK_APP_NAME -t python --region par --alias $CRON_TASK_APP_NAME --org Itou
-        $CLEVER_CLI link $CRON_TASK_APP_NAME --org $CRON_APPS_ORGANIZATION_NAME
+        $CLEVER_CLI link $CRON_TASK_APP_NAME --org Itou
         $CLEVER_CLI scale --flavor S
 
     # We need at the minimum a database and redis in order to boot the app, as well as all the necessary
     # environment variables a configuration addon provides us
     - name: 🗺 Add environment variables and addons to the app
       run: |
-        $CLEVER_CLI link $CRON_TASK_APP_NAME --org $CRON_APPS_ORGANIZATION_NAME
+        $CLEVER_CLI link $CRON_TASK_APP_NAME --org Itou
         $CLEVER_CLI env set ITOU_ENVIRONMENT "FAST-MACHINE"
         $CLEVER_CLI service link-addon c1-prod-database-encrypted
         $CLEVER_CLI service link-addon c1-deployment-config

--- a/.github/workflows/imports-asp.yml
+++ b/.github/workflows/imports-asp.yml
@@ -22,7 +22,6 @@ env:
   CLEVER_CLI: clever-tools-latest_linux/clever
   CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
   CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
-  ITOU_ORGANIZATION_NAME: ${{ secrets.CLEVER_ORGANIZATION_NAME }}
   DEPLOY_BRANCH: master_clever
   PYTHON_VERSION: "3.10"
 
@@ -57,14 +56,14 @@ jobs:
         tar -xvf $CLEVER_TAR_FILE
         $CLEVER_CLI login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
         $CLEVER_CLI create $IMPORT_APP_NAME -t python --region par --alias $IMPORT_APP_NAME --org Itou
-        $CLEVER_CLI link $IMPORT_APP_NAME --org $ITOU_ORGANIZATION_NAME
+        $CLEVER_CLI link $IMPORT_APP_NAME --org Itou
         $CLEVER_CLI scale --flavor XL
 
     # We need at the minimum a database and redis in order to boot the app, as well as all the necessary
     # environment variables a configuration addon provides us
     - name: 🗺 Add environment variables and addons to the app
       run: |
-        $CLEVER_CLI link $IMPORT_APP_NAME --org $ITOU_ORGANIZATION_NAME
+        $CLEVER_CLI link $IMPORT_APP_NAME --org Itou
         $CLEVER_CLI env set ITOU_ENVIRONMENT "FAST-MACHINE"
         $CLEVER_CLI service link-addon c1-deployment-config
         $CLEVER_CLI service link-addon c1-imports-config

--- a/.github/workflows/populate-metabase-itou.yml
+++ b/.github/workflows/populate-metabase-itou.yml
@@ -28,7 +28,6 @@ env:
   CLEVER_CLI: clever-tools-latest_linux/clever
   CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
   CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
-  CRON_APPS_ORGANIZATION_NAME: ${{ secrets.CLEVER_CRON_APPS_ORGANIZATION_NAME }}
   DEPLOY_BRANCH: master_clever
   PYTHON_VERSION: "3.10"
 
@@ -74,14 +73,14 @@ jobs:
         tar -xvf $CLEVER_TAR_FILE
         $CLEVER_CLI login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
         $CLEVER_CLI create $CRON_TASK_APP_NAME -t python --region par --alias $CRON_TASK_APP_NAME --org Itou
-        $CLEVER_CLI link $CRON_TASK_APP_NAME --org $CRON_APPS_ORGANIZATION_NAME
+        $CLEVER_CLI link $CRON_TASK_APP_NAME --org Itou
         $CLEVER_CLI scale --flavor XL
 
     # We need at the minimum a database and redis in order to boot the app, as well as all the necessary
     # environment variables a configuration addon provides us
     - name: 🗺 Add environment variables and addons to the app
       run: |
-        $CLEVER_CLI link $CRON_TASK_APP_NAME --org $CRON_APPS_ORGANIZATION_NAME
+        $CLEVER_CLI link $CRON_TASK_APP_NAME --org Itou
         $CLEVER_CLI env set ITOU_ENVIRONMENT "FAST-MACHINE"
         $CLEVER_CLI service link-addon c1-deployment-config
         $CLEVER_CLI service link-addon c1-bucket-config

--- a/.github/workflows/review-app-removal.yml
+++ b/.github/workflows/review-app-removal.yml
@@ -11,7 +11,6 @@ env:
   CLEVER_CLI: clever-tools-latest_linux/clever
   CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
   CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
-  REVIEW_APPS_ORGANIZATION_NAME: ${{ secrets.CLEVER_REVIEW_APPS_ORG }}
   BRANCH: ${{ github.head_ref }}
 
 
@@ -37,7 +36,7 @@ jobs:
         curl $CLEVER_TOOLS_DOWNLOAD_URL > $CLEVER_TAR_FILE
         tar -xvf $CLEVER_TAR_FILE
         $CLEVER_CLI login --token $CLEVER_TOKEN --secret $CLEVER_SECRET
-        $CLEVER_CLI link $REVIEW_APP_NAME --org $REVIEW_APPS_ORGANIZATION_NAME
+        $CLEVER_CLI link $REVIEW_APP_NAME --org itou_review_apps
 
     - name: 🗑 Delete the review app
       run: |


### PR DESCRIPTION
Most of them aren't actually secrets.

Since the secrets in GH are not readable, it's better to have them explicited here.

After this we're going to be able to remove every secret except CLEVER_SECRET & CLEVER_TOKEN.
