### PR TITLE
postgres: moins de durabilité et plus de vitesse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,18 @@ jobs:
           --health-retries 5
 
     steps:
+    - name: 🐘 Non-durable PostgreSQL
+      run: |
+        psql <<SQL
+          ALTER SYSTEM SET fsync=off;
+          ALTER SYSTEM SET synchronous_commit=off;
+          ALTER SYSTEM SET full_page_writes=off;
+        SQL
+        docker kill --signal=SIGHUP ${{ job.services.postgres.id }}
+      env:
+        PGPASSWORD: password
+        PGHOST: localhost
+        PGUSER: postgres
     - uses: actions/checkout@v3
     - name: 🌍 Install spatial libraries
       run: sudo apt-get update && sudo apt-get install binutils build-essential libproj-dev gdal-bin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
   # https://hub.docker.com/r/mdillon/postgis/tags
   postgres:
     container_name: itou_postgres
+    # Disable some safety switches for a faster postgres: https://www.postgresql.org/docs/current/non-durability.html
+    command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off
     environment:
       # Required by the "_/postgres" image used by "postgis/postgis"
       # https://registry.hub.docker.com/_/postgres/


### PR DESCRIPTION
### Quoi ?

Désactive certains mécanismes de postgresql assurant la durabilité des données.

### Pourquoi ?

Pour des tests un peu plus rapides:
- chez moi, ce n'est pas incroyable mais c'est toujours cela de pris: je passe de 43 sec en moyenne à 40 sec
- sur Github, vu la variabilité d'un build à l'autre, c'est assez dur à mesurer mais devrait grapiller quelques secondes également

(cf https://www.postgresql.org/docs/current/non-durability.html pour les sécurités désactivées).
