### PR TITLE
Ajoute une marge au défilement vers un endroit de la page

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -1,3 +1,8 @@
+/* Scroll past the sticky header when navigating to a fragment. */
+[id] {
+    scroll-margin-top: 120px;
+}
+
 .container-search {
     background-position: top left, top right;
     background-repeat: no-repeat;

--- a/itou/templates/layout/_header.html
+++ b/itou/templates/layout/_header.html
@@ -10,6 +10,7 @@
         </div>
     </div>
 </section>
+{# NOTE: Keep sticky header height in check with itou.css scroll-margin-top #}
 <header class="s-header s-header--emploi sticky-top" role="banner" id="header">
     <section class="s-header__container container">
         <div class="s-header__row row">


### PR DESCRIPTION
### Quoi ?

Ajoute une marge au défilement vers un endroit de la page

### Pourquoi ?

Autrement, la nav bar cache l’élément pointé.

### Comment ?

https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top