### PR TITLE
templates: Fix regression on Select2MultipleWidget

### DIFF
--- a/itou/templates/apply/list_for_prescriber.html
+++ b/itou/templates/apply/list_for_prescriber.html
@@ -86,5 +86,7 @@
 
 {% block script %}
     {{ block.super }}
+    <!-- Needed to use Select2MultipleWidget. -->
+    {{ filters_form.media.js }}
     <script src='{% static "js/job_applications_filters.js" %}'></script>
 {% endblock %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -120,5 +120,7 @@
 
 {% block script %}
     {{ block.super }}
+    <!-- Needed to use Select2MultipleWidget. -->
+    {{ filters_form.media.js }}
     <script src='{% static "js/job_applications_filters.js" %}'></script>
 {% endblock %}


### PR DESCRIPTION
### Quoi ?

Le `{{ filters_form.media.js }}` ne servait en fait pas que pour le date picker :)

### Captures d'écran (optionnel)
Avec le bug  : 
![Screenshot from 2022-10-21 12-09-18](https://user-images.githubusercontent.com/7632730/197171562-0a96347a-cf2f-452c-bb0c-5cd5789cb722.png)

Une fois corrigé (aka comme avant la regression):
![Screenshot from 2022-10-21 12-08-53](https://user-images.githubusercontent.com/7632730/197171631-c1a5b1ad-9675-450a-a88b-14216feafca9.png)