### PR TITLE
ajout des id af pour la prise en compte mesures MP

### DIFF
--- a/itou/metabase/management/commands/sql/026_suivi_etp_realises_v2.sql
+++ b/itou/metabase/management/commands/sql/026_suivi_etp_realises_v2.sql
@@ -8,6 +8,7 @@ with constantes as (
 
 select 
     distinct emi.emi_pph_id as identifiant_salarie, /* ici on considère bien le salarié qu'une fois pour éviter des doublons et donc sur estimer les ETPs */
+    emi.emi_afi_id as id_annexe_financiere,
     make_date(cast(emi.emi_sme_annee as integer), cast(emi.emi_sme_mois as integer), 1) as date_saisie,
     to_date (emi.emi_date_validation ,'dd/mm/yyyy') as date_validation_declaration,
     emi.emi_part_etp as nombre_etp_consommes_asp,

--- a/itou/metabase/management/commands/sql/027_suivi_etp_conventionnes_v2.sql
+++ b/itou/metabase/management/commands/sql/027_suivi_etp_conventionnes_v2.sql
@@ -7,7 +7,8 @@ with constantes as
 )
 
 select
-    distinct af.af_numero_convention,
+    distinct af.af_id_annexe_financiere as id_annexe_financiere, 
+    af.af_numero_convention,
     af.af_numero_annexe_financiere,
     date_part('year', af.af_date_debut_effet_v2) as annee_af,
     af.af_etat_annexe_financiere_code,


### PR DESCRIPTION
### Pourquoi ?

Ajout de l'id de l'annexe financiere car les mesures DC et MP du même type de structure peuvent avoir le même numéro d'annexe financière et de convention. L'id de l'af, lui, est unique -> Nouvelle référence

