### PR TITLE
requirements: migration de requests à httpx

### DIFF
--- a/itou/external_data/apis/pe_connect.py
+++ b/itou/external_data/apis/pe_connect.py
@@ -1,6 +1,6 @@
 import logging
 
-import requests
+import httpx
 from django.conf import settings
 from django.db import transaction
 from django.forms.models import model_to_dict
@@ -35,7 +35,7 @@ def _call_api(api_path, token):
     For further processing, returning something else than `None` is considered a success
     """
     url = f"{settings.API_ESD['BASE_URL']}/{api_path}"
-    response = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=settings.REQUESTS_TIMEOUT)
+    response = httpx.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=settings.REQUESTS_TIMEOUT)
     if response.status_code == 200:
         result = response.json()
         # logger.debug(f"CALL {url}: {result}")

--- a/itou/utils/slack.py
+++ b/itou/utils/slack.py
@@ -6,14 +6,14 @@ https://gist.github.com/devStepsize/b1b795309a217d24566dcc0ad136f784
 """
 import json
 
-import requests
+import httpx
 from django.conf import settings
 
 
 def send_slack_message(text="Hello world :wave:"):
     if not settings.SLACK_CRON_WEBHOOK_URL:
         return
-    response = requests.post(
+    response = httpx.post(
         url=settings.SLACK_CRON_WEBHOOK_URL,
         data=json.dumps({"text": text}),
         headers={"Content-Type": "application/json"},

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -26,7 +26,6 @@ django-admin-logs  # https://pypi.org/project/django-admin-logs/
 # Test & Mock
 # ------------------------------------------------------------------------------
 freezegun  # https://github.com/spulec/freezegun
-requests-mock  # https://github.com/jamielennox/requests-mock
 respx  # https://lundberg.github.io/respx/
 pytest  # https://github.com/pytest-dev/pytest
 pytest-django # https://github.com/pytest-dev/pytest-django/

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1166,12 +1166,7 @@ requests==2.28.1 \
     #   -r requirements/base.txt
     #   django-allauth
     #   django-anymail
-    #   requests-mock
     #   requests-oauthlib
-requests-mock==1.10.0 \
-    --hash=sha256:2fdbb637ad17ee15c06f33d31169e71bf9fe2bdb7bc9da26185be0dd8d842699 \
-    --hash=sha256:59c9c32419a9fb1ae83ec242d98e889c45bd7d7a65d48375cc243ec08441658b
-    # via -r requirements/dev.in
 requests-oauthlib==1.3.1 \
     --hash=sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5 \
     --hash=sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a
@@ -1206,7 +1201,6 @@ six==1.16.0 \
     #   cssbeautifier
     #   jsbeautifier
     #   python-dateutil
-    #   requests-mock
 sniffio==1.3.0 \
     --hash=sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101 \
     --hash=sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384


### PR DESCRIPTION
### Quoi ?

`httpx` est majoritairement utilisé mais quelques utilisations de `requests` persistent.

:warning: Concernant les utilisations dans `itou/allauth_adapters/peamu`, la migration est plus compliqué car `django-allauth` (et son `OAuth2TestsMixin`) utilisent (et mockent) `requests`: cette PR ne s'occupe pas de cette partie.

### Pourquoi ?

Cela permet d'uniformiser notre code et de supprimer la dépendance `requests_mock` en faveur de `respx`.
