### PR TITLE
metabase: Utilise l'adresse de la structure parente à la place de l'antenne

### DIFF
--- a/itou/metabase/management/commands/_siaes.py
+++ b/itou/metabase/management/commands/_siaes.py
@@ -82,7 +82,14 @@ TABLE.add_columns(
     ]
 )
 
-TABLE.add_columns(get_address_columns(comment_suffix=" de la structure"))
+
+def get_structure_mere(siae):
+    if siae.convention and siae.source == Siae.SOURCE_USER_CREATED:
+        return siae.convention.siaes.get(source=Siae.SOURCE_ASP)
+    return siae
+
+
+TABLE.add_columns(get_address_columns(comment_suffix=" de la structure", custom_fn=get_structure_mere))
 
 TABLE.add_columns(
     [

--- a/itou/metabase/management/commands/_utils.py
+++ b/itou/metabase/management/commands/_utils.py
@@ -123,33 +123,33 @@ def get_department_and_region_columns(name_suffix="", comment_suffix="", custom_
     ]
 
 
-def get_address_columns(name_suffix="", comment_suffix=""):
+def get_address_columns(name_suffix="", comment_suffix="", custom_fn=lambda o: o):
     return [
         {
             "name": f"adresse_ligne_1{name_suffix}",
             "type": "varchar",
             "comment": f"Première ligne adresse{comment_suffix}",
-            "fn": lambda o: o.address_line_1,
+            "fn": lambda o: custom_fn(o).address_line_1,
         },
         {
             "name": f"adresse_ligne_2{name_suffix}",
             "type": "varchar",
             "comment": f"Seconde ligne adresse{comment_suffix}",
-            "fn": lambda o: o.address_line_2,
+            "fn": lambda o: custom_fn(o).address_line_2,
         },
         {
             "name": f"code_postal{name_suffix}",
             "type": "varchar",
             "comment": f"Code postal{comment_suffix}",
-            "fn": lambda o: o.post_code,
+            "fn": lambda o: custom_fn(o).post_code,
         },
         {
             "name": f"ville{name_suffix}",
             "type": "varchar",
             "comment": f"Ville{comment_suffix}",
-            "fn": lambda o: o.city,
+            "fn": lambda o: custom_fn(o).city,
         },
-    ] + get_department_and_region_columns(name_suffix, comment_suffix)
+    ] + get_department_and_region_columns(name_suffix, comment_suffix, custom_fn)
 
 
 def get_establishment_last_login_date_column():

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -253,9 +253,10 @@ class Command(BaseCommand):
         """
         queryset = (
             Siae.objects.active()
+            .select_related("convention")
             .prefetch_related(
                 "members",
-                "convention",
+                "convention__siaes",
                 "siaemembership_set",
                 "job_applications_received",
                 "job_applications_received__logs",


### PR DESCRIPTION
Not tested, this is way too much of a hassle.
Refer to the associated branches to see why or come have a chat with me.
