### PR TITLE
BOOST : Modification de l'e-mail envoyé pour un compte inconnu demandant un reset de mot de passe

### DIFF
--- a/itou/templates/account/email/unknown_account_message.txt
+++ b/itou/templates/account/email/unknown_account_message.txt
@@ -1,0 +1,18 @@
+Bonjour, 
+
+Vous recevez cet e-mail parce que vous, ou quelqu’un d’autre, avez demandé à réinitialiser le mot de passe associé à votre compte sur les emplois de l’inclusion (https://emplois.inclusion.beta.gouv.fr/).
+
+Toutefois, nous n’avons trouvé aucun compte utilisateur associé à votre adresse e-mail.
+
+Si vous n’avez fait aucune demande de nouveau mot de passe, vous pouvez ignorer cet e-mail.
+
+Si vous avez fait cette demande de nouveau mot de passe :
+
+- Assurez-vous que vous n’aviez pas créé votre compte sur les emplois de l’inclusion depuis une autre adresse e-mail.
+- Vous pouvez créer un nouveau compte en utilisant le lien ci-dessous :
+
+https://emplois.inclusion.beta.gouv.fr/accounts/signup/ 
+
+Cordialement,
+
+L’équipe des emplois de l’inclusion

--- a/itou/templates/account/email/unknown_account_subject.txt
+++ b/itou/templates/account/email/unknown_account_subject.txt
@@ -1,0 +1,1 @@
+E-mail de réinitialisation du mot de passe 


### PR DESCRIPTION
### Quoi ?

Modification du gabarit par défaut pour l'e-mail envoyé lors d'une demande de réinitialisation de mot de passe lorsque le compte est inconnu.

### Pourquoi ?

Le message envoyé était celui par défaut, en anglais, avec quelques petits bout de "french in the text".

### Comment ?

Surcharge du gabarit `allauth` par défaut.