### PR TITLE
Revert "Bump database connect timeout to 15 seconds"

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -176,7 +176,7 @@ DATABASES = {
         "USER": os.getenv("POSTGRESQL_ADDON_CUSTOM_USER") or os.getenv("POSTGRESQL_ADDON_USER"),
         "PASSWORD": os.getenv("POSTGRESQL_ADDON_CUSTOM_PASSWORD") or os.getenv("POSTGRESQL_ADDON_PASSWORD"),
         "OPTIONS": {
-            "connect_timeout": 15,
+            "connect_timeout": 5,
         },
     }
 }


### PR DESCRIPTION
This reverts commit 3d503a04e1b39557ec86f1612bab57ecd0b4cfa3.

Does not help, the issue seems to lie on Clever deployment side. The
`c1-worker` machine can access the database in a few ms using the
POSTGRESQL_ADDON_DIRECT_URI.