### PR TITLE
Metabase: Envoyer l'output des crons vers le bucket

### DIFF
--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -11,25 +11,30 @@ set -o errexit
 # NOTE(vperron): this is not a proper getopt parsing but getopt is SO verbose for
 # just that simple use that I have rather use a very simple version. This script
 # is intended to be automated by a proper tool like Airflow anyway.
-if [[ "$1" == "--daily" ]]; then
-    django-admin send_slack_message ":rocket: lancement mise à jour de données C1 -> Metabase"
-    django-admin populate_metabase_emplois --mode=siaes
-    django-admin populate_metabase_emplois --mode=job_descriptions
-    django-admin populate_metabase_emplois --mode=organizations
-    django-admin populate_metabase_emplois --mode=job_seekers
-    django-admin populate_metabase_emplois --mode=job_applications
-    django-admin populate_metabase_emplois --mode=selected_jobs
-    django-admin populate_metabase_emplois --mode=approvals
-    django-admin populate_metabase_emplois --mode=final_tables
-    django-admin populate_metabase_emplois --mode=data_inconsistencies
-    django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"
-elif [[ "$1" == "--monthly" ]]; then
-    django-admin send_slack_message ":rocket: lancement mise à jour de données peu fréquentes C1 -> Metabase"
-    django-admin populate_metabase_emplois --mode=rome_codes
-    django-admin populate_metabase_emplois --mode=insee_codes
-    django-admin populate_metabase_emplois --mode=departments
-    django-admin populate_metabase_emplois --mode=final_tables
-    django-admin send_slack_message ":white_check_mark: succès mise à jour de données peu fréquentes C1 -> Metabase"
-else
-    echo "populate_metabase_emplois shell script: unknown mode='$1' selected"
-fi
+function populate_metabase_emplois {
+    if [[ "$1" == "--daily" ]]; then
+        django-admin send_slack_message ":rocket: lancement mise à jour de données C1 -> Metabase"
+        django-admin populate_metabase_emplois --mode=siaes
+        django-admin populate_metabase_emplois --mode=job_descriptions
+        django-admin populate_metabase_emplois --mode=organizations
+        django-admin populate_metabase_emplois --mode=job_seekers
+        django-admin populate_metabase_emplois --mode=job_applications
+        django-admin populate_metabase_emplois --mode=selected_jobs
+        django-admin populate_metabase_emplois --mode=approvals
+        django-admin populate_metabase_emplois --mode=final_tables
+        django-admin populate_metabase_emplois --mode=data_inconsistencies
+        django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"
+    elif [[ "$1" == "--monthly" ]]; then
+        django-admin send_slack_message ":rocket: lancement mise à jour de données peu fréquentes C1 -> Metabase"
+        django-admin populate_metabase_emplois --mode=rome_codes
+        django-admin populate_metabase_emplois --mode=insee_codes
+        django-admin populate_metabase_emplois --mode=departments
+        django-admin populate_metabase_emplois --mode=final_tables
+        django-admin send_slack_message ":white_check_mark: succès mise à jour de données peu fréquentes C1 -> Metabase"
+    else
+        echo "populate_metabase_emplois shell script: unknown mode='$1' selected"
+    fi
+}
+
+# `$1` is needed to forward the selected mode (e.g. `--daily`)
+populate_metabase_emplois $1 |& tee -a "shared_bucket/populate_metabase_emplois/output_$(date '+%Y-%m-%d_%H-%M-%S').log"

--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -11,25 +11,27 @@ set -o errexit
 # NOTE(vperron): this is not a proper getopt parsing but getopt is SO verbose for
 # just that simple use that I have rather use a very simple version. This script
 # is intended to be automated by a proper tool like Airflow anyway.
-if [[ "$1" == "--daily" ]]; then
-    django-admin send_slack_message ":rocket: lancement mise à jour de données C1 -> Metabase"
-    django-admin populate_metabase_emplois --mode=siaes
-    django-admin populate_metabase_emplois --mode=job_descriptions
-    django-admin populate_metabase_emplois --mode=organizations
-    django-admin populate_metabase_emplois --mode=job_seekers
-    django-admin populate_metabase_emplois --mode=job_applications
-    django-admin populate_metabase_emplois --mode=selected_jobs
-    django-admin populate_metabase_emplois --mode=approvals
-    django-admin populate_metabase_emplois --mode=final_tables
-    django-admin populate_metabase_emplois --mode=data_inconsistencies
-    django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"
-elif [[ "$1" == "--monthly" ]]; then
-    django-admin send_slack_message ":rocket: lancement mise à jour de données peu fréquentes C1 -> Metabase"
-    django-admin populate_metabase_emplois --mode=rome_codes
-    django-admin populate_metabase_emplois --mode=insee_codes
-    django-admin populate_metabase_emplois --mode=departments
-    django-admin populate_metabase_emplois --mode=final_tables
-    django-admin send_slack_message ":white_check_mark: succès mise à jour de données peu fréquentes C1 -> Metabase"
-else
-    echo "populate_metabase_emplois shell script: unknown mode='$1' selected"
-fi
+(
+    if [[ "$1" == "--daily" ]]; then
+        django-admin send_slack_message ":rocket: lancement mise à jour de données C1 -> Metabase"
+        django-admin populate_metabase_emplois --mode=siaes
+        django-admin populate_metabase_emplois --mode=job_descriptions
+        django-admin populate_metabase_emplois --mode=organizations
+        django-admin populate_metabase_emplois --mode=job_seekers
+        django-admin populate_metabase_emplois --mode=job_applications
+        django-admin populate_metabase_emplois --mode=selected_jobs
+        django-admin populate_metabase_emplois --mode=approvals
+        django-admin populate_metabase_emplois --mode=final_tables
+        django-admin populate_metabase_emplois --mode=data_inconsistencies
+        django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"
+    elif [[ "$1" == "--monthly" ]]; then
+        django-admin send_slack_message ":rocket: lancement mise à jour de données peu fréquentes C1 -> Metabase"
+        django-admin populate_metabase_emplois --mode=rome_codes
+        django-admin populate_metabase_emplois --mode=insee_codes
+        django-admin populate_metabase_emplois --mode=departments
+        django-admin populate_metabase_emplois --mode=final_tables
+        django-admin send_slack_message ":white_check_mark: succès mise à jour de données peu fréquentes C1 -> Metabase"
+    else
+        echo "populate_metabase_emplois shell script: unknown mode='$1' selected"
+    fi
+) |& tee -a "shared_bucket/populate_metabase_emplois/output_$(date '+%Y-%m-%d_%H-%M-%S').log"

--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -11,30 +11,25 @@ set -o errexit
 # NOTE(vperron): this is not a proper getopt parsing but getopt is SO verbose for
 # just that simple use that I have rather use a very simple version. This script
 # is intended to be automated by a proper tool like Airflow anyway.
-function populate_metabase_emplois {
-    if [[ "$1" == "--daily" ]]; then
-        django-admin send_slack_message ":rocket: lancement mise à jour de données C1 -> Metabase"
-        django-admin populate_metabase_emplois --mode=siaes
-        django-admin populate_metabase_emplois --mode=job_descriptions
-        django-admin populate_metabase_emplois --mode=organizations
-        django-admin populate_metabase_emplois --mode=job_seekers
-        django-admin populate_metabase_emplois --mode=job_applications
-        django-admin populate_metabase_emplois --mode=selected_jobs
-        django-admin populate_metabase_emplois --mode=approvals
-        django-admin populate_metabase_emplois --mode=final_tables
-        django-admin populate_metabase_emplois --mode=data_inconsistencies
-        django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"
-    elif [[ "$1" == "--monthly" ]]; then
-        django-admin send_slack_message ":rocket: lancement mise à jour de données peu fréquentes C1 -> Metabase"
-        django-admin populate_metabase_emplois --mode=rome_codes
-        django-admin populate_metabase_emplois --mode=insee_codes
-        django-admin populate_metabase_emplois --mode=departments
-        django-admin populate_metabase_emplois --mode=final_tables
-        django-admin send_slack_message ":white_check_mark: succès mise à jour de données peu fréquentes C1 -> Metabase"
-    else
-        echo "populate_metabase_emplois shell script: unknown mode='$1' selected"
-    fi
-}
-
-# `$1` is needed to forward the selected mode (e.g. `--daily`)
-populate_metabase_emplois $1 |& tee -a "shared_bucket/populate_metabase_emplois/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
+if [[ "$1" == "--daily" ]]; then
+    django-admin send_slack_message ":rocket: lancement mise à jour de données C1 -> Metabase"
+    django-admin populate_metabase_emplois --mode=siaes
+    django-admin populate_metabase_emplois --mode=job_descriptions
+    django-admin populate_metabase_emplois --mode=organizations
+    django-admin populate_metabase_emplois --mode=job_seekers
+    django-admin populate_metabase_emplois --mode=job_applications
+    django-admin populate_metabase_emplois --mode=selected_jobs
+    django-admin populate_metabase_emplois --mode=approvals
+    django-admin populate_metabase_emplois --mode=final_tables
+    django-admin populate_metabase_emplois --mode=data_inconsistencies
+    django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"
+elif [[ "$1" == "--monthly" ]]; then
+    django-admin send_slack_message ":rocket: lancement mise à jour de données peu fréquentes C1 -> Metabase"
+    django-admin populate_metabase_emplois --mode=rome_codes
+    django-admin populate_metabase_emplois --mode=insee_codes
+    django-admin populate_metabase_emplois --mode=departments
+    django-admin populate_metabase_emplois --mode=final_tables
+    django-admin send_slack_message ":white_check_mark: succès mise à jour de données peu fréquentes C1 -> Metabase"
+else
+    echo "populate_metabase_emplois shell script: unknown mode='$1' selected"
+fi

--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -8,6 +8,9 @@ cd "$APP_HOME" || exit 1
 
 set -o errexit
 
+OUTPUT_PATH=shared_bucket/populate_metabase_emplois
+mkdir -p $OUTPUT_PATH
+
 # NOTE(vperron): this is not a proper getopt parsing but getopt is SO verbose for
 # just that simple use that I have rather use a very simple version. This script
 # is intended to be automated by a proper tool like Airflow anyway.
@@ -34,4 +37,4 @@ set -o errexit
     else
         echo "populate_metabase_emplois shell script: unknown mode='$1' selected"
     fi
-) |& tee -a "shared_bucket/populate_metabase_emplois/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
+) |& tee -a "$OUTPUT_PATH/output_$(date '+%Y-%m-%d_%H-%M-%S').log"


### PR DESCRIPTION
### Pourquoi ?

Avoir l'output des MAJ Metabase dans un bucket était bien pratique mais a été perdu quand on est passé sur notre worker. Cette PR rétablit cette pratique.

### Comment

- Premier essai avec une `function` bash jolie mais s'obstine à ne pas fonctionner et ce silencieusement ¯\_(ツ)_/¯. Voir le premier commit reverté. Je squasherais au merge (TODO).
- Second essai plus simple avec `()` testé OK sur le worker.