### PR TITLE
Améliorations des performances de la requête de récupération des membres d'une organisation

### DIFF
--- a/itou/common_apps/organizations/models.py
+++ b/itou/common_apps/organizations/models.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.conf import settings
 from django.db import models
-from django.db.models import OuterRef, Prefetch, Q, Subquery
+from django.db.models import Prefetch, Q
 from django.utils import timezone
 
 from itou.utils.emails import get_email_message
@@ -181,9 +181,9 @@ class MembershipQuerySet(models.QuerySet):
         """
         Return a User QuerySet. Useful to iterate over User objects instead of Membership ones.
         """
-        memberships = memberships.filter(user=OuterRef("pk"))
-        user_model = memberships.model._meta.get_field("user").related_model
-        return user_model.objects.filter(pk=Subquery(memberships.values("user")))
+        user_field = memberships.model._meta.get_field("user")
+        remote_field_lookup = user_field.remote_field.name  # for exemple "siaememberships"
+        return user_field.related_model.objects.filter(**{f"{remote_field_lookup}__in": memberships})
 
 
 class MembershipAbstract(models.Model):


### PR DESCRIPTION
### Pourquoi ?

Elle prend plusieurs secondes pour récupérer une personne ([voir lien sentry](https://sentry.io/organizations/itou/performance/les-emplois-prod:13fe28555ff34107b1bbe4e05e31ae24/?project=6164438&query=transaction.duration%3A%3C15m+http.method%3AGET&referrer=performance-transaction-summary&statsPeriod=7d&transaction=%2Fsiae%2Fcolleagues&unselectedSeries=p100%28%29)).

### Comment ?

Suppression de la Subquery en utilisant plutôt la relation direct

### Captures d'écran (optionnel)
![Screenshot from 2022-12-05 16-07-22](https://user-images.githubusercontent.com/7632730/205672208-a6a64a41-e956-44e3-a15e-6ffd177f78e3.png)
![Screenshot from 2022-12-05 16-07-28](https://user-images.githubusercontent.com/7632730/205672216-eab9586c-6586-45c3-98da-167e11bfcdf4.png)

