### PR TITLE
settings: ajout d'un connect_timeout pour PostgreSQL

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -170,6 +170,9 @@ DATABASES = {
         "PORT": os.getenv("POSTGRESQL_ADDON_DIRECT_PORT") or os.getenv("POSTGRESQL_ADDON_PORT"),
         "USER": os.getenv("POSTGRESQL_ADDON_CUSTOM_USER") or os.getenv("POSTGRESQL_ADDON_USER"),
         "PASSWORD": os.getenv("POSTGRESQL_ADDON_CUSTOM_PASSWORD") or os.getenv("POSTGRESQL_ADDON_PASSWORD"),
+        "OPTIONS": {
+            "connect_timeout": 5,
+        },
     }
 }
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -176,6 +176,12 @@ DATABASES = {
     }
 }
 
+if os.getenv("DATABASE_PERSISTENT_CONNECTIONS") == "True":
+    # Since we have the health checks enabled, no need to define a max age:
+    # if the connection was closed on the database side, the check will detect it
+    DATABASES["default"]["CONN_MAX_AGE"] = None
+    DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
+
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 AUTH_PASSWORD_VALIDATORS = [


### PR DESCRIPTION
### Pourquoi ?

Actuellement lorsque notre connection à postgresql saute nos workers uwsgi se retrouvent bloqués à essayer de se connecter, jusqu'à ce que le harakiri uwsgi intervienne (60 sec). Pendant ce temps, plus aucun worker uwsgi n'est dispo et le site ne répond donc plus.

Mettre le connect_timeout à 5 seconds devrait limiter ce blocage :crossed_fingers: 
