### PR TITLE
Suspension des PASS IAE: simplification du gabarit

### DIFF
--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -33,7 +33,7 @@
             </div>
             {% bootstrap_field form.reason %}
 
-            <div id="js-warning-message-unsuspend" class="alert alert-warning d-none">
+            <div class="alert alert-warning">
                 <div class="row">
                     <div class="col-auto pr-0">
                         <i class="ri-information-line ri-xl text-warning"></i>
@@ -104,21 +104,4 @@
     {{ block.super }}
     <!-- Needed to use the Datepicker JS widget. -->
     {{ form.media }}
-
-    {# Clicking on a reason that can be unsuspend by other SIAE show warning message #}
-    <script type="text/javascript">
-        $(document).ready(() => {
-            var reasons_can_be_unsuspend = {{ form.reasons_can_be_unsuspend|js }};
-            function ajust_form_according_reason() {
-                const value = $('input[name="reason"]:checked').val();
-                if (reasons_can_be_unsuspend.includes(value)) {
-                    $('#js-warning-message-unsuspend').show("slidedown");
-                } else {
-                    $('#js-warning-message-unsuspend').hide("slideup");
-                }
-            }
-            $('#id_reason input').on('change', ajust_form_according_reason);
-            ajust_form_according_reason();
-        });
-    </script>
 {% endblock %}

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -123,10 +123,6 @@ class SuspensionForm(forms.ModelForm):
         # Show new reasons but keep old ones for history.
         self.fields["reason"].choices = Suspension.Reason.displayed_choices_for_siae(self.siae)
 
-        self.reasons_can_be_unsuspend = [
-            choice for choice, _ in self.fields["reason"].choices if choice in Suspension.REASONS_ALLOWING_UNSUSPEND
-        ]
-
         # End date is not strictly required because it can be set
         # with `set_default_end_date` input
         self.fields["end_at"].required = False


### PR DESCRIPTION
Now all the "Siae accessible reasons" for a suspension are within the list of reasons allowing an unsuspend, so we can remove some complicated logic.

Also, keep loading the datepicker now.
