### PR TITLE
Retire job_autocomplete.js de la page edit_job_description_details

### DIFF
--- a/itou/templates/siaes/edit_job_description_details.html
+++ b/itou/templates/siaes/edit_job_description_details.html
@@ -82,8 +82,3 @@
         </form>
     </div>
 {% endblock %}
-
-{% block script %}
-    {{ block.super }}
-    <script src="{% static "js/job_autocomplete.js" %}"></script>
-{% endblock %}


### PR DESCRIPTION
### Quoi ?

Retire job_autocomplete.js de la page edit_job_description_details

### Pourquoi ?

Le script n’est pas utilisé sur la page.