### PR TITLE
import_ea_eatt: Restaurer l'import timeit

### DIFF
--- a/itou/siaes/management/commands/import_ea_eatt.py
+++ b/itou/siaes/management/commands/import_ea_eatt.py
@@ -13,9 +13,9 @@ from itou.siaes.management.commands._import_siae.utils import (
     get_filename,
     remap_columns,
     sync_structures,
-    timeit,
 )
 from itou.siaes.models import Siae
+from itou.utils.python import timeit
 from itou.utils.validators import validate_siret
 
 

--- a/itou/siaes/management/commands/import_geiq.py
+++ b/itou/siaes/management/commands/import_geiq.py
@@ -12,9 +12,9 @@ from itou.siaes.management.commands._import_siae.utils import (
     get_filename,
     remap_columns,
     sync_structures,
-    timeit,
 )
 from itou.siaes.models import Siae
+from itou.utils.python import timeit
 from itou.utils.validators import validate_siret
 
 


### PR DESCRIPTION
There must have been as mishap in a rebase somewhere, this is not supposed to happen :/
En attendant, cette commande crashe.