### PR TITLE
Retire l’APM

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -56,7 +56,6 @@ THIRD_PARTY_APPS = [
     "import_export",
     "hijack",
     "hijack.contrib.admin",
-    "elasticapm.contrib.django",
 ]
 
 
@@ -508,17 +507,6 @@ SPECTACULAR_SETTINGS = {
     "TITLE": "API - Les emplois de l'inclusion",
     "DESCRIPTION": "Documentation de l'API **emplois.inclusion.beta.gouv.fr**",
     "VERSION": "1.0.0",
-}
-
-ELASTIC_APM = {
-    "ENABLED": bool(os.getenv("APM_SERVER_URL")),
-    "SERVICE_NAME": "itou-django",
-    "SERVICE_VERSION": os.getenv("COMMIT_ID"),
-    "SERVER_URL": os.getenv("APM_SERVER_URL"),
-    "SECRET_TOKEN": os.getenv("APM_AUTH_TOKEN"),
-    "ENVIRONMENT": ITOU_ENVIRONMENT,
-    "DJANGO_TRANSACTION_NAME_FROM_ROUTE": True,
-    "TRANSACTION_SAMPLE_RATE": 0.1,
 }
 
 # Requests default timeout is None... See https://blog.mathieu-leplatre.info/handling-requests-timeout-in-python.html

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -74,11 +74,6 @@ DATABASES["default"]["NAME"] = os.getenv("PGDATABASE", "itou")  # noqa: F405
 DATABASES["default"]["USER"] = os.getenv("PGUSER", "postgres")  # noqa: F405
 DATABASES["default"]["PASSWORD"] = os.getenv("PGPASSWORD", "password")  # noqa: F405
 
-ELASTIC_APM["ENABLED"] = False  # noqa: F405
-# FIXME(vperron): Remove this as soon as the checks are disabled
-# followup on https://github.com/elastic/apm-agent-python/pull/1632
-ELASTIC_APM["SERVER_URL"] = "http://127.0.0.1"  # noqa: F405
-
 if os.getenv("SQL_DEBUG", "False") == "True":
     LOGGING.setdefault("loggers", {})["django.db.backends"] = {  # noqa: F405
         "level": "DEBUG",

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -108,4 +108,3 @@ python-dotenv  # https://github.com/theskumar/python-dotenv
 # ------------------------------------------------------------------------------
 uwsgi==2.0.*  # https://github.com/unbit/uwsgi
 sentry-sdk  # https://github.com/getsentry/sentry-python
-elastic-apm==6.13.0  # https://www.elastic.co/guide/en/apm/agent/python/current/django-support.html

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -62,7 +62,6 @@ certifi==2022.9.24 \
     --hash=sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14 \
     --hash=sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382
     # via
-    #   elastic-apm
     #   httpcore
     #   httpx
     #   requests
@@ -249,8 +248,6 @@ drf-spectacular==0.22.1 \
     --hash=sha256:17ac5e31e5d6150dd5fa10843b429202f4f38069202acc44394cc5a771de63d9 \
     --hash=sha256:866e16ddaae167a1234c76cd8c351161373551db994ce9665b347b32d5daf38b
     # via -r requirements/base.in
-elastic-apm==6.13.0 \
-    --hash=sha256:04aec2676bf996a359554bf0498c7c5d3415e2e75e138dc42f3abfb5a99b7902
     # via -r requirements/base.in
 et-xmlfile==1.1.0 \
     --hash=sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c \
@@ -751,7 +748,6 @@ urllib3==1.26.12 \
     --hash=sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997
     # via
     #   botocore
-    #   elastic-apm
     #   requests
     #   sentry-sdk
 uwsgi==2.0.21 \
@@ -824,7 +820,6 @@ wrapt==1.14.1 \
     --hash=sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af
     # via
     #   deprecated
-    #   elastic-apm
 xlrd==2.0.1 \
     --hash=sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd \
     --hash=sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -115,7 +115,6 @@ certifi==2022.9.24 \
     --hash=sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382
     # via
     #   -r requirements/base.txt
-    #   elastic-apm
     #   httpcore
     #   httpx
     #   requests
@@ -422,9 +421,6 @@ editorconfig==0.12.3 \
     # via
     #   cssbeautifier
     #   jsbeautifier
-elastic-apm==6.13.0 \
-    --hash=sha256:04aec2676bf996a359554bf0498c7c5d3415e2e75e138dc42f3abfb5a99b7902
-    # via -r requirements/base.txt
 et-xmlfile==1.1.0 \
     --hash=sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c \
     --hash=sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada
@@ -1320,7 +1316,6 @@ urllib3==1.26.12 \
     # via
     #   -r requirements/base.txt
     #   botocore
-    #   elastic-apm
     #   requests
     #   sentry-sdk
 uwsgi==2.0.21 \
@@ -1407,7 +1402,6 @@ wrapt==1.14.1 \
     #   -r requirements/base.txt
     #   astroid
     #   deprecated
-    #   elastic-apm
 xlrd==2.0.1 \
     --hash=sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd \
     --hash=sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88


### PR DESCRIPTION
### Pourquoi ?

Sentry offre la même fonctionnalité, mais plus pratique a utiliser. L’APM n’est pas très utilisé de toute façon.
Le client APM a déjà noyé Sentry sous les erreurs, cassant notre surveillance applicative et demandant du temps et de l’argent pour résoudre le problème.