### PR TITLE
Supprime les `cached_property` de quelques méthodes du contrôle a posteriori

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -320,7 +320,7 @@ class EvaluatedSiae(models.Model):
     def __str__(self):
         return f"{self.siae}"
 
-    @cached_property
+    @property
     def can_review(self):
         if self.reviewed_at is None:
             return self.state in {
@@ -546,7 +546,7 @@ class EvaluatedJobApplication(models.Model):
         ):
             return evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
 
-    @cached_property
+    @property
     def should_select_criteria(self):
         if self.state == evaluation_enums.EvaluatedJobApplicationsState.PENDING:
             return evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.PENDING

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -970,7 +970,6 @@ class EvaluatedJobApplicationModelTest(TestCase):
             evaluated_job_application.should_select_criteria,
         )
         del evaluated_job_application.state
-        del evaluated_job_application.should_select_criteria
 
         editable_status = [
             evaluation_enums.EvaluatedJobApplicationsState.PROCESSING,
@@ -984,7 +983,6 @@ class EvaluatedJobApplicationModelTest(TestCase):
                         evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.EDITABLE,
                         evaluated_job_application.should_select_criteria,
                     )
-                    del evaluated_job_application.should_select_criteria
 
         not_editable_status = [
             state
@@ -999,7 +997,6 @@ class EvaluatedJobApplicationModelTest(TestCase):
                         evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.NOTEDITABLE,
                         evaluated_job_application.should_select_criteria,
                     )
-                    del evaluated_job_application.should_select_criteria
 
         # REVIEWED
         evaluated_siae = evaluated_job_application.evaluated_siae
@@ -1011,7 +1008,6 @@ class EvaluatedJobApplicationModelTest(TestCase):
             evaluated_job_application.should_select_criteria,
         )
         del evaluated_job_application.state
-        del evaluated_job_application.should_select_criteria
 
         for state in [
             state
@@ -1024,7 +1020,6 @@ class EvaluatedJobApplicationModelTest(TestCase):
                         evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.NOTEDITABLE,
                         evaluated_job_application.should_select_criteria,
                     )
-                    del evaluated_job_application.should_select_criteria
 
     def test_save_selected_criteria(self):
         evaluated_job_application = EvaluatedJobApplicationFactory()


### PR DESCRIPTION
### Quoi ?

Supprime les `cached_property` de quelques méthodes du contrôle a posteriori

### Pourquoi ?

`can_review` et `should_select_criteria` utilisent `state`, qui est une `cached_property`. Ces deux méthodes ne sont pas “chères” et ne méritent pas un cache.