### PR TITLE
[FIX] Corrige une erreur dans la page d'admin pour les utilisateurs avec des droits limités

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -158,7 +158,7 @@ class ApprovalAdmin(admin.ModelAdmin):
     )
 
     def get_form(self, request, obj=None, **kwargs):
-        if self.has_change_permission(request, obj) or self.has_add_permission(request, obj):
+        if self.has_change_permission(request, obj) or self.has_add_permission(request):
             # When a user has only the "view" permission it seems that ModelForm.fields is empty,
             # ApprovalAdminForm wants to modify that attribute which result in a KeyError,
             # so we return the custom form only for user with the "change" permission.


### PR DESCRIPTION
Génère une `TypeError: BaseModelAdmin.has_add_permission() takes 2 positional arguments but 3 were given`.
Commit responsable : 05d9167a8 :confounded:.