### PR TITLE
Boost - Retirer le bandeau alerte dans l’écran de validation de l’éligibilité IAE par un employeur 

### DIFF
--- a/itou/templates/apply/process_eligibility.html
+++ b/itou/templates/apply/process_eligibility.html
@@ -29,12 +29,6 @@
         Si le candidat ne remplit pas les conditions administratives, <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/derogation-aux-criteres-administratifs/" target="_blank" rel="noreferrer noopener">orientez-le vers un prescripteur habilité</a>.
     </p>
 
-    <div class="alert alert-warning">
-        <p class="mb-0">
-            <i>Dans le cadre de l'expérimentation actuelle, nous vous informons que la liste des critères d'éligibilité à l'IAE est susceptible d'évoluer à la marge.</i>
-        </p>
-    </div>
-
     <hr>
 
     <h2 class="h1">Critères d'éligibilité</h2>


### PR DESCRIPTION
### Quoi ?

Retirer le bandeau alerte dans l’écran de validation de l’éligibilité IAE par un employeur 

### Pourquoi ?

Ce n'est plus d'actualité 

### Captures d'écran (optionnel)
Avant :
<img width="989" alt="Capture d’écran 2022-10-07 à 10 55 56" src="https://user-images.githubusercontent.com/7632730/200541197-fc2c5902-16a5-4955-81b3-5ba7e8d544e5.png">


