### PR TITLE
Sanction des campagnes de contrôle a posteriori

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -139,9 +139,20 @@ class EvaluationCampaignAdmin(admin.ModelAdmin):
 class EvaluatedSiaeAdmin(admin.ModelAdmin):
     list_display = ("evaluation_campaign", "siae", "reviewed_at")
     list_display_links = ("siae",)
-    readonly_fields = ("evaluation_campaign", "siae", "reviewed_at", "final_reviewed_at", "state")
+    readonly_fields = (
+        "evaluation_campaign",
+        "siae",
+        "reviewed_at",
+        "final_reviewed_at",
+        "state",
+        "notified_at",
+        "notification_reason",
+        "notification_text",
+    )
     list_filter = (
         "reviewed_at",
+        "notified_at",
+        "notification_reason",
         "evaluation_campaign__institution__department",
     )
     search_fields = ("siae__name",)

--- a/itou/siae_evaluations/enums.py
+++ b/itou/siae_evaluations/enums.py
@@ -50,6 +50,14 @@ class EvaluatedSiaeState(models.TextChoices):
     ACCEPTED = "ACCEPTED"
     REFUSED = "REFUSED"
     ADVERSARIAL_STAGE = "ADVERSARIAL_STAGE"
+    NOTIFICATION_PENDING = "NOTIFICATION_PENDING"
+
+
+class EvaluatedSiaeNotificationReason(models.TextChoices):
+    DELAY = ("DELAY", "Non respect des délais")
+    INVALID_PROOF = ("INVALID_PROOF", "Pièce justificative incorrecte")
+    MISSING_PROOF = ("MISSING_PROOF", "Pièce justificative manquante")
+    OTHER = ("OTHER", "Autre")
 
 
 class EvaluatedAdministrativeCriteriaState(models.TextChoices):

--- a/itou/siae_evaluations/factories.py
+++ b/itou/siae_evaluations/factories.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from itou.eligibility.models import AdministrativeCriteria
 from itou.institutions.factories import InstitutionFactory
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
-from itou.siae_evaluations import enums as evaluation_enums, models
+from itou.siae_evaluations import models
 from itou.siaes.factories import SiaeFactory
 
 
@@ -34,7 +34,7 @@ class EvaluatedSiaeFactory(factory.django.DjangoModelFactory):
         model = models.EvaluatedSiae
 
     class Params:
-        accepted = factory.Trait(
+        complete = factory.Trait(
             evaluation_campaign=factory.SubFactory(
                 EvaluationCampaignFactory,
                 evaluations_asked_at=factory.LazyFunction(lambda: timezone.now() - relativedelta(weeks=12)),
@@ -43,7 +43,7 @@ class EvaluatedSiaeFactory(factory.django.DjangoModelFactory):
             job_app=factory.RelatedFactory(
                 "itou.siae_evaluations.factories.EvaluatedJobApplicationFactory",
                 factory_related_name="evaluated_siae",
-                accepted=True,
+                complete=True,
             ),
             reviewed_at=factory.LazyFunction(timezone.now),
             final_reviewed_at=factory.LazyFunction(timezone.now),
@@ -58,7 +58,7 @@ class EvaluatedJobApplicationFactory(factory.django.DjangoModelFactory):
         model = models.EvaluatedJobApplication
 
     class Params:
-        accepted = factory.Trait(
+        complete = factory.Trait(
             criteria=factory.RelatedFactory(
                 "itou.siae_evaluations.factories.EvaluatedAdministrativeCriteriaFactory",
                 factory_related_name="evaluated_job_application",
@@ -70,7 +70,6 @@ class EvaluatedJobApplicationFactory(factory.django.DjangoModelFactory):
                     lambda siae: siae.factory_parent.evaluated_siae.evaluation_campaign.ended_at
                     - relativedelta(days=5)
                 ),
-                review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
             )
         )
 

--- a/itou/siae_evaluations/migrations/0011_evaluatedsiae_notification.py
+++ b/itou/siae_evaluations/migrations/0011_evaluatedsiae_notification.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siae_evaluations", "0010_finalize_evaluation_campaign_2021"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evaluatedsiae",
+            name="notification_reason",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("DELAY", "Non respect des délais"),
+                    ("INVALID_PROOF", "Pièce justificative incorrecte"),
+                    ("MISSING_PROOF", "Pièce justificative manquante"),
+                    ("OTHER", "Autre"),
+                ],
+                max_length=255,
+                null=True,
+                verbose_name="raison principale",
+            ),
+        ),
+        migrations.AddField(
+            model_name="evaluatedsiae",
+            name="notification_text",
+            field=models.TextField(blank=True, null=True, verbose_name="commentaire"),
+        ),
+        migrations.AddField(
+            model_name="evaluatedsiae",
+            name="notified_at",
+            field=models.DateTimeField(blank=True, null=True, verbose_name="notifiée le"),
+        ),
+    ]

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -497,7 +497,7 @@
                 </div>
             </div>
 
-            {% if active_campaigns %}
+            {% if active_campaigns or evaluated_siae_notifications %}
                 <div class="card c-card has-links-inside">
                     <p class="h4 card-header">
                         Contrôle a posteriori <span class="badge badge-accent-03 text-primary">Nouveau</span>
@@ -512,6 +512,13 @@
                                     </a>
                                     {# note vincentporte: static icon, will be displayed dynamically later.#}
                                     <i class="ri-error-warning-fill ri-lg mr-1 text-danger"></i>
+                                </li>
+                            {% endfor %}
+                            {% for evaluated_siae in evaluated_siae_notifications %}
+                                <li class="card-text mb-3">
+                                    <a href="{% url "siae_evaluations_views:siae_sanction" evaluated_siae.pk %}">
+                                        Voir le résultat du contrôle “{{ evaluated_siae.evaluation_campaign.name }}”
+                                    </a>
                                 </li>
                             {% endfor %}
                         </ul>

--- a/itou/templates/siae_evaluations/email/to_siae_sanctioned_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_sanctioned_body.txt
@@ -1,0 +1,10 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+Le résultat de la campagne de contrôle a posteriori “{{ evaluation_campaign.name }}” est disponible.
+Rendez-vous sur le tableau de bord de {{ siae.kind }} {{ siae.name }} ID-{{ siae.pk }}, à la rubrique « Voir le résultat du contrôle “{{ evaluation_campaign.name }}” ».
+{{ dashboard_url }}
+
+Cordialement,
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/to_siae_sanctioned_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_sanctioned_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+Résultat du contrôle - {{ siae.kind }} {{ siae.name }} ID-{{ siae.pk }}
+{% endblock %}

--- a/itou/templates/siae_evaluations/evaluated_siae_sanction.html
+++ b/itou/templates/siae_evaluations/evaluated_siae_sanction.html
@@ -1,0 +1,38 @@
+{% extends "layout/content.html" %}
+
+{% block title %}
+    Résultat de la campagne de contrôle a posteriori {{ evaluated_siae.evaluation_campaign }}{{ block.super }}
+{% endblock %}
+
+{% block content %}
+    <div class="row justify-content-center">
+        <div class="col-lg-8 col-md-10 col-12">
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="card">
+                        <div class="card-header">
+                            <h1>Résultat de la campagne de contrôle a posteriori {{ evaluated_siae.evaluation_campaign.name }}</h1>
+                        </div>
+                        <div class="card-body">
+                            <p>
+                                <b>Résultat :</b> <b class="text-danger">Négatif</b>
+                            </p>
+                            <p>
+                                <b>Raison principale :</b> <b class="text-info">{{ evaluated_siae.get_notification_reason_display }}</b>
+                            </p>
+                            <p>
+                                <b>Commentaire de votre DDETS</b>
+                                <div class="card">
+                                    <div class="card-body">{{ evaluated_siae.notification_text }}</div>
+                                </div>
+                            </p>
+                        </div>
+                        <div class="card-body">
+                            <a class="btn btn-primary float-right" href="{% url "dashboard:index" %}">Revenir au tableau de bord</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/itou/templates/siae_evaluations/includes/siae_infos.html
+++ b/itou/templates/siae_evaluations/includes/siae_infos.html
@@ -5,11 +5,13 @@
     <div class="col-lg-3 col-md-3 col-4">
         <p class="small mb-0">
             {% if evaluated_siae.evaluation_is_final %}
-                <p class="badge{% if evaluated_siae.state == "ACCEPTED" %} badge-success{% else %} badge-danger{% endif %} float-right">
+                <p class="badge badge-pill{% if evaluated_siae.state == "ACCEPTED" %} badge-success{% elif evaluated_siae.state == "NOTIFICATION_PENDING" %} badge-accent-03 text-primary{% else %} badge-danger{% endif %} float-right">
                     {% if evaluated_siae.state == "ACCEPTED" %}
-                        Résultat positif
+                        <i class="ri-checkbox-circle-line mr-1"></i> Résultat positif
                     {% elif evaluated_siae.state == "REFUSED" %}
-                        Résultat négatif
+                        <i class="ri-close-circle-line mr-1"></i> Résultat négatif
+                    {% elif evaluated_siae.state == "NOTIFICATION_PENDING" %}
+                        <i class="ri-arrow-right-circle-line mr-1"></i> Notification à faire
                     {% else %}
                         Non contrôlée
                     {% endif %}

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
@@ -114,7 +114,7 @@
                                     <a href="{% url 'siae_evaluations_views:institution_evaluated_job_application' evaluated_job_application.pk %}" class="btn btn-outline-primary btn-sm float-right">
                                         Contrôler cette auto-prescription
                                     </a>
-                                {% elif evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" or evaluated_siae.state == "ADVERSARIAL_STAGE" %}
+                                {% elif evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" or evaluated_siae.state == "ADVERSARIAL_STAGE" or evaluated_siae.state == "NOTIFICATION_PENDING" %}
                                     <a href="{% url 'siae_evaluations_views:institution_evaluated_job_application' evaluated_job_application.pk %}" class="btn btn-outline-primary btn-sm float-right">
                                         Revoir ses justificatifs
                                     </a>

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
@@ -36,19 +36,29 @@
                                 {% include "siae_evaluations/includes/siae_infos.html" with evaluated_siae=evaluated_siae %}
                             </div>
                             <div class="card-body">
-                                <a href="{% url 'siae_evaluations_views:institution_evaluated_siae_detail' evaluated_siae.pk %}" class="btn btn-outline-primary btn-sm float-right">
-                                    {% if evaluated_siae.evaluation_is_final %}
-                                        Voir le résultat
-                                    {% else %}
-                                        {% if evaluated_siae.state == "SUBMITTED" or evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}
-                                            Contrôler cette SIAE
-                                        {% elif evaluated_siae.state == "ADVERSARIAL_STAGE" %}
-                                            Revoir ses justificatifs
-                                        {% else %}
-                                            Voir
-                                        {% endif %}
+                                <div class="float-right">
+                                    {% if evaluated_siae.state == "REFUSED" and evaluated_siae.notified_at %}
+                                        <a class="btn btn-outline-primary btn-sm mr-1" href="{% url "siae_evaluations_views:institution_evaluated_siae_sanction" evaluated_siae.pk %}">Voir la notification de sanction</a>
                                     {% endif %}
-                                </a>
+                                    <a href="{% url 'siae_evaluations_views:institution_evaluated_siae_detail' evaluated_siae.pk %}" class="btn btn-outline-primary btn-sm">
+                                        {% if evaluated_siae.evaluation_is_final %}
+                                            Voir le résultat
+                                        {% else %}
+                                            {% if evaluated_siae.state == "SUBMITTED" or evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}
+                                                Contrôler cette SIAE
+                                            {% elif evaluated_siae.state == "ADVERSARIAL_STAGE" %}
+                                                Revoir ses justificatifs
+                                            {% else %}
+                                                Voir
+                                            {% endif %}
+                                        {% endif %}
+                                    </a>
+                                    {% if evaluated_siae.state == "NOTIFICATION_PENDING" %}
+                                        <a class="btn btn-primary btn-sm ml-1" href="{% url "siae_evaluations_views:institution_evaluated_siae_notify" evaluated_siae.pk %}">
+                                            <i class="ri-notification-4-line"></i> Notifier le résultat
+                                        </a>
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_notify.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_notify.html
@@ -1,0 +1,31 @@
+{% extends "layout/content.html" %}
+
+{% load bootstrap4 %}
+
+{% block title %}Notifier la sanction du contrôle pour {{ evaluated_siae }}{{ block.super }}{% endblock %}
+
+{% block content %}
+    <div class="row justify-content-center">
+        <div class="col-lg-8 col-md-10 col-12">
+            <div class="row mt-3">
+                <div class="col-12">
+                    <h1>
+                        Notifier la sanction du contrôle pour <span class="text-muted">{{ evaluated_siae }}</span>
+                    </h1>
+                    <h2>
+                        Résultat de la campagne : <b class="text-danger">Négatif</b>
+                    </h2>
+                    {% bootstrap_form_errors form type="all" %}
+                    <form method="post">
+                        {% csrf_token %}
+                        {% bootstrap_form form %}
+                        <a class="btn btn-link" href="{% url "siae_evaluations_views:institution_evaluated_siae_list" evaluated_siae.evaluation_campaign_id %}">
+                            Revenir à la liste
+                        </a>
+                        <button class="btn btn-primary float-right">Envoyer ce résultat</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/itou/www/siae_evaluations_views/tests/test_views.py
+++ b/itou/www/siae_evaluations_views/tests/test_views.py
@@ -1,0 +1,113 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from itou.institutions.factories import InstitutionMembershipFactory
+from itou.siae_evaluations import enums as evaluation_enums
+from itou.siae_evaluations.factories import EvaluatedSiaeFactory
+from itou.siaes.factories import SiaeMembershipFactory
+
+
+class EvaluatedSiaeSanctionViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        institution_membership = InstitutionMembershipFactory(institution__name="DDETS 87")
+        cls.institution_user = institution_membership.user
+        siae_membership = SiaeMembershipFactory(siae__name="Les petits jardins")
+        cls.siae_user = siae_membership.user
+        cls.evaluated_siae = EvaluatedSiaeFactory(
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.REFUSED_2,
+            evaluation_campaign__institution=institution_membership.institution,
+            evaluation_campaign__name="Contrôle 2022",
+            siae=siae_membership.siae,
+            notified_at=timezone.now(),
+            notification_reason=evaluation_enums.EvaluatedSiaeNotificationReason.INVALID_PROOF,
+            notification_text="A envoyé une photo de son chat. Séparé de son chat pendant une journée.",
+        )
+
+    def assertSanctionContent(self, response):
+        self.assertContains(
+            response,
+            "<h1>Résultat de la campagne de contrôle a posteriori Contrôle 2022</h1>",
+            count=1,
+        )
+        self.assertContains(
+            response,
+            '<b>Résultat :</b> <b class="text-danger">Négatif</b>',
+            count=1,
+        )
+        self.assertContains(
+            response,
+            '<b>Raison principale :</b> <b class="text-info">Pièce justificative incorrecte</b>',
+            count=1,
+        )
+        self.assertContains(
+            response,
+            """
+            <b>Commentaire de votre DDETS</b>
+            <div class="card">
+                <div class="card-body">A envoyé une photo de son chat. Séparé de son chat pendant une journée.</div>
+            </div>
+            """,
+            html=True,
+            count=1,
+        )
+
+    def test_anonymous_view_siae(self):
+        url = reverse(
+            "siae_evaluations_views:siae_sanction",
+            kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
+        )
+        response = self.client.get(url)
+        self.assertRedirects(response, reverse("account_login") + f"?next={url}")
+
+    def test_anonymous_view_institution(self):
+        url = reverse(
+            "siae_evaluations_views:institution_evaluated_siae_sanction",
+            kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
+        )
+        response = self.client.get(url)
+        self.assertRedirects(response, reverse("account_login") + f"?next={url}")
+
+    def test_view_as_institution(self):
+        self.client.force_login(self.institution_user)
+        response = self.client.get(
+            reverse(
+                "siae_evaluations_views:institution_evaluated_siae_sanction",
+                kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
+            )
+        )
+        self.assertSanctionContent(response)
+
+    def test_view_as_other_institution(self):
+        other = InstitutionMembershipFactory()
+        self.client.force_login(other.user)
+        response = self.client.get(
+            reverse(
+                "siae_evaluations_views:institution_evaluated_siae_sanction",
+                kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
+            )
+        )
+        assert response.status_code == 404
+
+    def test_view_as_siae(self):
+        self.client.force_login(self.siae_user)
+        response = self.client.get(
+            reverse(
+                "siae_evaluations_views:siae_sanction",
+                kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
+            )
+        )
+        self.assertSanctionContent(response)
+
+    def test_view_as_other_siae(self):
+        siae_membership = SiaeMembershipFactory()
+        self.client.force_login(siae_membership.user)
+        response = self.client.get(
+            reverse(
+                "siae_evaluations_views:siae_sanction",
+                kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
+            )
+        )
+        assert response.status_code == 404

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -230,7 +230,8 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
 
     def test_recently_closed_campaign(self):
         evaluated_siae = EvaluatedSiaeFactory(
-            accepted=True,
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
             evaluation_campaign__institution=self.institution,
         )
         self.client.force_login(self.user)
@@ -259,7 +260,8 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
 
     def test_closed_campaign(self):
         evaluated_siae = EvaluatedSiaeFactory(
-            accepted=True,
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
             evaluation_campaign__institution=self.institution,
             evaluation_campaign__ended_at=timezone.now() - CAMPAIGN_VIEWABLE_DURATION,
         )
@@ -444,7 +446,8 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
 
     def test_recently_closed_campaign(self):
         evaluated_siae = EvaluatedSiaeFactory(
-            accepted=True,
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
             evaluation_campaign__institution=self.institution,
         )
         job_app = evaluated_siae.evaluated_job_applications.get()
@@ -585,7 +588,8 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
 
     def test_closed_campaign(self):
         evaluated_siae = EvaluatedSiaeFactory(
-            accepted=True,
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
             evaluation_campaign__institution=self.institution,
             evaluation_campaign__ended_at=timezone.now() - CAMPAIGN_VIEWABLE_DURATION,
         )
@@ -998,7 +1002,11 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_recently_closed_campaign(self):
-        evaluated_siae = EvaluatedSiaeFactory(accepted=True, evaluation_campaign__institution=self.institution)
+        evaluated_siae = EvaluatedSiaeFactory(
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
+            evaluation_campaign__institution=self.institution,
+        )
         job_app = evaluated_siae.evaluated_job_applications.get()
         self.client.force_login(self.user)
         response = self.client.get(
@@ -1025,7 +1033,8 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
 
     def test_post_recently_closed_campaign(self):
         evaluated_siae = EvaluatedSiaeFactory(
-            accepted=True,
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
             evaluation_campaign__institution=self.institution,
         )
         job_app = evaluated_siae.evaluated_job_applications.get()
@@ -1041,7 +1050,8 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
 
     def test_access_closed_campaign(self):
         evaluated_siae = EvaluatedSiaeFactory(
-            accepted=True,
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
             evaluation_campaign__institution=self.institution,
             evaluation_campaign__ended_at=timezone.now() - CAMPAIGN_VIEWABLE_DURATION,
         )
@@ -1127,7 +1137,11 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.assertContains(response, self.btn_modifier_html, html=True, count=1)
 
     def test_evaluations_from_previous_campaigns_read_only(self):
-        evaluated_siae = EvaluatedSiaeFactory(accepted=True, evaluation_campaign__institution=self.institution)
+        evaluated_siae = EvaluatedSiaeFactory(
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
+            evaluation_campaign__institution=self.institution,
+        )
         past_job_application = evaluated_siae.evaluated_job_applications.get()
 
         self.client.force_login(self.user)
@@ -1155,7 +1169,11 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         )
 
     def test_post_to_evaluations_from_previous_campaigns(self):
-        evaluated_siae = EvaluatedSiaeFactory(accepted=True, evaluation_campaign__institution=self.institution)
+        evaluated_siae = EvaluatedSiaeFactory(
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
+            evaluation_campaign__institution=self.institution,
+        )
         past_job_application = evaluated_siae.evaluated_job_applications.get()
 
         self.client.force_login(self.user)
@@ -1295,7 +1313,8 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
     def test_post_on_closed_campaign(self):
         self.client.force_login(self.user)
         evaluated_siae = EvaluatedSiaeFactory(
-            accepted=True,
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
             evaluation_campaign__institution=self.institution,
         )
         job_app = evaluated_siae.evaluated_job_applications.get()

--- a/itou/www/siae_evaluations_views/urls.py
+++ b/itou/www/siae_evaluations_views/urls.py
@@ -19,6 +19,23 @@ urlpatterns = [
         name="institution_evaluated_siae_detail",
     ),
     path(
+        "institution_evaluated_siae_notify/<int:evaluated_siae_pk>/",
+        views.InstitutionEvaluatedSiaeNotifyView.as_view(),
+        name="institution_evaluated_siae_notify",
+    ),
+    path(
+        "institution_evaluated_siae_sanction/<int:evaluated_siae_pk>/",
+        views.evaluated_siae_sanction,
+        {"viewer_type": "institution"},
+        name="institution_evaluated_siae_sanction",
+    ),
+    path(
+        "evaluated_siae_sanction/<int:evaluated_siae_pk>/",
+        views.evaluated_siae_sanction,
+        {"viewer_type": "siae"},
+        name="siae_sanction",
+    ),
+    path(
         "institution_evaluated_job_application/<int:evaluated_job_application_pk>/",
         views.institution_evaluated_job_application,
         name="institution_evaluated_job_application",


### PR DESCRIPTION
### Quoi ?

Implémente le processus des sanction des campagnes de contrôle a posteriori

Après un résultat négatif d’évaluation, la DDETS applique des sanctions à la SIAE contrevenante. Les sanctions sont annoncées par une notification. Dans la liste des SIAE contrôlées, le système affiche maintenant “Notification à faire” là où “Résultat négatif” était affiché.

Lorsque l’utilisateur de la DDETS clique sur le bouton notifier, il est dirigé vers une page pour renseigner la raison principale du refus et les détails de la sanctions. Une fois la sanction enregistrée, un email est envoyé aux membres de la SIAE contrôlé pour annoncer la disponibilité des résultats sur leur tableau de bord.

Les membres de la SIAE peuvent alors se connecter et voir le résultat de la sanction.

### Captures d'écran

#### Liste des SIAE contrôlées, notifier la sanction
![Screenshot from 2022-10-25 12-40-13](https://user-images.githubusercontent.com/2758243/197753125-529d8f98-fe16-4294-af3f-5c8351767fae.png)

#### Notification de sanction

![Screenshot from 2022-10-25 12-40-21](https://user-images.githubusercontent.com/2758243/197753223-5216c539-183a-4a4b-82ef-24a1c7e0c314.png)

#### Résultat négatif

![Screenshot from 2022-10-25 12-39-56](https://user-images.githubusercontent.com/2758243/197753272-620809ad-2427-47eb-811c-47c95356b34e.png)

#### Tableau de bord SIAE, voir le résultat

![Screenshot from 2022-10-25 12-39-42](https://user-images.githubusercontent.com/2758243/197753055-92d85cc7-7c48-48f5-bdd0-6e4af371313d.png)

#### Vue de la notification de sanction

![Screenshot from 2022-10-25 12-45-40](https://user-images.githubusercontent.com/2758243/197753585-190a929f-1b9e-464c-92ce-d51b2d79f68c.png)
