### PR TITLE
Suppression de JobSeekerExternalDataAdmin

### DIFF
--- a/itou/external_data/admin.py
+++ b/itou/external_data/admin.py
@@ -10,12 +10,6 @@ class ExternalDataImportAdmin(admin.ModelAdmin):
     list_filter = ("source", "status")
 
 
-@admin.register(models.JobSeekerExternalData)
-class JobSeekerExternalDataAdmin(admin.ModelAdmin):
-    raw_id_fields = ("user",)
-    list_display = ("pk", "data_import", "created_at")
-
-
 @admin.register(models.RejectedEmailEventData)
 class RejectedEmailEventDataAdmin(admin.ModelAdmin):
     list_filter = ("reason",)


### PR DESCRIPTION
### Quoi ?

Retirer une page de l'admin qui ne fonctionne pas (trop de FK à charger dans un champ du formulaire d'édition).
Comme elle ne marche pas depuis un moment, personne ne l'utilise, ni n'en voit l'usage. Autant la supprimer.

### Pourquoi ?

La page ne charge pas (chargement trop long)

### Comment ?


### Captures d'écran (optionnel)



### Autre (optionnel)
