### PR TITLE
Metabase : optimiser la requete SIAEs

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -115,13 +115,13 @@ class Command(BaseCommand):
         new_table_name = get_new_table_name(table_name)
         old_table_name = get_old_table_name(table_name)
 
-        def drop_old_and_new_tables(table_name):
+        def drop_old_and_new_tables():
             with MetabaseDatabaseCursor() as (cur, conn):
                 cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(new_table_name)))
                 cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(old_table_name)))
                 conn.commit()
 
-        drop_old_and_new_tables(table_name)
+        drop_old_and_new_tables()
 
         total_rows = sum([queryset.count() for queryset in querysets])
 
@@ -203,7 +203,7 @@ class Command(BaseCommand):
             )
             conn.commit()
 
-        drop_old_and_new_tables(table_name)
+        drop_old_and_new_tables()
 
     def populate_siaes(self):
         ONE_MONTH_AGO = timezone.now() - timezone.timedelta(days=30)

--- a/itou/metabase/tables/siaes.py
+++ b/itou/metabase/tables/siaes.py
@@ -8,16 +8,11 @@ from itou.metabase.tables.utils import (
     get_choice,
     get_establishment_is_active_column,
     get_establishment_last_login_date_column,
-    get_first_membership_join_date,
 )
 from itou.siaes.models import Siae
 
 
 ONE_MONTH_AGO = timezone.now() - timezone.timedelta(days=30)
-
-
-def get_siae_first_join_date(siae):
-    return get_first_membership_join_date(memberships=siae.siaemembership_set)
 
 
 def get_siae_last_month_job_applications(siae):
@@ -86,13 +81,13 @@ TABLE.add_columns(
             "name": "date_inscription",
             "type": "date",
             "comment": "Date inscription du premier compte employeur",
-            "fn": get_siae_first_join_date,
+            "fn": lambda o: o.first_membership_join_date,
         },
         {
             "name": "total_membres",
             "type": "integer",
             "comment": "Nombre de comptes employeur rattachés à la structure",
-            "fn": lambda o: o.members.count(),
+            "fn": lambda o: o.members_count,
         },
         {
             "name": "total_candidatures",

--- a/itou/metabase/tables/siaes.py
+++ b/itou/metabase/tables/siaes.py
@@ -49,8 +49,8 @@ TABLE.add_columns(
 
 
 def get_parent_siae(siae):
-    if siae.convention and siae.source == Siae.SOURCE_USER_CREATED:
-        return siae.convention.siaes.get(source=Siae.SOURCE_ASP)
+    if siae.convention_id and siae.source == Siae.SOURCE_USER_CREATED:
+        return siae.convention.siaes.all()[0]
     return siae
 
 

--- a/itou/metabase/tables/siaes.py
+++ b/itou/metabase/tables/siaes.py
@@ -20,17 +20,6 @@ def get_siae_first_join_date(siae):
     return get_first_membership_join_date(memberships=siae.siaemembership_set)
 
 
-def get_siae_last_ja_transition_date(siae):
-    timestamps = []
-    for ja in siae.job_applications_received.all():
-        ja_timestamps = [
-            log.timestamp for log in ja.logs.all() if log.to_state != JobApplicationWorkflow.STATE_OBSOLETE
-        ]
-        if len(ja_timestamps) >= 1:
-            timestamps.append(max(ja_timestamps))
-    return max(timestamps, default=None)
-
-
 def get_siae_last_month_job_applications(siae):
     return [ja for ja in siae.job_applications_received.all() if ja.created_at > ONE_MONTH_AGO]
 
@@ -204,7 +193,7 @@ TABLE.add_columns(
             "name": "date_dernière_évolution_candidature",
             "type": "date",
             "comment": "Date de dernière évolution candidature sauf passage obsolète",
-            "fn": get_siae_last_ja_transition_date,
+            "fn": lambda o: o.last_job_application_transition_date,
         },
         {
             "name": "total_fiches_de_poste_actives",

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -159,9 +159,7 @@ def get_establishment_last_login_date_column():
             "name": "date_dernière_connexion",
             "type": "date",
             "comment": "Date de dernière connexion utilisateur",
-            "fn": lambda o: max([u.last_login for u in o.members.all() if u.last_login], default=None)
-            if o.members.exists()
-            else None,
+            "fn": lambda o: o.members_last_login,
         },
     ]
 
@@ -172,10 +170,8 @@ def get_establishment_is_active_column():
             "name": "active",
             "type": "boolean",
             "comment": "Dernière connexion dans les 7 jours",
-            "fn": lambda o: any(
-                [u.last_login > timezone.now() - timezone.timedelta(days=7) for u in o.members.all() if u.last_login]
-            )
-            if o.members.exists()
+            "fn": lambda o: o.members_last_login > timezone.now() - timezone.timedelta(days=7)
+            if o.members_last_login
             else False,
         },
     ]


### PR DESCRIPTION
Tentative d'amélioration de la situation.

Initialement:
```
timeit: method=handle completed in seconds=153.54
```

Nous pensons que trop d'objets liés sont retournés via les très nombreux prefetch; essayer de descendre ce nombre via des annotations.


```
pm populate_metabase_emplois --mode=siaes

timeit: method=handle completed in seconds=51.27

         9911195 function calls (9827528 primitive calls) in 52.888 seconds                              
                                                                                                                                                                                                                   
   Ordered by: cumulative time                                                                           
                                                                                                         
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)                                                                                                                                            
        1    0.000    0.000   52.960   52.960 populate_metabase_emplois.py:208(populate_siaes)           
        1    0.005    0.005   52.956   52.956 populate_metabase_emplois.py:102(populate_table)                                                                                                                     
14574/14166    0.032    0.000   48.866    0.003 query.py:1865(_fetch_all)                                                                                                                                          
      282    0.004    0.000   47.949    0.170 compiler.py:1368(execute_sql)                                                                                                                                        
      396   47.559    0.120   47.566    0.120 {method 'execute' of 'psycopg2.extensions.cursor' objects}                                                                                                           
      282    0.001    0.000   47.296    0.168 utils.py:101(execute)                                                                                                                                                
      282    0.001    0.000   47.284    0.168 utils.py:66(execute)                                                                                                                                                 
      282    0.001    0.000   47.283    0.168 utils.py:76(_execute_with_wrappers)                        
      282    0.001    0.000   47.282    0.168 utils.py:82(_execute)                                      
       71    0.002    0.000   43.519    0.613 populate_metabase_emplois.py:154(inject_chunk)                                                                                                                       
14366/14094    0.008    0.000   42.125    0.003 query.py:379(__iter__)                                                                                                                                             
    81065    0.078    0.000   40.937    0.001 query.py:81(__iter__)                                                                                                                                                
       72    0.001    0.000    6.800    0.094 utils.py:23(chunked_queryset)                                                                                                                                        
      280    0.002    0.000    6.772    0.024 compiler.py:1340(results_iter)                                                                                                                                       
    12992    0.009    0.000    6.765    0.001 query.py:411(__getitem__)                                                                                                                                            
      143    0.000    0.000    6.747    0.047 query.py:278(__iter__)        
 ```