### PR TITLE
matomo-metabase: Lancer le cron plus tard dans la semaine

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -8,5 +8,5 @@
   "0 12 * * * $ROOT/clevercloud/run_management_command.sh evaluation_campaign_notify",
   "0 0 * * * $ROOT/clevercloud/run_management_command.sh scan_s3_files c1-prod --daily",
   "0 0 1 * * $ROOT/clevercloud/run_management_command.sh scan_s3_files c1-prod",
-  "0 0 * * SUN $ROOT/clevercloud/crons/populate_metabase_matomo.sh"
+  "0 2 * * MON $ROOT/clevercloud/crons/populate_metabase_matomo.sh"
 ]


### PR DESCRIPTION
We don't want it to run on sunday, but after the beginning of the next week to not lose 6 days waiting for an analysis.

Also, start it a little later in the night to not be surprised by matomo latencies or daylight saving time.
