### PR TITLE
Boost pour le C2

### DIFF
--- a/itou/metabase/management/commands/_approvals.py
+++ b/itou/metabase/management/commands/_approvals.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from itou.approvals.models import Approval, PoleEmploiApproval
 from itou.metabase.management.commands._utils import (
     MetabaseTable,
+    anonymize,
     get_ai_stock_approval_pks,
     get_department_and_region_columns,
     get_hiring_siae,
@@ -76,6 +77,12 @@ TABLE.add_columns(
         {"name": "date_début", "type": "date", "comment": "Date de début", "fn": lambda o: o.start_at},
         {"name": "date_fin", "type": "date", "comment": "Date de fin", "fn": lambda o: o.end_at},
         {"name": "durée", "type": "interval", "comment": "Durée", "fn": lambda o: o.end_at - o.start_at},
+        {
+            "name": "id_candidat_anonymisé",
+            "type": "varchar",
+            "comment": "ID anonymisé du candidat",
+            "fn": lambda o: anonymize(o.user.pk, salt="job_seeker.id"),
+        },
         {
             "name": "id_structure",
             "type": "integer",

--- a/itou/metabase/management/commands/_approvals.py
+++ b/itou/metabase/management/commands/_approvals.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from itou.approvals.models import Approval, PoleEmploiApproval
 from itou.metabase.management.commands._utils import (
     MetabaseTable,
-    anonymize,
     get_ai_stock_approval_pks,
     get_department_and_region_columns,
     get_hiring_siae,
@@ -81,7 +80,7 @@ TABLE.add_columns(
             "name": "id_candidat_anonymisé",
             "type": "varchar",
             "comment": "ID anonymisé du candidat",
-            "fn": lambda o: anonymize(o.user.pk, salt="job_seeker.id"),
+            "fn": lambda o: hash_content(o.user.pk),
         },
         {
             "name": "id_structure",

--- a/itou/metabase/management/commands/_job_applications.py
+++ b/itou/metabase/management/commands/_job_applications.py
@@ -2,15 +2,12 @@ from itou.job_applications.enums import SenderKind
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.metabase.management.commands._utils import (
     MetabaseTable,
-    anonymize,
     get_ai_stock_approval_pks,
     get_choice,
     get_department_and_region_columns,
+    hash_content,
 )
 from itou.prescribers.enums import PrescriberOrganizationKind
-
-
-JOB_APPLICATION_PK_ANONYMIZATION_SALT = "job_application.id"
 
 
 # Reword the original SenderKind.SENDER_KIND_CHOICES
@@ -127,7 +124,7 @@ TABLE.add_columns(
             "name": "id_anonymisé",
             "type": "varchar",
             "comment": "ID anonymisé de la candidature",
-            "fn": lambda o: anonymize(o.pk, salt=JOB_APPLICATION_PK_ANONYMIZATION_SALT),
+            "fn": lambda o: hash_content(o.pk),
         },
         {
             "name": "date_candidature",
@@ -183,7 +180,7 @@ TABLE.add_columns(
             "name": "id_candidat_anonymisé",
             "type": "varchar",
             "comment": "ID anonymisé du candidat",
-            "fn": lambda o: anonymize(o.job_seeker_id, salt="job_seeker.id"),
+            "fn": lambda o: hash_content(o.job_seeker_id),
         },
         {
             "name": "id_structure",

--- a/itou/metabase/management/commands/_job_applications.py
+++ b/itou/metabase/management/commands/_job_applications.py
@@ -71,9 +71,9 @@ def get_ja_sender_organization_safir(ja):
     return None
 
 
-def get_ja_sender_full_name_if_pe(ja):
+def get_ja_sender_full_name_if_pe_or_spip(ja):
     org = ja.sender_prescriber_organization
-    if org and org.kind == PrescriberOrganizationKind.PE:
+    if org and org.kind in [PrescriberOrganizationKind.PE, PrescriberOrganizationKind.SPIP]:
         return f"{ja.sender.last_name.upper()} {ja.sender.first_name}"
     return None
 
@@ -241,10 +241,10 @@ TABLE.add_columns(
             "fn": get_ja_sender_organization_safir,
         },
         {
-            "name": "nom_prénom_conseiller_pe",
+            "name": "nom_prénom_conseiller",
             "type": "varchar",
-            "comment": "Nom prénom du conseiller PE",
-            "fn": get_ja_sender_full_name_if_pe,
+            "comment": "Nom prénom du conseiller PE ou SPIP",
+            "fn": get_ja_sender_full_name_if_pe_or_spip,
         },
         {
             "name": "date_embauche",

--- a/itou/metabase/management/commands/_job_seekers.py
+++ b/itou/metabase/management/commands/_job_seekers.py
@@ -8,11 +8,11 @@ from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.metabase.management.commands._utils import (
     MetabaseTable,
-    anonymize,
     get_ai_stock_job_seeker_pks,
     get_choice,
     get_department_and_region_columns,
     get_hiring_siae,
+    hash_content,
 )
 
 
@@ -181,7 +181,7 @@ TABLE.add_columns(
             "name": "id_anonymisé",
             "type": "varchar",
             "comment": "ID anonymisé du candidat",
-            "fn": lambda o: anonymize(o.id, salt="job_seeker.id"),
+            "fn": lambda o: hash_content(o.id),
         },
         {
             "name": "sexe_selon_nir",

--- a/itou/metabase/management/commands/_job_seekers.py
+++ b/itou/metabase/management/commands/_job_seekers.py
@@ -184,6 +184,12 @@ TABLE.add_columns(
             "fn": lambda o: hash_content(o.id),
         },
         {
+            "name": "hash_nir",
+            "type": "varchar",
+            "comment": "Version obfusquée du NIR",
+            "fn": lambda o: hash_content(o.nir) if o.nir else None,
+        },
+        {
             "name": "sexe_selon_nir",
             "type": "varchar",
             "comment": "Sexe du candidat selon le NIR",

--- a/itou/metabase/management/commands/_utils.py
+++ b/itou/metabase/management/commands/_utils.py
@@ -6,7 +6,6 @@ from operator import attrgetter
 
 from django.conf import settings
 from django.utils import timezone
-from django.utils.crypto import salted_hmac
 from psycopg2 import sql
 
 from itou.approvals.models import Approval
@@ -64,14 +63,6 @@ def chunks(items, n):
     """
     for i in range(0, len(items), n):
         yield items[i : i + n]
-
-
-def anonymize(value, salt):
-    """
-    Use a salted hash to anonymize sensitive ids,
-    mainly job_seeker id and job_application id.
-    """
-    return salted_hmac(salt, value, secret=settings.SECRET_KEY).hexdigest()
 
 
 def get_first_membership_join_date(memberships):

--- a/itou/metabase/management/commands/populate_metabase_itou.py
+++ b/itou/metabase/management/commands/populate_metabase_itou.py
@@ -54,13 +54,13 @@ from itou.metabase.management.commands._database_tables import (
 )
 from itou.metabase.management.commands._dataframes import get_df_from_rows, store_df
 from itou.metabase.management.commands._utils import (
-    anonymize,
     build_final_tables,
     chunked_queryset,
     compose,
     convert_boolean_to_int,
     enable_sql_logging,
     get_active_siae_pks,
+    hash_content,
 )
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae, SiaeJobDescription
@@ -340,9 +340,7 @@ class Command(BaseCommand):
                     row = OrderedDict()
 
                     row["id_fiche_de_poste"] = jd.pk
-                    row["id_anonymisé_candidature"] = anonymize(
-                        ja.pk, salt=_job_applications.JOB_APPLICATION_PK_ANONYMIZATION_SALT
-                    )
+                    row["id_anonymisé_candidature"] = hash_content(ja.pk)
 
                     rows.append(row)
             if self.dry_run and len(rows) >= 1000:

--- a/itou/metabase/management/commands/sql/019_candidatures_echelle_locale.sql
+++ b/itou/metabase/management/commands/sql/019_candidatures_echelle_locale.sql
@@ -119,7 +119,7 @@ select
     safir_org_prescripteur,
     id_org_prescripteur,
     nom_org_prescripteur,
-    Nom_prénom_conseiller_pe,
+    nom_prénom_conseiller,
     dept_org,
     région_org,
     injection_ai,

--- a/itou/metabase/tests/test_approvals.py
+++ b/itou/metabase/tests/test_approvals.py
@@ -23,7 +23,10 @@ def test_hashed_approval_number():
     )
 
 
-@override_settings(SECRET_KEY="foobar2022")
+@override_settings(METABASE_HASH_SALT="foobar2000")
 def test_id_candidat_anonymisé():
-    approval = ApprovalFactory(user__pk=18)
-    assert TABLE.get(column_name="id_candidat_anonymisé", input=approval) == "4532819e6f4be94d2716bb5d5c6f61e7fd8bc4e3"
+    approval = ApprovalFactory(user__pk=123456)
+    assert (
+        TABLE.get(column_name="id_candidat_anonymisé", input=approval)
+        == "24be2dc555f5db9a3348fa2290204ce75b7a9240a8049cfe0ff6c445dc63956f"
+    )

--- a/itou/metabase/tests/test_approvals.py
+++ b/itou/metabase/tests/test_approvals.py
@@ -21,3 +21,9 @@ def test_hashed_approval_number():
         TABLE.get(column_name="hash_numéro_pass_iae", input=approval)
         == "6cc868860cee823f0ffe0b3498bb4ebda51baa1b7858e2022f6590b0bd86c31c"
     )
+
+
+@override_settings(SECRET_KEY="foobar2022")
+def test_id_candidat_anonymisé():
+    approval = ApprovalFactory(user__pk=18)
+    assert TABLE.get(column_name="id_candidat_anonymisé", input=approval) == "4532819e6f4be94d2716bb5d5c6f61e7fd8bc4e3"

--- a/itou/metabase/tests/test_job_applications.py
+++ b/itou/metabase/tests/test_job_applications.py
@@ -28,7 +28,7 @@ class MetabaseJobApplicationTest(TestCase):
     def test_ja_sent_by_pe(self):
         ja = JobApplicationSentByPrescriberPoleEmploiFactory()
         self.assertEqual(
-            TABLE.get(column_name="nom_prénom_conseiller_pe", input=ja),
+            TABLE.get(column_name="nom_prénom_conseiller", input=ja),
             f"{ja.sender.last_name.upper()} {ja.sender.first_name}",
         )
         self.assertEqual(
@@ -37,10 +37,20 @@ class MetabaseJobApplicationTest(TestCase):
         )
         self.assertEqual(len(ja.sender_prescriber_organization.code_safir_pole_emploi), 5)
 
-    def test_ja_sent_by_non_pe_prescriber_organization(self):
+    def test_ja_sent_by_spip(self):
+        ja = JobApplicationSentByPrescriberOrganizationFactory(
+            sender_prescriber_organization__kind=PrescriberOrganizationKind.SPIP
+        )
+        self.assertEqual(
+            TABLE.get(column_name="nom_prénom_conseiller", input=ja),
+            f"{ja.sender.last_name.upper()} {ja.sender.first_name}",
+        )
+        self.assertEqual(TABLE.get(column_name="safir_org_prescripteur", input=ja), None)
+
+    def test_ja_sent_by_exotic_prescriber_organization(self):
         ja = JobApplicationSentByPrescriberOrganizationFactory(
             sender_prescriber_organization__kind=PrescriberOrganizationKind.CHRS
         )
         self.assertNotEqual(ja.sender_prescriber_organization.kind, PrescriberOrganizationKind.PE)
-        self.assertEqual(TABLE.get(column_name="nom_prénom_conseiller_pe", input=ja), None)
+        self.assertEqual(TABLE.get(column_name="nom_prénom_conseiller", input=ja), None)
         self.assertEqual(TABLE.get(column_name="safir_org_prescripteur", input=ja), None)


### PR DESCRIPTION
### Quoi ?

- Le champ `candidatures.nom_conseiller_pe` est renommé en `candidatures.nom_conseiller` et est maintenant aussi rempli pour les conseillers SPIP.
- Ajout du champ manquant `pass_agréments.id_candidat_anonymisé`.
- Utilisation de la méthode `hash_content` partout pour harmoniser.
- Ajout du champ `candidats.hash_nir` pour suivre quels candidats ont un NIR ou non, et plus tard croiser avec d'autres sources obfusquées de la même manière. Malheureusement non testé car sur la table problématique `job_seekers`.

### Pourquoi ?

Pour faire avancer le C2.
