### PR TITLE
Améliorer la fréquence de frobulation des désactuateurs

### DIFF
--- a/itou/jobs/models.py
+++ b/itou/jobs/models.py
@@ -6,6 +6,26 @@ from django.contrib.postgres.search import SearchVectorField
 from django.db import models
 
 
+# This list has been retrieved by an API call to
+# <PE_API_URL>/partenaire/rome/v1/granddomaine
+ROME_DOMAINS = {
+    "A": "Agriculture et Pêche, Espaces naturels et Espaces verts, Soins aux animaux",
+    "B": "Arts et Façonnage d'ouvrages d'art",
+    "C": "Banque, Assurance, Immobilier",
+    "D": "Commerce, Vente et Grande distribution",
+    "E": "Communication, Média et Multimédia",
+    "F": "Construction, Bâtiment et Travaux publics",
+    "G": "Hôtellerie-Restauration, Tourisme, Loisirs et Animation",
+    "H": "Industrie",
+    "I": "Installation et Maintenance",
+    "J": "Santé",
+    "K": "Services à la personne et à la collectivité",
+    "L": "Spectacle",
+    "M": "Support à l'entreprise",
+    "N": "Transport et Logistique",
+}
+
+
 class Rome(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
     code = models.CharField(verbose_name="Code ROME", max_length=5, primary_key=True)

--- a/itou/templates/search/includes/siaes_search_filters.html
+++ b/itou/templates/search/includes/siaes_search_filters.html
@@ -42,5 +42,10 @@
             {% bootstrap_field form.contract_types form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
         {% endif %}
 
+        {% if form.domains %}
+            <hr>
+            {% bootstrap_field form.domains form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
+        {% endif %}
+
     </div>
 </div>

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -46,7 +46,7 @@
                        data-matomo-category="candidature"
                        data-matomo-action="clic"
                        data-matomo-option="clic-onglet-employeur"
-                       href="{% url "search:siaes_results" %}?distance={{ distance }}&city={{ city.slug }}&city_name={{ city }}&{{ kinds_query }}&{{ contract_types_query }}">
+                       href="{% url "search:siaes_results" %}?{{ filters_query_string }}">
                         <i class="ri-hotel-line ri-xl mr-1"></i>
                         Employeurs
                         {% if siaes_count %}
@@ -60,7 +60,7 @@
                        data-matomo-category="candidature"
                        data-matomo-action="clic"
                        data-matomo-option="clic-onglet-fichesdeposte"
-                       href="{% url "search:job_descriptions_results" %}?distance={{ distance }}&city={{ city.slug }}&city_name={{ city }}&{{ kinds_query }}&{{ contract_types_query }}">
+                       href="{% url "search:job_descriptions_results" %}?{{ filters_query_string }}">
                         <i class="ri-briefcase-4-line ri-xl mr-1"></i>
                         <span class="d-lg-none d-xl-none">Postes</span>
                         <span class="d-none d-lg-inline">Postes ouverts au recrutement</span>

--- a/itou/www/search/forms.py
+++ b/itou/www/search/forms.py
@@ -4,6 +4,7 @@ from django.utils.datastructures import MultiValueDict
 
 from itou.cities.models import City
 from itou.common_apps.address.departments import DEPARTMENTS, DEPARTMENTS_WITH_DISTRICTS, format_district
+from itou.jobs.models import ROME_DOMAINS
 from itou.siaes.enums import ContractType, SiaeKind
 
 
@@ -106,6 +107,13 @@ class JobDescriptionSearchForm(SiaeSearchForm):
     contract_types = forms.MultipleChoiceField(
         label="Types de contrats",
         choices=CONTRACT_TYPE_CHOICES,
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+    )
+
+    domains = forms.MultipleChoiceField(
+        label="Domaines métier",
+        choices=list(ROME_DOMAINS.items()),
         required=False,
         widget=forms.CheckboxSelectMultiple,
     )

--- a/itou/www/search/tests.py
+++ b/itou/www/search/tests.py
@@ -193,10 +193,6 @@ class SearchPrescriberTest(TestCase):
 
 class JobDescriptionSearchViewTest(TestCase):
     def setUp(self):
-        # FIXME(vperron): this should probably be done ONCE with the initialization of any test DB,
-        # which would also fix the constant calling of this with every test that uses SiaeFactory,
-        # which is a slow process since it's reading JSON, injecting in the database, etc etc.
-        create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         self.url = reverse("search:job_descriptions_results")
 
     def test_not_existing(self):
@@ -204,6 +200,7 @@ class JobDescriptionSearchViewTest(TestCase):
         self.assertContains(response, "Aucun résultat avec les filtres actuels.")
 
     def test_district(self):
+        create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         city_slug = "paris-75"
         paris_city = City.objects.create(
             name="Paris", slug=city_slug, department="75", post_codes=["75001"], coords=Point(5, 23)
@@ -232,6 +229,7 @@ class JobDescriptionSearchViewTest(TestCase):
         self.assertContains(response, capfirst(job.display_name), html=True)
 
     def test_kind(self):
+        create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         city = create_city_saint_andre()
         SiaeFactory(department="44", coords=city.coords, post_code="44117", kind=SiaeKind.AI)
 
@@ -242,6 +240,7 @@ class JobDescriptionSearchViewTest(TestCase):
         self.assertContains(response, "Aucun résultat")
 
     def test_distance(self):
+        create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         # 3 SIAEs in two departments to test distance and department filtering
         vannes = create_city_vannes()
         SIAE_VANNES = "SIAE Vannes"
@@ -301,6 +300,7 @@ class JobDescriptionSearchViewTest(TestCase):
         self.assertContains(response, SIAE_VANNES.capitalize())
 
     def test_order_by(self):
+        create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         guerande = create_city_guerande()
 
         siae = SiaeFactory(department="44", coords=guerande.coords, post_code="44350")
@@ -327,6 +327,7 @@ class JobDescriptionSearchViewTest(TestCase):
         assert list(siaes_results) == [job2, job1, job3]
 
     def test_is_popular(self):
+        create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         city = create_city_saint_andre()
         siae = SiaeFactory(department="44", coords=city.coords, post_code="44117")
         job = SiaeJobDescriptionFactory(siae=siae)
@@ -348,6 +349,7 @@ class JobDescriptionSearchViewTest(TestCase):
         )
 
     def test_no_department(self):
+        create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         st_andre = create_city_saint_andre()
         siae_without_dpt = SiaeFactory(department="", coords=st_andre.coords, post_code="44117", kind=SiaeKind.AI)
         siae = SiaeFactory(department="44", coords=st_andre.coords, post_code="44117", kind=SiaeKind.AI)

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -37,14 +37,6 @@ class EmployerSearchBaseView(FormView):
         # in the case of SIAEs, keep the filter from the URL if present.
         # this enables not losing the count while changing tabs.
         contract_types = form.cleaned_data.get("contract_types", self.request.GET.getlist("contract_types", []))
-        context = {
-            "form": form,
-            "city": city,
-            "distance": distance,
-            "kinds_query": urlencode({"kinds": kinds}, doseq=True),
-            "contract_types_query": urlencode({"contract_types": contract_types}, doseq=True),
-            "ea_eatt_kinds": [SiaeKind.EA, SiaeKind.EATT],
-        }
 
         siaes = (
             Siae.objects.active()
@@ -89,13 +81,26 @@ class EmployerSearchBaseView(FormView):
         if districts:
             siaes = siaes.filter(post_code__in=districts)
 
-        context.update(
-            {
-                "results_page": self.get_results_page(siaes, job_descriptions),
-                "siaes_count": siaes.count(),
-                "job_descriptions_count": job_descriptions.count(),
-            }
-        )
+        context = {
+            "form": form,
+            "ea_eatt_kinds": [SiaeKind.EA, SiaeKind.EATT],
+            "city": city,
+            "distance": distance,
+            "filters_query_string": urlencode(
+                {
+                    "city": city.slug,
+                    "city_name": str(city),
+                    "distance": distance,
+                    "kinds": kinds,
+                    "contract_types": contract_types,
+                    "departments": departments,
+                },
+                doseq=True,
+            ),
+            "results_page": self.get_results_page(siaes, job_descriptions),
+            "siaes_count": siaes.count(),
+            "job_descriptions_count": job_descriptions.count(),
+        }
 
         return render(self.request, self.template_name, context)
 

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -81,6 +81,13 @@ class EmployerSearchBaseView(FormView):
         if districts:
             siaes = siaes.filter(post_code__in=districts)
 
+        domains = self.request.GET.getlist("domains")
+        if domains:
+            query = Q()
+            for domain in domains:
+                query |= Q(appellation__rome__code__startswith=domain)
+            job_descriptions = job_descriptions.filter(query)
+
         context = {
             "form": form,
             "ea_eatt_kinds": [SiaeKind.EA, SiaeKind.EATT],
@@ -94,6 +101,7 @@ class EmployerSearchBaseView(FormView):
                     "kinds": kinds,
                     "contract_types": contract_types,
                     "departments": departments,
+                    "domains": domains,
                 },
                 doseq=True,
             ),


### PR DESCRIPTION
### Pourquoi ?

Ce changement permet une amélioration de la frobulation.
En effet nos désactuateurs ont souffert d'une perte fibulaire de 300 thétas, ce qui est énorme.

### Comment ?
A l'aide de tests rigoureux, corriger la trajectoire tentaculatoire du `DeadBeefService`.
Refonte totale des racamiers dans l'application.

Lire le détail des commits pour plus d'explications.
