### PR TITLE
Ajout de la raison de refus “candidature en doublon”

### DIFF
--- a/itou/job_applications/enums.py
+++ b/itou/job_applications/enums.py
@@ -32,6 +32,7 @@ class RefusalReason(models.TextChoices):
         "L'embauche du candidat empêche la réalisation des objectifs du dialogue de gestion",
     )
     NO_POSITION = "no_position", "Pas de recrutement en cours"
+    DUPLICATE = "duplicate", "Candidature en doublon"
     OTHER = "other", "Autre (détails dans le message ci-dessous)"
 
     # Hidden reasons kept for history.

--- a/itou/job_applications/migrations/0044_alter_jobapplication_refusal_reason.py
+++ b/itou/job_applications/migrations/0044_alter_jobapplication_refusal_reason.py
@@ -30,6 +30,7 @@ class Migration(migrations.Migration):
                         "L'embauche du candidat empêche la réalisation des objectifs du dialogue de gestion",
                     ),
                     ("no_position", "Pas de recrutement en cours"),
+                    ("duplicate", "Candidature en doublon"),
                     ("other", "Autre (détails dans le message ci-dessous)"),
                     ("approval_expiration_too_close", "La date de fin du PASS IAE / agrément est trop proche"),
                     ("unavailable", "Candidat indisponible ou non intéressé par le poste"),


### PR DESCRIPTION
### Quoi ?

Ajout de la raison de refus “candidature en doublon”

### Pourquoi ?

C’est une raison fréquemment citée par les employeurs, qui cochaient “autre” jusqu’à maintenant.

### Captures d'écran

![Screenshot from 2022-10-26 16-17-40](https://user-images.githubusercontent.com/2758243/198051714-8a5ffe69-add6-4e5e-9c53-962b5d23bf5c.png)

![Screenshot from 2022-10-26 16-17-19](https://user-images.githubusercontent.com/2758243/198051729-404a9522-11bb-401d-a876-648d34bbb05a.png)
