### PR TITLE
Autorise la modification des justificatifs pendant la revue de la phase contradictoire

### DIFF
--- a/itou/templates/siae_evaluations/includes/criterion_validation.html
+++ b/itou/templates/siae_evaluations/includes/criterion_validation.html
@@ -12,7 +12,7 @@
                     <i class="ri-share-box-line"></i>
                 </a>
             </div>
-            {% if evaluated_siae.state == "SUBMITTED" or evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}
+            {% if can_edit_proof %}
                 {% if evaluated_administrative_criteria.review_state == 'PENDING' %}
                     <div class="col-lg-2 col-md-2 col-9">
                         <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_administrative_criteria' evaluated_administrative_criteria.pk 'accept' %}">


### PR DESCRIPTION
### Quoi ?

Autorise la modification des justificatifs pendant la revue de la phase contradictoire

### Pourquoi ?

Auparavant, durant la phase contradictoire, cliquer sur le bouton Accepter ou Refuser sur la page de revue des justificatifs pour une candidature enregistrait immédiatement le résultat, sans laisser la possibilité à l’utilisateur de Modifier le justificatif.

Maintenant, tant que la revue n’est pas validée par la DDETS, l’utilisateur peut changer la pièce justificative.