### PR TITLE
Amélioration des performances pour le filtre "PASS IAE actif" pour le listing des candidatures

### DIFF
--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -379,23 +379,6 @@ class JobApplicationQuerySetTest(TestCase):
         self.assertTrue(hasattr(qs, "has_suspended_approval"))
         self.assertFalse(qs.has_suspended_approval)
 
-    def test_with_has_active_approval(self):
-        job_app = JobApplicationSentByJobSeekerFactory()
-        qs = JobApplication.objects.with_has_suspended_approval().with_has_active_approval().get(pk=job_app.pk)
-        self.assertTrue(hasattr(qs, "has_active_approval"))
-        self.assertFalse(qs.has_active_approval)
-
-        job_app = JobApplicationWithApprovalFactory()
-        qs = JobApplication.objects.with_has_suspended_approval().with_has_active_approval().get(pk=job_app.pk)
-        self.assertTrue(hasattr(qs, "has_active_approval"))
-        self.assertTrue(qs.has_active_approval)
-
-        job_app = JobApplicationWithApprovalFactory()
-        SuspensionFactory(approval=job_app.approval)
-        qs = JobApplication.objects.with_has_suspended_approval().with_has_active_approval().get(pk=job_app.pk)
-        self.assertTrue(hasattr(qs, "has_active_approval"))
-        self.assertFalse(qs.has_active_approval)
-
     def test_with_last_change(self):
         job_app = JobApplicationSentByJobSeekerFactory()
         qs = JobApplication.objects.with_last_change().get(pk=job_app.pk)
@@ -490,7 +473,6 @@ class JobApplicationQuerySetTest(TestCase):
         self.assertTrue(hasattr(qs, "selected_jobs"))
         self.assertTrue(hasattr(qs, "has_suspended_approval"))
         self.assertTrue(hasattr(qs, "is_pending_for_too_long"))
-        self.assertTrue(hasattr(qs, "has_active_approval"))
         self.assertTrue(hasattr(qs, "last_jobseeker_eligibility_diagnosis"))
         self.assertTrue(hasattr(qs, f"last_eligibility_diagnosis_criterion_{level1_criterion.pk}"))
         self.assertTrue(hasattr(qs, f"last_eligibility_diagnosis_criterion_{level2_criterion.pk}"))

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -598,7 +598,10 @@ class FilterJobApplicationsForm(forms.Form):
             # Filter on the `has_suspended_approval` annotation, which is set in `with_list_related_data()`.
             filters["has_suspended_approval"] = True
         if data.get("pass_iae_active"):
-            filters["has_active_approval"] = True
+            # Simplification of CommonApprovalQuerySet.valid_lookup()
+            filters["approval__end_at__gte"] = timezone.now().date()
+            # The date is not enough to know if an approval is valid or not
+            filters["has_suspended_approval"] = False
         if data.get("eligibility_validated"):
             filters["last_jobseeker_eligibility_diagnosis__isnull"] = False
         if data.get("start_date"):


### PR DESCRIPTION
### Quoi ?

Remplacement d'une boucle de sous-requêtes par des clauses `WHERE`.
Dans mes tests on passe de ~8s à moins de 200ms.

### Pourquoi ?

Ralentissement notable et généralisé du site.

### Autres

Cette page à d'autre problème de performance qui couvent mais je n'ai pas trouvé de moyen simple de les corriger :
1. Le `.prefect_related()` de `.with_list_related_data()` récupère pour toutes les candidatures (ie: 3k+) et pas juste celles filtrées (ie: 500+)
https://github.com/betagouv/itou/blob/80e56f1f9d71a84cf4feb5bf101ba5c63f19bc72/itou/www/apply/views/list_views.py#L115-L117
2. `.with_has_suspended_approval()` fait aussi une boucle de sous-requête mais il y a moins d'objet donc ça devrait tenir pour le moment
https://github.com/betagouv/itou/blob/80e56f1f9d71a84cf4feb5bf101ba5c63f19bc72/itou/job_applications/models.py#L154-L156