### PR TITLE
Recherche de postes : Filtre des offres par type de contrat

### DIFF
--- a/itou/templates/search/includes/siaes_search_filters.html
+++ b/itou/templates/search/includes/siaes_search_filters.html
@@ -36,5 +36,11 @@
 
         <hr>
         {% bootstrap_field form.kinds form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
+
+        {% if form.contract_types %}
+            <hr>
+            {% bootstrap_field form.contract_types form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
+        {% endif %}
+
     </div>
 </div>

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -46,7 +46,7 @@
                        data-matomo-category="candidature"
                        data-matomo-action="clic"
                        data-matomo-option="clic-onglet-employeur"
-                       href="{% url "search:siaes_results" %}?distance={{ distance }}&city={{ city.slug }}&city_name={{ city }}&{{ kinds_query }} ">
+                       href="{% url "search:siaes_results" %}?distance={{ distance }}&city={{ city.slug }}&city_name={{ city }}&{{ kinds_query }}&{{ contract_types_query }}">
                         <i class="ri-hotel-line ri-xl mr-1"></i>
                         Employeurs
                         {% if siaes_count %}
@@ -60,7 +60,7 @@
                        data-matomo-category="candidature"
                        data-matomo-action="clic"
                        data-matomo-option="clic-onglet-fichesdeposte"
-                       href="{% url "search:job_descriptions_results" %}?distance={{ distance }}&city={{ city.slug }}&city_name={{ city }}&{{ kinds_query }} ">
+                       href="{% url "search:job_descriptions_results" %}?distance={{ distance }}&city={{ city.slug }}&city_name={{ city }}&{{ kinds_query }}&{{ contract_types_query }}">
                         <i class="ri-briefcase-4-line ri-xl mr-1"></i>
                         <span class="d-lg-none d-xl-none">Postes</span>
                         <span class="d-none d-lg-inline">Postes ouverts au recrutement</span>

--- a/itou/www/search/forms.py
+++ b/itou/www/search/forms.py
@@ -4,7 +4,7 @@ from django.utils.datastructures import MultiValueDict
 
 from itou.cities.models import City
 from itou.common_apps.address.departments import DEPARTMENTS, DEPARTMENTS_WITH_DISTRICTS, format_district
-from itou.siaes.enums import SiaeKind
+from itou.siaes.enums import ContractType, SiaeKind
 
 
 class SiaeSearchForm(forms.Form):
@@ -90,6 +90,25 @@ class SiaeSearchForm(forms.Form):
             choices=choices,
             widget=forms.CheckboxSelectMultiple(),
         )
+
+
+class JobDescriptionSearchForm(SiaeSearchForm):
+
+    CONTRACT_TYPE_CHOICES = sorted(
+        [(k, v) for k, v in ContractType.choices if k not in (ContractType.OTHER, ContractType.BUSINESS_CREATION)],
+        key=lambda d: d[1],
+    ) + [
+        (ContractType.BUSINESS_CREATION, ContractType.BUSINESS_CREATION.label),
+        (ContractType.OTHER, ContractType.OTHER.label),
+        ("", "Contrat non précisé"),
+    ]
+
+    contract_types = forms.MultipleChoiceField(
+        label="Types de contrats",
+        choices=CONTRACT_TYPE_CHOICES,
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+    )
 
 
 class PrescriberSearchForm(forms.Form):

--- a/itou/www/search/tests.py
+++ b/itou/www/search/tests.py
@@ -217,8 +217,7 @@ class JobDescriptionSearchViewTest(TestCase):
             1  # select the city
             + 1  # fetch initial job descriptions to add to the form fields
             + 2  # count the number of results for siaes & job descriptions
-            + 1  # select the job descriptions pager
-            + 1  # prefetch active job descriptions
+            + 1  # select the job descriptions for the page
             + NUM_CSRF_SESSION_REQUESTS
         ):
             response = self.client.get(self.url, {"city": city_slug})

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -50,7 +50,7 @@ class EmployerSearchBaseView(FormView):
         job_descriptions = (
             SiaeJobDescription.objects.active()
             .within(city.coords, distance)
-            .select_related("location")
+            .select_related("siae", "location")
             .exclude(siae__block_job_applications=True)
             .annotate(
                 distance=Case(


### PR DESCRIPTION
### Quoi ?

- Optimiser une requête qui sinon peut se révéler assez douloureuse
- Ajouter un filtrage des offres et structures par types de postes proposés

### Pourquoi ?

Demandes et attentes du métier, tout simplement. 

### Captures d'écran
![Screenshot 2022-11-16 at 19-38-42 Les emplois de l'inclusion](https://user-images.githubusercontent.com/88618/202265278-9bf2d6c0-d65a-4b71-81c8-e78c3e49d636.png)
