### PR TITLE
Metabase : Résolution de bug mineur

### DIFF
--- a/itou/metabase/sql/024_tx_refus_siae.sql
+++ b/itou/metabase/sql/024_tx_refus_siae.sql
@@ -46,7 +46,7 @@ select
     région_structure,
     candidatures_echelle_locale.ville,
     nom_epci,
-    code_commune,
+    candidatures_echelle_locale.code_commune,
     nom_arrondissement,
     bassin_d_emploi    
 from 
@@ -76,6 +76,6 @@ group by
     nombre_etp_conventionnes,
     candidatures_echelle_locale.ville,
     nom_epci,
-    code_commune,
+    candidatures_echelle_locale.code_commune,
     nom_arrondissement,
     bassin_d_emploi 


### PR DESCRIPTION
- Résolution de l'erreur `psycopg2.errors.AmbiguousColumn: column reference "code_commune" is ambiguous` introduite par l'introduction récente de la nouvelle colonne `structures.code_commune`. Erreur quasi impossible à anticiper étant donné que nous n'avons plus de dry run et que nous ne testons pas encore les requêtes SQL de fin de MAJ. Néanmoins ce genre d'erreur est rarissime en pratique, je ne me souviens pas avoir jamais rencontré ce scénario.
