### PR TITLE
Recalcul de l’état d’une EvaluatedSiae avant notification de revue

### DIFF
--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -1047,27 +1047,6 @@ class EvaluatedSiaeModelTest(TestCase):
         evaluated_siae.refresh_from_db()
         self.assertIsNotNone(evaluated_siae.reviewed_at)
 
-    def test_review_emails(self):
-        fake_now = timezone.now()
-        values = [
-            (evaluation_enums.EvaluatedSiaeState.ACCEPTED, None, "la conformité des justificatifs"),
-            (evaluation_enums.EvaluatedSiaeState.ACCEPTED, fake_now, "la conformité des nouveaux justificatifs"),
-            (evaluation_enums.EvaluatedSiaeState.REFUSED, None, "un ou plusieurs justificatifs sont attendus"),
-            (
-                evaluation_enums.EvaluatedSiaeState.ADVERSARIAL_STAGE,
-                fake_now,
-                "plusieurs de vos justificatifs n’ont pas été validés",
-            ),
-        ]
-
-        for state, reviewed_at, txt in values:
-            with mock.patch.object(EvaluatedSiae, "state", state):
-                with self.subTest(state=state, reviewed_at=reviewed_at, txt=txt):
-                    evaluated_siae = EvaluatedSiaeFactory(reviewed_at=reviewed_at)
-                    evaluated_siae.review()
-                    email = mail.outbox[-1]
-                    self.assertIn(txt, email.body)
-
     def test_get_email_to_institution_submitted_by_siae(self):
         institution = InstitutionWith2MembershipFactory()
         evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign__institution=institution)

--- a/itou/templates/siae_evaluations/email/to_institution_selected_siae_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_selected_siae_body.txt
@@ -4,18 +4,18 @@
 Bonjour,
 
 
-La procédure de  transmission des justificatifs dans le cadre du contrôle a posteriori sur les embauches réalisées en auto-prescription embauches réalisées entre le {{evaluated_period_start_at|date:"d E Y"}} et le {{evaluated_period_end_at|date:"d E Y"}}, est ouverte pour les SIAE.
+La procédure de transmission des justificatifs dans le cadre du contrôle a posteriori sur les embauches réalisées en auto-prescription embauches réalisées entre le {{evaluated_period_start_at|date:"d E Y"}} et le {{evaluated_period_end_at|date:"d E Y"}}, est ouverte pour les SIAE.
 
 Vous pouvez consulter la liste des SIAE qui ont été aléatoirement sélectionnées pour cette campagne de contrôle. Cette liste a été établie sur la base du taux de SIAE à contrôler que vous aviez préalablement validé.
 
 Cette phase de transmission et vérification des justificatifs est ouverte jusqu’au {{ end_date|date:"d E Y" }}. Passé ce délai les justificatifs non fournis par les SIAE seront enregistrés comme manquants.
 
-Comment ça marche ? 
+Comment ça marche ?
 
 1- Consultez la liste des SIAE soumises au contrôle et suivez l’avancée du dossier
 Dans votre tableau de bord, à la rubrique “ Contrôler les pièces justificatives” vous trouverez la liste des SIAE qui doivent justifier certaines de leurs auto-prescriptions.
 
-2- Suivez et vérifiez les pièces justificatives transmises par les SIAE 
+2- Suivez et vérifiez les pièces justificatives transmises par les SIAE
 Vous recevez une notification e-mail chaque fois qu’une SIAE transmet l’intégralité des justificatifs demandés.
 Vous pouvez consulter les justificatifs pour chaque salarié, les valider ou les rejeter en expliquant la raison.
 
@@ -23,7 +23,7 @@ Vous pouvez consulter les justificatifs pour chaque salarié, les valider ou les
 Après avoir traité toutes les justificatifs d’une SIAE, vous pouvez finaliser le contrôle en cliquant sur le bouton “Valider”. La SIAE sera automatiquement notifiée.
 
 
-Vous trouverez plus d’informations dans ce mode d’emploi :  https://communaute.inclusion.beta.gouv.fr/doc/emplois/mode-demploi-sur-le-controle-a-posteriori-pour-les-ddets/
+Vous trouverez plus d’informations dans ce mode d’emploi : https://communaute.inclusion.beta.gouv.fr/doc/emplois/mode-demploi-sur-le-controle-a-posteriori-pour-les-ddets/
 
 Cordialement,
 

--- a/itou/templates/siae_evaluations/email/to_siae_adversarial_stage_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_adversarial_stage_body.txt
@@ -2,11 +2,15 @@
 {% block body %}
 Bonjour,
 
-Vous trouverez ci-après le résultat du contrôle a posteriori sur vos auto-prescriptions réalisées entre le {{evaluation_campaign.evaluated_period_start_at|date:"d E Y"}} et le {{evaluation_campaign.evaluated_period_end_at|date:"d E Y"}}.
+La {{evaluation_campaign.institution.name}} a vérifié tous les justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le {{evaluation_campaign.evaluated_period_start_at|date:"d E Y"}} et le {{evaluation_campaign.evaluated_period_end_at|date:"d E Y"}}
 
-La {{evaluation_campaign.institution.name}} a vérifié les nouveaux justificatifs transmis par votre structure {{ siae.kind }} {{ siae.name }} ID-{{siae.id}} dans le cadre de la phase contradictoire du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le {{evaluation_campaign.evaluated_period_start_at|date:"d E Y"}} et le {{evaluation_campaign.evaluated_period_end_at|date:"d E Y"}}.
+Suite à cette vérification, un ou plusieurs justificatifs sont attendus par la {{evaluation_campaign.institution.name}}.
 
-Un ou plusieurs de vos justificatifs n’ont pas été validés par conséquent votre résultat concernant cette procédure est négatif (vous serez alerté des sanctions éventuelles concernant votre SIAE prochainement) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
+Rendez-vous sur le tableau de bord de {{ siae.kind }} {{ siae.name }} ID-{{siae.id}} à la rubrique “Justifier mes auto-prescriptions”.
+
+Les embauches avec le statut “nouveaux justificatifs à traiter”, nécessitent la transmission d’un nouveau justificatif pour chaque critère concerné.  Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
+
+En cas de besoin, vous pouvez consulter ce mode d’emploi : {{ itou_community_url }}/doc/non-knowledgebase/controle-a-posteriori-pour-les-siae/
 
 Cordialement,
 {% endblock %}

--- a/itou/templates/siae_evaluations/email/to_siae_adversarial_stage_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_adversarial_stage_body.txt
@@ -8,7 +8,7 @@ Suite à cette vérification, un ou plusieurs justificatifs sont attendus par la
 
 Rendez-vous sur le tableau de bord de {{ siae.kind }} {{ siae.name }} ID-{{siae.id}} à la rubrique “Justifier mes auto-prescriptions”.
 
-Les embauches avec le statut “nouveaux justificatifs à traiter”, nécessitent la transmission d’un nouveau justificatif pour chaque critère concerné.  Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
+Les embauches avec le statut “nouveaux justificatifs à traiter”, nécessitent la transmission d’un nouveau justificatif pour chaque critère concerné. Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
 
 En cas de besoin, vous pouvez consulter ce mode d’emploi : {{ itou_community_url }}/doc/non-knowledgebase/controle-a-posteriori-pour-les-siae/
 

--- a/itou/templates/siae_evaluations/email/to_siae_notify_before_adversarial_stage_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_notify_before_adversarial_stage_body.txt
@@ -27,7 +27,7 @@ Accès direct à votre liste d’auto-prescriptions : {{ evaluated_job_app_list_
 Pour chaque embauche, cliquez sur “Sélectionner les critères”,
 les critères que vous avez enregistrés sont affichés.
 Sélectionnez le ou les critères que vous souhaitez justifier (sur cette page, nous vous rappelons le nombre minimum de justificatifs requis en fonction du type de critères et de SIAE).
-Ensuite cliquez sur  “Ajouter un justificatif”  pour déposer le justificatif demandé.
+Ensuite cliquez sur “Ajouter un justificatif” pour déposer le justificatif demandé.
 
 3- Validez votre dossier de contrôle :
 

--- a/itou/templates/siae_evaluations/email/to_siae_refused_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_refused_body.txt
@@ -2,15 +2,11 @@
 {% block body %}
 Bonjour,
 
-La {{evaluation_campaign.institution.name}} a vérifié tous les justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le {{evaluation_campaign.evaluated_period_start_at|date:"d E Y"}} et le {{evaluation_campaign.evaluated_period_end_at|date:"d E Y"}}
+Vous trouverez ci-après le résultat du contrôle a posteriori sur vos auto-prescriptions réalisées entre le {{evaluation_campaign.evaluated_period_start_at|date:"d E Y"}} et le {{evaluation_campaign.evaluated_period_end_at|date:"d E Y"}}.
 
-Suite à cette vérification, un ou plusieurs justificatifs sont attendus par la {{evaluation_campaign.institution.name}}.
+La {{evaluation_campaign.institution.name}} a vérifié les nouveaux justificatifs transmis par votre structure {{ siae.kind }} {{ siae.name }} ID-{{siae.id}} dans le cadre de la phase contradictoire du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le {{evaluation_campaign.evaluated_period_start_at|date:"d E Y"}} et le {{evaluation_campaign.evaluated_period_end_at|date:"d E Y"}}.
 
-Rendez-vous sur le tableau de bord de {{ siae.kind }} {{ siae.name }} ID-{{siae.id}} à la rubrique “Justifier mes auto-prescriptions”.
-
-Les embauches avec le statut “nouveaux justificatifs à traiter”, nécessitent la transmission d’un nouveau justificatif pour chaque critère concerné.  Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
-
-En cas de besoin, vous pouvez consulter ce mode d’emploi : {{ itou_community_url }}/doc/non-knowledgebase/controle-a-posteriori-pour-les-siae/
+Un ou plusieurs de vos justificatifs n’ont pas été validés par conséquent votre résultat concernant cette procédure est négatif (vous serez alerté des sanctions éventuelles concernant votre SIAE prochainement) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
 
 Cordialement,
 {% endblock %}

--- a/itou/templates/siae_evaluations/email/to_siae_selected_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_selected_body.txt
@@ -24,7 +24,7 @@ Accès direct à votre liste d’auto-prescriptions : {{ url }}
 
 Pour chaque embauche, cliquez sur “Sélectionner les critères”, les critères que vous avez enregistrés sont affichés.
 Sélectionnez le ou les critères que vous souhaitez justifier (un nombre minimum de justificatifs est requis en fonction du type de critères et de SIAE).
-Ensuite cliquez sur  “Ajouter un justificatif”  pour déposer le justificatif demandé.
+Ensuite cliquez sur “Ajouter un justificatif” pour déposer le justificatif demandé.
 
 3- Validez votre dossier de contrôle :
 


### PR DESCRIPTION
**Notion : https://www.notion.so/BUG-Contr-le-a-posteriori-Un-mail-de-r-sultat-n-gatif-a-t-transmis-une-SIAE-alors-que-son-r-su-b2a0f543f3f94651ae109d12ff638dd8**

### Pourquoi ?

Des emails indiquant une sortie de phase contradictoire négative ont été envoyés à des SIAE, qui voyaient bien leur résultat de contrôle positif dans l’interface. Évidemment, c’est perturbant.

### Comment ?
Recalcule l’état après la mise à jour de `review()`, avant d’envoyer l’email.

L’email `to_siae_refused` était envoyé pour signifier le début de la phase contradictoire. Le `to_siae_adversarial_phase` était envoyé à la fin de la phase contradictoire. Les deux ont été inversés pour :
1. Une première revue négative (qui démarre la phase contradictoire) envoie le message “vous entrez en phase contradictoire” (`to_siae_adversarial_stage`)
2. Une seconde revue négative envoi le message “vos auto-prescription étaient incorrect, votre institution va vous contacter et éventuellement décider de sanctions”

### Autre

La propriété `self.state` est assignée à la variable `previous_state` pour clarifier.

https://itou-inclusion.slack.com/archives/C02J7LWNT6Z/p1670503261205909