### PR TITLE
[Metabase] Hotfix d'une erreur sur les Agréments PE

### DIFF
--- a/itou/metabase/management/commands/_approvals.py
+++ b/itou/metabase/management/commands/_approvals.py
@@ -80,7 +80,7 @@ TABLE.add_columns(
             "name": "id_candidat_anonymisé",
             "type": "varchar",
             "comment": "ID anonymisé du candidat",
-            "fn": lambda o: hash_content(o.user.pk),
+            "fn": lambda o: hash_content(o.user.pk) if isinstance(o, Approval) else None,
         },
         {
             "name": "id_structure",

--- a/itou/metabase/tests/test_approvals.py
+++ b/itou/metabase/tests/test_approvals.py
@@ -1,6 +1,6 @@
 from django.test import override_settings
 
-from itou.approvals.factories import ApprovalFactory
+from itou.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
 from itou.metabase.management.commands._approvals import TABLE
 
 
@@ -30,3 +30,8 @@ def test_id_candidat_anonymisé():
         TABLE.get(column_name="id_candidat_anonymisé", input=approval)
         == "24be2dc555f5db9a3348fa2290204ce75b7a9240a8049cfe0ff6c445dc63956f"
     )
+
+
+def test_id_candidat_anonymisé_for_pe_approval():
+    pe_approval = PoleEmploiApprovalFactory()
+    assert TABLE.get(column_name="id_candidat_anonymisé", input=pe_approval) is None


### PR DESCRIPTION
### Quoi ?

Hotfix d'une erreur sur les Agréments PE.

### Pourquoi ?

Ma PR récente https://github.com/betagouv/itou/pull/1660 a malheureusement cassé le script quotidien d'injection des données C1 dans le C2 (aussi connu sous le nom de "populate_metabase_itou"). Mea culpa, je ne l'ai pas assez testée manuellement (j'ai zappé un dry run) et bien que j'ai écris des tests ils ne couvraient pas ce cas, ce qui est corrigé avec le test ajouté par cette PR.
