### PR TITLE
Retire type="text/javascript" des tags <script>

### DIFF
--- a/itou/static/js/formset_add_remove_row.js
+++ b/itou/static/js/formset_add_remove_row.js
@@ -8,7 +8,7 @@
     3- Add this snippet to the script block:
     ```
     <script src="{% static "js/formset_add_remove_row.js" %}"></script>
-    <script type='text/javascript'>
+    <script>
         $(document).on('click', '.add-form-row', function(e){
             e.preventDefault();
             // First argument is a selector targeting the row to clone..

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -108,10 +108,10 @@
 {% endblock %}
 
 {% block script %}
-    <script type="text/javascript" src="{% static 'js/split_nir.js' %}"></script>
+    <script src="{% static 'js/split_nir.js' %}"></script>
     {% if preview_mode %}
         {# Show the confirmation modal after submitting the form. #}
-        <script nonce="{{ CSP_NONCE }}" type="text/javascript">
+        <script nonce="{{ CSP_NONCE }}">
             // Adding the "show" CSS class is not enough and not documented.
             // A JS initialization is recommended.
             $("#nir-confirmation-modal").modal("show");

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -97,7 +97,7 @@
     <script src="{% static 'js/split_nir.js' %}"></script>
     {% if preview_mode %}
         {# Show the confirmation modal after submitting the form. #}
-        <script nonce="{{ CSP_NONCE }}" type="text/javascript">
+        <script nonce="{{ CSP_NONCE }}">
             // Adding the "show" CSS class is not enough and not documented.
             // A JS initialization is recommended.
             $("#email-confirmation-modal").modal("show");

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -106,7 +106,7 @@
     {{ block.super }}
 
     {# Clicking on a reason that does not require the opinion of a prescriber hide email field  #}
-    <script nonce="{{ CSP_NONCE }}" type="text/javascript">
+    <script nonce="{{ CSP_NONCE }}">
         $(document).ready(() => {
             var reasons_max_durations = {{ form.reasons_max_duration_labels|js }};
             var reasons_not_need_prescriber_opinion = {{ form.reasons_not_need_prescriber_opinion|js }};

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -68,7 +68,7 @@
 {% block script %}
     {{ block.super }}
     <script src="{% static 'js/formset_add_remove_row.js' %}"></script>
-    <script nonce="{{ CSP_NONCE }}" type='text/javascript'>
+    <script nonce="{{ CSP_NONCE }}">
         $(document).ready(function(){
             addRemoveButton(".inline-form-row", ".inline-col", "form");
         });

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -213,7 +213,6 @@
                     var d = document,
                     g = d.createElement('script'),
                     s = d.getElementsByTagName('script')[0];
-                    g.type = 'text/javascript';
                     g.async = true;
                     g.defer = true;
                     g.src = u + 'piwik.js';

--- a/itou/templates/signup/job_seeker_nir.html
+++ b/itou/templates/signup/job_seeker_nir.html
@@ -54,5 +54,5 @@
 {% endblock %}
 
 {% block script %}
-    <script type="text/javascript" src="{% static 'js/split_nir.js' %}"></script>
+    <script src="{% static 'js/split_nir.js' %}"></script>
 {% endblock script %}


### PR DESCRIPTION
### Pourquoi ?

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type

> The HTML specification urges authors to omit the attribute rather than
  provide a redundant MIME type.