### PR TITLE
Utilisation de Bootstrap pour afficher/masquer la sélection du ratio de contrôle a posteriori

### DIFF
--- a/itou/static/js/siae_evaluations_sample_selection.js
+++ b/itou/static/js/siae_evaluations_sample_selection.js
@@ -13,15 +13,11 @@
     }
   }
 
-  function optOutToggle() {
-    const ratioSection = document.getElementById("ratio-select");
-    document.getElementById("id_opt_out").addEventListener("change", function (e) {
-      ratioSection.classList.toggle("d-none", e.target.checked);
-      showConfirm = !e.target.checked;
-    })
-  }
-
   function initConfirmModal() {
+    document.getElementById("id_opt_out").addEventListener("change", function (e) {
+      showConfirm = !e.target.checked;
+    });
+
     document.getElementById("ratio-form").addEventListener("submit", function (e) {
       const text = "Le ratio sélectionné ne sera plus modifiable pour cette campagne de contrôle. Confirmez-vous son enregistrement ?";
       if (showConfirm && !window.confirm(text)) {
@@ -35,6 +31,5 @@
   }
 
   initSlider();
-  optOutToggle();
   initConfirmModal();
 })()

--- a/itou/templates/siae_evaluations/samples_selection.html
+++ b/itou/templates/siae_evaluations/samples_selection.html
@@ -67,7 +67,7 @@
 
                     {% bootstrap_form_errors form alert_error_type="all" %}
 
-                    <div id="ratio-select">
+                    <div id="ratio-select" class="collapse show">
                         <h3>Validation de l'échantillon des SIAE</h3>
                         <p>
                             Pour initier le contrôle a posteriori des auto-prescriptions, nous avons besoin de connaître le pourcentage

--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.conf import settings
+from django.forms import widgets
 from django.utils import timezone
 
 from itou.siae_evaluations import enums as evaluation_enums
@@ -7,7 +8,18 @@ from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria, Evalua
 
 
 class SetChosenPercentForm(forms.ModelForm):
-    opt_out = forms.BooleanField(label="Je choisis de ne pas débuter le contrôle", required=False)
+    opt_out = forms.BooleanField(
+        label="Je choisis de ne pas débuter le contrôle",
+        required=False,
+        widget=widgets.CheckboxInput(
+            attrs={
+                "aria-expanded": "true",
+                "aria-controls": "ratio-select",
+                "data-target": "#ratio-select",
+                "data-toggle": "collapse",
+            }
+        ),
+    )
 
     class Meta:
         model = EvaluationCampaign


### PR DESCRIPTION
### Quoi ?

Utilisation de Bootstrap pour afficher/masquer la sélection du ratio de contrôle a posteriori

### Pourquoi ?

Améliore l’accessibilité du code, permet d’avoir les transitions et de faciliter la maintenance en retirant un peu de de code JavaScript.

### Captures d'écran
[Screencast from 10-24-2022 11:47:43 AM.webm](https://user-images.githubusercontent.com/2758243/197500069-0b8e2c90-27b5-44d6-b497-41aebb02c976.webm)
