### PR TITLE
Ajout des SIAE, Organisations prescriptrices & institutions dans le suivi Matomo

### DIFF
--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -4,6 +4,10 @@ from django.urls import reverse
 from itou.utils import constants as global_constants
 
 
+def join_keys_str(collection):
+    return ";".join(str(o.pk) for o in collection)
+
+
 def sort_organizations(collection):
     return sorted(collection, key=lambda o: (o.kind, o.display_name))
 
@@ -50,6 +54,7 @@ def get_context_siae(user, siae_pk):
         if membership.siae_id == siae_pk:
             matomo_context.update(
                 {
+                    "account_current_siae_id": siae_pk,
                     "account_sub_type": "employer_admin" if membership.is_admin else "employer_not_admin",
                 }
             )
@@ -60,6 +65,7 @@ def get_context_siae(user, siae_pk):
                 }
             )
     context["user_siaes"] = sort_organizations(siaes)
+    matomo_context["account_siae_ids"] = join_keys_str(context["user_siaes"])
     return context, matomo_context
 
 
@@ -81,6 +87,7 @@ def get_context_prescriber(user, prescriber_org_pk):
             org = membership.organization
             matomo_context.update(
                 {
+                    "account_current_prescriber_org_id": org.pk,
                     "account_sub_type": "prescriber_with_authorized_org"
                     if org.is_authorized
                     else "prescriber_with_unauthorized_org",
@@ -93,6 +100,7 @@ def get_context_prescriber(user, prescriber_org_pk):
                 }
             )
     context["user_prescriberorganizations"] = sort_organizations(prescriber_orgs)
+    matomo_context["account_organization_ids"] = join_keys_str(context["user_prescriberorganizations"])
     return context, matomo_context
 
 
@@ -114,6 +122,7 @@ def get_context_institution(user, institution_pk):
             institution = membership.institution
             matomo_context.update(
                 {
+                    "account_current_institution_id": institution.pk,
                     "account_sub_type": "inspector_admin" if membership.is_admin else "inspector_not_admin",
                 }
             )
@@ -125,6 +134,7 @@ def get_context_institution(user, institution_pk):
             )
 
     context["user_institutions"] = sort_organizations(institutions)
+    matomo_context["account_institution_ids"] = join_keys_str(context["user_institutions"])
     return context, matomo_context
 
 

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -1,150 +1,157 @@
-from collections import OrderedDict
-
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 
 from itou.utils import constants as global_constants
 
 
+def sort_organizations(collection):
+    return sorted(collection, key=lambda o: (o.kind, o.display_name))
+
+
 def get_current_organization_and_perms(request):
-    """
-    Put things into the context to make them available in templates.
-    https://docs.djangoproject.com/en/2.1/ref/templates/api/#using-requestcontext
-    """
+    siae_pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_SIAE_KEY)
+    prescriber_org_pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY)
+    institution_pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_INSTITUTION_KEY)
 
-    prescriber_organization = None
-    user_prescriberorganizations = []
-    user_institutions = []
-    current_institution = None
-    siae = None
-    user_is_prescriber_org_admin = False
-    user_is_siae_admin = False
-    user_is_institution_admin = False
-    user_siaes = []
+    if request.user.is_authenticated:
+        context, extra_context, extra_matomo_context = {}, {}, {}
+        matomo_context = {"is_authenticated": "yes"} | user_to_account_type(request.user)
 
-    current_user = request.user
-
-    if current_user.is_authenticated:
-        # SIAE ?
-        siae_pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_SIAE_KEY)
         if siae_pk:
-            memberships = request.user.active_or_in_grace_period_siae_memberships()
-            user_siaes = [membership.siae for membership in memberships]
-
-            for membership in memberships:
-                if membership.siae_id == siae_pk:
-                    siae = membership.siae
-                    user_is_siae_admin = membership.is_admin
-                    break
-            if siae is None:
-                if request.path != reverse("account_logout"):
-                    raise PermissionDenied
-
-        # Prescriber organization ?
-        prescriber_org_pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY)
+            extra_context, extra_matomo_context = get_context_siae(request.user, siae_pk)
+            if "current_siae" not in extra_context and request.path != reverse("account_logout"):
+                raise PermissionDenied
 
         if prescriber_org_pk:
-            # Membership can now be deactivated, hence filtering on `membership.is_active` (same as SIAE above)
-            memberships = (
-                current_user.prescribermembership_set.filter(is_active=True)
-                .order_by("created_at")
-                .select_related("organization")
-            )
-
-            for membership in memberships:
-                # Same as above:
-                # In order to avoid an extra SQL query, fetch related organizations
-                # and artifially reconstruct the list of organizations the user belongs to
-                # (and other stuff while at it)
-                user_prescriberorganizations.append(membership.organization)
-                if membership.organization.pk == prescriber_org_pk:
-                    prescriber_organization = membership.organization
-                    user_is_prescriber_org_admin = membership.is_admin
-
-        # Institution?
-        institution_pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_INSTITUTION_KEY)
+            extra_context, extra_matomo_context = get_context_prescriber(request.user, prescriber_org_pk)
 
         if institution_pk:
-            memberships = (
-                current_user.institutionmembership_set.filter(is_active=True)
-                .order_by("created_at")
-                .select_related("institution")
-            )
+            extra_context, extra_matomo_context = get_context_institution(request.user, institution_pk)
 
-            for membership in memberships:
-                # Same as above:
-                # In order to avoid an extra SQL query, fetch related institutions
-                # and artificially reconstruct the list of institutions the user belongs to
-                # (and other stuff while at it)
-                user_institutions.append(membership.institution)
-                if membership.institution.pk == institution_pk:
-                    current_institution = membership.institution
-                    user_is_institution_admin = membership.is_admin
+        context.update(extra_context)
+        return context | {"matomo_custom_variables": matomo_context | extra_matomo_context}
 
-    # Sort items nicely for dropdown menu.
-    user_siaes.sort(key=lambda o: (o.kind, o.display_name))
-    user_prescriberorganizations.sort(key=lambda o: (o.kind, o.display_name))
-    user_institutions.sort(key=lambda o: (o.kind, o.display_name))
-
-    context = {
-        "current_prescriber_organization": prescriber_organization,
-        "current_siae": siae,
-        "current_institution": current_institution,
-        "user_is_prescriber_org_admin": user_is_prescriber_org_admin,
-        "user_is_siae_admin": user_is_siae_admin,
-        "user_is_institution_admin": user_is_institution_admin,
-        "user_siaes": user_siaes,
-        "user_prescriberorganizations": user_prescriberorganizations,
-        "user_institutions": user_institutions,
+    return {
+        "matomo_custom_variables": {
+            "is_authenticated": "no",
+            "account_type": "anonymous",
+            "account_sub_type": "anonymous",
+        }
     }
 
-    context.update(
-        get_matomo_context(
-            user=request.user,
-            prescriber_organization=prescriber_organization,
-            user_is_siae_admin=user_is_siae_admin,
-            user_is_institution_admin=user_is_institution_admin,
-        )
-    )
 
-    return context
-
-
-def get_matomo_context(user, prescriber_organization, user_is_siae_admin, user_is_institution_admin):
-    is_authenticated = "yes" if user.is_authenticated else "no"
-
-    if not user.is_authenticated:
-        account_type = "anonymous"
-        account_sub_type = "anonymous"
-    elif user.is_job_seeker:
-        account_type = "job_seeker"
-        account_sub_type = "job_seeker_with_peconnect" if user.is_peamu else "job_seeker_without_peconnect"
-    elif user.is_prescriber:
-        account_type = "prescriber"
-        if prescriber_organization:
-            account_sub_type = (
-                "prescriber_with_authorized_org"
-                if prescriber_organization.is_authorized
-                else "prescriber_with_unauthorized_org"
+def get_context_siae(user, siae_pk):
+    context = {}
+    matomo_context = {}
+    memberships = user.active_or_in_grace_period_siae_memberships()
+    siaes = []
+    for membership in memberships:
+        siaes.append(membership.siae)
+        if membership.siae_id == siae_pk:
+            matomo_context.update(
+                {
+                    "account_sub_type": "employer_admin" if membership.is_admin else "employer_not_admin",
+                }
             )
-        else:
-            account_sub_type = "prescriber_without_org"
-    elif user.is_siae_staff:
-        account_type = "employer"
-        account_sub_type = "employer_admin" if user_is_siae_admin else "employer_not_admin"
-    elif user.is_labor_inspector:
-        account_type = "labor_inspector"
-        account_sub_type = "inspector_admin" if user_is_institution_admin else "inspector_not_admin"
-    else:
-        account_type = "unknown"
-        account_sub_type = "unknown"
+            context.update(
+                {
+                    "current_siae": membership.siae,
+                    "user_is_siae_admin": membership.is_admin,
+                }
+            )
+    context["user_siaes"] = sort_organizations(siaes)
+    return context, matomo_context
 
-    matomo_custom_variables = OrderedDict(
-        [
-            ("is_authenticated", is_authenticated),
-            ("account_type", account_type),
-            ("account_sub_type", account_sub_type),
-        ]
+
+def get_context_prescriber(user, prescriber_org_pk):
+    context = {}
+    matomo_context = {}
+    memberships = (
+        user.prescribermembership_set.filter(is_active=True).order_by("created_at").select_related("organization")
     )
 
-    return {"matomo_custom_variables": matomo_custom_variables}
+    prescriber_orgs = []
+    for membership in memberships:
+        # Same as above:
+        # In order to avoid an extra SQL query, fetch related organizations
+        # and artifially reconstruct the list of organizations the user belongs to
+        # (and other stuff while at it)
+        prescriber_orgs.append(membership.organization)
+        if membership.organization.pk == prescriber_org_pk:
+            org = membership.organization
+            matomo_context.update(
+                {
+                    "account_sub_type": "prescriber_with_authorized_org"
+                    if org.is_authorized
+                    else "prescriber_with_unauthorized_org",
+                }
+            )
+            context.update(
+                {
+                    "current_prescriber_organization": org,
+                    "user_is_prescriber_org_admin": membership.is_admin,
+                }
+            )
+    context["user_prescriberorganizations"] = sort_organizations(prescriber_orgs)
+    return context, matomo_context
+
+
+def get_context_institution(user, institution_pk):
+    context = {}
+    matomo_context = {}
+    memberships = (
+        user.institutionmembership_set.filter(is_active=True).order_by("created_at").select_related("institution")
+    )
+
+    institutions = []
+    for membership in memberships:
+        # Same as above:
+        # In order to avoid an extra SQL query, fetch related institutions
+        # and artificially reconstruct the list of institutions the user belongs to
+        # (and other stuff while at it)
+        institutions.append(membership.institution)
+        if membership.institution.pk == institution_pk:
+            institution = membership.institution
+            matomo_context.update(
+                {
+                    "account_sub_type": "inspector_admin" if membership.is_admin else "inspector_not_admin",
+                }
+            )
+            context.update(
+                {
+                    "current_institution": institution,
+                    "user_is_institution_admin": membership.is_admin,
+                }
+            )
+
+    context["user_institutions"] = sort_organizations(institutions)
+    return context, matomo_context
+
+
+def user_to_account_type(user):
+    if user.is_job_seeker:
+        return {
+            "account_type": "job_seeker",
+            "account_sub_type": "job_seeker_with_peconnect" if user.is_peamu else "job_seeker_without_peconnect",
+        }
+    elif user.is_siae_staff:
+        return {
+            "account_type": "employer",
+            "account_sub_type": "employer_not_admin",
+        }
+    elif user.is_prescriber:
+        return {
+            "account_type": "prescriber",
+            "account_sub_type": "prescriber_without_org",
+        }
+    elif user.is_labor_inspector:
+        return {
+            "account_type": "labor_inspector",
+            "account_sub_type": "inspector_not_admin",
+        }
+
+    # especially usual in tests.
+    return {
+        "account_type": "unknown",
+        "account_sub_type": "unknown",
+    }

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -6,7 +6,6 @@ import importlib
 import json
 import logging
 import uuid
-from collections import OrderedDict
 from unittest import mock
 
 import faker
@@ -91,25 +90,6 @@ def get_response_for_middlewaremixin(request):
 
 
 class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
-    """Test `itou.utils.perms.context_processors.get_current_organization_and_perms` processor."""
-
-    @property
-    def default_result(self):
-        return {
-            "current_prescriber_organization": None,
-            "current_siae": None,
-            "current_institution": None,
-            "user_is_prescriber_org_admin": False,
-            "user_is_siae_admin": False,
-            "user_is_institution_admin": False,
-            "user_siaes": [],
-            "user_prescriberorganizations": [],
-            "user_institutions": [],
-            "matomo_custom_variables": OrderedDict(
-                [("is_authenticated", "yes"), ("account_type", None), ("account_sub_type", None)]
-            ),
-        }
-
     def go_to_dashboard(self, user, establishment_session_key, establishment_pk):
         factory = RequestFactory()
         request = factory.get("/")
@@ -133,15 +113,16 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
 
         with self.assertNumQueries(1):
             result = get_current_organization_and_perms(request)
-            expected = self.default_result | {
+            assert result == {
                 "current_siae": siae,
                 "user_is_siae_admin": True,
                 "user_siaes": [siae],
-                "matomo_custom_variables": OrderedDict(
-                    [("is_authenticated", "yes"), ("account_type", "employer"), ("account_sub_type", "employer_admin")]
-                ),
+                "matomo_custom_variables": {
+                    "is_authenticated": "yes",
+                    "account_type": "employer",
+                    "account_sub_type": "employer_admin",
+                },
             }
-            self.assertDictEqual(expected, result)
 
     def test_siae_multiple_memberships(self):
         # Specify name to ensure alphabetical sorting order.
@@ -161,20 +142,16 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
 
         with self.assertNumQueries(1):
             result = get_current_organization_and_perms(request)
-
-            expected = self.default_result | {
+            assert result == {
                 "current_siae": siae2,
-                "user_siaes": [siae1, siae2],
                 "user_is_siae_admin": False,
-                "matomo_custom_variables": OrderedDict(
-                    [
-                        ("is_authenticated", "yes"),
-                        ("account_type", "employer"),
-                        ("account_sub_type", "employer_not_admin"),
-                    ]
-                ),
+                "user_siaes": [siae1, siae2],
+                "matomo_custom_variables": {
+                    "is_authenticated": "yes",
+                    "account_type": "employer",
+                    "account_sub_type": "employer_not_admin",
+                },
             }
-            self.assertDictEqual(expected, result)
 
     def test_prescriber_organization_one_membership(self):
         organization = PrescriberOrganizationWithMembershipFactory()
@@ -189,19 +166,16 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
 
         with self.assertNumQueries(1):
             result = get_current_organization_and_perms(request)
-            expected = self.default_result | {
+            assert result == {
                 "current_prescriber_organization": organization,
                 "user_prescriberorganizations": [organization],
                 "user_is_prescriber_org_admin": True,
-                "matomo_custom_variables": OrderedDict(
-                    [
-                        ("is_authenticated", "yes"),
-                        ("account_type", "prescriber"),
-                        ("account_sub_type", "prescriber_with_unauthorized_org"),
-                    ]
-                ),
+                "matomo_custom_variables": {
+                    "is_authenticated": "yes",
+                    "account_type": "prescriber",
+                    "account_sub_type": "prescriber_with_unauthorized_org",
+                },
             }
-            self.assertDictEqual(expected, result)
 
     def test_prescriber_organization_multiple_membership(self):
         # Specify name to ensure alphabetical sorting order.
@@ -220,19 +194,16 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
 
         with self.assertNumQueries(1):
             result = get_current_organization_and_perms(request)
-            expected = self.default_result | {
+            assert result == {
                 "current_prescriber_organization": organization1,
                 "user_prescriberorganizations": [organization1, organization2],
                 "user_is_prescriber_org_admin": True,
-                "matomo_custom_variables": OrderedDict(
-                    [
-                        ("is_authenticated", "yes"),
-                        ("account_type", "prescriber"),
-                        ("account_sub_type", "prescriber_with_unauthorized_org"),
-                    ]
-                ),
+                "matomo_custom_variables": {
+                    "is_authenticated": "yes",
+                    "account_type": "prescriber",
+                    "account_sub_type": "prescriber_with_unauthorized_org",
+                },
             }
-            self.assertDictEqual(expected, result)
 
     def test_labor_inspector_one_institution(self):
         institution = InstitutionWithMembershipFactory()
@@ -247,19 +218,16 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
 
         with self.assertNumQueries(1):
             result = get_current_organization_and_perms(request)
-            expected = self.default_result | {
+            assert result == {
                 "current_institution": institution,
                 "user_institutions": [institution],
                 "user_is_institution_admin": True,
-                "matomo_custom_variables": OrderedDict(
-                    [
-                        ("is_authenticated", "yes"),
-                        ("account_type", "labor_inspector"),
-                        ("account_sub_type", "inspector_admin"),
-                    ]
-                ),
+                "matomo_custom_variables": {
+                    "is_authenticated": "yes",
+                    "account_type": "labor_inspector",
+                    "account_sub_type": "inspector_admin",
+                },
             }
-            self.assertDictEqual(expected, result)
 
     def test_labor_inspector_multiple_institutions(self):
         # Specify name to ensure alphabetical sorting order.
@@ -278,19 +246,16 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
 
         with self.assertNumQueries(1):
             result = get_current_organization_and_perms(request)
-            expected = self.default_result | {
+            assert result == {
                 "current_institution": institution2,
                 "user_institutions": [institution1, institution2],
                 "user_is_institution_admin": False,
-                "matomo_custom_variables": OrderedDict(
-                    [
-                        ("is_authenticated", "yes"),
-                        ("account_type", "labor_inspector"),
-                        ("account_sub_type", "inspector_not_admin"),
-                    ]
-                ),
+                "matomo_custom_variables": {
+                    "is_authenticated": "yes",
+                    "account_type": "labor_inspector",
+                    "account_sub_type": "inspector_not_admin",
+                },
             }
-            self.assertDictEqual(expected, result)
 
 
 class UtilsGeocodingTest(TestCase):

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -121,6 +121,8 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                     "is_authenticated": "yes",
                     "account_type": "employer",
                     "account_sub_type": "employer_admin",
+                    "account_current_siae_id": siae.pk,
+                    "account_siae_ids": str(siae.pk),
                 },
             }
 
@@ -150,6 +152,8 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                     "is_authenticated": "yes",
                     "account_type": "employer",
                     "account_sub_type": "employer_not_admin",
+                    "account_current_siae_id": siae2.pk,
+                    "account_siae_ids": f"{siae1.pk};{siae2.pk}",
                 },
             }
 
@@ -174,6 +178,8 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                     "is_authenticated": "yes",
                     "account_type": "prescriber",
                     "account_sub_type": "prescriber_with_unauthorized_org",
+                    "account_current_prescriber_org_id": organization.pk,
+                    "account_organization_ids": str(organization.pk),
                 },
             }
 
@@ -202,6 +208,8 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                     "is_authenticated": "yes",
                     "account_type": "prescriber",
                     "account_sub_type": "prescriber_with_unauthorized_org",
+                    "account_current_prescriber_org_id": organization1.pk,
+                    "account_organization_ids": f"{organization1.pk};{organization2.pk}",
                 },
             }
 
@@ -226,6 +234,8 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                     "is_authenticated": "yes",
                     "account_type": "labor_inspector",
                     "account_sub_type": "inspector_admin",
+                    "account_institution_ids": str(institution.pk),
+                    "account_current_institution_id": institution.pk,
                 },
             }
 
@@ -254,6 +264,8 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                     "is_authenticated": "yes",
                     "account_type": "labor_inspector",
                     "account_sub_type": "inspector_not_admin",
+                    "account_institution_ids": f"{institution1.pk};{institution2.pk}",
+                    "account_current_institution_id": institution2.pk,
                 },
             }
 


### PR DESCRIPTION
### Quoi ?

Cf le titre.

### Pourquoi ?
Cela permettra de suivre sur chaque page quelle organisation / institution / siae consulte quoi.


### Comment ?
Complément aux variables matomo déjà en place.