### PR TITLE
Mode lecture seule pour les campagnes de contrôle a posteriori terminées

### DIFF
--- a/itou/siae_evaluations/constants.py
+++ b/itou/siae_evaluations/constants.py
@@ -1,0 +1,4 @@
+from dateutil.relativedelta import relativedelta
+
+
+CAMPAIGN_VIEWABLE_DURATION = relativedelta(years=3)

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -20,6 +20,8 @@ from itou.siaes.models import Siae
 from itou.users.enums import KIND_SIAE_STAFF
 from itou.utils.emails import get_email_message
 
+from .constants import CAMPAIGN_VIEWABLE_DURATION
+
 
 def select_min_max_job_applications(job_applications):
     # select SELECTION_PERCENTAGE % max, within bounds
@@ -98,7 +100,7 @@ class EvaluationCampaignQuerySet(models.QuerySet):
         return self.filter(self.in_progress_q)
 
     def viewable(self):
-        recent_q = Q(ended_at__gte=timezone.now() - relativedelta(years=3))
+        recent_q = Q(ended_at__gte=timezone.now() - CAMPAIGN_VIEWABLE_DURATION)
         return self.filter(self.in_progress_q | recent_q)
 
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -606,7 +606,8 @@
                 {% if can_view_stats_ddets and active_campaigns %}
                     <div class="card">
                         <p class="h4 card-header">
-                            Contrôle a posteriori <span class="badge badge-accent-03 text-primary">Nouveau</span>
+                            Contrôle a posteriori
+                            {% if campaign_in_progress %}<span class="badge badge-accent-03 text-primary">Nouveau</span>{% endif %}
                         </p>
                         <div class="card-body">
                             <ul class="list-unstyled">

--- a/itou/templates/siae_evaluations/institution_evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_job_application.html
@@ -17,21 +17,29 @@
                         <div class="card-body">
                             {% for evaluated_administrative_criteria in evaluated_job_application.evaluated_administrative_criteria.all %}
                                 {% include "siae_evaluations/includes/criterion_infos.html" with criteria=evaluated_administrative_criteria.administrative_criteria review_state=evaluated_administrative_criteria.review_state %}
-                                {% include "siae_evaluations/includes/criterion_validation.html" with evaluated_administrative_criteria=evaluated_administrative_criteria evaluated_siae=evaluated_siae %}
+                                {% if evaluated_siae.evaluation_campaign.ended_at %}
+                                    <a href="{{ evaluated_administrative_criteria.proof_url }}" rel="noopener" target="_blank" title="Revoir ce justificatif (ouverture dans un nouvel onglet)">
+                                        Revoir ce justificatif
+                                    </a>
+                                {% else %}
+                                    {% include "siae_evaluations/includes/criterion_validation.html" with evaluated_administrative_criteria=evaluated_administrative_criteria evaluated_siae=evaluated_siae %}
+                                {% endif %}
                             {% endfor %}
-                            <div class="row  my-3">
-                                <div class="col-md-12">
-                                    <form method="post" action="" class="js-prevent-multiple-submit">
-                                        {% csrf_token %}
+                            {% if not evaluated_siae.evaluation_campaign.ended_at %}
+                                <div class="row my-3">
+                                    <div class="col-md-12">
+                                        <form method="post" action="" class="js-prevent-multiple-submit">
+                                            {% csrf_token %}
 
-                                        {% bootstrap_form form alert_error_type="all" %}
-                                        <button type="submit"
-                                                class="btn {% if evaluated_job_application.state == 'ACCEPTED' or evaluated_job_application.state == 'REFUSED' or evaluated_job_application.state == 'REFUSED_2' %}btn-primary {% else %}btn-outline-primary {% endif %}float-right">
-                                            Enregistrer le commentaire et retourner à la liste des auto-prescriptions
-                                        </button>
-                                    </form>
+                                            {% bootstrap_form form alert_error_type="all" %}
+                                            <button type="submit"
+                                                    class="btn {% if evaluated_job_application.state == 'ACCEPTED' or evaluated_job_application.state == 'REFUSED' or evaluated_job_application.state == 'REFUSED_2' %}btn-primary {% else %}btn-outline-primary {% endif %}float-right">
+                                                Enregistrer le commentaire et retourner à la liste des auto-prescriptions
+                                            </button>
+                                        </form>
+                                    </div>
                                 </div>
-                            </div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
@@ -49,23 +49,25 @@
                             {{ evaluated_siae.siae.phone|format_phone }}
                         </a>
                     </p>
-                    <div class="row">
-                        <div class="col-8">
-                            <p>
-                                Lorsque vous aurez contrôlé<strong>tous vos justificatifs</strong> pour cette SIAE,
-                                veuillez valider le contrôle effectué pour la notifier de son résultat.
-                            </p>
-                        </div>
+                    {% if not evaluated_siae.evaluation_campaign.ended_at %}
+                        <div class="row">
+                            <div class="col-8">
+                                <p>
+                                    Lorsque vous aurez contrôlé <strong>tous vos justificatifs</strong> pour cette SIAE,
+                                    veuillez valider le contrôle effectué pour la notifier de son résultat.
+                                </p>
+                            </div>
 
-                        <div class="col-4">
-                            <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_siae_validation' evaluated_siae.pk %}">
-                                {% csrf_token %}
-                                <button class="btn {% if evaluated_siae.can_review %}btn-primary {% else %}btn-outline-primary disabled {% endif %}btn-sm float-right">
-                                    Valider
-                                </button>
-                            </form>
+                            <div class="col-4">
+                                <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_siae_validation' evaluated_siae.pk %}">
+                                    {% csrf_token %}
+                                    <button class="btn {% if evaluated_siae.can_review %}btn-primary {% else %}btn-outline-primary disabled {% endif %}btn-sm float-right">
+                                        Valider
+                                    </button>
+                                </form>
+                            </div>
                         </div>
-                    </div>
+                    {% endif %}
                 </div>
             </div>
             <div class="row">
@@ -98,7 +100,7 @@
                 <div class="row">
                     <div class="col-8">
                         <p>
-                            Lorsque vous aurez contrôlé<strong>tous vos justificatifs</strong> pour cette SIAE,
+                            Lorsque vous aurez contrôlé <strong>tous vos justificatifs</strong> pour cette SIAE,
                             veuillez valider le contrôle effectué pour la notifier de son résultat.
                         </p>
                     </div>

--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -34,7 +34,7 @@
             <div class="row">
                 <div class="col-md-8">
                     <p>
-                        Lorsque vous aurez ajouté<strong>tous vos justificatifs</strong>,
+                        Lorsque vous aurez ajouté <strong>tous vos justificatifs</strong>,
                         veuillez les soumettre à validation, la DDETS effectuera un contrôle de ceux-ci et reviendra vers vous.
                     </p>
                 </div>
@@ -60,7 +60,7 @@
                 <div class="row mt-3">
                     <div class="col-8">
                         <p>
-                            Lorsque vous aurez ajouté<strong>tous vos justificatifs</strong>,
+                            Lorsque vous aurez ajouté <strong>tous vos justificatifs</strong>,
                             veuillez les soumettre à validation, la DDETS effectuera un contrôle de ceux-ci et reviendra vers vous.
                         </p>
                     </div>

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from allauth.account.models import EmailAddress, EmailConfirmationHMAC
-from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core import mail
 from django.test import TestCase, override_settings
@@ -24,6 +23,7 @@ from itou.job_applications.notifications import (
 )
 from itou.prescribers import factories as prescribers_factories
 from itou.prescribers.enums import PrescriberOrganizationKind
+from itou.siae_evaluations.constants import CAMPAIGN_VIEWABLE_DURATION
 from itou.siae_evaluations.factories import EvaluatedSiaeFactory, EvaluationCampaignFactory
 from itou.siaes.enums import SiaeKind
 from itou.siaes.factories import (
@@ -228,7 +228,7 @@ class DashboardViewTest(TestCase):
             ),
         )
 
-        evaluation_campaign.ended_at = timezone.now() - relativedelta(years=3)
+        evaluation_campaign.ended_at = timezone.now() - CAMPAIGN_VIEWABLE_DURATION
         evaluation_campaign.save(update_fields=["ended_at"])
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Contrôle a posteriori")

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from allauth.account.models import EmailAddress, EmailConfirmationHMAC
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core import mail
 from django.test import TestCase, override_settings
@@ -215,6 +216,19 @@ class DashboardViewTest(TestCase):
         )
 
         evaluation_campaign.ended_at = timezone.now()
+        evaluation_campaign.save(update_fields=["ended_at"])
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertContains(response, "Contrôle a posteriori")
+        self.assertNotContains(response, reverse("siae_evaluations_views:samples_selection"))
+        self.assertContains(
+            response,
+            reverse(
+                "siae_evaluations_views:institution_evaluated_siae_list",
+                kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
+            ),
+        )
+
+        evaluation_campaign.ended_at = timezone.now() - relativedelta(years=3)
         evaluation_campaign.save(update_fields=["ended_at"])
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, "Contrôle a posteriori")

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -31,6 +31,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
     job_applications_categories = []
     num_rejected_employee_records = 0
     active_campaigns = []
+    campaign_in_progress = False
 
     # `current_org` can be a Siae, a PrescriberOrganization or an Institution.
     current_org = None
@@ -85,7 +86,8 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
 
     if request.user.is_labor_inspector:
         current_org = get_current_institution_or_404(request)
-        active_campaigns = EvaluationCampaign.objects.for_institution(current_org).in_progress()
+        active_campaigns = EvaluationCampaign.objects.for_institution(current_org).viewable()
+        campaign_in_progress = any(campaign.ended_at is None for campaign in active_campaigns)
 
     context = {
         "job_applications_categories": job_applications_categories,
@@ -102,6 +104,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_view_stats_dgefp": request.user.can_view_stats_dgefp(current_org=current_org),
         "num_rejected_employee_records": num_rejected_employee_records,
         "active_campaigns": active_campaigns,
+        "campaign_in_progress": campaign_in_progress,
         "precriber_kind_pe": PrescriberOrganizationKind.PE,
         "precriber_kind_dept": PrescriberOrganizationKind.DEPT,
     }

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -9,6 +9,7 @@ from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.institutions.factories import InstitutionMembershipFactory
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.siae_evaluations import enums as evaluation_enums
+from itou.siae_evaluations.constants import CAMPAIGN_VIEWABLE_DURATION
 from itou.siae_evaluations.factories import (
     EvaluatedAdministrativeCriteriaFactory,
     EvaluatedJobApplicationFactory,
@@ -260,7 +261,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         evaluated_siae = EvaluatedSiaeFactory(
             accepted=True,
             evaluation_campaign__institution=self.institution,
-            evaluation_campaign__ended_at=timezone.now() - relativedelta(years=3),
+            evaluation_campaign__ended_at=timezone.now() - CAMPAIGN_VIEWABLE_DURATION,
         )
         self.client.force_login(self.user)
         response = self.client.get(
@@ -470,7 +471,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_siae = EvaluatedSiaeFactory(
             accepted=True,
             evaluation_campaign__institution=self.institution,
-            evaluation_campaign__ended_at=timezone.now() - relativedelta(years=3),
+            evaluation_campaign__ended_at=timezone.now() - CAMPAIGN_VIEWABLE_DURATION,
         )
         self.client.force_login(self.user)
         response = self.client.get(
@@ -926,7 +927,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_siae = EvaluatedSiaeFactory(
             accepted=True,
             evaluation_campaign__institution=self.institution,
-            evaluation_campaign__ended_at=timezone.now() - relativedelta(years=3),
+            evaluation_campaign__ended_at=timezone.now() - CAMPAIGN_VIEWABLE_DURATION,
         )
         job_app = evaluated_siae.evaluated_job_applications.get()
         self.client.force_login(self.user)


### PR DESCRIPTION
### Quoi ?

Mode lecture seule pour les campagnes de contrôle a posteriori terminées

### Pourquoi ?

Les campagnes de contrôle a posteriori terminées étaient masquées dans l’interface. Les utilisateurs y accédant par les URLs recevaient une erreur 404. L’objectif est de montrer les résultats de la campagne. Ultérieurement, la notification de sanction sera ajoutée à la liste des résultats.

### Captures d'écran
#### Tableau de bord (campagne terminée)
![Tableau de bord (campagne terminée)](https://user-images.githubusercontent.com/2758243/195092118-3fd3fa46-7e1e-438d-b716-4abf5e573a13.png)
#### Liste des SIAE
![Liste des SIAE](https://user-images.githubusercontent.com/2758243/195092115-911c46cb-fbb3-4585-a330-bc532f869479.png)
#### Liste des candidatures évaluées pour une SIAE
![Liste des candidatures évaluées pour une SIAE](https://user-images.githubusercontent.com/2758243/195092112-260b3394-490a-440d-aaf1-a30ff278b93b.png)
#### Détail d’une candidature évaluée pour une SIAE
![Détail d’une candidature évaluée pour une SIAE](https://user-images.githubusercontent.com/2758243/195092107-9be5f347-d4fc-4289-809b-39d63ab2d9e3.png)

