### PR TITLE
[Supportix] Corrections et améliorations pour les fiches salariés

### DIFF
--- a/itou/asp/management/commands/check_asp_ref.py
+++ b/itou/asp/management/commands/check_asp_ref.py
@@ -1,0 +1,80 @@
+import json
+
+from django.core.management.base import BaseCommand
+from django.utils import dateparse
+
+from itou.asp import models
+
+
+class Command(BaseCommand):
+    def _format_date(self, date):
+        return dateparse.parse_date(date) if date else date
+
+    def _check_objects(self, model, file, file_converters):
+        data_in_db = {obj.pk: obj for obj in model.objects.all()}
+        with open(file) as fp:
+            data_in_file = {obj["pk"]: obj for obj in json.load(fp)}
+
+        primary_keys = set(sorted(set(data_in_db.keys()) & set(data_in_file.keys()), key=int))
+        pk_with_incoherent_data = set()
+
+        for pk in primary_keys:
+            try:
+                has_diff = any(
+                    getattr(data_in_db[pk], field_name)
+                    != file_converters.get(field_name, lambda x: x)(data_in_file[pk]["fields"][field_name])
+                    for field_name in data_in_file[pk]["fields"]
+                )
+            except Exception as e:
+                self.stdout.write(f"ERROR for pk={pk}: {e!r}")
+            else:
+                if has_diff:
+                    self.stdout.write(
+                        f"Diff for pk={pk}: "
+                        + repr(
+                            {
+                                field_name: (
+                                    getattr(data_in_db[pk], field_name),
+                                    file_converters.get(field_name, lambda x: x)(
+                                        data_in_file[pk]["fields"][field_name]
+                                    ),
+                                )
+                                for field_name in data_in_file[pk]["fields"]
+                            }
+                        )
+                    )
+                    pk_with_incoherent_data.add(pk)
+
+        self.stdout.write(f"Objects in database: {len(data_in_db)}")
+        self.stdout.write(f"Objects in file: {len(data_in_file)}")
+        self.stdout.write(f"PK missing from the database: {primary_keys - set(data_in_db.keys())}")
+        self.stdout.write(f"PK missing from the file: {primary_keys - set(data_in_file.keys())}")
+        self.stdout.write(f"PK with incoherent data: {pk_with_incoherent_data}")
+
+    def handle(self, *args, **options):
+        self.stdout.write("=== Checking INSEE communes ===")
+        self._check_objects(
+            models.Commune,
+            "itou/asp/fixtures/asp_INSEE_communes.json",
+            file_converters={"start_date": self._format_date, "end_date": self._format_date},
+        )
+
+        self.stdout.write("=== Checking INSEE departments ===")
+        self._check_objects(
+            models.Department,
+            "itou/asp/fixtures/asp_INSEE_departments.json",
+            file_converters={"start_date": self._format_date, "end_date": self._format_date},
+        )
+
+        self.stdout.write("=== Checking INSEE countries ===")
+        self._check_objects(
+            models.Country,
+            "itou/asp/fixtures/asp_INSEE_countries.json",
+            file_converters={
+                "start_date": self._format_date,
+                "end_date": self._format_date,
+                "code": str,
+                "group": str,
+                "department": str,
+            },
+        )

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -1,3 +1,5 @@
+import contextlib
+import json
 from typing import Optional, Union
 
 from django.core.exceptions import ValidationError
@@ -379,9 +381,9 @@ class EmployeeRecord(models.Model):
         self.processed_at = timezone.now()
         self.asp_processing_code = code
         self.asp_processing_label = label
-        # NOTE(vperron): the following line should perform json.loads(archive) in order
-        # to actually store a JSON dictionary instead of a serialized string.
-        # The current records should then be migrated in-place.
+        if archive is not None:
+            with contextlib.suppress(json.JSONDecodeError):
+                archive = json.loads(archive)
         self.archived_json = archive
         self.save()
 

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -509,35 +509,6 @@ class EmployeeRecord(models.Model):
         return er_copy
 
     @property
-    def is_archived(self):
-        """
-        Once in final state (PROCESSED), an employee record is archived.
-        See model save() and clean() method.
-        """
-        return self.status == Status.PROCESSED and self.archived_json is not None
-
-    @property
-    def is_updatable(self):
-        """
-        Once in final state (PROCESSED), an EmployeeRecord is not updatable anymore.
-
-        Check this property before using save()
-
-        If an employee record is archived or in SENT status, updating and using save()
-        will throw a ValidationError
-
-        An EmployeeRecord object must not be updated when it has been sent to ASP (waiting for validation)
-        except via specific business methods
-
-        See model save() and clean() method.
-        """
-        return self.status not in [Status.SENT, Status.READY] and not self.is_archived
-
-    @property
-    def is_processed_as_duplicate(self):
-        return self.archived_json is None and self.processed_as_duplicate
-
-    @property
     def can_be_disabled(self):
         return self.status in self.CAN_BE_DISABLED_STATES
 

--- a/itou/employee_record/tests/tests_management_commands.py
+++ b/itou/employee_record/tests/tests_management_commands.py
@@ -1,4 +1,3 @@
-import json
 from unittest import mock
 
 from django.test.utils import override_settings
@@ -153,10 +152,10 @@ class EmployeeRecordManagementCommandTest(ManagementCommandTestCase):
         self.assertEqual(Status.PROCESSED, employee_record.status)
         self.assertIsNotNone(employee_record.archived_json)
 
-        employee_record_json = json.loads(employee_record.archived_json)
-
-        self.assertEqual(EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE, employee_record_json.get("codeTraitement"))
-        self.assertIsNotNone(employee_record_json.get("libelleTraitement"))
+        self.assertEqual(
+            EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE, employee_record.archived_json.get("codeTraitement")
+        )
+        self.assertIsNotNone(employee_record.archived_json.get("libelleTraitement"))
 
     @mock.patch("pysftp.Connection", SFTPEvilConnectionMock)
     @mock.patch(

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -147,7 +147,6 @@
         {% elif form.status.value == "DISABLED" %}
             <div class="text-right">
                 <a href="{% url "employee_record_views:reactivate" employee_record.id %}" class="btn btn-outline-primary mt-2">Réactiver la fiche salarié</a>
-                <a href="{% url "employee_record_views:summary" employee_record.id %}?status=DISABLED" class="btn btn-outline-primary mt-2">Voir le détail de la fiche salarié</a>
             </div>
         {% endif %}
     </div>


### PR DESCRIPTION
### Quoi ?

1. Suppression du bouton "Voir le detail de la fiche salarié" quand la FS est dans l'état "Désactivée"
    ![image](https://user-images.githubusercontent.com/20045330/198316851-6325d4dc-2b23-4e5b-b053-e8521a6a94f9.png)
3. Ajout d'une action dans l'admin pour simplifier l'envois de "Notification de changement de la fiche salarié".
4. On stocke le JSON reçu et pas la représentation JSON du JSON pour l'archive ASP.
    Pas de migration de données vu qu'on supprime l'archive au bout d'un moment et que l'information est tout de même présente même l'affichage est moche.
5. Ajout de la commande `check_asp_ref` pour faire la diff entre le contenu de la BDD et les fichiers de fixture.
    Remonté par une erreur sentry, au final il n'y avais qu'une (1) commune qui posant problème.