### PR TITLE
github: try enabling dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/requirements"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "requirement"
+      prefix-development: "dev requirement"
+    # Only allow updates to the lockfile for pip and
+    # ignore any version updates that affect the manifest
+    versioning-strategy: lockfile-only

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,17 +1,17 @@
-psycopg2==2.9.3  # https://github.com/psycopg/psycopg2
-requests==2.28.1  # https://github.com/psf/requests
-python-dateutil==2.8.2  # https://pypi.org/project/python-dateutil/
+psycopg2==2.*  # https://github.com/psycopg/psycopg2
+requests==2.*  # https://github.com/psf/requests
+python-dateutil==2.*  # https://pypi.org/project/python-dateutil/
 openpyxl==3.0.10  # https://openpyxl.readthedocs.io/en/stable/
 
 # lxml improves performance of Excel file generation with openpyxl
-lxml==4.9.1  # https://lxml.de/
+lxml==4.*  # https://lxml.de/
 
 Unidecode==1.3.4  # https://github.com/avian2/unidecode
 
 # Django
 # ------------------------------------------------------------------------------
 
-django==4.1.2  # https://www.djangoproject.com/
+django==4.1.*  # https://www.djangoproject.com/
 
 # django-allauth
 django-allauth==0.51.0  # https://github.com/pennersr/django-allauth
@@ -107,5 +107,5 @@ python-dotenv==0.21.0
 # Production requirements
 # ------------------------------------------------------------------------------
 uwsgi==2.0.21  # https://github.com/unbit/uwsgi
-sentry-sdk==1.9.0  # https://github.com/getsentry/sentry-python
+sentry-sdk==1.*  # https://github.com/getsentry/sentry-python
 elastic-apm==6.13.0  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html


### PR DESCRIPTION
### Quoi ?

Active le bot `dependabot` pour avoir des PRs de mise à jour des dépendances automatiquement.

### Pourquoi ?

Pour [automatiser la gestion des dépendances](https://www.notion.so/Automatisation-de-la-gestion-des-versions-de-d-pendances-1ad38c9b15c247c9a01e8f2095346f71)

### Notes

J'ai commencé à relâcher certains pins dans `base.in` afin que`dependabot` puisse trouver des choses à mettre à jour (en plus des dépendances de dev).

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file pour la doc