### PR TITLE
Bump database connect timeout to 15 seconds

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -176,7 +176,7 @@ DATABASES = {
         "USER": os.getenv("POSTGRESQL_ADDON_CUSTOM_USER") or os.getenv("POSTGRESQL_ADDON_USER"),
         "PASSWORD": os.getenv("POSTGRESQL_ADDON_CUSTOM_PASSWORD") or os.getenv("POSTGRESQL_ADDON_PASSWORD"),
         "OPTIONS": {
-            "connect_timeout": 5,
+            "connect_timeout": 15,
         },
     }
 }


### PR DESCRIPTION
The c1-worker machine deployment has been failing since at least
December 9th, always on a time out attempting to connect to the
database.

Give the machine more time to establish the connection.