### PR TITLE
Affichage du reliquat d'un PASS IAE

### DIFF
--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -53,13 +53,17 @@ Arguments:
 
     <ul class="list-unstyled pl-2 border-left approval-left-border">
 
-        {# Validity. #}
-        <li{% if not common_approval.is_suspended %} class="text-success"{% endif %}>
-            Valide du {{ common_approval.start_at|date:"d/m/Y" }} au {{ common_approval.end_at|date:"d/m/Y" }}
+        <li>Date de début : {{ common_approval.start_at|date:"d/m/Y" }}</li>
+        <li>
+            Date de fin prévisionnelle : {{ common_approval.end_at|date:"d/m/Y" }}
+            <i class="ri-information-line ri-xl" data-toggle="tooltip" title="La date de fin prévisionnelle est amenée à évoluer si le PASS IAE est prolongé ou suspendu."></i>
         </li>
-
-        {# Delivery date. #}
-        <li>Délivrance : le {{ common_approval.start_at|date:"d/m/Y" }}</li>
+        <li>
+            Reliquat : <span{% if common_approval.remainder %} class="text-success"{% endif %}>{{ common_approval.remainder.days }} jours restants</span>
+            <i class="ri-information-line ri-xl"
+               data-toggle="tooltip"
+               title="Le reliquat est calculé sur la base d'un nombre de jours calendaires : il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+        </li>
 
         {% if common_approval.is_pass_iae %}
             {# Suspensions history. #}

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -378,8 +378,9 @@ class DashboardViewTest(TestCase):
         response = self.client.get(url)
         self.assertContains(response, "PASS IAE (agrément) disponible :")
         self.assertContains(response, format_approval_number(approval))
-        self.assertContains(response, "Valide du 21/06/2022 au 06/12/2022")
-        self.assertContains(response, "Délivrance : le 21/06/2022")
+        self.assertContains(response, "Date de début : 21/06/2022")
+        self.assertContains(response, "Date de fin prévisionnelle : 06/12/2022")
+        self.assertContains(response, 'Reliquat : <span class="text-success">82 jours restants</span>')
 
     @override_settings(TALLY_URL="http://tally.fake")
     def test_prescriber_with_authorization_pending_dashboard_must_contain_tally_link(self):


### PR DESCRIPTION
### Quoi ?

Donner plus de visibilité sur la durée d’un PASS IAE car les suspensions modifient la date de fin et un employeur peut penser à tort qu’un PASS IAE est valide pour une longue durée.

### Pourquoi ?

La date de fin du PASS IAE est amenée à évoluer (surtout avec les suspensions on peut avoir une date de fin repoussé de 12 mois et dès lors qu’une embauche est déclarée la date de fin est modifiée et les utilisateurs ne comprennent pas forcément

### Comment ?

Indiquer le reliquat de jours restants et préciser que la date de fin du PASS est prévisionnelle  

### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.

### Autre (optionnel)

- si des tests manquent, indiquer la raison, la probabilité, et les risques associés à ce manque
- être explicite sur le délai attendu pour une revue de code
- être explicite sur la qualité attendue pour la revue de code
- etc.
