### PR TITLE
Permettre à un utilisateur de reprendre sa création de compte via Inclusion Connect

### DIFF
--- a/itou/openid_connect/inclusion_connect/urls.py
+++ b/itou/openid_connect/inclusion_connect/urls.py
@@ -7,6 +7,7 @@ app_name = "inclusion_connect"
 
 urlpatterns = [
     path("authorize", views.inclusion_connect_authorize, name="authorize"),
+    path("resume_registration", views.inclusion_connect_resume_registration, name="resume_registration"),
     path("callback", views.inclusion_connect_callback, name="callback"),
     path("logout", views.inclusion_connect_logout, name="logout"),
 ]


### PR DESCRIPTION
### Quoi ?

Dans le cas ou un utilisateur ne peut pas confirmer son email pour inclusion Connect (il ne reçoit pas l’email) il est complique de lui éviter de recommencer à 0 le processus de création de compte une fois qu’on valide l’email manuellement dans l’admin de Keycloak.

### Pourquoi ?

Simplifier la vie au support pour leur éviter de gérer le canal (prescripteur ou employeur, invité ou non, etc) dans la reponse à envoyer après avoir valider l'email dans l'admin d'Inclusion Connect

### Comment ?

Ajouter une vue qui reprend les informations présentent dans la session.
