### PR TITLE
data.inclusion: amélioration de la gestion des antennes

### DIFF
--- a/itou/api/data_inclusion_api/serializers.py
+++ b/itou/api/data_inclusion_api/serializers.py
@@ -1,4 +1,4 @@
-from typing import Optional
+import re
 
 from django.utils import text, timezone
 from rest_framework import serializers
@@ -17,6 +17,7 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
     id = serializers.UUIDField(source="uid")
     typologie = serializers.ChoiceField(source="kind", choices=SiaeKind.choices)
     nom = serializers.CharField(source="display_name")
+    siret = serializers.SerializerMethodField()
     rna = serializers.ReadOnlyField(default="")
     presentation_resume = serializers.SerializerMethodField()
     presentation_detail = serializers.SerializerMethodField()
@@ -29,7 +30,7 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
     adresse = serializers.CharField(source="address_line_1")
     complement_adresse = serializers.CharField(source="address_line_2")
     date_maj = serializers.SerializerMethodField()
-    structure_parente = serializers.SerializerMethodField()
+    antenne = serializers.SerializerMethodField()
     lien_source = serializers.SerializerMethodField()
 
     class Meta:
@@ -54,10 +55,33 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
             "latitude",
             "source",
             "date_maj",
-            "structure_parente",
+            "antenne",
             "lien_source",
         ]
         read_only_fields = fields
+
+    def get_siret(self, obj) -> str:
+        if obj.source == Siae.SOURCE_USER_CREATED:
+            if re.search(r"999\d\d$", obj.siret) is None:
+                # Though this siae may refer to another siae with its asp_id, it owns a proper siret,
+                # which makes it a structure in its own right according to data.inclusion
+                return obj.siret
+
+            # The `999\d\d` pattern should not be published. There might be a valid siret available
+            # for this asp_id on another siae : use the oldest.
+            a_parent_siae = (
+                Siae.objects.exclude(source=Siae.SOURCE_USER_CREATED)
+                .filter(convention__asp_id=obj.asp_id)
+                .order_by("created_at", "pk")
+                .first()
+            )
+            if a_parent_siae is not None:
+                return a_parent_siae.siret
+
+            # default to siren
+            return obj.siret[:9]
+
+        return obj.siret
 
     def get_presentation_resume(self, obj) -> str:
         return text.Truncator(obj.description).chars(280)
@@ -67,18 +91,14 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
             return ""
         return obj.description
 
-    def get_structure_parente(self, obj) -> Optional[str]:
-        if obj.source != Siae.SOURCE_USER_CREATED:
-            return None
+    def get_antenne(self, obj) -> bool:
+        if obj.source == Siae.SOURCE_USER_CREATED and re.search(r"999\d\d$", obj.siret) is not None:
+            return True
 
-        try:
-            structure_parente = Siae.objects.exclude(source=Siae.SOURCE_USER_CREATED).get(
-                convention__asp_id=obj.asp_id
-            )
-        except (Siae.DoesNotExist, Siae.MultipleObjectsReturned):
-            return None
+        if Siae.objects.filter(siret=obj.siret).count() >= 2:
+            return True
 
-        return structure_parente.uid
+        return False
 
     def get_date_maj(self, obj) -> str:
         dt = obj.updated_at or obj.created_at
@@ -110,7 +130,7 @@ class PrescriberOrgStructureSerializer(serializers.ModelSerializer):
     complement_adresse = serializers.CharField(source="address_line_2")
     source = serializers.ReadOnlyField(default="")
     date_maj = serializers.SerializerMethodField()
-    structure_parente = serializers.SerializerMethodField()
+    antenne = serializers.ReadOnlyField(default=False)
     lien_source = serializers.SerializerMethodField()
 
     class Meta:
@@ -135,7 +155,7 @@ class PrescriberOrgStructureSerializer(serializers.ModelSerializer):
             "latitude",
             "source",
             "date_maj",
-            "structure_parente",
+            "antenne",
             "lien_source",
         ]
         read_only_fields = fields
@@ -151,9 +171,6 @@ class PrescriberOrgStructureSerializer(serializers.ModelSerializer):
     def get_date_maj(self, obj) -> str:
         dt = obj.updated_at or obj.created_at
         return dt.astimezone(timezone.get_current_timezone()).isoformat()
-
-    def get_structure_parente(self, obj) -> Optional[str]:
-        return None
 
     def get_lien_source(self, obj) -> str:
         url = obj.get_card_url()

--- a/itou/api/data_inclusion_api/serializers.py
+++ b/itou/api/data_inclusion_api/serializers.py
@@ -32,6 +32,11 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
     date_maj = serializers.SerializerMethodField()
     antenne = serializers.SerializerMethodField()
     lien_source = serializers.SerializerMethodField()
+    horaires_ouverture = serializers.ReadOnlyField(default="")
+    accessibilite = serializers.ReadOnlyField(default="")
+    labels_nationaux = serializers.ReadOnlyField(default=[])
+    labels_autres = serializers.ReadOnlyField(default=[])
+    thematiques = serializers.ReadOnlyField(default=[])
 
     class Meta:
         model = Siae
@@ -57,6 +62,11 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
             "date_maj",
             "antenne",
             "lien_source",
+            "horaires_ouverture",
+            "accessibilite",
+            "labels_nationaux",
+            "labels_autres",
+            "thematiques",
         ]
         read_only_fields = fields
 
@@ -81,6 +91,8 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
             # default to siren
             return obj.siret[:9]
 
+        # If the siae source is other than SOURCE_USER_CREATED,
+        # then its siret **should** be valid.
         return obj.siret
 
     def get_presentation_resume(self, obj) -> str:
@@ -95,10 +107,7 @@ class SiaeStructureSerializer(serializers.ModelSerializer):
         if obj.source == Siae.SOURCE_USER_CREATED and re.search(r"999\d\d$", obj.siret) is not None:
             return True
 
-        if Siae.objects.filter(siret=obj.siret).count() >= 2:
-            return True
-
-        return False
+        return Siae.objects.filter(siret=obj.siret).count() >= 2
 
     def get_date_maj(self, obj) -> str:
         dt = obj.updated_at or obj.created_at
@@ -132,6 +141,11 @@ class PrescriberOrgStructureSerializer(serializers.ModelSerializer):
     date_maj = serializers.SerializerMethodField()
     antenne = serializers.ReadOnlyField(default=False)
     lien_source = serializers.SerializerMethodField()
+    horaires_ouverture = serializers.ReadOnlyField(default="")
+    accessibilite = serializers.ReadOnlyField(default="")
+    labels_nationaux = serializers.ReadOnlyField(default=[])
+    labels_autres = serializers.ReadOnlyField(default=[])
+    thematiques = serializers.ReadOnlyField(default=[])
 
     class Meta:
         model = PrescriberOrganization
@@ -157,6 +171,11 @@ class PrescriberOrgStructureSerializer(serializers.ModelSerializer):
             "date_maj",
             "antenne",
             "lien_source",
+            "horaires_ouverture",
+            "accessibilite",
+            "labels_nationaux",
+            "labels_autres",
+            "thematiques",
         ]
         read_only_fields = fields
 


### PR DESCRIPTION
### Quoi/Pourquoi ?

* (ajout des nouveaux champs du schéma: horaires_ouverture, accessibilite, labels_nationaux, labels_autres, thematiques. Non renseignés car à priori données non présentes)
* suppression des sirets matchant le pattern `999\d\d$` de l'api (tambouille interne des emplois, légalement pas top d'exposer ces sirets)
* remplacement du champ `structure_parente` (une ref à l'identifiant d'une autre siae) par le champ `antenne` (un flag)
* pour les siaes ayant la source `USER_CREATED` et un siret avec le pattern `999\d\d$`, on récupére quand c'est possible le siret d'une siae qui a le même asp_id et on les flags systématiquement comme antenne
* pour les siaes ayant la source `USER_CREATED` mais un vrai siret, on garde ce siret
* pour les siaes ayant des sirets dupliqués, quelque soit la source, on les flag toutes comme antennes car il est probable qu'aucune des siaes ne puisse être assimilée à une structure "mère", et encore moins de façon automatique

Conceptuellement, le modèle data.inclusion liste des structures. Chaque structure peut être un établissement ou une antenne d'établissement. Une structure est considérée comme une antenne dès lors qu'elle n'a pas de siret propre (ex: guichet local, service interne à un établissement). De plus, on considère que les établissements ne sont pas doublonnés dans un jeu de données : il y a, par siret, un établissement, et un nombre quelconque d'antennes.

Côté emplois, un même siret peut être dupliqué par 'SiaeKind' existant (`EI`, `ACI`, etc.) et les informations de contacts et d'adresses par exemple peuvent varier. Comme on ne peut déduire automatiquement et fiablement quelle siae a les informations "générales" de l'établissement (en partant que ces informations existent, ce qui n'est pas garantit), cette PR marque toutes les siaes avec des sirets dupliqués comme des antennes.