### PR TITLE
github actions: annulation du run de la CI lorsqu'un nouveau commit est poussé sur une PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     env:
       DJANGO_SETTINGS_MODULE: config.settings.dev
       PYTHONPATH: .
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: true
     services:
       postgres:
         # Docker Hub image


### PR DESCRIPTION
### Pourquoi ?

Réduire la file d'attente des Github Actions

