### PR TITLE
Permettre de changer le username d'un nouvel utilisateur

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -182,7 +182,7 @@ class ItouUserAdmin(UserAdmin):
         "pk",
         "nir",
     )
-    readonly_fields = ("pk", "username", "jobseeker_hash_id", "identity_provider")
+    readonly_fields = ("pk", "jobseeker_hash_id", "identity_provider")
 
     fieldsets = UserAdmin.fieldsets + (
         (
@@ -260,7 +260,7 @@ class ItouUserAdmin(UserAdmin):
         if not request.user.is_superuser:
             rof += ("is_staff", "is_superuser", "groups", "user_permissions")
         if obj and obj.has_sso_provider:
-            rof += ("first_name", "last_name", "email")
+            rof += ("first_name", "last_name", "email", "username")
         return rof
 
 


### PR DESCRIPTION
### Quoi ?

Permettre de changer le username d'un nouvel utilisateur

### Pourquoi ?

Le support doit parfois créer des comptes candidats à la main dans l'admin

