### PR TITLE
Modification des règles de prolongation

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -198,7 +198,8 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     ASP_ITOU_PREFIX = settings.ASP_ITOU_PREFIX
 
     # The period of time during which it is possible to prolong a PASS IAE.
-    IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS = 3
+    IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_START = 12
+    IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_END = 3
 
     # Error messages.
     ERROR_PASS_IAE_SUSPENDED_FOR_USER = (
@@ -391,9 +392,9 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
 
     @property
     def is_open_to_prolongation(self):
-        now = timezone.now().date()
-        lower_bound = self.end_at - relativedelta(months=self.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS)
-        upper_bound = self.end_at + relativedelta(months=self.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS)
+        now = timezone.localdate()
+        lower_bound = self.start_at + relativedelta(months=self.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_START)
+        upper_bound = self.end_at + relativedelta(months=self.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_END)
         return lower_bound <= now <= upper_bound
 
     @cached_property

--- a/itou/www/approvals_views/tests/test_detail.py
+++ b/itou/www/approvals_views/tests/test_detail.py
@@ -88,6 +88,7 @@ class TestApprovalDetailView:
     def test_prolongation_button(self, client):
         approval = ApprovalFactory(
             with_jobapplication=True,
+            start_at=timezone.localdate() - relativedelta(months=12),
             end_at=timezone.localdate() + relativedelta(months=2),
         )
         job_application = approval.jobapplication_set.get()
@@ -100,7 +101,7 @@ class TestApprovalDetailView:
         response = client.get(url)
         assertContains(response, reverse("approvals:declare_prolongation", kwargs={"approval_id": approval.id}))
 
-        approval.end_at = timezone.localdate() + relativedelta(months=4)
+        approval.end_at = timezone.localdate() - relativedelta(months=4)
         approval.save()
         # Clear cached property
         del approval.can_be_prolonged

--- a/itou/www/approvals_views/tests/test_prolongation.py
+++ b/itou/www/approvals_views/tests/test_prolongation.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from django.utils.html import escape
 from django.utils.http import urlencode
 
-from itou.approvals.models import Approval, Prolongation
+from itou.approvals.models import Prolongation
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
@@ -23,17 +23,13 @@ class ApprovalProlongationTest(TestCase):
         self.prescriber_organization = PrescriberOrganizationWithMembershipFactory(authorized=True)
         self.prescriber = self.prescriber_organization.members.first()
 
-        today = timezone.now().date()
-
-        # Set "now" to be "after" the day approval is open to prolongation.
-        approval_end_at = (
-            today + relativedelta(months=Approval.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS) - relativedelta(days=1)
-        )
+        today = timezone.localdate()
         self.job_application = JobApplicationWithApprovalFactory(
             state=JobApplicationWorkflow.STATE_ACCEPTED,
             # Ensure that the job_application cannot be canceled.
             hiring_start_at=today - relativedelta(days=1),
-            approval__end_at=approval_end_at,
+            approval__start_at=today - relativedelta(months=12),
+            approval__end_at=today + relativedelta(months=2),
         )
         self.siae = self.job_application.to_siae
         self.siae_user = self.job_application.to_siae.members.first()


### PR DESCRIPTION
### Quoi ?

En tant qu’employeur qui cherche a déclarer un CDI inclusion, je ne peux pas demander la prolongation du PASS IAE 12 mois après la date de début du PASS IAE, je dois attendre 3 mois avant l’expiration du PASS IAE pour le faire, c’est assez complexe

### Pourquoi ?

Diminuer la friction utilisateurs dans l’enregistremnt du CDI inclusion pour des SIAE qui rencontrent déjà bcp de difficultés la dessus

### Comment ?

Modifier le blocage actuel de 3 mois avant date de fin du PASS IAE à 12 mois après la date de début du PASS IAE pour permettre la déclaration d’une prolongation

