### PR TITLE
Envoi de notifications lors du passage forcé en phase contradictoire

### DIFF
--- a/itou/templates/siae_evaluations/email/to_siae_forced_to_adversarial_stage_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_forced_to_adversarial_stage_body.txt
@@ -1,0 +1,15 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+Sauf erreur de notre part, vous n’avez pas transmis les justificatifs dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription.
+
+La {{ evaluation_campaign.institution }} ne peut donc pas faire de contrôle, par conséquent vous entrez dans une phase dite contradictoire de 6 semaines (durant laquelle il vous faut transmettre les justificatifs demandés) et qui se clôturera sur une décision (validation ou sanction pouvant aller jusqu’à un retrait d’aide au poste) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
+
+Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de {{ siae.kind }} {{ siae.name }} ID-{{ siae.pk }} à la rubrique “Justifier mes auto-prescriptions”.
+{{ auto_prescription_url }}
+
+En cas de besoin, vous pouvez consulter ce mode d’emploi.
+
+Cordialement,
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/to_siae_forced_to_adversarial_stage_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_forced_to_adversarial_stage_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+Résultat du contrôle - {{ siae.kind }} {{ siae.name }} ID-{{ siae.pk }}
+{% endblock %}


### PR DESCRIPTION
### Quoi ?

Envoi de notifications lors du passage forcé en phase contradictoire

### Pourquoi ?

6 semaines après le début d’une campagne de contrôle a posteriori, les SIAE n’ayant pas transmis leurs justificatifs passent en phase contradictoire. Ce changement permet de les informer par email.