### PR TITLE
Mise au point d'un accès stats pour la DGPE (Direction Générale Pôle emploi)

### DIFF
--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -88,6 +88,9 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
     In case 3, we talk about "prescripteur habilité" in French.
     """
 
+    # DGPE, as in "Direction Générale Pôle emploi" is a special PE agency which oversees the whole country.
+    DGPE_SAFIR_CODE = "00162"
+
     # DRPE, as in "Direction Régionale Pôle emploi", are special PE agencies which oversee their whole region.
     # We keep it simple by hardcoding their (short) list here to avoid the complexity of adding a field or a kind.
     DRPE_SAFIR_CODES = [
@@ -291,6 +294,13 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
         subject = "prescribers/email/must_validate_prescriber_organization_email_subject.txt"
         body = "prescribers/email/must_validate_prescriber_organization_email_body.txt"
         return get_email_message(to, context, subject, body)
+
+    @property
+    def is_dgpe(self):
+        """
+        DGPE, as in "Direction Générale Pôle emploi" is a special PE agency which oversees the whole country.
+        """
+        return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi == self.DGPE_SAFIR_CODE
 
     @property
     def is_drpe(self):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -26,7 +26,7 @@ from itou.asp.models import (
     LaneType,
     RSAAllocation,
 )
-from itou.common_apps.address.departments import REGIONS, department_from_postcode
+from itou.common_apps.address.departments import DEPARTMENTS, REGIONS, department_from_postcode
 from itou.common_apps.address.format import format_address
 from itou.common_apps.address.models import AddressMixin
 from itou.institutions.enums import InstitutionKind
@@ -670,6 +670,8 @@ class User(AbstractUser, AddressMixin):
     def get_stats_pe_departments(self, current_org):
         if not self.can_view_stats_pe(current_org=current_org):
             raise PermissionDenied
+        if current_org.is_dgpe:
+            return DEPARTMENTS.keys()
         if current_org.is_drpe:
             return REGIONS[current_org.region]
         return [current_org.department]

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -230,7 +230,9 @@ def render_stats_pe(request, page_title):
     params = {
         DEPARTMENT_FILTER_KEY: [DEPARTMENTS[d] for d in departments],
     }
-    if current_org.is_drpe:
+    if current_org.is_dgpe:
+        matomo_custom_url_suffix = "dgpe"
+    elif current_org.is_drpe:
         matomo_custom_url_suffix = f"{format_region_for_matomo(current_org.region)}/drpe"
     else:
         matomo_custom_url_suffix = format_region_and_department_for_matomo(current_org.department)


### PR DESCRIPTION
**Carte Notion : [lien](https://www.notion.so/Accorder-la-DG-PE-une-vision-nationale-sur-leur-tableaux-de-bord-priv-s-c16cac799d614549871c73d2e7fb3e77)**

### Quoi ?

Mise au point d'un accès stats pour la DGPE (Direction Générale Pôle emploi) pour pouvoir consulter les stats PE de toute la France.

### Pourquoi ?

Jusqu'ici les stats PE n'étaient visibles soit que pour un département (agence classique) soit pour une région (DRPE).

### Notes

Testé OK en local dev.
