### PR TITLE
Matomo : récupérer les custom vars

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -46,6 +46,7 @@ METABASE_CUSTOM_VARS_TABLE_NAME = "suivi_visites_custom_vars_v0"
 
 def matomo_api_call(options):
     response = httpx.get(f"{settings.MATOMO_BASE_URL}?{urllib.parse.urlencode(options)}", timeout=MATOMO_TIMEOUT)
+    print(response.content)
     csv_content = response.content.decode("utf-16")
     yield from csv.DictReader(io.StringIO(csv_content), dialect="excel")
 
@@ -105,28 +106,32 @@ class Command(BaseCommand):
             "token_auth": settings.MATOMO_AUTH_TOKEN,
         }
 
-        for dashboard, public_name in DASHBOARDS_TO_DOWNLOAD.items():
-            dashboard_options = base_options | {
-                "idSite": "146",  # pilotage
-                "segment": f"pageUrl=={constants.PILOTAGE_SITE_URL}/tableaux-de-bord/{dashboard}/",
-            }
-            for row in matomo_api_call(dashboard_options):
-                row["Date"] = at
-                row["tableau de bord"] = public_name
-                if not column_names:
-                    column_names = list(row.keys())
-                all_rows.append(list(row.values()))
+        # for dashboard, public_name in DASHBOARDS_TO_DOWNLOAD.items():
+        #     dashboard_options = base_options | {
+        #         "idSite": "146",  # pilotage
+        #         "segment": f"pageUrl=={constants.PILOTAGE_SITE_URL}/tableaux-de-bord/{dashboard}/",
+        #     }
+        #     for row in matomo_api_call(dashboard_options):
+        #         row["Date"] = at
+        #         row["tableau de bord"] = public_name
+        #         if not column_names:
+        #             column_names = list(row.keys())
+        #         all_rows.append(list(row.values()))
 
-        if wet_run:
-            update_table_at_date(METABASE_DASHBOARDS_TABLE_NAME, column_names, at, all_rows)
+        # if wet_run:
+        #     update_table_at_date(METABASE_DASHBOARDS_TABLE_NAME, column_names, at, all_rows)
 
         all_rows = []
         custom_var_options = base_options | {
             "idSite": "117",
             "flat": "1",
-            "method": "CustomVariables.getCustomVariables",
+            # "method": "CustomVariables.getCustomVariables",
+            "method": "Live.getLastVisitsDetails",
+            # "segment": f"pageUrl=={constants.PILOTAGE_SITE_URL}/tableaux-de-bord/{dashboard}/",
         }
         for row in matomo_api_call(custom_var_options):
+            print(row)
+            break
             row["Date"] = at
             column_names = list(row.keys())
             all_rows.append(list(row.values()))

--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -119,3 +119,17 @@ class Command(BaseCommand):
 
         if wet_run:
             update_table_at_date(METABASE_DASHBOARDS_TABLE_NAME, column_names, at, all_rows)
+
+        all_rows = []
+        custom_var_options = base_options | {
+            "idSite": "117",
+            "flat": "1",
+            "method": "CustomVariables.getCustomVariables",
+        }
+        for row in matomo_api_call(custom_var_options):
+            row["Date"] = at
+            column_names = list(row.keys())
+            all_rows.append(list(row.values()))
+
+        if wet_run:
+            update_table_at_date(METABASE_CUSTOM_VARS_TABLE_NAME, column_names, at, all_rows)

--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -28,10 +28,9 @@ DASHBOARDS_TO_DOWNLOAD = {
 
 MATOMO_OPTIONS = {
     "expanded": 1,
-    "filter_limit": 400,
+    "filter_limit": -1,
     "format": "CSV",
     "format_metrics": 1,
-    "idSite": "146",  # pilotage
     "language": "en",
     "method": "API.get",
     "module": "API",
@@ -41,7 +40,42 @@ MATOMO_OPTIONS = {
 
 MATOMO_TIMEOUT = 60  # in seconds. Matomo can be slow.
 
-METABASE_TABLE_NAME = "suivi_visiteurs_tb_publics_v0"
+METABASE_DASHBOARDS_TABLE_NAME = "suivi_visiteurs_tb_publics_v0"
+METABASE_CUSTOM_VARS_TABLE_NAME = "suivi_visites_custom_vars_v0"
+
+
+def matomo_api_call(options):
+    response = httpx.get(f"{settings.MATOMO_BASE_URL}?{urllib.parse.urlencode(options)}", timeout=MATOMO_TIMEOUT)
+    csv_content = response.content.decode("utf-16")
+    yield from csv.DictReader(io.StringIO(csv_content), dialect="excel")
+
+
+def update_table_at_date(table_name, column_names, at, rows):
+    with MetabaseDatabaseCursor() as (cursor, conn):
+        cursor.execute(
+            sql.SQL("CREATE TABLE IF NOT EXISTS {table_name} ({fields_with_type})").format(
+                table_name=sql.Identifier(table_name),
+                fields_with_type=sql.SQL(",").join(
+                    [sql.SQL(" ").join([sql.Identifier(col), sql.SQL("varchar")]) for col in column_names]
+                ),
+            )
+        )
+        conn.commit()
+        cursor.execute(
+            sql.SQL("""DELETE FROM {table_name} WHERE "Date" = {value}""").format(
+                table_name=sql.Identifier(table_name),
+                col_name=sql.Identifier("Date"),
+                value=sql.Literal(str(at)),
+            )
+        )
+        insert_query = sql.SQL("insert into {table_name} ({fields}) values %s").format(
+            table_name=sql.Identifier(table_name),
+            fields=sql.SQL(",").join(
+                [sql.Identifier(col) for col in column_names],
+            ),
+        )
+        psycopg2_extras.execute_values(cursor, insert_query, rows)
+        conn.commit()
 
 
 class Command(BaseCommand):
@@ -58,53 +92,30 @@ class Command(BaseCommand):
         # NOTE(vperron): if you need to initiate this table, just run the following line with
         # dtstart=datetime.date(2022,1,1)
         for monday in rrule(WEEKLY, byweekday=MO, dtstart=max_date - datetime.timedelta(days=7), until=max_date):
-            self._fetch_matomo_row(monday.date(), wet_run=wet_run)
+            self._process_matomo_weekly_data(monday.date(), wet_run=wet_run)
 
-    def _fetch_matomo_row(self, at, wet_run=False):
-        MATOMO_COLUMNS = None
+    def _process_matomo_weekly_data(self, at, wet_run=False):
+        """A helper whose sole purpose is to ease the initialization of all the Matomo tables in metabase.
+        Call it with a given week and it's going to do all the initialization.
+        """
+        column_names = None  # unknown column names initially, they're all the same for every dashboard
         all_rows = []
+        base_options = MATOMO_OPTIONS | {
+            "date": f"{at}",
+            "token_auth": settings.MATOMO_AUTH_TOKEN,
+        }
 
         for dashboard, public_name in DASHBOARDS_TO_DOWNLOAD.items():
-            options_dict = MATOMO_OPTIONS | {
-                "date": f"{at}",
+            dashboard_options = base_options | {
+                "idSite": "146",  # pilotage
                 "segment": f"pageUrl=={constants.PILOTAGE_SITE_URL}/tableaux-de-bord/{dashboard}/",
-                "token_auth": settings.MATOMO_AUTH_TOKEN,
             }
-            response = httpx.get(
-                f"{settings.MATOMO_BASE_URL}?{urllib.parse.urlencode(options_dict)}", timeout=MATOMO_TIMEOUT
-            )
-            csv_content = response.content.decode("utf-16")
-            reader = csv.DictReader(io.StringIO(csv_content), dialect="excel")
-            for row in reader:
+            for row in matomo_api_call(dashboard_options):
                 row["Date"] = at
                 row["tableau de bord"] = public_name
-                if not MATOMO_COLUMNS:
-                    MATOMO_COLUMNS = list(row.keys())
+                if not column_names:
+                    column_names = list(row.keys())
                 all_rows.append(list(row.values()))
 
         if wet_run:
-            with MetabaseDatabaseCursor() as (cursor, conn):
-                cursor.execute(
-                    sql.SQL("CREATE TABLE IF NOT EXISTS {table_name} ({fields_with_type})").format(
-                        table_name=sql.Identifier(METABASE_TABLE_NAME),
-                        fields_with_type=sql.SQL(",").join(
-                            [sql.SQL(" ").join([sql.Identifier(col), sql.SQL("varchar")]) for col in MATOMO_COLUMNS]
-                        ),
-                    )
-                )
-                conn.commit()
-                cursor.execute(
-                    sql.SQL("""DELETE FROM {table_name} WHERE "Date" = {value}""").format(
-                        table_name=sql.Identifier(METABASE_TABLE_NAME),
-                        col_name=sql.Identifier("Date"),
-                        value=sql.Literal(str(at)),
-                    )
-                )
-                insert_query = sql.SQL("insert into {table_name} ({fields}) values %s").format(
-                    table_name=sql.Identifier(METABASE_TABLE_NAME),
-                    fields=sql.SQL(",").join(
-                        [sql.Identifier(col) for col in MATOMO_COLUMNS],
-                    ),
-                )
-                psycopg2_extras.execute_values(cursor, insert_query, all_rows)
-                conn.commit()
+            update_table_at_date(METABASE_DASHBOARDS_TABLE_NAME, column_names, at, all_rows)

--- a/itou/truc.py
+++ b/itou/truc.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+# with open("pec.json", mode="r", encoding="utf-8") as f:
+#     import json
+
+#     offers = json.load(f)
+
+# raw_offers.extend(offers)
+
+
+class Color(Enum):
+    RED: 1
+
+
+class DiffItemKind(Enum):
+    ADDITION: 1
+    DELETION: 2
+    EDITION: 3
+    SUMMARY: 4


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/242f90ec76d9411b848830197dd7e949?v=0992cca6c85448ebb13ce1e8a5b3c7eb&p=77ff17bc5fe941539ba998015e4de50b&pm=c

### Pourquoi ?

Après [pas mal de discussions](https://itou-inclusion.slack.com/archives/CT7986ULC/p1670492038231759) et itérations il semble que malheureusement ce n'est pas cela que l'on veut. On veut pouvoir annoter parmi les visites de chaque TB (Siae, prescripteurs) quel était le current_siae ou le current_prescriber_org qui l'a regardé, et compter.


### Comment (optionnel)
Cela nécessite d'exporter à mon avis la donnée __brute__ : une ligne par visite avec toutes les custom vars associées.

On aurait donc fait fausse route.
