### PR TITLE
Correction des doublons pour les fiches salariés d'actualisation

### DIFF
--- a/itou/employee_record/factories.py
+++ b/itou/employee_record/factories.py
@@ -28,7 +28,7 @@ class EmployeeRecordFactory(factory.django.DjangoModelFactory):
             return
 
         self.siret = self.job_application.to_siae.siret
-        self.approval_number = self.job_application.approval.number
+        self.approval_number = self.approval_number or self.job_application.approval.number
         self.asp_id = self.job_application.to_siae.convention.asp_id
 
 

--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -552,6 +552,12 @@ class JobApplicationQuerySetTest(TestCase):
             approval=job_app.approval,
         )
         self.assertIn(job_app, JobApplication.objects.eligible_as_employee_record(job_app.to_siae))
+        # ...and with an employee record already existing for that employee
+        EmployeeRecordFactory(
+            job_application__to_siae=job_app.to_siae,
+            approval_number=job_app.approval.number,
+        )
+        self.assertNotIn(job_app, JobApplication.objects.eligible_as_employee_record(job_app.to_siae))
 
     def test_with_accepted_at_for_created_from_pe_approval(self):
         JobApplicationFactory(


### PR DESCRIPTION
 ### Quoi ?

On ne propose plus de FS d'actualisation si une FS existe déjà pour cette SIAE et ce PASS IAE, l'existante fait foi.

### Pourquoi ?

Correction suite à f540bbe87.
