### PR TITLE
[Supportix] Correction de deux erreurs sentry

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -132,7 +132,6 @@ class StartDateFilter(admin.SimpleListFilter):
 
 @admin.register(models.Approval)
 class ApprovalAdmin(admin.ModelAdmin):
-    form = ApprovalAdminForm
     list_display = ("pk", "number", "user", "birthdate", "start_at", "end_at", "is_valid", "created_at")
     list_select_related = ("user",)
     search_fields = ("pk", "number", "user__first_name", "user__last_name", "user__email")
@@ -157,6 +156,14 @@ class ApprovalAdmin(admin.ModelAdmin):
         JobApplicationInline,
         PkSupportRemarkInline,
     )
+
+    def get_form(self, request, obj=None, **kwargs):
+        if self.has_change_permission(request, obj) or self.has_add_permission(request, obj):
+            # When a user has only the "view" permission it seems that ModelForm.fields is empty,
+            # ApprovalAdminForm wants to modify that attribute which result in a KeyError,
+            # so we return the custom form only for user with the "change" permission.
+            kwargs["form"] = ApprovalAdminForm
+        return super().get_form(request, obj, **kwargs)
 
     def save_model(self, request, obj, form, change):
         if not obj.pk:

--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -64,6 +64,8 @@ def etablissement_get_or_error(siret):
     except httpx.HTTPStatusError as e:
         if e.response.status_code == httpx.codes.BAD_REQUEST:
             error = f"Erreur dans le format du SIRET : « {siret} »."
+        elif e.response.status_code == httpx.codes.FORBIDDEN:
+            error = "Cette entreprise a exercé son droit d'opposition auprès de l'INSEE."
         elif e.response.status_code == httpx.codes.NOT_FOUND:
             error = f"SIRET « {siret} » non reconnu."
         else:

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -968,6 +968,14 @@ class ApiEntrepriseTest(SimpleTestCase):
         self.assertEqual(result, (None, "Erreur dans le format du SIRET : « 26570134200148 »."))
 
     @respx.mock
+    def test_etablissement_get_or_error_with_other_http_forbidden_error(self):
+        self.siret_endpoint.respond(403)
+
+        result = api_entreprise.etablissement_get_or_error("26570134200148")
+
+        self.assertEqual(result, (None, "Cette entreprise a exercé son droit d'opposition auprès de l'INSEE."))
+
+    @respx.mock
     def test_etablissement_get_or_error_with_other_http_not_found_error(self):
         self.siret_endpoint.respond(404)
 


### PR DESCRIPTION
### Quoi ?

1. La `KeyError` était levée quand un membre du groupe `itou-support-externe` voulais afficher un PASS IAE depuis l'admin.
2. Ajout d'un message plus métier pour les erreurs 403 de l'API Sirene.