### PR TITLE
Remplacer l'icone de téléchargement

### DIFF
--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -33,7 +33,7 @@
                             <td>{{ month.c }}</td>
                             <td>
                                 {% if export_for == "siae" %}
-                                    <i class="ri-download-2-line mr-1"></i>
+                                    <i class="ri-download-line mr-1"></i>
                                     <a class="matomo-event text-decoration-none"
                                        data-matomo-category="candidatures"
                                        data-matomo-action="exports"
@@ -43,7 +43,7 @@
                                         Télécharger
                                     </a>
                                 {% else %}
-                                    <i class="ri-download-2-line mr-1"></i>
+                                    <i class="ri-download-line mr-1"></i>
                                     <a class="matomo-event text-decoration-none"
                                        data-matomo-category="candidatures"
                                        data-matomo-action="exports"

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -296,7 +296,7 @@
                             <a href="{% url 'home:hp' %}">Postuler pour un candidat</a>
                         </li>
                         <li class="card-text mb-3">
-                            <i class="ri-download-2-line ri-lg"></i>
+                            <i class="ri-download-line ri-lg"></i>
                             <a href="{% url 'apply:list_for_prescriber_exports' %}">
                                 Export des candidatures
                             </a>
@@ -426,7 +426,7 @@
                             </li>
                         {% endif %}
                         <li class="card-text mb-3">
-                            <i class="ri-download-2-line ri-lg mr-1"></i>
+                            <i class="ri-download-line ri-lg mr-1"></i>
                             <a href="{% url 'apply:list_for_siae_exports' %}">
                                 Export des candidatures
                             </a>


### PR DESCRIPTION
### Quoi ?

Changer de version d'icone de téléchargment de remix icon

### Pourquoi ?
Pour harmoniser avec le thème et répondre à cette demande UX
https://www.notion.so/Modifier-l-icon-download-2d03a2efc1164ee59f4191c4109badd6 

### Comment ?

En remplacant la classe `ri-download-2-line` par `ri-download-line`

![capture 2022-11-07 à 16 01 23](https://user-images.githubusercontent.com/3874024/200342613-659cd326-44a0-46bd-ab60-c01d2da1fc08.png)
![capture 2022-11-07 à 16 01 30](https://user-images.githubusercontent.com/3874024/200342616-cfd9669c-ffca-4a2a-b006-829c72ad626a.png)
