### PR TITLE
SiaeJobDescription: correction de la méthode active()

### DIFF
--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -494,7 +494,12 @@ class SiaeJobDescriptionQuerySet(models.QuerySet):
         return self.order_by("-updated_at", "-created_at")
 
     def active(self):
-        return self.filter(is_active=True)
+        subquery = Subquery(
+            Siae.objects.filter(
+                pk=OuterRef("siae"),
+            ).active()
+        )
+        return self.annotate(is_siae_active=Exists(subquery)).filter(is_active=True, is_siae_active=True)
 
     def within(self, point, distance_km):
         return self.filter(


### PR DESCRIPTION
Il faut absolument (ce qui n'etait pas fait) que l'on vérifie aussi l'état actif de la SIAE sous-jacente, sinon cela n'a pas vraiment de sens.
Actuellement notre recherche d'emplois par fiche de poste affiche des offres actives qui sont liées à des SIAE inactives donc non listées.