### PR TITLE
Renommer docker-compose en docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 
 # Run Docker images
 run:
-	docker-compose up
+	docker compose up
 
 $(VIRTUAL_ENV): $(REQUIREMENTS_PATH)
 	$(PYTHON_VERSION) -m venv $@
@@ -168,13 +168,13 @@ psql_to_csv:
 .PHONY: postgres_backup postgres_backups_cp_locally postgres_backups_list postgres_backup_restore postgres_restore_latest_backup postgres_backups_clean postgres_dump_cities
 
 postgres_backup:
-	docker-compose exec postgres backup
+	docker compose exec postgres backup
 
 postgres_backups_cp_locally:
 	docker cp itou_postgres:/backups ~/Desktop/backups
 
 postgres_backups_list:
-	docker-compose exec postgres backups
+	docker compose exec postgres backups
 
 # - Note: Django must be stopped to avoid a "database "itou" is being accessed by other users" error.
 # make postgres_backup_restore FILE=backup_2019_10_08T12_33_00.sql.gz
@@ -184,9 +184,9 @@ postgres_backups_list:
 postgres_backup_restore:
 	# Copy the backup file in the container first.
 	# Example: docker cp FILE itou_postgres:/backups/
-	docker-compose up -d --no-deps postgres && \
-	docker-compose exec postgres restore $(FILE) && \
-	docker-compose stop
+	docker compose up -d --no-deps postgres && \
+	docker compose exec postgres restore $(FILE) && \
+	docker compose stop
 
 # Download last prod backup and inject it locally.
 # ----------------------------------------------------
@@ -197,7 +197,7 @@ postgres_restore_latest_backup: ./scripts/import-latest-db-backup.sh
 	./scripts/import-latest-db-backup.sh
 
 postgres_backups_clean:
-	docker-compose exec postgres clean
+	docker compose exec postgres clean
 
 postgres_dump_cities:
 	docker exec -ti itou_postgres bash -c "pg_dump --no-owner --no-privileges --data-only -d itou -t cities_city > /backups/cities.sql"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Lors des mises à jour Python (par ex. ajout d'un package à Django), vous devez
 reconstruire (*rebuild*) votre image Docker en exécutant la commande suivante :
 
 ```sh
-docker-compose up --build
+docker compose up --build
 ```
 
 #### Effacer l'ancienne base de données
@@ -89,7 +89,7 @@ docker volume rm itou_postgres_data
 docker volume rm itou_postgres_data_backup
 
 # ou
-docker-compose down -v
+docker compose down -v
 ```
 
 #### Lancer le serveur de développement
@@ -98,13 +98,13 @@ docker-compose down -v
 $ make run
 
 # Équivalent de :
-$ docker-compose up
+$ docker compose up
 ```
 
 Ou pour utiliser [un débogueur interactif](https://github.com/docker/compose/issues/4677#issuecomment-320804194) type `ipdb` :
 
 ```sh
-$ docker-compose run --service-ports django
+$ docker compose run --service-ports django
 ```
 
 ### Accéder au serveur de développement

--- a/docker/dev/postgres/maintenance/backup
+++ b/docker/dev/postgres/maintenance/backup
@@ -3,7 +3,7 @@
 ### Create a database backup.
 ###
 ### Usage:
-###     $ docker-compose -f <environment>.yml (exec |run --rm) postgres backup
+###     $ docker compose -f <environment>.yml (exec |run --rm) postgres backup
 
 set -o errexit
 set -o pipefail

--- a/docker/dev/postgres/maintenance/backups
+++ b/docker/dev/postgres/maintenance/backups
@@ -3,7 +3,7 @@
 ### View backups.
 ###
 ### Usage:
-###     $ docker-compose -f <environment>.yml (exec |run --rm) postgres backups
+###     $ docker compose -f <environment>.yml (exec |run --rm) postgres backups
 
 set -o errexit
 set -o pipefail

--- a/docker/dev/postgres/maintenance/clean
+++ b/docker/dev/postgres/maintenance/clean
@@ -3,7 +3,7 @@
 ### Delete backup files older than 7 days.
 ###
 ### Usage:
-###     $ docker-compose -f <environment>.yml (exec |run --rm) postgres clean
+###     $ docker compose -f <environment>.yml (exec |run --rm) postgres clean
 
 set -o errexit
 set -o pipefail

--- a/docker/dev/postgres/maintenance/restore
+++ b/docker/dev/postgres/maintenance/restore
@@ -6,7 +6,7 @@
 ###     <1> filename of an existing backup.
 ###
 ### Usage:
-###     $ docker-compose -f <environment>.yml (exec |run --rm) postgres restore <1>
+###     $ docker compose -f <environment>.yml (exec |run --rm) postgres restore <1>
 
 set -o errexit
 set -o pipefail

--- a/scripts/import-latest-db-backup.sh
+++ b/scripts/import-latest-db-backup.sh
@@ -21,7 +21,7 @@ ITOU_DB_BACKUP_PATH=$PATH_TO_ITOU_BACKUPS/backups/$ITOU_DB_BACKUP_NAME
 
 echo "Going to inject ITOU_DB_BACKUP_PATH=$ITOU_DB_BACKUP_PATH"
 
-docker cp $ITOU_DB_BACKUP_PATH itou_postgres:/backups && docker-compose -f docker-compose.yml down && make postgres_backup_restore FILE=$ITOU_DB_BACKUP_NAME; echo "Ignore warnings above."
+docker cp $ITOU_DB_BACKUP_PATH itou_postgres:/backups && docker compose down && make postgres_backup_restore FILE=$ITOU_DB_BACKUP_NAME; echo "Ignore warnings above."
 
 cat << EOF
 


### PR DESCRIPTION
### Quoi ?

Utilisation de [la « nouvelle » version de Docker compose](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command) au lieu de l'ancien projet qui est déprécié.


### Pourquoi ?

Pragmatiquement, pour faire marcher mon environnement local qui ne contient plus docker-compose.
