### PR TITLE
[Metabase] Ajout du champ `candidats.adresse_en_qpv`

### DIFF
--- a/itou/metabase/management/commands/_job_seekers.py
+++ b/itou/metabase/management/commands/_job_seekers.py
@@ -1,3 +1,4 @@
+import functools
 from datetime import date, timedelta
 from functools import partial
 from operator import attrgetter
@@ -14,6 +15,7 @@ from itou.metabase.management.commands._utils import (
     get_hiring_siae,
     hash_content,
 )
+from itou.users.models import User
 
 
 # Reword the original EligibilityDiagnosis.AUTHOR_KIND_CHOICES
@@ -174,6 +176,35 @@ def get_birth_month_from_nir(job_seeker):
     return None
 
 
+@functools.cache
+def _get_qpv_job_seeker_pks():
+    """
+    Load once and for all the list of all job seeker pks which are located in a QPV zone.
+
+    The alternative would have been to naively compute `QPV.in_qpv(u, geom_field="coords")` for each and every one
+    of the ~700k job seekers, which would have resulted in a undesirable deluge of 700k micro SQL requests.
+
+    Unfortunately we failed so far at finding a clean ORM friendly way to do this in a single SQL request.
+    """
+    qpv_job_seekers = User.objects.raw(
+        # Takes only ~2s on local dev.
+        "SELECT uu.id FROM users_user uu INNER JOIN geo_qpv gq ON ST_Contains(gq.geometry, uu.coords::geometry)"
+    )
+    # A list of ~100k integers is permanently loaded in memory. It is fortunately not a very high volume of data.
+    # Objects returned by `raw` are defered which means their fields are not preloaded unless they have been
+    # explicitely specified in the SQL request. We did specify and thus preload `id` fields.
+    return [job_seeker.pk for job_seeker in qpv_job_seekers]
+
+
+def get_job_seeker_qpv_info(job_seeker):
+    if not job_seeker.coords or job_seeker.geocoding_score < 0.8:
+        # Under this geocoding score, we can't assert the quality of the QPV information.
+        return "Adresse non-géolocalisée"
+    if job_seeker.pk in _get_qpv_job_seeker_pks():
+        return "Adresse en QPV"
+    return "Adresse hors QPV"
+
+
 TABLE = MetabaseTable(name="candidats")
 TABLE.add_columns(
     [
@@ -251,6 +282,12 @@ TABLE.add_columns(get_department_and_region_columns(comment_suffix=" du candidat
 
 TABLE.add_columns(
     [
+        {
+            "name": "adresse_en_qpv",
+            "type": "varchar",
+            "comment": "Analyse QPV sur adresse du candidat",
+            "fn": get_job_seeker_qpv_info,
+        },
         {
             "name": "total_candidatures",
             "type": "integer",

--- a/itou/metabase/tests/test_utils.py
+++ b/itou/metabase/tests/test_utils.py
@@ -1,12 +1,9 @@
-import pytest
-
 from itou.geo.factories import QPVFactory
 from itou.geo.utils import coords_to_geometry
 from itou.metabase.management.commands._utils import get_qpv_job_seeker_pks
 from itou.users.factories import JobSeekerFactory
 
 
-@pytest.mark.django_db
 def test_get_qpv_job_seeker_pks():
     for code in ["QP093028"]:
         QPVFactory(code=code)

--- a/itou/metabase/tests/test_utils.py
+++ b/itou/metabase/tests/test_utils.py
@@ -5,8 +5,7 @@ from itou.users.factories import JobSeekerFactory
 
 
 def test_get_qpv_job_seeker_pks():
-    for code in ["QP093028"]:
-        QPVFactory(code=code)
+    QPVFactory(code="QP093028")
 
     # Somewhere in QPV QP093028 (Aubervilliers)
     job_seeker_in_qpv = JobSeekerFactory(coords=coords_to_geometry("48.917735", "2.387311"))

--- a/itou/metabase/tests/test_utils.py
+++ b/itou/metabase/tests/test_utils.py
@@ -1,0 +1,21 @@
+import pytest
+
+from itou.geo.factories import QPVFactory
+from itou.geo.utils import coords_to_geometry
+from itou.metabase.management.commands._utils import get_qpv_job_seeker_pks
+from itou.users.factories import JobSeekerFactory
+
+
+@pytest.mark.django_db
+def test_get_qpv_job_seeker_pks():
+    for code in ["QP093028"]:
+        QPVFactory(code=code)
+
+    # Somewhere in QPV QP093028 (Aubervilliers)
+    job_seeker_in_qpv = JobSeekerFactory(coords=coords_to_geometry("48.917735", "2.387311"))
+
+    # Somewhere not in a QPV near Aubervilliers
+    job_seeker_not_in_qpv = JobSeekerFactory(coords=coords_to_geometry("48.899", "2.412"))
+
+    assert job_seeker_in_qpv.pk in get_qpv_job_seeker_pks()
+    assert job_seeker_not_in_qpv.pk not in get_qpv_job_seeker_pks()


### PR DESCRIPTION
### Quoi ?

Ajout du champ `candidats.adresse_en_qpv`.

### Pourquoi ?

Pour profiter de la nouvelle app django `geo` récemment introduite qui permet de vérifier si n'importe quelle adresse donnée est ou non en QPV. On l'applique sur l'adresse du candidat si présente.

### Notes

- Testé OK en dry run local.
- Pas de test car sur la table `_job_seekers` problématique.