### PR TITLE
Amélioration de l’envoi d’email et de sa testabilité

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -469,10 +469,9 @@ ANYMAIL = {
     "WEBHOOK_SECRET": os.getenv("MAILJET_WEBHOOK_SECRET"),
 }
 
-if ITOU_ENVIRONMENT in ["DEMO", "PROD", "STAGING"]:
-    EMAIL_BACKEND = "itou.utils.tasks.AsyncEmailBackend"
-elif ITOU_ENVIRONMENT in ["REVIEW-APP", "FAST-MACHINE"]:
-    EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
+EMAIL_BACKEND = "itou.utils.tasks.AsyncEmailBackend"
+# This is the "real" email backend used by the async wrapper / email backend
+ASYNC_EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
 
 SEND_EMAIL_DELAY_BETWEEN_RETRIES_IN_SECONDS = 5 * 60
 SEND_EMAIL_RETRY_TOTAL_TIME_IN_SECONDS = 24 * 3600

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -16,7 +16,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "192.168.0.1", "0.0.0.0"]
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+ASYNC_EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 SHOW_TEST_ACCOUNTS_BANNER = True
 

--- a/itou/conftest.py
+++ b/itou/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from django.conf import settings
 from django.contrib.gis.db.models.fields import get_srid_info
 from django.core.cache import cache
 from django.db import connection
@@ -52,3 +53,9 @@ def preload_spatial_reference(django_db_setup, django_db_blocker):
 @pytest.fixture(autouse=True)
 def reset_cache():
     cache.clear()
+
+
+@pytest.fixture(autouse=True, scope="session")
+def django_test_environment_email_fixup(django_test_environment) -> None:
+    settings.EMAIL_BACKEND = "itou.utils.tasks.AsyncEmailBackend"
+    settings.ASYNC_EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"

--- a/itou/utils/tasks.py
+++ b/itou/utils/tasks.py
@@ -13,10 +13,6 @@ from itou.utils.iterators import chunks
 logging.getLogger("huey").setLevel(logging.WARNING)
 
 
-# This is the "real" email backend used by the async wrapper / email backend
-ASYNC_EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
-
-
 # Mailjet max number of recipients (CC, BCC, TO)
 _MAILJET_MAX_RECIPIENTS = 50
 _EMAIL_KEYS = ("from_email", "cc", "bcc", "subject", "body")
@@ -91,63 +87,25 @@ def _serializeEmailMessage(email_message):
 
 
 def _deserializeEmailMessage(serialized_email_message):
-    """
-    Creates a "light" version of the original `EmailMessage` passed to the email backend.
-
-    In order to be serializable, we:
-    * only get the fields actually used by the app (defined in counterpart `_serializeEmailMessage`)
-    * add a reference to the "synchronous" email backend (for convenience)
-
-    *Tip*: use non-serializable objects only when deserialization is over... (f.i. email backends)
-    """
-    return EmailMessage(connection=get_connection(backend=ASYNC_EMAIL_BACKEND), **serialized_email_message)
+    return EmailMessage(**serialized_email_message)
 
 
 @task(retries=_NB_RETRIES, retry_delay=settings.SEND_EMAIL_DELAY_BETWEEN_RETRIES_IN_SECONDS)
 def _async_send_messages(serializable_email_messages):
-    """Async email sending "delegate"
-
-    This function sends emails with the backend defined in `ASYNC_EMAIL_BACKEND`
-    and is triggerred by an email backend wrappper: `AsyncEmailBackend`.
-
-    As it is decorated as a Huey task, all parameters must be serializable via Pickle.
-
-    Huey stores some data via the broker persistance mechanism (Redis | in-memory | SQLite)
-    for RPC/async/retry purposes.
-
-    In order to send data to a remote broker and perform callback function call on the client,
-    Huey must use a serialization mechanism to send "over the wire" (Pickle here).
-
-    In this case for a `@task`, data sent by Huey are:
-    * the function name (to use as a callback)
-    * its call parameters (to make the call)
-
-    The main parameter is a list of `EmailMessage` objects to be send.
-
-    By design, an `EmailMessage` instance holds references to some non-serializable ressources:
-    * a connection to the email backend (if not `None`)
-    * inner locks for atomic/threadsafe operations
-    * ...
-
-    Making `EmailMessage` serializable is the purpose of `_serializeEmailMessage` and `_deserializeEmailMessage`.
-
-    If there are many async tasks to be defined or for specific objects,
-    it may be better to use a custom serializer.
-
-    By design (see `BaseEmailBackend.send_messages`), this function must return
-    the number of email correctly processed.
     """
+    An `EmailMessage` instance holds references to some non-serializable
+    ressources, such as a connection to the email backend (if not `None`).
 
-    count = 0
-
-    for email in serializable_email_messages:
-        message = _deserializeEmailMessage(email)
-        for sanitized_message in sanitize_mailjet_recipients(message):
-            sanitized_message.send()
-            count += 1
-
-    # This part is processed by an external worker. Return count is irrelevant, so:
-    return count
+    Making `EmailMessage` serializable is the purpose of
+    `_serializeEmailMessage` and `_deserializeEmailMessage`.
+    """
+    messages = []
+    with get_connection(backend=settings.ASYNC_EMAIL_BACKEND) as connection:
+        for serialized_email in serializable_email_messages:
+            email = _deserializeEmailMessage(serialized_email)
+            messages.extend(sanitize_mailjet_recipients(email))
+        connection.send_messages(messages)
+    return len(messages)
 
 
 class AsyncEmailBackend(BaseEmailBackend):
@@ -160,13 +118,11 @@ class AsyncEmailBackend(BaseEmailBackend):
     * wraps an email backend defined in `settings.ASYNC_EMAIL_BACKEND`
     * delegate the actual email sending to a function with *serializable* parameters
 
-    See:
-    * `base.py` section "Huey" for details on `ASYNC_EMAIL_BACKEND`
-    * `_async_send_messages` for more on details on async/serialization concerns
+    See `_async_send_messages` for more on details on the serialization and
+    asynchronous processing
     """
 
     def send_messages(self, email_messages):
-        # Turn emails into something serializable
         if not email_messages:
             return
 


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/Tester-l-envoi-d-e-mail-530ca30075de462481a6baed89a3f2b0**

### Pourquoi ?

Utiliser le même moteur d’envoi d’email en production et en test, pour des tests plus réalistes.

Amélioration des performances en diminuant le nombre de connexions.

Petites améliorations de la documentation.