### PR TITLE
Réparation de l’envoi d’email pour les campagnes de contrôle a posteriori

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -264,7 +264,7 @@ class EvaluationCampaign(models.Model):
     # fixme vincentporte : to refactor. move all get_email_to_institution_xxx() method
     # to emails.py in institution model
     def get_email_to_institution_ratio_to_select(self, ratio_selection_end_at):
-        to = self.institution.active_members
+        to = self.institution.active_members.values_list("email", flat=True)
         context = {
             "ratio_selection_end_at": ratio_selection_end_at,
             "dashboard_url": f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{reverse('dashboard:index')}",
@@ -274,7 +274,7 @@ class EvaluationCampaign(models.Model):
         return get_email_message(to, context, subject, body)
 
     def get_email_to_institution_selected_siae(self):
-        to = self.institution.active_members
+        to = self.institution.active_members.values_list("email", flat=True)
         context = {
             # end_date for eligible siaes to return their documents of proofs is 6 weeks after notification
             "end_date": self.evaluations_asked_at + relativedelta(weeks=6),
@@ -379,7 +379,7 @@ class EvaluatedSiae(models.Model):
 
     # fixme vincentporte : to refactor. move all get_email_to_siae_xxx() method to emails.py in siae model
     def get_email_to_siae_selected(self):
-        to = self.siae.active_admin_members
+        to = self.siae.active_admin_members.values_list("email", flat=True)
         evaluated_siae_url = reverse(
             "siae_evaluations_views:siae_job_applications_list",
             kwargs={"evaluated_siae_pk": self.pk},
@@ -396,14 +396,14 @@ class EvaluatedSiae(models.Model):
         return get_email_message(to, context, subject, body)
 
     def get_email_to_siae_reviewed(self, adversarial=False):
-        to = self.siae.active_admin_members
+        to = self.siae.active_admin_members.values_list("email", flat=True)
         context = {"evaluation_campaign": self.evaluation_campaign, "siae": self.siae, "adversarial": adversarial}
         subject = "siae_evaluations/email/to_siae_reviewed_subject.txt"
         body = "siae_evaluations/email/to_siae_reviewed_body.txt"
         return get_email_message(to, context, subject, body)
 
     def get_email_to_siae_refused(self):
-        to = self.siae.active_admin_members
+        to = self.siae.active_admin_members.values_list("email", flat=True)
         context = {
             "evaluation_campaign": self.evaluation_campaign,
             "siae": self.siae,
@@ -413,7 +413,7 @@ class EvaluatedSiae(models.Model):
         return get_email_message(to, context, subject, body)
 
     def get_email_to_siae_adversarial_stage(self):
-        to = self.siae.active_admin_members
+        to = self.siae.active_admin_members.values_list("email", flat=True)
         context = {
             "evaluation_campaign": self.evaluation_campaign,
             "siae": self.siae,
@@ -425,7 +425,7 @@ class EvaluatedSiae(models.Model):
     # fixme vincentporte : to refactor. move all get_email_to_institution_xxx() method
     # to emails.py in institution model
     def get_email_to_institution_submitted_by_siae(self):
-        to = self.evaluation_campaign.institution.active_members
+        to = self.evaluation_campaign.institution.active_members.values_list("email", flat=True)
         context = {
             "siae": self.siae,
             "dashboard_url": f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{reverse('dashboard:index')}",

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -492,7 +492,7 @@ class EvaluationCampaignEmailMethodsTest(TestCase):
         date = timezone.now().date()
         email = evaluation_campaign.get_email_to_institution_ratio_to_select(date)
 
-        self.assertEqual(email.to, list(institution.active_members))
+        self.assertEqual(email.to, list(u.email for u in institution.active_members))
         self.assertIn(reverse("dashboard:index"), email.body)
         self.assertIn(
             f"Le choix du taux de SIAE à contrôler est possible jusqu’au {dateformat.format(date, 'd E Y')}",
@@ -505,7 +505,7 @@ class EvaluationCampaignEmailMethodsTest(TestCase):
         evaluated_siae = EvaluatedSiaeFactory(siae=siae)
         email = evaluated_siae.get_email_to_siae_selected()
 
-        self.assertEqual(email.to, list(evaluated_siae.siae.active_admin_members))
+        self.assertEqual(email.to, list(u.email for u in evaluated_siae.siae.active_admin_members))
         self.assertEqual(
             email.subject,
             (
@@ -525,7 +525,7 @@ class EvaluationCampaignEmailMethodsTest(TestCase):
         evaluation_campaign = EvaluationCampaignFactory(institution=institution, evaluations_asked_at=fake_now)
 
         email = evaluation_campaign.get_email_to_institution_selected_siae()
-        self.assertEqual(email.to, list(institution.active_members))
+        self.assertEqual(email.to, list(u.email for u in institution.active_members))
         self.assertIn(dateformat.format(fake_now + relativedelta(weeks=6), "d E Y"), email.body)
         self.assertIn(dateformat.format(evaluation_campaign.evaluated_period_start_at, "d E Y"), email.body)
         self.assertIn(dateformat.format(evaluation_campaign.evaluated_period_end_at, "d E Y"), email.body)
@@ -842,7 +842,7 @@ class EvaluatedSiaeModelTest(TestCase):
 
         self.assertEqual(email.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(len(email.to), len(evaluated_siae.siae.active_admin_members))
-        self.assertEqual(email.to[0].email, evaluated_siae.siae.active_admin_members.first().email)
+        self.assertEqual(email.to[0], evaluated_siae.siae.active_admin_members.first().email)
         self.assertIn(evaluated_siae.siae.kind, email.subject)
         self.assertIn(evaluated_siae.siae.name, email.subject)
         self.assertIn(str(evaluated_siae.siae.id), email.subject)
@@ -868,7 +868,7 @@ class EvaluatedSiaeModelTest(TestCase):
 
         self.assertEqual(email.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(len(email.to), len(evaluated_siae.siae.active_admin_members))
-        self.assertEqual(email.to[0].email, evaluated_siae.siae.active_admin_members.first().email)
+        self.assertEqual(email.to[0], evaluated_siae.siae.active_admin_members.first().email)
         self.assertIn(evaluated_siae.siae.kind, email.subject)
         self.assertIn(evaluated_siae.siae.name, email.subject)
         self.assertIn(str(evaluated_siae.siae.id), email.subject)
@@ -890,7 +890,7 @@ class EvaluatedSiaeModelTest(TestCase):
 
         self.assertEqual(email.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(len(email.to), len(evaluated_siae.siae.active_admin_members))
-        self.assertEqual(email.to[0].email, evaluated_siae.siae.active_admin_members.first().email)
+        self.assertEqual(email.to[0], evaluated_siae.siae.active_admin_members.first().email)
         self.assertIn(evaluated_siae.siae.kind, email.subject)
         self.assertIn(evaluated_siae.siae.name, email.subject)
         self.assertIn(str(evaluated_siae.siae.id), email.subject)

--- a/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
@@ -691,7 +691,7 @@ class SiaeSubmitProofsViewTest(TestCase):
         )
         self.assertEqual(
             email.to[0],
-            evaluated_job_application.evaluated_siae.evaluation_campaign.institution.active_members.first(),
+            evaluated_job_application.evaluated_siae.evaluation_campaign.institution.active_members.first().email,
         )
 
     def test_campaign_is_ended(self):


### PR DESCRIPTION
### Quoi ?

Réparation de l’envoi d’email pour les campagnes de contrôle a posteriori

### Pourquoi ?

La représentation textuelle de l’objet utilisateur peut contenir des caractères sortant de l’ASCII, ce qui n’est pas valide pour une adresse email. Selon les heuristiques des bibliothèques, l’email pouvait être accepté ou non. Autant se conformer au reste du système et utiliser le champ `email`.