### PR TITLE
Commande `transfer_employee_records` : On n'ouvre plus de connexion SFTP en mode `--archive`

### DIFF
--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -314,8 +314,8 @@ class Command(EmployeeRecordTransferCommand):
 
     def handle(
         self,
-        upload=True,
-        download=True,
+        upload=False,
+        download=False,
         preflight=False,
         dry_run=False,
         asp_test=False,

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -216,7 +216,7 @@ class Command(EmployeeRecordTransferCommand):
         for batch in chunks(new_notifications, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS):
             self._upload_batch_file(conn, batch, dry_run)
 
-    def handle(self, upload=True, download=True, preflight=False, wet_run=False, asp_test=False, **options):
+    def handle(self, upload=False, download=False, preflight=False, wet_run=False, asp_test=False, **options):
         if not settings.ASP_FS_SFTP_HOST:
             self.stdout.write("Your environment is missing ASP_FS_SFTP_HOST to run this command.")
             return


### PR DESCRIPTION
### Pourquoi ?

La connexion SFTP n'est utile que pour `--upload` et `--download` pas pour `--preflight` ou `--archive`, sauf que actuellement `--archive` échoue si l'ouverture de la connexion SFTP échoue.
