### PR TITLE
Correction d'un 1+N dans l'api des SIAEs

### DIFF
--- a/itou/api/siae_api/tests.py
+++ b/itou/api/siae_api/tests.py
@@ -25,6 +25,15 @@ class SiaeAPIFetchListTest(APITestCase):
             with_jobs=True, romes=("N1101", "N1105", "N1103", "N4105"), department="44", coords=self.saint_andre.coords
         )
 
+    def test_performances(self):
+        num_queries = 1  # Get city with insee_code
+        num_queries += 1  # Count siaes
+        num_queries += 1  # Select sias
+        num_queries += 1  # prefetch job_description_through
+        with self.assertNumQueries(num_queries):
+            query_params = {"code_insee": self.saint_andre.code_insee, "distance_max_km": 100}
+            self.client.get(ENDPOINT_URL, query_params, format="json")
+
     def test_fetch_siae_list_without_params(self):
         """
         The query parameters for INSEE code and distance are mandatories

--- a/itou/api/siae_api/viewsets.py
+++ b/itou/api/siae_api/viewsets.py
@@ -126,7 +126,7 @@ On peut spécifier la direction de tri :
 
     def get_queryset(self):
         # We only get to this point if permissions are OK
-        queryset = Siae.objects
+        queryset = Siae.objects.prefetch_job_description_through(with_is_popular=False)
 
         # Get (registered) query parameters filters
         queryset = self._filter_by_query_params(self.request, queryset)

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -66,13 +66,14 @@ class SiaeQuerySet(OrganizationQuerySet):
     def within(self, point, distance_km):
         return self.filter(coords__dwithin=(point, D(km=distance_km)))
 
-    def prefetch_job_description_through(self, **kwargs):
+    def prefetch_job_description_through(self, with_is_popular=True, **kwargs):
         qs = (
             SiaeJobDescription.objects.filter(is_active=True, **kwargs)
-            .with_annotation_is_popular()
             .select_related("appellation__rome")
             .order_by("-updated_at", "-created_at")
         )
+        if with_is_popular:
+            qs = qs.with_annotation_is_popular()
         return self.prefetch_related(Prefetch("job_description_through", queryset=qs))
 
     def with_count_recent_received_job_apps(self):


### PR DESCRIPTION
La requête prend plus de 450ms au lieu de ~50 sans les innombrables mini requêtes
https://sentry.io/organizations/itou/performance/les-emplois-prod:ea4f95dcbba74f8ea42db112427d1ca7/?project=6164438&query=transaction.duration%3A%3C15m+http.method%3AGET&referrer=performance-transaction-summary&statsPeriod=24h&transaction=%2Fapi%2Fv1%2Fsiaes%2F&unselectedSeries=p100%28%29