### PR TITLE
Retrait des instructions concernant “DJANGO_SECRET_KEY” du README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,6 @@ dépendances sont bien à jour.
 $ make venv
 ```
 
-La variable d’environnement `DJANGO_SECRET_KEY` doit avoir une valeur. Par
-exemple, à l’aide de :
-
-```sh
-export DJANGO_SECRET_KEY=$(openssl rand -base64 42)
-```
-
 Dans un Virtualenv, vous pouvez utiliser les commandes Django habituelles
 (`./manage.py`) mais également certaines recettes du Makefile, celles-ci
 seront lancées directement dans votre venv si `USE_VENV=1` est utilisé.


### PR DESCRIPTION
### Quoi ?

Retrait des instructions concernant “DJANGO_SECRET_KEY” du README

### Pourquoi ?

Ces instructions ne sont plus utiles, une bonne valeur par défaut a été choisie dans bd61a67522aa80870b1b0631fa1434b74c623576.