### PR TITLE
Corrige la requête de dernier scan antivirus

### DIFF
--- a/itou/antivirus/management/commands/scan_s3_files.py
+++ b/itou/antivirus/management/commands/scan_s3_files.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         now = timezone.now()
-        files = File.objects.exclude(scan__clamav_completed_at__gt=now - relativedelta(month=1)).order_by(
+        files = File.objects.exclude(scan__clamav_completed_at__gt=now - relativedelta(months=1)).order_by(
             F("scan__clamav_completed_at").asc(nulls_first=True)
         )[: self.BATCH_SIZE]
         # Indicate these files are being processed to concurrent scans.


### PR DESCRIPTION
`relativedelta` utilise le pluriel pour les durées. Le singulier permet de fixer la valeur. Donc `relativedelta(month=1)` signifie le mois de Janvier.