### PR TITLE
Retrait des URLs de page d’erreur

### DIFF
--- a/clevercloud/http.json
+++ b/clevercloud/http.json
@@ -1,7 +1,4 @@
 {
-    "error_pages": {
-        "404": "404/"
-    },
     "force_https": true,
     "charset": "utf-8"
 }

--- a/config/urls.py
+++ b/config/urls.py
@@ -75,10 +75,6 @@ urlpatterns = [
     path("welcoming_tour/", include("itou.www.welcoming_tour.urls")),
     # Static pages.
     path("accessibility/", TemplateView.as_view(template_name="static/accessibility.html"), name="accessibility"),
-    # Errors pages.
-    path("403/", TemplateView.as_view(template_name="403.html"), name="403"),
-    path("404/", TemplateView.as_view(template_name="404.html"), name="404"),
-    path("500/", TemplateView.as_view(template_name="500.html"), name="500"),
 ]
 
 if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:


### PR DESCRIPTION
### Pourquoi ?

Les pages 403 et 500 n’étaient jamais utilisées.
La page 404 n’est pas claire. D’après https://www.clever-cloud.com/doc/deploy/application/python/python_apps/, qui documente le format de `http.json` :

> error_pages: configure custom files for error pages

La directive "/404" n’est pas un fichier. Je m’attendais à ce que CleverCloud utilise la directive NGINX `error_page`, qui cause :

> an internal redirect to the specified uri with the client request
  method changed to “GET”.

Mes tests sur la /review app/ révèlent un comportement différent, où la 404 de Django est affiché, y compris pour les URL commençant par /static/notfound. Au final, les fichiers statiques ne sont pas chargés directement par le client, mais par le navigateur à la lecture du fichier HTML (ce sont les fichiers JavaScript, CSS, les images, etc.). Afficher une 404 générique est acceptable, puisqu’un utilisateur classique ne verra jamais la page correspondant à l’erreur.