### PR TITLE
Erreur propre en cas de changement d'email sur France Connect + conflit sur les emplois

### DIFF
--- a/itou/openid_connect/france_connect/tests.py
+++ b/itou/openid_connect/france_connect/tests.py
@@ -53,6 +53,7 @@ def mock_oauth_dance(test_class, expected_route="dashboard:index"):
     url = reverse("france_connect:callback")
     response = test_class.client.get(url, data={"code": "123", "state": csrf_signed})
     test_class.assertRedirects(response, reverse(expected_route))
+    return response
 
 
 @override_settings(

--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -13,7 +13,7 @@ from django.utils.http import urlencode
 from itou.utils.constants import ITOU_SESSION_NIR_KEY
 from itou.utils.urls import get_absolute_url
 
-from ..models import TooManyKindsException
+from ..models import MultipleUsersFoundException, TooManyKindsException
 from . import constants
 from .models import FranceConnectState, FranceConnectUserData
 
@@ -132,6 +132,14 @@ def france_connect_callback(request):  # pylint: disable=too-many-return-stateme
             return HttpResponseRedirect(reverse("login:siae_staff"))
         if e.user.is_labor_inspector:
             return HttpResponseRedirect(reverse("login:labor_inspector"))
+    except MultipleUsersFoundException as e:
+        return _redirect_to_job_seeker_login_on_error(
+            "Vous avez deux comptes sur la plateforme et nous detectons un conflit d'email : "
+            f"{e.users[0].email} et {e.users[1].email}."
+            "Veuillez vous rapprocher du support pour débloquer la situation en suivant "
+            "<a href='https://communaute.inclusion.beta.gouv.fr/aide/emplois/#support'>ce lien</a>.",
+            request=request,
+        )
 
     nir = request.session.get(ITOU_SESSION_NIR_KEY)
     if nir:

--- a/itou/www/approvals_views/tests/test_pe_approval.py
+++ b/itou/www/approvals_views/tests/test_pe_approval.py
@@ -242,7 +242,7 @@ class PoleEmploiApprovalCreateTest(TestCase):
         self.assertEqual(Approval.objects.count(), initial_approval_count + 1)
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(
-            str(messages[-1]),
+            messages[-1].message,
             "L'agrément a bien été importé, vous pouvez désormais le prolonger ou le suspendre.",
         )
 
@@ -265,7 +265,7 @@ class PoleEmploiApprovalCreateTest(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(Approval.objects.count(), initial_approval_count)
         messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(str(messages[-1]), "Cet agrément a déjà été importé.")
+        self.assertEqual(messages[-1].message, "Cet agrément a déjà été importé.")
 
     def test_from_existing_user_with_approval(self):
         """
@@ -286,4 +286,4 @@ class PoleEmploiApprovalCreateTest(TestCase):
         next_url = reverse("approvals:pe_approval_search_user", kwargs={"pe_approval_id": self.pe_approval.id})
         self.assertEqual(response.url, next_url)
         messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(str(messages[-1]), "Le candidat associé à cette adresse e-mail a déjà un PASS IAE valide.")
+        self.assertEqual(messages[-1].message, "Le candidat associé à cette adresse e-mail a déjà un PASS IAE valide.")

--- a/itou/www/invitations_views/tests/tests_prescriber_organization.py
+++ b/itou/www/invitations_views/tests/tests_prescriber_organization.py
@@ -251,7 +251,7 @@ class TestAcceptPrescriberWithOrgInvitation(InclusionConnectBaseTestCase):
         # Signup should have failed : as the email used in IC isn't the one from the invitation
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
-        self.assertIn("ne correspond pas à l’adresse e-mail de l’invitation", str(messages[0]))
+        self.assertIn("ne correspond pas à l’adresse e-mail de l’invitation", messages[0].message)
         self.assertEqual(response.wsgi_request.get_full_path(), previous_url)
         self.assertFalse(User.objects.filter(email=invitation.email).exists())
 

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -126,7 +126,7 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
         # Signup should have failed : as the email used in IC isn't the one from the invitation
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
-        self.assertIn("ne correspond pas à l’adresse e-mail de l’invitation", str(messages[0]))
+        self.assertIn("ne correspond pas à l’adresse e-mail de l’invitation", messages[0].message)
         self.assertEqual(response.wsgi_request.get_full_path(), previous_url)
         self.assertFalse(User.objects.filter(email=invitation.email).exists())
 

--- a/itou/www/login/tests.py
+++ b/itou/www/login/tests.py
@@ -1,16 +1,23 @@
-from django.test import TestCase
+import respx
+from django.contrib.messages import get_messages
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from itou.openid_connect.france_connect import constants as fc_constants
+from itou.openid_connect.france_connect.tests import FC_USERINFO, mock_oauth_dance
 from itou.openid_connect.inclusion_connect.testing import InclusionConnectBaseTestCase
 from itou.users import enums as users_enums
+from itou.users.enums import IdentityProvider
 from itou.users.factories import (
     DEFAULT_PASSWORD,
     JobSeekerFactory,
     LaborInspectorFactory,
     PrescriberFactory,
     SiaeStaffFactory,
+    UserFactory,
 )
+from itou.utils.testing import reload_module
 from itou.www.login.forms import ItouLoginForm
 
 
@@ -167,3 +174,33 @@ class JopbSeekerLoginTest(TestCase):
         }
         response = self.client.post(url, data=form_data)
         self.assertRedirects(response, reverse("account_email_verification_sent"))
+
+    @respx.mock
+    @override_settings(
+        FRANCE_CONNECT_BASE_URL="https://france.connect.fake",
+        FRANCE_CONNECT_CLIENT_ID="IC_CLIENT_ID_123",
+        FRANCE_CONNECT_CLIENT_SECRET="IC_CLIENT_SECRET_123",
+    )
+    @reload_module(fc_constants)
+    def test_conflict_on_email_change_in_france_connect(self):
+        """
+        The job seeker has 2 accounts : a django one, and a FC one, with 2 different email adresses.
+        Then he changes the email adresse on FC to use the django account email.
+        """
+        UserFactory(email=FC_USERINFO["email"], identity_provider=IdentityProvider.DJANGO)
+        UserFactory(
+            username=FC_USERINFO["sub"],
+            email="seconde@email.com",
+            identity_provider=IdentityProvider.FRANCE_CONNECT,
+        )
+
+        # Temporary NIR is not stored with user information.
+        response = mock_oauth_dance(self, expected_route="login:job_seeker")
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(
+            messages[0].message,
+            "Vous avez deux comptes sur la plateforme et nous detectons un conflit d'email : seconde@email.com "
+            "et wossewodda-3728@yopmail.com.Veuillez vous rapprocher du support pour débloquer la situation "
+            "en suivant <a href='https://communaute.inclusion.beta.gouv.fr/aide/emplois/#support'>ce lien</a>.",
+        )

--- a/itou/www/signup/tests/test_prescriber.py
+++ b/itou/www/signup/tests/test_prescriber.py
@@ -926,7 +926,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(InclusionConnectBaseTestCas
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
         error_message = "Un compte employeur existe déjà avec cette adresse e-mail"
-        self.assertIn(error_message, str(messages[0]))
+        self.assertIn(error_message, messages[0].message)
 
         user = User.objects.get(email=OIDC_USERINFO["email"])
         self.assertNotEqual(user.first_name, OIDC_USERINFO["given_name"])
@@ -984,7 +984,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(InclusionConnectBaseTestCas
         self.assertEqual(len(messages), 1)
         self.assertIn(
             "est différente de celle que vous avez indiquée précédemment",
-            str(messages[0]),
+            messages[0].message,
         )
 
         # Organization

--- a/itou/www/signup/tests/test_siae.py
+++ b/itou/www/signup/tests/test_siae.py
@@ -298,7 +298,7 @@ class SiaeSignupViewsExceptionsTest(TestCase):
         response = self.client.get(url)
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
-        self.assertEqual("Vous ne pouvez pas rejoindre une SIAE avec ce compte.", str(messages[0]))
+        self.assertEqual("Vous ne pouvez pas rejoindre une SIAE avec ce compte.", messages[0].message)
         self.assertRedirects(response, reverse("home:hp"))
 
         # Check `User` state.


### PR DESCRIPTION
### Quoi ?

Meilleur prise en charge du cas où un utilisateur a 2 comptes, un django, un France connect, et change son email sur france connect en utilisant celui du compte django.

### Comment ?

On lui affiche un bandeau d'erreur lui disant de se rapprocher du support.

### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.

### Autre (optionnel)

- si des tests manquent, indiquer la raison, la probabilité, et les risques associés à ce manque
- être explicite sur le délai attendu pour une revue de code
- être explicite sur la qualité attendue pour la revue de code
- etc.
