### PR TITLE
Affiche EvaluatedSiae.state dans la liste des champs de l’admin

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -137,7 +137,7 @@ class EvaluationCampaignAdmin(admin.ModelAdmin):
 
 @admin.register(models.EvaluatedSiae)
 class EvaluatedSiaeAdmin(admin.ModelAdmin):
-    list_display = ("evaluation_campaign", "siae", "reviewed_at")
+    list_display = ["evaluation_campaign", "siae", "state", "reviewed_at"]
     list_display_links = ("siae",)
     readonly_fields = (
         "evaluation_campaign",


### PR DESCRIPTION
### Pourquoi ?

Demande de Zohra, pour faciliter le suivi des campagnes de contrôle a posteriori.