### PR TITLE
Ajoute la possibilité de trier les fiches salariés

### DIFF
--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -12,6 +12,11 @@
         $("#status-filter-form-group :input").change(function() {
             $("#status-filter-form").submit();
         });
+        $("#order-form-group :input").click(function(event) {
+            // Fill the hidden order input of the form
+            $("#id_order").val(event.target.value);
+            $("#status-filter-form").submit();
+        });
     </script>
 {% endblock %}
 
@@ -23,6 +28,7 @@
 
     <div class="mt-3">
         <div class="row">
+
             <div class="col-sm-3">
                 <div class="card-deck">
                     <div class="card">
@@ -46,6 +52,8 @@
                                         </div>
                                     {% endfor %}
                                 </div>
+                                {# Filled via jQuery #}
+                                {{ form.order.as_hidden }}
                             </form>
                         </div>
                     </div>
@@ -138,6 +146,21 @@
                     </div>
                 {% endif %}
 
+                <div class="row justify-content-end">
+                    <div class="col-12 col-sm-auto">
+                        <span class="font-weight-bold mr-2">Trier par</span>
+                        <button type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            {{ ordered_by_label }}
+                        </button>
+                        <div class="dropdown-menu dropdown-menu-right" id="order-form-group">
+                            {% for order_value, order_label in form.order.field.choices %}
+                                <button class="dropdown-item {% if order_value == form.order.value %}active{% endif %}" type="button" value="{{ order_value }}">
+                                    {{ order_label }}
+                                </button>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
                 {# "Real" employee records objects #}
                 <div class="employee-records-list">
                     {% if employee_records_list %}

--- a/itou/www/employee_record_views/enums.py
+++ b/itou/www/employee_record_views/enums.py
@@ -1,0 +1,10 @@
+from django.db import models
+
+
+class EmployeeRecordOrder(models.TextChoices):
+
+    # HIRING_START_AT_DESC is the default value, hence its first position
+    HIRING_START_AT_DESC = "-hiring_start_at", "La plus récente d'abord"
+    HIRING_START_AT_ASC = "hiring_start_at", "La plus ancienne d'abord"
+    NAME_ASC = "name", "Nom A - Z"
+    NAME_DESC = "-name", "Nom Z - A"

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -11,6 +11,8 @@ from itou.users.models import JobSeekerProfile, User
 from itou.utils.validators import validate_pole_emploi_id
 from itou.utils.widgets import DuetDatePickerWidget
 
+from .enums import EmployeeRecordOrder
+
 
 # Endpoint for INSEE communes autocomplete
 COMMUNE_AUTOCOMPLETE_SOURCE_URL = reverse_lazy("autocomplete:communes")
@@ -35,6 +37,14 @@ class SelectEmployeeRecordStatusForm(forms.Form):
         widget=forms.RadioSelect(),
         choices=STATUS_CHOICES,
         initial=Status.NEW,
+        required=False,
+    )
+
+    order = forms.ChoiceField(
+        widget=forms.RadioSelect(),
+        choices=EmployeeRecordOrder.choices,
+        initial=EmployeeRecordOrder.HIRING_START_AT_DESC,
+        required=False,
     )
 
 


### PR DESCRIPTION
### Quoi ?

Ajout d'un dropdown pour choisir entre le tri par date de début de contrat (valeur par défaut) et le tri par nom

[Ticket notion](https://www.notion.so/1-2-Simplifier-la-recherche-des-fiches-salari-En-tant-que-SIAE-je-veux-trier-les-fiches-salari-ede1158ea9434e9b9af7c822665d9fb3)

### Pourquoi ?

Pour faciliter la recherche d'un salarié

### Captures d'écran (optionnel)

![employee_sort](https://user-images.githubusercontent.com/1089744/203828865-beb28589-8803-4cb2-b5d8-957fe1567b70.gif)
