### PR TITLE
Correction de l'affichage des PASS IAE pour les prescripteurs

### DIFF
--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -17,35 +17,54 @@
 
     {% if job_application.to_siae.is_subject_to_eligibility_rules %}
 
-        {% if job_application.state.is_accepted and job_application.approval %}
+        {% if request.user.is_siae_staff %}
+            {% if job_application.state.is_accepted and job_application.approval %}
 
-            <div class="alert alert-info">
-                <div class="row">
-                    <div class="col-auto pr-0">
-                        <i class="ri-information-line ri-xl text-info"></i>
+                <div class="alert alert-info">
+                    <div class="row">
+                        <div class="col-auto pr-0">
+                            <i class="ri-information-line ri-xl text-info"></i>
+                        </div>
+                        <div class="col">
+                            <b>PASS IAE</b>
+                            <p class="mb-0">
+                                Désormais, le PASS IAE est visible depuis le profil salarié, la gestion de celui-ci également (exemple : « suspendre » ou  « prolonger » un PASS IAE).
+                            </p>
+                        </div>
+                        <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                            <a class="btn btn-emploi matomo-event"
+                               href="{% url 'approvals:detail' pk=job_application.approval.id %}"
+                               data-matomo-category="salaries"
+                               data-matomo-action="clic"
+                               data-matomo-option="detail-salarie-depuis-candidature">
+                                Accéder au Profil salarié
+                            </a>
+                        </div>
                     </div>
-                    <div class="col">
-                        <b>PASS IAE</b>
-                        <p class="mb-0">
-                            Désormais, le PASS IAE est visible depuis le profil salarié, la gestion de celui-ci également (exemple : « suspendre » ou  « prolonger » un PASS IAE).
-                        </p>
-                    </div>
-                    <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-                        <a class="btn btn-emploi matomo-event"
-                           href="{% url 'approvals:detail' pk=job_application.approval.id %}"
-                           data-matomo-category="salaries"
-                           data-matomo-action="clic"
-                           data-matomo-option="detail-salarie-depuis-candidature">
-                            Accéder au Profil salarié
-                        </a>
+                </div>
+
+            {% elif not job_application.state.is_cancelled %}
+                {# Employers need to know the expiration date of an approval #}
+                {# to decide whether they may accept a job application or not. #}
+                {% include "approvals/includes/card.html" with common_approval=job_application.job_seeker.latest_common_approval job_application=job_application %}
+            {% endif %}
+        {% elif request.user.is_prescriber %}
+            <div class="card my-4">
+                <div class="card-body">
+                    {# Approval status. #}
+                    <div class="card-text">
+                        {% if job_application.approval %}
+                            {% include "approvals/includes/status.html" with common_approval=job_application.approval %}
+                        {% elif job_application.hiring_without_approval %}
+                            Vous n'avez pas demandé de PASS IAE (agrément).
+                        {% elif job_application.approval_manually_refused_at %}
+                            PASS IAE refusé (délai de carence non respecté).
+                        {% else %}
+                            PASS IAE (agrément) en cours de délivrance.
+                        {% endif %}
                     </div>
                 </div>
             </div>
-
-        {% elif not job_application.state.is_cancelled %}
-            {# Employers need to know the expiration date of an approval #}
-            {# to decide whether they may accept a job application or not. #}
-            {% include "approvals/includes/card.html" with common_approval=job_application.job_seeker.latest_common_approval job_application=job_application %}
         {% endif %}
 
     {% endif %}


### PR DESCRIPTION
### Quoi ?

Afficher le statut du PASS pour les prescripteurs qui n'ont pas accès à l'espace salarié

