### PR TITLE
Boost C2

### DIFF
--- a/itou/cities/factories.py
+++ b/itou/cities/factories.py
@@ -85,7 +85,7 @@ def create_city_vannes():
         coords=Point(-2.8186843, 47.657641),
         # Dummy
         post_codes=["56000"],
-        code_insee="56000",
+        code_insee="56260",
     )
 
 

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -294,6 +294,8 @@ class Command(BaseCommand):
                     row = OrderedDict()
 
                     row["id_fiche_de_poste"] = jd.pk
+                    row["id_candidature"] = ja.pk
+                    # TODO @dejafait : eventually drop this obsolete field
                     row["id_anonymisé_candidature"] = hash_content(ja.pk)
 
                     rows.append(row)
@@ -324,8 +326,6 @@ class Command(BaseCommand):
         Populate job seekers table and add detailed stats about
         diagnoses and administrative criteria, including one column
         for each of the 15 possible criteria.
-
-        Note that job seeker id is anonymized.
         """
         queryset = (
             User.objects.filter(is_job_seeker=True)

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -95,6 +95,7 @@ class Command(BaseCommand):
 
         self.populate_fluxiae_view(vue_name="fluxIAE_AnnexeFinanciere")
         self.populate_fluxiae_view(vue_name="fluxIAE_AnnexeFinanciereACI")
+        self.populate_fluxiae_view(vue_name="fluxIAE_Convention")
         self.populate_fluxiae_view(vue_name="fluxIAE_ContratMission", skip_first_row=False)
         self.populate_fluxiae_view(vue_name="fluxIAE_Encadrement")
         self.populate_fluxiae_view(vue_name="fluxIAE_EtatMensuelAgregat")

--- a/itou/metabase/tables/approvals.py
+++ b/itou/metabase/tables/approvals.py
@@ -77,6 +77,13 @@ TABLE.add_columns(
         {"name": "date_fin", "type": "date", "comment": "Date de fin", "fn": lambda o: o.end_at},
         {"name": "durée", "type": "interval", "comment": "Durée", "fn": lambda o: o.end_at - o.start_at},
         {
+            "name": "id",
+            "type": "integer",
+            "comment": "ID C1 du candidat",
+            "fn": lambda o: o.user.pk if isinstance(o, Approval) else None,
+        },
+        {
+            # TODO @dejafait : eventually drop this obsolete field
             "name": "id_candidat_anonymisé",
             "type": "varchar",
             "comment": "ID anonymisé du candidat",

--- a/itou/metabase/tables/approvals.py
+++ b/itou/metabase/tables/approvals.py
@@ -80,14 +80,14 @@ TABLE.add_columns(
             "name": "id",
             "type": "integer",
             "comment": "ID C1 du candidat",
-            "fn": lambda o: o.user.pk if isinstance(o, Approval) else None,
+            "fn": lambda o: o.user_id if isinstance(o, Approval) else None,
         },
         {
             # TODO @dejafait : eventually drop this obsolete field
             "name": "id_candidat_anonymisé",
             "type": "varchar",
             "comment": "ID anonymisé du candidat",
-            "fn": lambda o: hash_content(o.user.pk) if isinstance(o, Approval) else None,
+            "fn": lambda o: hash_content(o.user_id) if isinstance(o, Approval) else None,
         },
         {
             "name": "id_structure",

--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -121,6 +121,13 @@ TABLE = MetabaseTable(name="candidatures")
 TABLE.add_columns(
     [
         {
+            "name": "id",
+            "type": "integer",
+            "comment": "ID C1 de la candidature",
+            "fn": lambda o: o.pk,
+        },
+        {
+            # TODO @dejafait : eventually drop this obsolete field
             "name": "id_anonymisé",
             "type": "varchar",
             "comment": "ID anonymisé de la candidature",
@@ -177,6 +184,13 @@ TABLE.add_columns(
             "fn": lambda o: o.get_refusal_reason_display() if o.refusal_reason != "" else None,
         },
         {
+            "name": "id_candidat",
+            "type": "integer",
+            "comment": "ID C1 du candidat",
+            "fn": lambda o: o.job_seeker_id,
+        },
+        {
+            # TODO @dejafait : eventually drop this obsolete field
             "name": "id_candidat_anonymisé",
             "type": "varchar",
             "comment": "ID anonymisé du candidat",

--- a/itou/metabase/tables/job_seekers.py
+++ b/itou/metabase/tables/job_seekers.py
@@ -188,10 +188,17 @@ TABLE = MetabaseTable(name="candidats")
 TABLE.add_columns(
     [
         {
+            "name": "id",
+            "type": "integer",
+            "comment": "ID C1 du candidat",
+            "fn": lambda o: o.pk,
+        },
+        {
+            # TODO @dejafait : eventually drop this obsolete field
             "name": "id_anonymisé",
             "type": "varchar",
             "comment": "ID anonymisé du candidat",
-            "fn": lambda o: hash_content(o.id),
+            "fn": lambda o: hash_content(o.pk),
         },
         {
             "name": "hash_nir",

--- a/itou/metabase/tables/organizations.py
+++ b/itou/metabase/tables/organizations.py
@@ -159,8 +159,6 @@ TABLE.add_columns(
             "comment": "Date de la dernière création de candidature",
             "fn": get_org_last_job_application_creation_date,
         },
-        {"name": "longitude", "type": "float", "comment": "Longitude", "fn": lambda o: o.longitude},
-        {"name": "latitude", "type": "float", "comment": "Latitude", "fn": lambda o: o.latitude},
     ]
 )
 

--- a/itou/metabase/tables/siaes.py
+++ b/itou/metabase/tables/siaes.py
@@ -89,7 +89,7 @@ def get_parent_siae(siae):
     return siae
 
 
-TABLE.add_columns(get_address_columns(comment_suffix=" de la structure", custom_fn=get_parent_siae))
+TABLE.add_columns(get_address_columns(comment_suffix=" de la structure mère", custom_fn=get_parent_siae))
 
 TABLE.add_columns(
     [

--- a/itou/metabase/tables/siaes.py
+++ b/itou/metabase/tables/siaes.py
@@ -218,7 +218,5 @@ TABLE.add_columns(
             "comment": "Nombre de fiches de poste inactives de la structure",
             "fn": lambda o: len([jd for jd in o.job_description_through.all() if not jd.is_active]),
         },
-        {"name": "longitude", "type": "float", "comment": "Longitude", "fn": lambda o: o.longitude},
-        {"name": "latitude", "type": "float", "comment": "Latitude", "fn": lambda o: o.latitude},
     ]
 )

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -138,6 +138,18 @@ def get_address_columns(name_suffix="", comment_suffix="", custom_fn=lambda o: o
             "comment": f"Ville{comment_suffix}",
             "fn": lambda o: custom_fn(o).city,
         },
+        {
+            "name": f"longitude{name_suffix}",
+            "type": "float",
+            "comment": f"Longitude{comment_suffix}",
+            "fn": lambda o: custom_fn(o).longitude,
+        },
+        {
+            "name": f"latitude{name_suffix}",
+            "type": "float",
+            "comment": f"Latitude{comment_suffix}",
+            "fn": lambda o: custom_fn(o).latitude,
+        },
     ] + get_department_and_region_columns(name_suffix, comment_suffix, custom_fn)
 
 

--- a/itou/metabase/tests/test_siaes.py
+++ b/itou/metabase/tests/test_siaes.py
@@ -1,15 +1,19 @@
 import pytest
 
+from itou.cities.factories import create_city_vannes
 from itou.metabase.tables.siaes import TABLE
 from itou.siaes.factories import SiaeFactory
 
 
 @pytest.mark.django_db
 def test_address_fields():
-    parent = SiaeFactory(source="ASP")
+    vannes = create_city_vannes()
+    parent = SiaeFactory(source="ASP", post_code=vannes.post_codes[0])
     antenna = SiaeFactory(source="USER_CREATED", convention=parent.convention)
     assert TABLE.get(column_name="adresse_ligne_1", input=antenna) == parent.address_line_1
     assert TABLE.get(column_name="adresse_ligne_2", input=antenna) == parent.address_line_2
     assert TABLE.get(column_name="code_postal", input=antenna) == parent.post_code
+    assert TABLE.get(column_name="code_commune", input=antenna) != parent.post_code
+    assert TABLE.get(column_name="code_commune", input=antenna) == vannes.code_insee
     assert TABLE.get(column_name="ville", input=antenna) == parent.city
     assert TABLE.get(column_name="département", input=antenna) == parent.department

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -205,7 +205,6 @@
         {% endif %}
         {# end of if user.is_labor_inspector #}
 
-
         {% if can_view_stats_dashboard_widget %}
             {% include "dashboard/includes/stats.html" %}
         {% endif %}

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -24,7 +24,7 @@
                 {% if can_view_stats_pe %}
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
-                        <a href="{% url 'stats:stats_pe_delay_main' %}">Voir les données du délai d'entrée en IAE</a>
+                        <a href="{% url 'stats:stats_pe_state_main' %}">Voir les données de l’état des candidatures orientées</a>
                     </li>
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
@@ -32,11 +32,11 @@
                     </li>
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
-                        <a href="{% url 'stats:stats_pe_state_main' %}">Voir les données de l’état des candidatures orientées</a>
+                        <a href="{% url 'stats:stats_pe_tension' %}">Voir les données des fiches de poste en tension</a>
                     </li>
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
-                        <a href="{% url 'stats:stats_pe_tension' %}">Voir les données des fiches de poste en tension</a>
+                        <a href="{% url 'stats:stats_pe_delay_main' %}">Voir les données du délai d'entrée en IAE</a>
                     </li>
                 {% endif %}
                 {% if can_view_stats_ddets %}


### PR DESCRIPTION
### Quoi ?

Boost de plusieurs améliorations pour le C2.
- Ajout d'une colonne `code_commune` en plus de l'existante `code_postal`
- Déanonymisation de champs ID C1 non sensibles pour nous simplifier la vie. Bien sûr on continue d'obfusquer NIR et numéro de PASS IAE.
- Changement de l'ordre des sections stats dans le dashboard C1 pour les agents PE.
- Ajout de la table FluxIAE Convention (testé OK en local).
- Autres améliorations mineures

