### PR TITLE
Corriger une erreur sentry quand un utilisateur essaye d'afficher un PASS IAE

### DIFF
--- a/itou/www/approvals_views/tests/test_display.py
+++ b/itou/www/approvals_views/tests/test_display.py
@@ -5,8 +5,10 @@ from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 
+from itou.approvals.factories import ApprovalFactory
 from itou.job_applications.factories import JobApplicationFactory, JobApplicationWithApprovalFactory
 from itou.job_applications.models import JobApplication
+from itou.siaes.factories import SiaeMembershipFactory
 from itou.users.factories import UserFactory
 from itou.utils import constants as global_constants
 
@@ -53,6 +55,17 @@ class TestDisplayApproval(TestCase):
         self.assertContains(response, global_constants.ITOU_ASSISTANCE_URL)
         self.assertContains(response, "Imprimer ce PASS IAE")
         self.assertContains(response, "Astuce pour conserver cette attestation en format PDF")
+
+    def test_no_display_approval_no_job_applications(self, *args, **kwargs):
+        approval = ApprovalFactory()
+        siae_member = SiaeMembershipFactory().user
+        self.client.force_login(siae_member)
+
+        response = self.client.get(
+            reverse("approvals:display_printable_approval", kwargs={"approval_id": approval.pk})
+        )
+
+        self.assertEqual(response.status_code, 404)
 
     def test_display_approval_even_if_diagnosis_is_missing(self, *args, **kwargs):
         # An approval has been delivered but it does not come from Itou.

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -121,7 +121,7 @@ class ApprovalPrintableDisplay(ApprovalBaseViewMixin, TemplateView):
 
         # TODO(alaurent) We could probably just use "if not siae.is_subject_to_eligibility_rules"
         # Fix this when refactoring the database
-        if not job_application.can_display_approval:
+        if not job_application or not job_application.can_display_approval:
             # Message only visible in DEBUG
             raise Http404("Nous sommes au regret de vous informer que vous ne pouvez pas afficher cet agrément.")
 


### PR DESCRIPTION
### Quoi ?

Si on ne trouve pas de candidature, on doit lever une 404 "proprement"

Lien sentry : https://sentry.io/organizations/itou/issues/3749177330/?project=6164438&query=is%3Aunresolved&referrer=issue-stream


