### PR TITLE
Amélioration de la vue de reprise de création de compte avec Inclusion Connect

### DIFF
--- a/itou/openid_connect/inclusion_connect/tests.py
+++ b/itou/openid_connect/inclusion_connect/tests.py
@@ -7,6 +7,7 @@ from urllib.parse import quote, urlencode
 import httpx
 import respx
 from django.contrib import auth
+from django.contrib.messages import get_messages
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
@@ -312,6 +313,9 @@ class InclusionConnectViewTest(InclusionConnectBaseTestCase):
         url = f"{reverse('inclusion_connect:resume_registration')}"
         response = self.client.get(url)
         self.assertRedirects(response, reverse("home:hp"))
+        [message] = list(get_messages(response.wsgi_request))
+        assert message.tags == "error"
+        assert message.message == "Impossible de reprendre la création de compte."
 
     @respx.mock
     def test_resume_endpoint_with_already_finished_registration(self):
@@ -319,6 +323,9 @@ class InclusionConnectViewTest(InclusionConnectBaseTestCase):
         url = f"{reverse('inclusion_connect:resume_registration')}"
         response = self.client.get(url)
         self.assertRedirects(response, reverse("home:hp"))
+        [message] = list(get_messages(response.wsgi_request))
+        assert message.tags == "error"
+        assert message.message == "Impossible de reprendre la création de compte."
 
     def test_resume_endpoint(self):
         # Fill up session with authorize view

--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -120,6 +120,7 @@ def inclusion_connect_resume_registration(request):
     # If there's a token in the session then the user already came back to the callback view : nothing to resume.
     # If there's no session then the user never started a registration on this device : nothing to resume either.
     if not ic_session or ic_session["token"]:
+        messages.error(request, "Impossible de reprendre la création de compte.")
         return HttpResponseRedirect(reverse("home:hp"))
     data = generate_inclusion_params_from_session(ic_session)
     return HttpResponseRedirect(f"{constants.INCLUSION_CONNECT_ENDPOINT_AUTHORIZE}?{urlencode(data)}")


### PR DESCRIPTION
Dans les cas d'erreur, afficher un message à l'utilisateur au lieu de le rediriger silencieusement vers la homepage