### PR TITLE
Correction de Commune by_insee_code_and_period

### DIFF
--- a/itou/asp/admin.py
+++ b/itou/asp/admin.py
@@ -47,6 +47,7 @@ class ASPModelAdmin(admin.ModelAdmin):
 
 @admin.register(models.Commune)
 class CommuneAdmin(ASPModelAdmin):
+    list_display = ("pk", "code", "name", "start_date", "end_date", "created_by")
     search_fields = [
         "name",
         "code",

--- a/itou/asp/models.py
+++ b/itou/asp/models.py
@@ -347,6 +347,9 @@ class CommuneQuerySet(PeriodQuerySet):
         "Lookup a Commune object by INSEE code and valid at the given period"
         return (
             self.filter(code=insee_code, start_date__lte=period)
+            # Don't check for manually created Communes since we split multiples
+            # Commune with the same INSEE as SAINT-DENIS/STE_CLOTILDE
+            .filter(created_by__isnull=True)
             .filter((Q(end_date=None) | Q(end_date__gt=period)))
             .get()
         )


### PR DESCRIPTION
### Quoi ?

Vu le mécanique du formulaire de selection de commune de naissance des fiches ASP, on ne peut pas ajouter des Commune pour séparer plusieurs villes avec le même code INSEE.

On va donc ignorer les objects ajoutés à la main lors de l'appel à `by_insee_code_and_period()`

