### PR TITLE
Notifier les SIAE sans justificatifs vers la fin de la phase contradictoire

### DIFF
--- a/itou/siae_evaluations/factories.py
+++ b/itou/siae_evaluations/factories.py
@@ -74,7 +74,10 @@ class EvaluatedJobApplicationFactory(factory.django.DjangoModelFactory):
         )
 
     evaluated_siae = factory.SubFactory(EvaluatedSiaeFactory)
-    job_application = factory.SubFactory(JobApplicationWithApprovalFactory)
+    job_application = factory.SubFactory(
+        JobApplicationWithApprovalFactory,
+        to_siae=factory.SelfAttribute("..evaluated_siae.siae"),
+    )
 
 
 class EvaluatedAdministrativeCriteriaFactory(factory.django.DjangoModelFactory):

--- a/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
+++ b/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
@@ -1,18 +1,24 @@
 from dateutil.relativedelta import relativedelta
 from django.core.management import BaseCommand
+from django.db.models import Exists, F, OuterRef, Q
 from django.utils import timezone
 
-from itou.siae_evaluations.models import EvaluationCampaign
+from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria, EvaluationCampaign
 from itou.utils.emails import send_email_messages
 
 
 class Command(BaseCommand):
     def handle(self, **options):
         today = timezone.localdate()
-        for campaign in EvaluationCampaign.objects.filter(
-            evaluations_asked_at__date__lte=today - relativedelta(days=30),
-            ended_at=None,
-        ).select_related("institution"):
+        campaigns = EvaluationCampaign.objects.filter(ended_at=None).select_related("institution")
+        for campaign in campaigns.filter(
+            evaluations_asked_at__date__range=[
+                # Stop sending reminder after manual run of
+                # EvaluationCampaign.transition_to_adversarial_phase
+                today - EvaluationCampaign.ADVERSARIAL_STAGE_START_DELTA,
+                today - relativedelta(days=30),
+            ],
+        ):
             emails = []
             evaluated_siaes = (
                 campaign.evaluated_siaes.did_not_send_proof()
@@ -25,5 +31,29 @@ class Command(BaseCommand):
                 send_email_messages(emails)
                 evaluated_siaes.update(reminder_sent_at=timezone.now())
                 self.stdout.write(
-                    f"Emailed reminders to {len(emails)} SIAE which did not submit proofs to {campaign}."
+                    f"Emailed first reminders to {len(emails)} SIAE which did not submit proofs to {campaign}."
+                )
+
+        evaluations_asked_before = today - EvaluationCampaign.ADVERSARIAL_STAGE_START_DELTA - relativedelta(days=30)
+        for campaign in campaigns.filter(evaluations_asked_at__date__lte=evaluations_asked_before):
+            emails = []
+            evaluated_siaes = (
+                campaign.evaluated_siaes.exclude(
+                    Exists(
+                        EvaluatedAdministrativeCriteria.objects.filter(
+                            evaluated_job_application__evaluated_siae=OuterRef("pk"),
+                            submitted_at__gt=F("evaluated_job_application__evaluated_siae__reviewed_at"),
+                        )
+                    )
+                )
+                .filter(Q(reminder_sent_at=None) | Q(reminder_sent_at__lt=F("reviewed_at")))
+                .select_related("evaluation_campaign__institution", "siae__convention")
+            )
+            for evaluated_siae in evaluated_siaes:
+                emails.append(evaluated_siae.get_email_to_siae_notify_before_campaign_close())
+            if emails:
+                send_email_messages(emails)
+                evaluated_siaes.update(reminder_sent_at=timezone.now())
+                self.stdout.write(
+                    f"Emailed second reminders to {len(emails)} SIAE which did not submit proofs to {campaign}."
                 )

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -501,6 +501,23 @@ class EvaluatedSiae(models.Model):
         body = "siae_evaluations/email/to_siae_adversarial_stage_body.txt"
         return get_email_message(to, context, subject, body)
 
+    def get_email_to_siae_notify_before_campaign_close(self):
+        to = self.siae.active_admin_members.values_list("email", flat=True)
+        job_app_list_url = reverse(
+            "siae_evaluations_views:siae_job_applications_list",
+            kwargs={"evaluated_siae_pk": self.pk},
+        )
+        context = {
+            "adversarial_stage_start": self.evaluation_campaign.adversarial_stage_start_date,
+            "evaluation_campaign": self.evaluation_campaign,
+            "siae": self.siae,
+            "evaluated_job_app_list_url": f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{job_app_list_url}",
+            "itou_community_url": global_constants.ITOU_COMMUNITY_URL,
+        }
+        subject = "siae_evaluations/email/to_siae_notify_before_campaign_close_subject.txt"
+        body = "siae_evaluations/email/to_siae_notify_before_campaign_close_body.txt"
+        return get_email_message(to, context, subject, body)
+
     def get_email_to_siae_refused_no_proofs(self):
         to = self.siae.active_admin_members.values_list("email", flat=True)
         context = {

--- a/itou/templates/siae_evaluations/email/to_siae_notify_before_campaign_close_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_notify_before_campaign_close_body.txt
@@ -1,0 +1,23 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+Sauf erreur de notre part, vous n’avez pas encore transmis vos justificatifs dans le cadre du contrôle a posteriori des auto-prescriptions.
+
+Nous vous rappelons que votre structure {{ siae.kind }} {{ siae.name }} ID-{{ siae.pk }} (SIRET : {{ siae.convention.siret_signature }}) est soumise à la procédure de contrôle a posteriori sur les embauches réalisées en auto-prescription du {{ evaluation_campaign.evaluated_period_start_at }} au {{ evaluation_campaign.evaluated_period_end_at }}.
+
+Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez enregistrés lors de ces embauches.
+Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du {{ adversarial_stage_start|date }}.
+
+Ce délai comprend la transmission de vos justificatifs ET le contrôle effectué par votre DDETS.
+Attention : si vous transmettez vos justificatifs en dernière minute, la DDETS risque de ne pas avoir le temps de valider ou invalider vos justificatifs ; auquel cas, le contrôle sera automatiquement clôturé avec un résultat négatif.
+
+Pour transmettre les justificatifs demandés : RDV dans votre tableau de bord à la rubrique “Contrôle a posteriori” puis cliquez sur “Justifier mes auto-prescriptions”.
+{{ evaluated_job_app_list_url }}
+
+Voir le mode d’emploi : {{ itou_community_url }}/doc/emplois/controle-a-posteriori-pour-les-siae/
+
+En cas de question sur les critères ou les justificatifs vous devez vous adresser uniquement à votre DDETS.
+
+Cordialement,
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/to_siae_notify_before_campaign_close_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_notify_before_campaign_close_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+Contrôle a posteriori des auto-prescriptions : Plus que quelques jours pour transmettre vos justificatifs à la {{ evaluation_campaign.institution }}
+{% endblock %}


### PR DESCRIPTION
### Quoi ?

Notifier les SIAE sans justificatifs vers la fin de la phase contradictoire

30 jours après le début de la phase contradictoire, envoie un email aux SIAE qui n’ont pas transmis (ou retransmis après une revue négative) de justificatifs.