### PR TITLE
Correction du formatage du NIR lors du dépôt de candidature

### DIFF
--- a/itou/static/js/split_nir.js
+++ b/itou/static/js/split_nir.js
@@ -2,15 +2,15 @@
 
 "use strict";
 
-let form = $( ".js-format-nir" );
-let input = form.find( "input[name='nir']" ).first();
+$(document).ready(() => {
+  let form = $(".js-format-nir");
+  let input = form.find("input[name='nir']").first();
 
-$(input).keyup(function(e) {
-    if (e.keyCode == 8) {
-        // Ignore backspace key to let users erase content.
-        return;
+  function formatNir(nir) {
+    if (!nir) {
+      return "";
     }
-    let elements = $(this).val().replace(/\s+/g, '').split(""); // Delete already existing white spaces.
+    let elements = nir.replace(/\s+/g, '').split(""); // Delete already existing white spaces.
     let breakpoints = [0, 2, 4, 6, 9, 12]; // White spaces will be inserted after theses indexes + 1.
     let counter = 0; // When a white space is added, the total number of items in list should be increased by 1.
     $.each(elements, function( index, value ) {
@@ -19,5 +19,16 @@ $(input).keyup(function(e) {
             counter +=1;
         }
     });
-    $(input).val(elements.join(""));
-});
+    return elements.join("");
+  }
+
+  $(input).keyup(function(e) {
+      if (e.keyCode == 8) {
+          // Ignore backspace key to let users erase content.
+          return;
+      }
+      $(this).val(formatNir($(this).val()));
+  });
+  // Format the current content of the input
+  $(input).val(formatNir($(input).val()));
+})

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -1,15 +1,16 @@
 {% extends "apply/submit_base_two_columns.html" %}
 {% load bootstrap4 %}
 {% load format_filters %}
+{% load static %}
 
 {% block left_column %}
-    <form method="post" action="" class="js-prevent-multiple-submit">
+    <form method="post" action="" class="js-prevent-multiple-submit js-format-nir">
         <div class="card c-card p-3">
             <div class="card-body">
                 {% if nir %}
                     <div class="form-group form-group-required">
                         <label for="id_nir">Numéro de sécurité sociale du candidat</label>
-                        <input type="nir" name="nir" class="form-control" title="" required="" id="id_nir" disabled value="{{ nir|format_nir }}">
+                        <input id="id_nir" name="nir" class="form-control" disabled value="{{ nir }}">
                     </div>
                 {% endif %}
 
@@ -93,6 +94,7 @@
 {% endblock %}
 
 {% block script %}
+    <script src="{% static 'js/split_nir.js' %}"></script>
     {% if preview_mode %}
         {# Show the confirmation modal after submitting the form. #}
         <script type="text/javascript">


### PR DESCRIPTION
### Quoi ?

![image](https://user-images.githubusercontent.com/20045330/196160263-26786dfe-6a91-4571-8254-e44cc1a9d0a1.png)

### Pourquoi ?

Bien que cela n'a pas d'impact techniquement c'est, à juste titre, déroutant.

### Comment ?

Remplacement du filtre django `format_nir` par l'utilisation du JS déjà existant dans `split_nir.js`.
