### PR TITLE
Utilisation de l’appellation dans SiaeJobDescriptionFactory

### DIFF
--- a/itou/siaes/factories.py
+++ b/itou/siaes/factories.py
@@ -178,7 +178,6 @@ class SiaeJobDescriptionFactory(factory.django.DjangoModelFactory):
 
     appellation = factory.LazyAttribute(lambda obj: Appellation.objects.order_by("?").first())
     siae = factory.SubFactory(SiaeFactory)
-    custom_name = factory.Faker("job", locale="fr_FR")
     description = factory.Faker("sentence", locale="fr_FR")
     contract_type = factory.fuzzy.FuzzyChoice(ContractType.values)
     other_contract_type = factory.Faker("word", locale="fr_FR")

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -46,7 +46,7 @@ class EmployerSearchBaseView(FormView):
         job_descriptions = (
             SiaeJobDescription.objects.active()
             .within(city.coords, distance)
-            .select_related("siae", "location")
+            .select_related("siae", "location", "appellation")
             .exclude(siae__block_job_applications=True)
             .annotate(
                 distance=Case(


### PR DESCRIPTION
### Pourquoi ?

Éviter les descriptions de métier sans rapport avec le code ROME dans les tests.
Réduit la variabilité entre les lancements de tests. De nombreux tests font des `assertContains()` et `assertNotContains`, mais certaines appellation générées par Faker sont inclues dans une autre, générant de nombreux faux positifs.

Ce changement a révélé un `select_related` manquant dans la recherche de SIAEs.