### PR TITLE
Ajout d’un utilitaire pour envoyer des emails

### DIFF
--- a/itou/siae_evaluations/management/commands/patch_siae_emails.py
+++ b/itou/siae_evaluations/management/commands/patch_siae_emails.py
@@ -1,8 +1,7 @@
-from django.core import mail
 from django.core.management.base import BaseCommand
 
 from itou.siae_evaluations.models import EvaluatedSiae
-from itou.utils.emails import get_email_message
+from itou.utils.emails import get_email_message, send_email_messages
 
 
 def get_email_patch_siae(to):
@@ -28,7 +27,4 @@ class Command(BaseCommand):
             for evsiae in EvaluatedSiae.objects.filter(evaluation_campaign__name=evaluation_campaign_name)
             if evsiae.state in ["PENDING", "SUBMITTABLE"]
         )
-        emails = (get_email_patch_siae(evsiae.siae.active_admin_members) for evsiae in evsiaes)
-
-        connection = mail.get_connection()
-        connection.send_messages(emails)
+        send_email_messages(get_email_patch_siae(evsiae.siae.active_admin_members) for evsiae in evsiaes)

--- a/itou/siaes/management/commands/import_siae.py
+++ b/itou/siaes/management/commands/import_siae.py
@@ -14,7 +14,6 @@ and thus we need a proper tool to manage columns by their
 name instead of hardcoding column numbers as in `field = row[42]`.
 
 """
-from django.core import mail
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
@@ -31,6 +30,7 @@ from itou.siaes.management.commands._import_siae.utils import could_siae_be_dele
 from itou.siaes.management.commands._import_siae.vue_af import ACTIVE_SIAE_KEYS
 from itou.siaes.management.commands._import_siae.vue_structure import ASP_ID_TO_SIAE_ROW
 from itou.siaes.models import Siae, SiaeConvention
+from itou.utils.emails import send_email_messages
 from itou.utils.python import timeit
 
 
@@ -256,9 +256,7 @@ class Command(BaseCommand):
             siae.save()
         self.stdout.write("--- end of CSV output of all creatable_siaes ---")
 
-        activate_your_account_emails = (siae.activate_your_account_email() for siae in creatable_siaes)
-        connection = mail.get_connection()
-        connection.send_messages(activate_your_account_emails)
+        send_email_messages(siae.activate_your_account_email() for siae in creatable_siaes)
 
         self.stdout.write(f"{len(creatable_siaes)} structures will be created")
         self.stdout.write(f"{len([s for s in creatable_siaes if s.coords])} structures will have geolocation")

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -46,3 +46,8 @@ def get_email_message(to, context, subject, body, from_email=settings.DEFAULT_FR
         subject=subject,
         body=get_email_text_template(body, context),
     )
+
+
+def send_email_messages(email_messages):
+    with mail.get_connection() as connection:
+        connection.send_messages(email_messages)

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -1,7 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.core import mail
 from django.db import transaction
 from django.db.models import Min, Q
 from django.http import Http404, HttpResponseRedirect
@@ -19,6 +18,7 @@ from itou.siae_evaluations.models import (
     EvaluatedSiae,
     EvaluationCampaign,
 )
+from itou.utils.emails import send_email_messages
 from itou.utils.perms.institution import get_current_institution_or_404
 from itou.utils.perms.siae import get_current_siae_or_404
 from itou.utils.storage.s3 import S3Upload
@@ -192,8 +192,7 @@ class InstitutionEvaluatedSiaeNotifyView(LoginRequiredMixin, generic.UpdateView)
     def form_valid(self, form):
         messages.success(self.request, f"{self.object} a bien été notifiée de la sanction.")
         email = self.object.get_email_to_siae_sanctioned()
-        connection = mail.get_connection()
-        connection.send_messages([email])
+        send_email_messages([email])
         return super().form_valid(form)
 
     def get_success_url(self):
@@ -532,8 +531,7 @@ def siae_submit_proofs(request, evaluated_siae_pk):
 
         # note vincentporte : misconception. This view should be called with one evaluated_siae
         # check this impact when calling this view with evaluated_siae.pk in params
-        connection = mail.get_connection()
-        connection.send_messages([evaluated_siae.get_email_to_institution_submitted_by_siae()])
+        send_email_messages([evaluated_siae.get_email_to_institution_submitted_by_siae()])
 
         messages.success(
             request,


### PR DESCRIPTION
### Quoi ?

Ajout d’un utilitaire pour envoyer des emails

### Pourquoi ?

Centralise le motif souvent répété `mail.get_connection().send_messages([])`, avec l’utilisation d’un *context manager* pour une gestion plus claire de la connection.