### PR TITLE
ajout echelle plus locale au tx refus siae

### DIFF
--- a/itou/metabase/management/commands/sql/024_tx_refus_siae.sql
+++ b/itou/metabase/management/commands/sql/024_tx_refus_siae.sql
@@ -14,19 +14,19 @@ with etp_conventionnes as (
     )
 select 
     /* Nombre de candidatures acceptées initiées par l'employeur de type SIAE */
-    count(distinct candidatures.id_anonymisé) 
+    count(distinct candidatures_echelle_locale.id_anonymisé) 
         filter (
             where 
                 (origine = 'Employeur') 
                 and (état = 'Candidature acceptée')
                 and type_structure in ('EI', 'ETTI', 'AI', 'ACI', 'EITI')) as nombre_candidatures_acceptees_employeurs,
     /* Nombre de candidatures initiées par l'employeur de type SIAE */
-    count(distinct candidatures.id_anonymisé) 
+    count(distinct candidatures_echelle_locale.id_anonymisé) 
         filter (
             where 
                 (origine = 'Employeur') 
                 and type_structure in ('EI', 'ETTI', 'AI', 'ACI', 'EITI')) as nombre_candidatures_employeurs,
-    count(distinct candidatures.id_anonymisé) 
+    count(distinct candidatures_echelle_locale.id_anonymisé) 
         filter (
             where 
                 (état = 'Candidature acceptée')
@@ -43,23 +43,28 @@ select
     nombre_etp_conventionnes,
     type_structure,
     nom_département_structure,
-    région_structure
+    région_structure,
+    candidatures_echelle_locale.ville,
+    nom_epci,
+    code_commune,
+    nom_arrondissement,
+    bassin_d_emploi    
 from 
-    candidatures
+    candidatures_echelle_locale
 left join 
     fiches_de_poste_par_candidature fdpc 
-    on candidatures.id_anonymisé = fdpc.id_anonymisé_candidature 
+    on candidatures_echelle_locale.id_anonymisé = fdpc.id_anonymisé_candidature 
 left join 
     fiches_de_poste fdp on fdpc.id_fiche_de_poste = fdp.id
 left join 
-    structures on structures.id =candidatures.id_structure 
+    structures on structures.id =candidatures_echelle_locale.id_structure 
 left join 
     etp_conventionnes 
-        on etp_conventionnes.type_siae = candidatures.type_structure
-        and etp_conventionnes.nom_departement_af = candidatures.nom_département_structure
-        and etp_conventionnes.nom_region_af = candidatures.région_structure
+        on etp_conventionnes.type_siae = candidatures_echelle_locale.type_structure
+        and etp_conventionnes.nom_departement_af = candidatures_echelle_locale.nom_département_structure
+        and etp_conventionnes.nom_region_af = candidatures_echelle_locale.région_structure
 where 
-    candidatures.injection_ai = 0 
+    candidatures_echelle_locale.injection_ai = 0 
     and recrutement_ouvert = 1
      /*se restreindre aux 12 derniers mois*/
     and date_candidature >= date_trunc('month', CAST((CAST(now() AS timestamp) + (INTERVAL '-12 month')) AS timestamp)) 
@@ -68,4 +73,9 @@ group by
     type_structure,
     nom_département_structure,
     région_structure,
-    nombre_etp_conventionnes
+    nombre_etp_conventionnes,
+    candidatures_echelle_locale.ville,
+    nom_epci,
+    code_commune,
+    nom_arrondissement,
+    bassin_d_emploi 


### PR DESCRIPTION
### Quoi ?

ajout d'une echelle plus locale a la table tx refus siae

### Pourquoi ?

permettre de filtrer par epci/bassin d'emploi sur le TB 116

