### PR TITLE
API candidats

### DIFF
--- a/itou/api/applicants_api/perms.py
+++ b/itou/api/applicants_api/perms.py
@@ -1,0 +1,21 @@
+from rest_framework.permissions import IsAuthenticated
+
+from itou.siaes.models import SiaeMembership
+
+
+class ApplicantsAPIPermission(IsAuthenticated):
+    def has_permission(self, request, view) -> bool:
+        """
+        Check that user:
+            - belongs to one SIAE only (dedicated API account)
+            - is admin
+        """
+        if not super().has_permission(request, view):
+            return False
+
+        memberships = request.user.active_or_in_grace_period_siae_memberships()
+
+        try:
+            return memberships.get().is_admin
+        except (SiaeMembership.DoesNotExist, SiaeMembership.MultipleObjectsReturned):
+            return False

--- a/itou/api/applicants_api/serializers.py
+++ b/itou/api/applicants_api/serializers.py
@@ -1,0 +1,43 @@
+from rest_framework import serializers
+
+from itou.users.models import User
+
+
+class ApplicantSerializer(serializers.ModelSerializer):
+    """Applicant serializer: job seeker field of a job application"""
+
+    civilite = serializers.SerializerMethodField()
+    nom = serializers.CharField(source="first_name")
+    prenom = serializers.CharField(source="last_name")
+    courriel = serializers.CharField(source="email")
+    telephone = serializers.CharField(source="phone")
+    adresse = serializers.CharField(source="address_line_1")
+    complement_adresse = serializers.CharField(source="address_line_2")
+    code_postal = serializers.CharField(source="post_code")
+    ville = serializers.CharField(source="city")
+    date_naissance = serializers.DateField(source="birthdate")
+    lieu_naissance = serializers.CharField(source="birth_place")
+    pays_naissance = serializers.CharField(source="birth_country")
+    lien_cv = serializers.CharField(source="resume_link")
+
+    class Meta:
+        model = User
+        fields = (
+            "civilite",
+            "nom",
+            "prenom",
+            "courriel",
+            "telephone",
+            "adresse",
+            "complement_adresse",
+            "code_postal",
+            "ville",
+            "date_naissance",
+            "lieu_naissance",
+            "pays_naissance",
+            "lien_cv",
+        )
+        read_only_fields = fields
+
+    def get_civilite(self, obj) -> str:
+        return obj.title or "Non fournie"

--- a/itou/api/applicants_api/tests.py
+++ b/itou/api/applicants_api/tests.py
@@ -1,0 +1,118 @@
+from django.urls import reverse
+from rest_framework.test import APIClient, APITestCase
+
+from itou.asp.factories import CommuneFactory, CountryFactory
+from itou.institutions.factories import InstitutionWithMembershipFactory
+from itou.job_applications.factories import JobApplicationFactory
+from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
+from itou.siaes.factories import SiaeFactory
+from itou.users.factories import JobSeekerFactory
+
+
+class ApplicantsAPITest(APITestCase):
+
+    # For fake addresses
+    fixtures = [
+        "test_asp_INSEE_communes_factory.json",
+        "test_asp_INSEE_countries_factory.json",
+    ]
+
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse("v1:applicants-list")
+
+    def test_login_as_job_seeker(self):
+        user = JobSeekerFactory()
+        self.client.force_authenticate(user)
+
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(response.status_code, 403)
+
+    def test_login_as_prescriber_organisation(self):
+        user = PrescriberOrganizationWithMembershipFactory().members.first()
+        self.client.force_authenticate(user)
+
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(response.status_code, 403)
+
+    def test_login_as_institution(self):
+        user = InstitutionWithMembershipFactory().members.first()
+        self.client.force_authenticate(user)
+
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(response.status_code, 403)
+
+    def test_api_user_has_unique_siae_membership(self):
+        # Connected user must only be member of target SIAE
+        user = SiaeFactory(with_membership=True).members.first()
+        SiaeFactory(with_membership=True).members.add(user)
+
+        self.client.force_authenticate(user)
+        response = self.client.get(self.url, format="json")
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_api_user_is_admin(self):
+        # Connected user must only be admin of target SIAE
+        user = SiaeFactory(with_membership=True).members.first()
+        membership = user.siaemembership_set.first()
+        membership.is_admin = False
+        membership.save()
+
+        self.client.force_authenticate(user)
+        response = self.client.get(self.url, format="json")
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_login_as_siae(self):
+        # Connect with an admin user with member of a sigle SIAE
+        user = SiaeFactory(with_membership=True).members.first()
+        self.client.force_authenticate(user)
+
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("results"), [])
+
+    def test_applicant_data(self):
+        siae = SiaeFactory(with_membership=True)
+        job_seeker = JobApplicationFactory(to_siae=siae).job_seeker
+        # Will not refactor ASP factories:
+        # - too long,
+        # - not the point
+        # - scheduled in a future PR
+        # => will use some hard-coded values until then
+        job_seeker.address_line_1 = "address test"
+        job_seeker.address_line_2 = "address 2"
+        job_seeker.post_code = "37000"
+        job_seeker.city = "TOURS"
+        job_seeker.resume_link = "https://myresume.com/me"
+        job_seeker.birth_place = CommuneFactory()
+        job_seeker.birth_country = CountryFactory()
+        job_seeker.save()
+        user = siae.members.first()
+
+        self.client.force_authenticate(user)
+        response = self.client.get(self.url, format="json")
+
+        self.assertEqual(response.status_code, 200)
+
+        [result] = response.json().get("results")
+
+        self.assertEqual(
+            {
+                "civilite": job_seeker.title,
+                "nom": job_seeker.first_name,
+                "prenom": job_seeker.last_name,
+                "courriel": job_seeker.email,
+                "telephone": job_seeker.phone,
+                "adresse": job_seeker.address_line_1,
+                "complement_adresse": job_seeker.address_line_2,
+                "code_postal": job_seeker.post_code,
+                "ville": job_seeker.city,
+                "date_naissance": str(job_seeker.birthdate),
+                "lieu_naissance": job_seeker.birth_place.name,
+                "pays_naissance": job_seeker.birth_country.name,
+                "lien_cv": job_seeker.resume_link,
+            },
+            result,
+        )

--- a/itou/api/applicants_api/views.py
+++ b/itou/api/applicants_api/views.py
@@ -1,0 +1,53 @@
+from rest_framework import authentication, generics
+
+from itou.users.models import User
+
+from .perms import ApplicantsAPIPermission
+from .serializers import ApplicantSerializer
+
+
+class ApplicantsView(generics.ListAPIView):
+    """
+    # Liste des candidats par structure
+
+    Cette API retourne la liste de tous les demandeurs d'emploi liés à une candidature pour la structure en cours.
+
+    Les candidats sont triés par date de création dans la base des emplois de l'inclusion,
+    du plus récent au plus ancien.
+
+    # Permissions
+
+    L'utilisation de cette API nécessite un jeton d'autorisation (`token`).
+
+    Pour l'obtention d'un jeton, veuillez utiliser **les identifiants d'un compte administrateur de la structure.**
+
+    Voir le endpoint `auth-token` pour obtenir un jeton.
+
+    Ce compte ne doit être *uniquement membre* de la structure dont on souhaite récupérer la liste de candidats.
+
+    Dans l'idéal, il s'agit d'un compte dédié à l'utilisation de l'API.
+
+
+    # Paramètres
+
+    Cette api ne dispose pas de paramètres de filtrage ou de recherche :
+        elle retourne l'intégralité des candidats de la structure.
+    """
+
+    authentication_classes = (
+        authentication.TokenAuthentication,
+        authentication.SessionAuthentication,
+    )
+    permission_classes = (ApplicantsAPIPermission,)
+    serializer_class = ApplicantSerializer
+
+    def get_queryset(self):
+        # unique siae asserted by permission class
+        siae_id = self.request.user.siaemembership_set.get().siae_id
+
+        return (
+            User.objects.filter(job_applications__to_siae_id=siae_id, is_job_seeker=True)
+            .select_related("birth_place", "birth_country")
+            .prefetch_related("job_applications")
+            .order_by("-pk")
+        )

--- a/itou/api/urls.py
+++ b/itou/api/urls.py
@@ -5,6 +5,7 @@ from rest_framework.authtoken import views as auth_views
 
 from itou.api.data_inclusion_api.views import DataInclusionStructureView
 
+from .applicants_api.views import ApplicantsView
 from .employee_record_api.viewsets import (
     DummyEmployeeRecordViewSet,
     EmployeeRecordUpdateNotificationViewSet,
@@ -27,7 +28,6 @@ router.register(
 )
 router.register(r"dummy-employee-records", DummyEmployeeRecordViewSet, basename="dummy-employee-records")
 router.register(r"siaes", SiaeViewSet, basename="siaes")
-
 
 urlpatterns = [
     # TokenAuthentication endpoint to get token from login/password.
@@ -53,4 +53,5 @@ urlpatterns += router.urls
 
 urlpatterns += [
     path("structures/", DataInclusionStructureView.as_view(), name="structures-list"),
+    path("candidats/", ApplicantsView.as_view(), name="applicants-list"),
 ]


### PR DESCRIPTION
### Quoi ?

Une API mise à disposition pour que les structures puissent récupérer la liste de leur candidats.

### Pourquoi ?

Demande métier et utilisateur.

### Comment ?

- L'API ne demande pas de paramètre particulier,
- il est nécessaire d'utiliser les identifiants d'un compte administrateur de la structure pour pouvoir l'utiliser (via un token)
- endpoint : `/api/v1/candidats`

### Captures d'écran 

- redoc
![image](https://user-images.githubusercontent.com/147232/198679516-37bc21ab-4aae-4ca5-bf75-a56c1be459ae.png)

- interface de test
![image](https://user-images.githubusercontent.com/147232/198680167-89375e0a-7958-4c13-8ec2-9c8d7f4d4b3f.png)

