### PR TITLE
Utiliser la même date pour les sous-fonctions de `eligible_as_employee_record()`

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -320,18 +320,14 @@ class JobApplicationQuerySet(models.QuerySet):
                     Suspension.objects.filter(
                         siae=OuterRef("to_siae"),
                         approval=OuterRef("approval"),
-                        # Limit to recent suspension as the older ones will already have been handled by the support.
-                        # The date was chosen arbitrarily, don't mind it too much :).
-                        created_at__gte=timezone.make_aware(datetime.datetime(2022, 1, 1)),
+                        created_at__gte=EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE,
                     )
                 ),
                 has_recent_prolongation=Exists(
                     Prolongation.objects.filter(
                         declared_by_siae=OuterRef("to_siae"),
                         approval=OuterRef("approval"),
-                        # Limit to recent prolongation as the older ones will already have been handled by the support.
-                        # The date was chosen arbitrarily, don't mind it too much :).
-                        created_at__gte=timezone.make_aware(datetime.datetime(2022, 1, 1)),
+                        created_at__gte=EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE,
                     )
                 ),
             )

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -12,8 +12,7 @@
                     Début de contrat :&nbsp;<b>{{ item.hiring_start_at|default_if_none:"Non renseigné" }}</b>
                 </p>
                 <p class="m-0">
-                    Fin de contrat :&nbsp;<b{% if item.has_outdated_date %} class="text-danger"{% endif %}>{{ item.hiring_end_at|default_if_none:"Non renseigné" }}</b>
-                    {% if item.has_outdated_date %}<i class="ri-error-warning-fill ri-xl text-danger align-text-bottom"></i>{% endif %}
+                    Fin de contrat :&nbsp;<b>{{ item.hiring_end_at|default_if_none:"Non renseigné" }}</b>
                 </p>
                 <p class="m-0">
                     Numéro de PASS IAE (agrément) :&nbsp;<b>{{ item.approval.number|format_approval_number }}</b>
@@ -100,17 +99,18 @@
         {# Actions #}
         {% if form.status.value == "NEW" %}
             {% if item.has_outdated_date %}
-                <div class="alert alert-danger mt-4" role="status">
+                <div class="alert alert-warning mt-4" role="status">
                     <div class="row">
                         <div class="col-auto pr-0">
-                            <i class="ri-error-warning-fill ri-xl text-danger"></i>
+                            <i class="ri-error-warning-line ri-xl text-warning"></i>
                         </div>
                         <div class="col">
                             <p class="mb-2">
-                                <strong>Attention, une action de votre part est requise</strong>
+                                <strong>Une action de votre part est nécessaire</strong>
                             </p>
                             <p class="mb-0">
-                                La nouvelle date de fin du PASS IAE n’a pas pu être transmise à l’Extranet IAE 2.0 de l’ASP. Une mise à jour manuelle est nécessaire.
+                                La nouvelle date de fin du PASS IAE n’a pas pu être transmise automatiquement à l’Extranet IAE 2.0 de l’ASP.
+                                Une mise à jour manuelle est nécessaire.
                             </p>
                         </div>
                         <div class="col-auto align-self-center">

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -121,14 +121,17 @@
                     {% endif %}
                 </div>
                 {% if has_outdated_date %}
-                    <div class="alert alert-danger mb-4">
+                    <div class="alert alert-warning my-5">
                         <div class="row">
                             <div class="col-auto pr-0">
                                 <i class="ri-error-warning-line ri-xl text-danger"></i>
                             </div>
                             <div class="col">
+                                <p class="mb-2">
+                                    <strong>Une action de votre part est nécessaire</strong>
+                                </p>
                                 <p class="mb-0">
-                                    <strong>Attention, nous avons détecté une ou plusieurs fiches salarié dont la nouvelle date de fin du PASS IAE doit être transmise manuellement à l’ASP  </strong>
+                                    Attention, nous avons détecté une ou plusieurs fiches salariés dont la nouvelle date de fin du PASS IAE doit être transmise manuellement à l’ASP.
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
### Quoi ?

Remplacement de la date arbitraire _2022-01-01_ par `EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE` (_2021-09-27_)

Changement de wording et d'UI (`danger` -> `warning`) pour les messages liés aux FS d'actualisation.
Avant :
![Screenshot from 2022-12-06 11-28-40](https://user-images.githubusercontent.com/20045330/205890191-b5bc8e27-21db-441b-b833-6bc19b92ae2f.png)
Après :
![Screenshot from 2022-12-06 11-27-49](https://user-images.githubusercontent.com/20045330/205890206-3d445425-cb19-469a-9921-33cccf7012f1.png)


### Pourquoi ?

Cette date avait été choisie car on ne voulais pas faire remonter les anciennes candidatures comme FS actualisation, surtout qu'il était plus que probable que celle-ci est déjà été traitées par le support.

Mais un ticket support pourrais être facilement résolu en reculant cette date à début décembre, donc autant utiliser la même date que celle de disponibilité des fiches salariés.
Au pire des cas on va demander aux SIAE de recréer des FS alors que l'info est déjà présente coté ASP, mais vu que la majorité de nos problèmes récents sont liés à des problèmes de données ça ne me semble pas cher payé.