### PR TITLE
Correction de l'affichage du PASS IAE

### DIFF
--- a/itou/templates/approvals/printable_approval.html
+++ b/itou/templates/approvals/printable_approval.html
@@ -3,7 +3,7 @@
 {% load format_filters %}
 
 {% block title %}
-    Attestation de délivrance d'agrément pour {{ job_seeker.get_full_name|title }}.
+    Attestation de délivrance d'agrément pour {{ approval.user.get_full_name|title }}.
     {{ block.super }}
 {% endblock %}
 
@@ -47,8 +47,8 @@
 
             <span class="d-block">délivré par les emplois de l'inclusion</span>
 
-            {% if job_seeker.pole_emploi_id %}
-                <span class="d-block">Identifiant Pôle emploi : {{ job_seeker.pole_emploi_id }}</span>
+            {% if approval.user.pole_emploi_id %}
+                <span class="d-block">Identifiant Pôle emploi : {{ approval.user.pole_emploi_id }}</span>
             {% endif %}
 
         </section>
@@ -72,7 +72,7 @@
 
                 {% endif %}
 
-                la situation sociale et professionnelle de {{ job_seeker.get_full_name|title }}
+                la situation sociale et professionnelle de {{ approval.user.get_full_name|title }}
                 et de votre promesse d'embauche, les emplois de l'inclusion vous délivrent
                 un PASS IAE pour un parcours d'insertion par l'activité économique,
                 conformément aux dispositions des articles L 5132-1 à L 5132-17 du code du travail.

--- a/itou/www/approvals_views/tests/test_display.py
+++ b/itou/www/approvals_views/tests/test_display.py
@@ -1,10 +1,11 @@
 from unittest.mock import PropertyMock, patch
 
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 
-from itou.job_applications.factories import JobApplicationWithApprovalFactory
+from itou.job_applications.factories import JobApplicationFactory, JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication
 from itou.users.factories import UserFactory
 from itou.utils import constants as global_constants
@@ -26,6 +27,30 @@ class TestDisplayApproval(TestCase):
         self.assertEqual(response.context["approval"], job_application.approval)
         self.assertEqual(response.context["siae"], job_application.to_siae)
         self.assertEqual(response.context["job_seeker"], job_application.job_seeker)
+        self.assertContains(response, global_constants.ITOU_ASSISTANCE_URL)
+        self.assertContains(response, "Imprimer ce PASS IAE")
+        self.assertContains(response, "Astuce pour conserver cette attestation en format PDF")
+
+    def test_display_approval_multiple_job_applications(self, *args, **kwargs):
+        job_application = JobApplicationWithApprovalFactory()
+        JobApplicationFactory(
+            job_seeker=job_application.job_seeker,
+            approval=job_application.approval,
+            to_siae=job_application.to_siae,
+            state=job_application.state,
+            created_at=job_application.created_at - relativedelta(days=1),
+        )
+
+        siae_member = job_application.to_siae.members.first()
+        self.client.force_login(siae_member)
+
+        response = self.client.get(
+            reverse("approvals:display_printable_approval", kwargs={"approval_id": job_application.approval_id})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["approval"], job_application.approval)
+        self.assertEqual(response.context["siae"], job_application.to_siae)
         self.assertContains(response, global_constants.ITOU_ASSISTANCE_URL)
         self.assertContains(response, "Imprimer ce PASS IAE")
         self.assertContains(response, "Astuce pour conserver cette attestation en format PDF")

--- a/itou/www/approvals_views/urls.py
+++ b/itou/www/approvals_views/urls.py
@@ -9,7 +9,7 @@ app_name = "approvals"
 urlpatterns = [
     # PASS IAE
     path("detail/<int:pk>", views.ApprovalDetailView.as_view(), name="detail"),
-    path("display/<int:approval_id>", views.display_printable_approval, name="display_printable_approval"),
+    path("display/<int:approval_id>", views.ApprovalPrintableDisplay.as_view(), name="display_printable_approval"),
     path("list", views.ApprovalListView.as_view(), name="list"),
     path("declare_prolongation/<int:approval_id>", views.declare_prolongation, name="declare_prolongation"),
     path("suspend/<int:approval_id>", views.suspend, name="suspend"),

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -38,9 +38,9 @@ class ApprovalBaseViewMixin(LoginRequiredMixin):
             self.siae = get_current_siae_or_404(request)
 
     def get_context_data(self, **kwargs):
-        context_data = super().get_context_data(**kwargs)
-        context_data["siae"] = self.siae
-        return context_data
+        context = super().get_context_data(**kwargs)
+        context["siae"] = self.siae
+        return context
 
     # TODO(alaurent) : An Employee model linked to the siae, Approval and JobSeeker would make things easier here
     def get_job_application(self, approval):
@@ -62,15 +62,15 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
     template_name = "approvals/detail.html"
 
     def get_context_data(self, **kwargs):
-        context_data = super().get_context_data(**kwargs)
-        context_data["approval_can_be_suspended_by_siae"] = self.object.can_be_suspended_by_siae(self.siae)
-        context_data["hire_by_other_siae"] = not self.object.user.last_hire_was_made_by_siae(self.siae)
-        context_data["approval_can_be_prolonged_by_siae"] = self.object.can_be_prolonged_by_siae(self.siae)
+        context = super().get_context_data(**kwargs)
+        context["approval_can_be_suspended_by_siae"] = self.object.can_be_suspended_by_siae(self.siae)
+        context["hire_by_other_siae"] = not self.object.user.last_hire_was_made_by_siae(self.siae)
+        context["approval_can_be_prolonged_by_siae"] = self.object.can_be_prolonged_by_siae(self.siae)
         job_application = self.get_job_application(self.object)
-        context_data["job_application"] = job_application
+        context["job_application"] = job_application
         if job_application:
-            context_data["eligibility_diagnosis"] = job_application.get_eligibility_diagnosis()
-        context_data["all_job_applications"] = (
+            context["eligibility_diagnosis"] = job_application.get_eligibility_diagnosis()
+        context["all_job_applications"] = (
             JobApplication.objects.filter(
                 job_seeker=self.object.user,
                 to_siae=self.siae,
@@ -78,7 +78,7 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
             .select_related("sender")
             .prefetch_related("selected_jobs")
         )
-        return context_data
+        return context
 
 
 class ApprovalListView(ApprovalBaseViewMixin, ListView):
@@ -102,10 +102,10 @@ class ApprovalListView(ApprovalBaseViewMixin, ListView):
         return super().get_queryset().filter(*form_filters)
 
     def get_context_data(self, **kwargs):
-        context_data = super().get_context_data(**kwargs)
-        context_data["filters_form"] = self.form
-        context_data["filters_counter"] = self.form.get_filters_counter()
-        return context_data
+        context = super().get_context_data(**kwargs)
+        context["filters_form"] = self.form
+        context["filters_counter"] = self.form.get_filters_counter()
+        return context
 
 
 @login_required


### PR DESCRIPTION
### Quoi ?

Effet de bord du chantier espace salarié : on utilise l'id du pass IAE au lieu d'une candidature, hors on peut avoir de multiples candidatures acceptées pour un même utilisateur et une même SIAE
