### PR TITLE
HOTFIX: rattrapage de toutes les erreurs de geoloc du modèle User

### DIFF
--- a/itou/employee_record/tests/tests_models.py
+++ b/itou/employee_record/tests/tests_models.py
@@ -18,7 +18,6 @@ from itou.job_applications.factories import (
     JobApplicationWithoutApprovalFactory,
 )
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
-from itou.utils.apis.exceptions import AddressLookupError
 from itou.utils.mocks.address_format import mock_get_geocoding_data
 
 
@@ -117,7 +116,7 @@ class EmployeeRecordModelTest(EmployeeRecordFixtureTest):
         # Complete profile, but geoloc API not reachable
         job_application = JobApplicationWithJobSeekerProfileFactory()
 
-        with self.assertRaises(AddressLookupError):
+        with self.assertRaises(ValidationError):
             employee_record = EmployeeRecord.from_job_application(job_application)
             employee_record.update_as_ready()
 

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1141,7 +1141,7 @@ class JobSeekerProfile(models.Model):
         result, error = format_address(self.user)
 
         if error:
-            raise AddressLookupError(error)
+            raise ValidationError(error)
 
         # Fill matching fields
         self.hexa_lane_type = result.get("lane_type")
@@ -1156,7 +1156,11 @@ class JobSeekerProfile(models.Model):
         insee_code = result.get("insee_code")
 
         # This may raise an asp.exceptions.UnknownCommuneError : let it crash if needed
-        self.hexa_commune = Commune.by_insee_code(insee_code)
+        try:
+            self.hexa_commune = Commune.by_insee_code(insee_code)
+        except AddressLookupError:
+            raise ValidationError(f"Impossible de trouver la commune correspondate: code INSEE {insee_code}")
+
         self.save()
 
         return self


### PR DESCRIPTION
### Quoi ?

Correction rapide suite a erreur 500 possible sur la geoloc

### Pourquoi ?

Le modele JobSeekerProfile jette directement des erreurs de geoloc en cas de non résolution de la commune

### Comment ?

On transforme les erreurs de géoloc de `users.JobSeekerProfile` en `ValidationError` qui sont correctement gérées coté interface.

### Autre (optionnel)

- Pas de revue : hotfix. 
- Les autres erreurs de geoloc seront gérées par : https://github.com/betagouv/itou/pull/1611 