### PR TITLE
Rappel aux SIAE n’ayant pas soumis de pièces justificatives à J+30

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -4,5 +4,6 @@
   "25 8-18/2 * * 1-5 $ROOT/clevercloud/download_employee_records.sh",
   "55 8-18/2 * * 1-5 $ROOT/clevercloud/upload_employee_records.sh",
   "5 23 * * 1-5 $ROOT/clevercloud/archive_employee_records.sh",
-  "0 * * * * $ROOT/clevercloud/send_approvals_to_pe.sh"
+  "0 * * * * $ROOT/clevercloud/send_approvals_to_pe.sh",
+  "0 12 * * * $ROOT/clevercloud/evaluation_campaign_notifications.sh"
 ]

--- a/clevercloud/evaluation_campaign_notifications.sh
+++ b/clevercloud/evaluation_campaign_notifications.sh
@@ -1,0 +1,15 @@
+#! /bin/bash -l
+
+if [[ "$INSTANCE_NUMBER" != "0" ]]; then
+  echo "Instance number is ${INSTANCE_NUMBER}. Stop here."
+  exit 0
+fi
+
+if [[ "$CRON_ENABLED" != "1" ]]; then
+  echo "Cron workers not enabled."
+  exit 0
+fi
+
+cd ${APP_HOME} # Which has been loaded by the env.
+
+django-admin evaluation_campaign_notify

--- a/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
+++ b/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
@@ -1,0 +1,37 @@
+from dateutil.relativedelta import relativedelta
+from django.core.management import BaseCommand
+from django.db.models import Exists, OuterRef
+from django.utils import timezone
+
+from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria, EvaluationCampaign
+from itou.utils.emails import send_email_messages
+
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        today = timezone.localdate()
+        for campaign in EvaluationCampaign.objects.filter(
+            evaluations_asked_at__date__lte=today - relativedelta(days=30),
+            ended_at=None,
+        ).select_related("institution"):
+            emails = []
+            evaluated_siaes = (
+                campaign.evaluated_siaes.filter(reviewed_at=None, reminder_sent_at=None)
+                .exclude(
+                    Exists(
+                        EvaluatedAdministrativeCriteria.objects.filter(
+                            evaluated_job_application__evaluated_siae=OuterRef("pk"),
+                            submitted_at__isnull=False,
+                        )
+                    )
+                )
+                .select_related("evaluation_campaign__institution", "siae__convention")
+            )
+            for evaluated_siae in evaluated_siaes:
+                emails.append(evaluated_siae.get_email_to_siae_notify_before_adversarial_stage())
+            if emails:
+                send_email_messages(emails)
+                evaluated_siaes.update(reminder_sent_at=timezone.now())
+                self.stdout.write(
+                    f"Emailed reminders to {len(emails)} SIAE which did not submit proofs to {campaign}."
+                )

--- a/itou/siae_evaluations/migrations/0012_evaluatedsiae_reminder_sent_at.py
+++ b/itou/siae_evaluations/migrations/0012_evaluatedsiae_reminder_sent_at.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siae_evaluations", "0011_evaluatedsiae_notification"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evaluatedsiae",
+            name="reminder_sent_at",
+            field=models.DateTimeField(blank=True, null=True, verbose_name="rappel envoyé le"),
+        ),
+    ]

--- a/itou/siae_evaluations/tests/test_management_commands.py
+++ b/itou/siae_evaluations/tests/test_management_commands.py
@@ -1,0 +1,309 @@
+import datetime
+
+from dateutil.relativedelta import relativedelta
+from django.core.management import call_command
+from django.utils import timezone
+from freezegun import freeze_time
+
+from .. import enums as evaluation_enums
+from ..factories import (
+    EvaluatedAdministrativeCriteriaFactory,
+    EvaluatedJobApplicationFactory,
+    EvaluatedSiaeFactory,
+    EvaluationCampaignFactory,
+)
+
+
+class TestManagementCommand:
+    def test_no_campaign(self, capsys, mailoutbox):
+        call_command("evaluation_campaign_notify")
+        stdout, stderr = capsys.readouterr()
+        assert stdout == ""
+        assert stderr == ""
+        assert mailoutbox == []
+
+    def test_no_notification_for_new_campaigns(self, capsys, mailoutbox):
+        EvaluationCampaignFactory()
+        call_command("evaluation_campaign_notify")
+        stdout, stderr = capsys.readouterr()
+        assert stdout == ""
+        assert stderr == ""
+        assert mailoutbox == []
+
+    def test_no_notification_for_closed_campaigns(self, capsys, mailoutbox):
+        EvaluationCampaignFactory(
+            evaluations_asked_at=timezone.now() - relativedelta(days=30),
+            ended_at=timezone.now(),
+        )
+        call_command("evaluation_campaign_notify")
+        stdout, stderr = capsys.readouterr()
+        assert stdout == ""
+        assert stderr == ""
+        assert mailoutbox == []
+
+    @freeze_time("2022-12-07 11:11:11")
+    def test_notifies_all_campaigns(self, capsys, mailoutbox):
+        campaign1 = EvaluationCampaignFactory(
+            evaluations_asked_at=timezone.now() - relativedelta(days=30),
+            evaluated_period_start_at=datetime.date(2022, 1, 1),
+            evaluated_period_end_at=datetime.date(2022, 9, 30),
+            institution__name="DDETS 01",
+            name="Campagne 1",
+        )
+        evaluated_siae1 = EvaluatedSiaeFactory.create(
+            evaluation_campaign=campaign1,
+            siae__name="les petits jardins",
+            siae__convention__siret_signature="00000000000032",
+        )
+        campaign2 = EvaluationCampaignFactory(
+            evaluations_asked_at=timezone.now() - relativedelta(days=30),
+            evaluated_period_start_at=datetime.date(2022, 1, 1),
+            evaluated_period_end_at=datetime.date(2022, 9, 30),
+            institution__name="DDETS 02",
+            name="Campagne 1",
+        )
+        evaluated_siae2 = EvaluatedSiaeFactory.create(
+            evaluation_campaign=campaign2,
+            siae__name="Bazar antique",
+            siae__convention__siret_signature="12345678900012",
+        )
+        evaluated_siae3 = EvaluatedSiaeFactory.create(
+            evaluation_campaign=campaign2, siae__name="Trucs muche", siae__convention__siret_signature="12345678900024"
+        )
+        call_command("evaluation_campaign_notify")
+        stdout, stderr = capsys.readouterr()
+        assert sorted(stdout.splitlines()) == [
+            "Emailed reminders to 1 SIAE which did not submit proofs to DDETS 01 - Campagne 1.",
+            "Emailed reminders to 2 SIAE which did not submit proofs to DDETS 02 - Campagne 1.",
+        ]
+        assert stderr == ""
+        # EvaluatedSiae are not ordered.
+        [mail1, mail2, mail3] = sorted(mailoutbox, key=lambda mail: (mail.subject, mail.body))
+        assert mail1.subject == (
+            "Contrôle a posteriori des auto-prescriptions : "
+            "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 01"
+        )
+        assert (
+            f"Nous vous rappelons que votre structure EI les petits jardins ID-{evaluated_siae1.siae_id} "
+            "(SIRET : 00000000000032) est soumise à la procédure de contrôle a posteriori sur les embauches réalisées "
+            "en auto-prescription du 1 janvier 2022 au 30 septembre 2022.\n\n"
+            "Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez "
+            "enregistrés lors de ces embauches.\n"
+            "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
+            "7 novembre 2022.\n\n" in mail1.body
+        )
+        assert f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae1.pk}/" in mail1.body
+        assert mail2.subject == (
+            "Contrôle a posteriori des auto-prescriptions : "
+            "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 02"
+        )
+        assert (
+            f"Nous vous rappelons que votre structure EI Bazar antique ID-{evaluated_siae2.siae_id} "
+            "(SIRET : 12345678900012) est soumise à la procédure de contrôle a posteriori sur les embauches réalisées "
+            "en auto-prescription du 1 janvier 2022 au 30 septembre 2022.\n\n"
+            "Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez "
+            "enregistrés lors de ces embauches.\n"
+            "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
+            "7 novembre 2022.\n\n" in mail2.body
+        )
+        assert f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae2.pk}/" in mail2.body
+        assert mail3.subject == (
+            "Contrôle a posteriori des auto-prescriptions : "
+            "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 02"
+        )
+        assert (
+            f"Nous vous rappelons que votre structure EI Trucs muche ID-{evaluated_siae3.siae_id} "
+            "(SIRET : 12345678900024) est soumise à la procédure de contrôle a posteriori sur les embauches réalisées "
+            "en auto-prescription du 1 janvier 2022 au 30 septembre 2022.\n\n"
+            "Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez "
+            "enregistrés lors de ces embauches.\n"
+            "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
+            "7 novembre 2022.\n\n" in mail3.body
+        )
+        assert f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae3.pk}/" in mail3.body
+
+    @freeze_time("2022-12-07 11:11:11")
+    def test_notify_fallback(self, capsys, mailoutbox):
+        "Crons did not run at D+30, the system should catch up."
+        campaign = EvaluationCampaignFactory(
+            evaluations_asked_at=timezone.now() - relativedelta(days=31),
+            evaluated_period_start_at=datetime.date(2022, 1, 1),
+            evaluated_period_end_at=datetime.date(2022, 9, 30),
+            institution__name="DDETS 01",
+            name="Campagne 1",
+        )
+        evaluated_siae = EvaluatedSiaeFactory.create(
+            evaluation_campaign=campaign,
+            siae__name="les petits jardins",
+            siae__convention__siret_signature="00000000000032",
+        )
+        call_command("evaluation_campaign_notify")
+        stdout, stderr = capsys.readouterr()
+        assert stdout.splitlines() == [
+            "Emailed reminders to 1 SIAE which did not submit proofs to DDETS 01 - Campagne 1."
+        ]
+        assert stderr == ""
+        [mail] = mailoutbox
+        assert mail.subject == (
+            "Contrôle a posteriori des auto-prescriptions : "
+            "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 01"
+        )
+        assert (
+            f"Nous vous rappelons que votre structure EI les petits jardins ID-{evaluated_siae.siae_id} "
+            "(SIRET : 00000000000032) est soumise à la procédure de contrôle a posteriori sur les embauches réalisées "
+            "en auto-prescription du 1 janvier 2022 au 30 septembre 2022.\n\n"
+            "Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez "
+            "enregistrés lors de ces embauches.\n"
+            "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
+            "6 novembre 2022.\n\n" in mail.body
+        )
+        assert f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae.pk}/" in mail.body
+
+    @freeze_time("2022-12-07 11:11:11")
+    def test_does_not_notify_twice(self, capsys, mailoutbox):
+        campaign = EvaluationCampaignFactory(
+            evaluations_asked_at=timezone.now() - relativedelta(days=31),
+            evaluated_period_start_at=datetime.date(2022, 1, 1),
+            evaluated_period_end_at=datetime.date(2022, 9, 30),
+            institution__name="DDETS 01",
+            name="Campagne 1",
+        )
+        EvaluatedSiaeFactory.create(
+            evaluation_campaign=campaign,
+            siae__name="les petits jardins",
+            siae__convention__siret_signature="00000000000032",
+            reminder_sent_at=timezone.now() - relativedelta(days=1),
+        )
+        call_command("evaluation_campaign_notify")
+        stdout, stderr = capsys.readouterr()
+        assert stdout == ""
+        assert stderr == ""
+        assert mailoutbox == []
+
+    @freeze_time("2022-12-07 11:11:11")
+    def test_no_notification(self, capsys, mailoutbox):
+        campaign = EvaluationCampaignFactory(evaluations_asked_at=timezone.now() - relativedelta(days=30))
+        evaluated_job_app_submitted = EvaluatedJobApplicationFactory(evaluated_siae__evaluation_campaign=campaign)
+        EvaluatedAdministrativeCriteriaFactory(
+            evaluated_job_application=evaluated_job_app_submitted,
+            uploaded_at=timezone.now() - relativedelta(days=3),
+            submitted_at=timezone.now() - relativedelta(days=2),
+        )
+
+        evaluated_job_app_accepted = EvaluatedJobApplicationFactory(
+            evaluated_siae__evaluation_campaign=campaign,
+            evaluated_siae__reviewed_at=timezone.now() - relativedelta(days=1),
+            evaluated_siae__final_reviewed_at=timezone.now() - relativedelta(days=1),
+        )
+        EvaluatedAdministrativeCriteriaFactory(
+            evaluated_job_application=evaluated_job_app_accepted,
+            uploaded_at=timezone.now() - relativedelta(days=3),
+            submitted_at=timezone.now() - relativedelta(days=2),
+            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED,
+        )
+
+        evaluated_job_app_refused = EvaluatedJobApplicationFactory(
+            evaluated_siae__evaluation_campaign=campaign,
+            evaluated_siae__reviewed_at=timezone.now() - relativedelta(days=1),
+            evaluated_siae__final_reviewed_at=timezone.now() - relativedelta(days=1),
+        )
+        EvaluatedAdministrativeCriteriaFactory(
+            evaluated_job_application=evaluated_job_app_refused,
+            uploaded_at=timezone.now() - relativedelta(days=3),
+            submitted_at=timezone.now() - relativedelta(days=2),
+            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2,
+        )
+
+        evaluated_job_app_adversarial = EvaluatedJobApplicationFactory(
+            evaluated_siae__evaluation_campaign=campaign,
+            evaluated_siae__reviewed_at=timezone.now() - relativedelta(days=1),
+        )
+        EvaluatedAdministrativeCriteriaFactory(
+            evaluated_job_application=evaluated_job_app_adversarial,
+            uploaded_at=timezone.now() - relativedelta(days=3),
+            submitted_at=timezone.now() - relativedelta(days=2),
+            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED,
+        )
+
+        # Aversarial, no proof.
+        EvaluatedJobApplicationFactory(
+            evaluated_siae__evaluation_campaign=campaign,
+            evaluated_siae__reviewed_at=timezone.now() - relativedelta(days=1),
+        )
+
+        call_command("evaluation_campaign_notify")
+        stdout, stderr = capsys.readouterr()
+        assert stdout == ""
+        assert stderr == ""
+        assert mailoutbox == []
+
+    @freeze_time("2022-12-07 11:11:11")
+    def test_notification_for_siaes_without_proofs(self, capsys, mailoutbox):
+        campaign = EvaluationCampaignFactory(
+            evaluations_asked_at=timezone.now() - relativedelta(days=30),
+            evaluated_period_start_at=datetime.date(2022, 1, 1),
+            evaluated_period_end_at=datetime.date(2022, 9, 30),
+            institution__name="DDETS 01",
+            name="Campagne de test",
+        )
+
+        evaluated_siae_no_proof = EvaluatedSiaeFactory.create(
+            evaluation_campaign=campaign,
+            siae__name="les petits jardins",
+            siae__convention__siret_signature="00000000000032",
+        )
+        EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae_no_proof)
+
+        evaluated_siae_not_submitted = EvaluatedSiaeFactory.create(
+            evaluation_campaign=campaign,
+            siae__name="trier pour la planète",
+            siae__convention__siret_signature="12345678900012",
+        )
+        evaluated_job_app_not_submitted = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae_not_submitted)
+        EvaluatedAdministrativeCriteriaFactory(
+            evaluated_job_application=evaluated_job_app_not_submitted,
+            uploaded_at=timezone.now() - relativedelta(days=3),
+        )
+
+        call_command("evaluation_campaign_notify")
+        stdout, stderr = capsys.readouterr()
+        assert stdout == "Emailed reminders to 2 SIAE which did not submit proofs to DDETS 01 - Campagne de test.\n"
+        assert stderr == ""
+        mail1, mail2 = mailoutbox
+        if mail1.body > mail2.body:
+            # EvaluatedSiae are not ordered, email order is not deterministic.
+            mail2, mail1 = mail1, mail2
+        assert mail1.subject == (
+            "Contrôle a posteriori des auto-prescriptions : "
+            "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 01"
+        )
+        assert (
+            f"Nous vous rappelons que votre structure EI les petits jardins ID-{evaluated_siae_no_proof.siae_id} "
+            "(SIRET : 00000000000032) est soumise à la procédure de contrôle a posteriori sur les embauches réalisées "
+            "en auto-prescription du 1 janvier 2022 au 30 septembre 2022.\n\n"
+            "Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez "
+            "enregistrés lors de ces embauches.\n"
+            "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
+            "7 novembre 2022.\n\n" in mail1.body
+        )
+        assert (
+            f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_no_proof.pk}/"
+            in mail1.body
+        )
+        assert mail2.subject == (
+            "Contrôle a posteriori des auto-prescriptions : "
+            "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 01"
+        )
+        assert (
+            "Nous vous rappelons que votre structure EI trier pour la planète ID-"
+            f"{evaluated_siae_not_submitted.siae_id} (SIRET : 12345678900012) est soumise à la procédure de contrôle "
+            "a posteriori sur les embauches réalisées en auto-prescription du 1 janvier 2022 au 30 septembre 2022.\n\n"
+            "Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez "
+            "enregistrés lors de ces embauches.\n"
+            "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
+            "7 novembre 2022.\n\n" in mail2.body
+        )
+        assert (
+            f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_not_submitted.pk}/"
+            in mail2.body
+        )

--- a/itou/templates/siae_evaluations/email/to_siae_notify_before_adversarial_stage_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_notify_before_adversarial_stage_body.txt
@@ -1,0 +1,41 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+Sauf erreur de notre part, vous n’avez pas encore transmis vos justificatifs dans le cadre du contrôle a posteriori des auto-prescriptions.
+
+Nous vous rappelons que votre structure {{ siae.kind }} {{ siae.name }} ID-{{ siae.pk }} (SIRET : {{ siae.convention.siret_signature }}) est soumise à la procédure de contrôle a posteriori sur les embauches réalisées en auto-prescription du {{ evaluation_campaign.evaluated_period_start_at }} au {{ evaluation_campaign.evaluated_period_end_at }}.
+
+Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez enregistrés lors de ces embauches.
+Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du {{ evaluation_campaign.evaluations_asked_at|date }}.
+
+Ce délai comprend la transmission de vos justificatifs ET le contrôle effectué par votre DDETS.
+Attention : si vous transmettez vos justificatifs en dernière minute, la DDETS risque de ne pas avoir le temps de valider ou invalider vos justificatifs ; auquel cas, vous passerez systématiquement en phase contradictoire.
+
+Comment ça marche ?
+
+1- Visualiser la liste des embauches concernées par la procédure de contrôle :
+
+Depuis le tableau de bord de votre structure à la rubrique “Contrôle a posteriori”,
+cliquez sur “Justifier mes auto-prescriptions”.
+La liste des embauches concernées par la procédure est affichée.
+
+Accès direct à votre liste d’auto-prescriptions : {{ evaluated_job_app_list_url }}
+
+2- Transmettez vos justificatifs en ligne
+
+Pour chaque embauche, cliquez sur “Sélectionner les critères”,
+les critères que vous avez enregistrés sont affichés.
+Sélectionnez le ou les critères que vous souhaitez justifier (sur cette page, nous vous rappelons le nombre minimum de justificatifs requis en fonction du type de critères et de SIAE).
+Ensuite cliquez sur  “Ajouter un justificatif”  pour déposer le justificatif demandé.
+
+3- Validez votre dossier de contrôle :
+
+Lorsque tous les justificatifs sont ajoutés, cliquez sur “Soumettre à validation” pour les transmettre à votre DDETS.
+
+Vous serez notifié(e) par e-mail lorsque la DDETS aura vérifié vos justificatifs.
+
+Voir le mode d’emploi : {{ itou_community_url }}/doc/emplois/controle-a-posteriori-pour-les-siae/
+
+En cas de question sur les critères ou les justificatifs vous devez vous adresser uniquement à votre DDETS.
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/to_siae_notify_before_adversarial_stage_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_notify_before_adversarial_stage_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+Contrôle a posteriori des auto-prescriptions : Plus que quelques jours pour transmettre vos justificatifs à la {{ evaluation_campaign.institution }}
+{% endblock %}


### PR DESCRIPTION
### Quoi ?

Rappel aux SIAE n’ayant pas soumis de pièces justificatives à J+30

### Pourquoi ?

Inciter les SIAE à transmettre leurs pièces justificatives pendant la phase amiable du contrôle a posteriori.