### PR TITLE
Lancer pip-sync seulement sous Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ run:
 $(VIRTUAL_ENV): $(REQUIREMENTS_PATH)
 	$(PYTHON_VERSION) -m venv $@
 	$@/bin/pip install -r $^
-	$@/bin/pip-sync --force $^
+ifeq ($(shell uname -s),Linux)
+	$@/bin/pip-sync $^
+endif
 	touch $@
 
 venv: $(VIRTUAL_ENV)


### PR DESCRIPTION
### Quoi ?

Lancer pip-sync seulement sous Linux

### Pourquoi ?

pip-sync vérifie que seuls les dépendances listées dans un requirements.txt sont installées. Sur les plateformes utilisant le requirements.in comme `REQUIREMENTS_FILE`, le résultat de pip-sync est la désinstallation de nombreuses dépendances.

Refs 7f9f4a86251bc67b2c1eec0bf339d39fb9ac43ac,
https://github.com/betagouv/itou/pull/1571#pullrequestreview-1140870562