### PR TITLE
Mise à jour du tableau de bord “Sélectionner l’échantillon”

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -342,6 +342,35 @@
                         {% endif %}
                     </ul>
                 </div>
+
+                {% if can_view_stats_ddets and active_campaigns %}
+                    <div class="card">
+                        <p class="h4 card-header">
+                            Contrôle a posteriori
+                            {% if campaign_in_progress %}<span class="badge badge-accent-03 text-primary">Nouveau</span>{% endif %}
+                        </p>
+                        <div class="card-body">
+                            <ul class="list-unstyled">
+                                {% for active_campaign in active_campaigns %}
+                                    {% if active_campaign.evaluations_asked_at %}
+                                        <li class="card-text mb-3">
+                                            <i class="ri-file-copy-2-line ri-lg mr-1"></i>
+                                            <a href="{% url 'siae_evaluations_views:institution_evaluated_siae_list' active_campaign.pk %}">
+                                                {{ active_campaign.name }}
+                                            </a>
+                                        </li>
+                                    {% else %}
+                                        <li class="card-text mb-3">
+                                            <i class="ri-pulse-line ri-lg mr-1"></i>
+                                            <a href="{% url 'siae_evaluations_views:samples_selection' %}">{{ active_campaign|capfirst }}</a>
+                                        </li>
+                                    {% endif %}
+                                {% endfor %}
+
+                            </ul>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
 
         {% endif %}

--- a/itou/templates/siae_evaluations/samples_selection.html
+++ b/itou/templates/siae_evaluations/samples_selection.html
@@ -3,7 +3,7 @@
 {% load bootstrap4 %}
 {% load static %}
 
-{% block title %}{{ institution.name }} Sélectionner l'échantillon {{ block.super }}{% endblock %}
+{% block title %}Sélectionner l’échantillon pour {{ evaluation_campaign }} {{ block.super }}{% endblock %}
 
 {% block content %}
     <div class="card c-card mt-4 p-3">


### PR DESCRIPTION
### Quoi ?

Mise à jour du tableau de bord “Sélectionner l’échantillon”

### Pourquoi ?

Remplace le titre par le nom de la campagne, pour mieux distinguer des campagnes récemment terminées.

### Captures d'écran
![Screenshot from 2022-10-19 16-41-47](https://user-images.githubusercontent.com/2758243/196724178-ecc09216-7671-4ded-b949-34e725a0da9f.png)
![Screenshot from 2022-10-19 16-43-26](https://user-images.githubusercontent.com/2758243/196724188-b7eba91a-f546-4eb1-9ee5-4caa91cb56e5.png)
