### PR TITLE
Metabase autre amélioration de performances

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -88,7 +88,7 @@ class Command(BaseCommand):
             "siaes": 100,
             "job_descriptions": 100,
             "organizations": 100,
-            "job_seekers": 100,
+            "job_seekers": 1000,
             "job_applications": 1000,
             "selected_jobs": 10000,
             "approvals": 1000,
@@ -413,14 +413,13 @@ class Command(BaseCommand):
         queryset = (
             User.objects.filter(is_job_seeker=True)
             .prefetch_related(
-                "approvals",
                 "eligibility_diagnoses",
                 "eligibility_diagnoses__administrative_criteria",
                 "eligibility_diagnoses__author_prescriber_organization",
                 "eligibility_diagnoses__author_siae",
                 "job_applications",
                 "job_applications__to_siae",
-                "socialaccount_set",
+                "created_by",
             )
             .all()
         )

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
         # but it also increases RAM usage.
         self.METABASE_INSERT_BATCH_SIZE = {
             "siaes": 100,
-            "job_descriptions": 100,
+            "job_descriptions": 10000,
             "organizations": 100,
             "job_seekers": 1000,
             "job_applications": 1000,

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -89,7 +89,7 @@ class Command(BaseCommand):
             "job_descriptions": 100,
             "organizations": 100,
             "job_seekers": 100,
-            "job_applications": 100,
+            "job_applications": 1000,
             "selected_jobs": 10000,
             "approvals": 1000,
             "rome_codes": 1000,
@@ -346,10 +346,29 @@ class Command(BaseCommand):
 
     def populate_job_applications(self, batch_size):
         queryset = (
-            JobApplication.objects.select_related(
-                "to_siae", "sender", "sender_siae", "sender_prescriber_organization", "approval"
-            )
+            JobApplication.objects.select_related("to_siae", "sender", "sender_siae", "sender_prescriber_organization")
             .prefetch_related("logs")
+            .only(
+                "pk",
+                "created_at",
+                "sender_kind",
+                "sender_siae__kind",
+                "sender_prescriber_organization__kind",
+                "sender_prescriber_organization__name",
+                "sender_prescriber_organization__code_safir_pole_emploi",
+                "sender_prescriber_organization__is_authorized",
+                "sender__last_name",
+                "sender__first_name",
+                "state",
+                "refusal_reason",
+                "job_seeker_id",
+                "to_siae__kind",
+                "to_siae__brand",
+                "to_siae__name",
+                "to_siae__department",
+                "approval_id",
+                "approval_delivery_mode",
+            )
             .filter(created_from_pe_approval=False, to_siae_id__in=get_active_siae_pks())
             .all()
         )

--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -267,7 +267,7 @@ TABLE.add_columns(
             "name": "injection_ai",
             "type": "boolean",
             "comment": "Provient des injections AI",
-            "fn": lambda o: o.approval.pk in get_ai_stock_approval_pks() if o.approval else False,
+            "fn": lambda o: o.approval_id in get_ai_stock_approval_pks(),
         },
         {
             "name": "mode_attribution_pass_iae",

--- a/itou/metabase/tables/job_seekers.py
+++ b/itou/metabase/tables/job_seekers.py
@@ -15,6 +15,7 @@ from itou.metabase.tables.utils import (
     get_qpv_job_seeker_pks,
     hash_content,
 )
+from itou.users.enums import IdentityProvider
 
 
 # Reword the original EligibilityDiagnosis.AUTHOR_KIND_CHOICES
@@ -241,7 +242,7 @@ TABLE.add_columns(
             "name": "pe_connect",
             "type": "boolean",
             "comment": "Le candidat utilise PE Connect",
-            "fn": lambda o: o.is_peamu,
+            "fn": lambda o: o.identity_provider == IdentityProvider.PE_CONNECT,
         },
         {
             "name": "pe_inscrit",

--- a/itou/metabase/tables/organizations.py
+++ b/itou/metabase/tables/organizations.py
@@ -46,41 +46,22 @@ def _get_ja_sent_by_prescribers_without_org():
     )
 
 
-def _get_org_job_applications(org):
-    job_applications = list(org.jobapplication_set.all())
-    # We have to do all this in python to benefit from prefetch_related.
-    job_applications = [
-        ja
-        for ja in job_applications
-        if ja.created_from_pe_approval is False and ja.to_siae_id in get_active_siae_pks()
-    ]
-    return job_applications
-
-
 def get_org_job_applications_count(org):
     if org == ORG_OF_PRESCRIBERS_WITHOUT_ORG:
         # Number of job applications made by prescribers without org.
         return _get_ja_sent_by_prescribers_without_org().count()
-    return len(_get_org_job_applications(org))
+    return org.job_applications_count
 
 
 def get_org_accepted_job_applications_count(org):
     if org == ORG_OF_PRESCRIBERS_WITHOUT_ORG:
         return _get_ja_sent_by_prescribers_without_org().filter(state=JobApplicationWorkflow.STATE_ACCEPTED).count()
-    job_applications = [
-        ja for ja in _get_org_job_applications(org) if ja.state == JobApplicationWorkflow.STATE_ACCEPTED
-    ]
-    return len(job_applications)
+    return org.accepted_job_applications_count
 
 
 def get_org_last_job_application_creation_date(org):
     if org != ORG_OF_PRESCRIBERS_WITHOUT_ORG:
-        job_applications = _get_org_job_applications(org)
-        # We have to do all this in python to benefit from prefetch_related.
-        if len(job_applications) >= 1:
-            job_applications.sort(key=lambda o: o.created_at, reverse=True)
-            last_job_application = job_applications[0]
-            return last_job_application.created_at
+        return org.last_job_application_creation_date
     # This field makes no sense for prescribers without org.
     return None
 

--- a/itou/metabase/tables/selected_jobs.py
+++ b/itou/metabase/tables/selected_jobs.py
@@ -1,0 +1,27 @@
+from itou.metabase.tables.utils import MetabaseTable, hash_content
+
+
+TABLE = MetabaseTable(name="fiches_de_poste_par_candidature_v2")
+TABLE.add_columns(
+    [
+        {
+            "name": "id_fiche_de_poste",
+            "type": "int",
+            "comment": "ID fiche de poste",
+            "fn": lambda o: o["selected_jobs__id"],
+        },
+        {
+            "name": "id_candidature",
+            "type": "varchar",
+            "comment": "ID de la candidature",
+            "fn": lambda o: o["pk"],
+        },
+        {
+            # TODO @dejafait : eventually drop this obsolete field
+            "name": "id_anonymisé_candidature",
+            "type": "varchar",
+            "comment": "ID anonymisé de la candidature",
+            "fn": lambda o: hash_content(o["pk"]),
+        },
+    ]
+)


### PR DESCRIPTION
Améliorations sur un peu tous les exports.
Les benchmarks sont réalisé en local donc ne représentent pas exactement les gains que l'on aura en prod.

J'ai permis de spécifier une taille de batch différente pour tous les exports, et j'ai amélioré certaines requêtes / calculs
- `job_seekers` ~2.5x plus rapide (sur 1h en prod ?)
- `job_applications` 3x plus rapide (de 36 à 12 minutes juste en augmentant la taille des batchs)
- `selected_jobs` de 1h à 2 minutes
Les autres c'est du niveau de quelques minutes gagnées max (sur des exports de quelques minutes)