### PR TITLE
Remplace les transitions jQuery UI par jQuery

### DIFF
--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -115,9 +115,9 @@
             function ajust_form_according_reason() {
                 const value = $('input[name="reason"]:checked').val();
                 if (reasons_not_need_prescriber_opinion.includes(value)) {
-                    $('#js-field-email').hide("slidedown").find('.form-group').removeClass("form-group-required");
+                    $('#js-field-email').hide({}).find('.form-group').removeClass("form-group-required");
                 } else {
-                    $('#js-field-email').show("slideup").find('.form-group').addClass("form-group-required");
+                    $('#js-field-email').show({}).find('.form-group').addClass("form-group-required");
                 }
 
                 if (value in reasons_max_durations) {


### PR DESCRIPTION
### Quoi ?

Remplace les transitions jQuery UI par jQuery

### Pourquoi ?

Objectif : retirer jQuery UI à terme. Il ne reste “plus” que les autocomplete qui nécessitent jQuery UI.

### Captures d'écran
[Screencast from 2022-11-09 15-19-56.webm](https://user-images.githubusercontent.com/2758243/200873069-05321b54-939a-474a-9529-f3a3a68e2202.webm)
