### PR TITLE
settings: allow to view settings in admin for superuser

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -99,6 +99,7 @@ LOCAL_APPS = [
     "itou.status",
     "itou.antivirus",
     "itou.scripts",
+    "itou.settings_viewer",
 ]
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS

--- a/itou/settings_viewer/admin.py
+++ b/itou/settings_viewer/admin.py
@@ -1,0 +1,33 @@
+from django.contrib import admin
+
+from . import models, views
+
+
+class SettingAdmin(admin.ModelAdmin):
+    """Admin View for settings"""
+
+    def has_add_permission(self, request):
+        return False  # Hide the admin "+ Add" link for Queues
+
+    def has_change_permission(self, request):
+        return False
+
+    def has_module_permission(self, request):
+        """
+        return True if the given request has any permission in the given
+        app label.
+        Can be overridden by the user in subclasses. In such case it should
+        return True if the given request has permission to view the module on
+        the admin index page and access the module's index page. Overriding it
+        does not restrict access to the add, change or delete views. Use
+        `ModelAdmin.has_(add|change|delete)_permission` for that.
+        """
+        return request.user.is_superuser
+
+    def changelist_view(self, request):
+        """The 'change list' admin view for this model."""
+        # proxy request to setting view
+        return views.settings_list(request)
+
+
+admin.site.register(models.Setting, SettingAdmin)

--- a/itou/settings_viewer/apps.py
+++ b/itou/settings_viewer/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class DefaultConfig(AppConfig):
+    name = "itou.settings_viewer"
+    verbose_name = "Affichage des settings"

--- a/itou/settings_viewer/models.py
+++ b/itou/settings_viewer/models.py
@@ -1,0 +1,10 @@
+from django.db import models
+
+
+class Setting(models.Model):
+    """Placeholder model without database table, but with django admin page"""
+
+    class Meta:
+        managed = False  # not in Django's database
+        default_permissions = ()
+        permissions = [["view", "Access admin page"]]

--- a/itou/settings_viewer/templates/settings/list.html
+++ b/itou/settings_viewer/templates/settings/list.html
@@ -1,0 +1,42 @@
+{% extends "admin/base_site.html" %}
+
+{% block title %}Settings {{ block.super }}{% endblock %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <style>table {width: 100%;}</style>
+{% endblock %}
+
+{% block content_title %}<h1>Setting values</h1>{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
+    </div>
+{% endblock %}
+
+{% block content %}
+
+    <div id="content-main">
+
+        <div class="module">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for setting_key, setting_value in setting_items %}
+                        <tr class="{% cycle 'row1' 'row2' %}">
+                            <th>{{ setting_key }}</th>
+                            <td>{{ setting_value }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+{% endblock %}

--- a/itou/settings_viewer/tests.py
+++ b/itou/settings_viewer/tests.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from django.urls import reverse
+from pytest_django.asserts import assertContains, assertNotContains
+
+from itou.users.factories import JobSeekerFactory
+
+
+def test_as_superuser(client):
+    admin_user = JobSeekerFactory(is_staff=True, is_superuser=True)
+    client.force_login(admin_user)
+    response = client.get(reverse("admin:index"))
+    assert response.status_code == 200
+    assertContains(response, "Affichage des settings")
+    response = client.get(reverse("admin:settings_viewer_setting_changelist"))
+    assert response.status_code == 200
+    assertContains(response, "ALLOWED_HOSTS")
+    assertContains(response, "DATABASES")
+    assertContains(response, "SECRET_KEY")
+    assertNotContains(response, settings.SECRET_KEY)
+
+
+def test_as_staff(client):
+    admin_user = JobSeekerFactory(is_staff=True, is_superuser=False)
+    client.force_login(admin_user)
+    response = client.get(reverse("admin:index"))
+    assert response.status_code == 200
+    assertNotContains(response, "Affichage des settings")
+    response = client.get(reverse("admin:settings_viewer_setting_changelist"))
+    assert response.status_code == 302

--- a/itou/settings_viewer/views.py
+++ b/itou/settings_viewer/views.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.contrib import admin
+from django.contrib.auth.decorators import user_passes_test
+from django.shortcuts import render
+from django.views import debug
+from django.views.decorators.cache import never_cache
+
+
+def get_settings_list():
+    """Build the list of (setting, value, is_default_value)."""
+    # Code heavily inspired from django.core.management.commands.diffsettings
+    current_settings = settings._wrapped.__dict__
+    setting_cleanser = debug.SafeExceptionReporterFilter().cleanse_setting
+    return [(k, setting_cleanser(k, v)) for k, v in sorted(current_settings.items()) if not k.startswith("_")]
+
+
+@never_cache
+@user_passes_test(lambda user: user.is_active and user.is_superuser)
+def settings_list(request):
+    context_data = {
+        **admin.site.each_context(request),
+        "setting_items": get_settings_list(),
+    }
+    return render(request, "settings/list.html", context_data)


### PR DESCRIPTION
### Quoi ?

Ajoute la possibilité pour les superuser de voir les settings (non-sensibles) dans l'admin

### Pourquoi ?

Pour faciliter le debug 

### Comment ?

Ajout d'un modèle fictif avec son admin surchargé.

### Captures d'écran (optionnel)


![Screenshot 2022-11-28 at 13-48-01 Settings Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/204281749-efe0315b-0d25-4264-94d9-4e8d46c947f1.png)
