### PR TITLE
Amélioration de l'affichage des utilisateurs sur la page d'admin des pass IAE

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -286,7 +286,7 @@ class User(AbstractUser, AddressMixin):
     objects = ItouUserManager()
 
     def __str__(self):
-        return str(self.email)
+        return f"{self.get_full_name()} ({self.email})"
 
     def clean(self):
         """


### PR DESCRIPTION
### Quoi ?

Affichage des noms et prénoms des utilisateurs dans l'admin (au lieu de juste l'email).

### Pourquoi ?

le nom et le prénom du candidat n’est pas visible sur la page du PASS dans l’admin

### Comment ?

Attention : cela impacte TOUTES les pages de l'admin.

### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.

### Autre (optionnel)

- si des tests manquent, indiquer la raison, la probabilité, et les risques associés à ce manque
- être explicite sur le délai attendu pour une revue de code
- être explicite sur la qualité attendue pour la revue de code
- etc.
