### PR TITLE
Accélération de la page admin candidature

### DIFF
--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -41,7 +41,6 @@ class ManualApprovalDeliveryRequiredFilter(admin.SimpleListFilter):
 @admin.register(models.JobApplication)
 class JobApplicationAdmin(admin.ModelAdmin):
     form = JobApplicationAdminForm
-    date_hierarchy = "created_at"
     list_display = ("pk", "state", "sender_kind", "created_at")
     raw_id_fields = (
         "job_seeker",


### PR DESCRIPTION
### Pourquoi ?

La page est assez lente, et souvent utilisée par le support. En enlevant le gadget hiérarchie de date (on peut trier par date de création, et avec la pagination, il est facile de naviguer), les requêtes coûteuses pour le consituer sont évitées. Les gains sont très visibles sur les filtres.

Rechercher un email : 1300 ms → 400 ms
Filtrer par délivrance manuelle : 2000 ms → 300 ms
Les autres filtres montrent environ une amélioration 2x.