### PR TITLE
Makefile: ajout de l'option --use-pep517 pour forcer la création de wheels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ run:
 
 $(VIRTUAL_ENV): $(REQUIREMENTS_PATH)
 	$(PYTHON_VERSION) -m venv $@
-	$@/bin/pip install -r $^
+	$@/bin/pip install --use-pep517 -r $^
 ifeq ($(shell uname -s),Linux)
 	$@/bin/pip-sync $^
 endif

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements/dev.txt requirements/dev.in
 #
+# foobar added to change hash and invalidate cache
 anyio==3.6.2 \
     --hash=sha256:25ea0d673ae30af41a0c442f81cf3b38c7e79fdc7b60335a4c14e05eb0947421 \
     --hash=sha256:fbbe32bd270d2a2ef3ed1c5d45041250284e31fc0a4df4a5a6071842051a51e3


### PR DESCRIPTION
### Quoi ?

L'option `--use-pep517` forcera `pip` à construire des wheels en l'absence du paquet `wheel`.
Ces wheels seront stockés dans le cache github et les builds suivants pourront en profiter et éviteront de refaire des `python setup.py install` couteux (comme pour `uwsgi`).

### Pourquoi ?

Pour gagner 10-15 secondes sur chaque build.