### PR TITLE
Correction de la détection du dernier employeur

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -170,6 +170,13 @@ class JobApplicationQuerySet(models.QuerySet):
         return self.annotate(
             accepted_at=Case(
                 When(created_from_pe_approval=True, then=F("created_at")),
+                # A job_application created at the accepted status, still accepted
+                When(
+                    created_from_pe_approval=False,
+                    state=JobApplicationWorkflow.STATE_ACCEPTED,
+                    logs__isnull=True,
+                    then=F("created_at"),
+                ),
                 When(created_from_pe_approval=False, then=created_at_from_transition),
             )
         )

--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -615,6 +615,11 @@ class JobApplicationQuerySetTest(TestCase):
         job_application.refuse(job_application.sender)  # 2 transitions, still no accept
         self.assertIsNone(JobApplication.objects.with_accepted_at().first().accepted_at)
 
+    def test_with_accepted_at_for_accepted_with_no_transition(self):
+        JobApplicationSentBySiaeFactory(state=JobApplicationWorkflow.STATE_ACCEPTED)
+        job_application = JobApplication.objects.with_accepted_at().first()
+        self.assertEqual(job_application.accepted_at, job_application.created_at)
+
 
 class JobApplicationNotificationsTest(TestCase):
     @classmethod


### PR DESCRIPTION
### Quoi ?

Une candidature crée au statut acceptée est pour l'instant toujours listée en premier quand on cherche à connaître la dernière embauche d'un candidat, ce qui pose problème pour permettre la suspension de son pass.

### Pourquoi ?

On se base sur les transitions des candidatures, qui n'existent pas quand elles sont créées directement au statut acceptée. 

### Comment ?

Ajout d'un cas pour les candidature sans transition.