### PR TITLE
Acceptation d'une candidature : affichage de la modale de confirmation si les formulaires sont valides

### DIFF
--- a/itou/static/js/duet_date_picker_widget.js
+++ b/itou/static/js/duet_date_picker_widget.js
@@ -1,63 +1,68 @@
 "use strict"
 
-document.querySelectorAll("duet-date-picker").forEach(pickerInstance => {
+const initDuetDatePicker = function () {
+  document.querySelectorAll("duet-date-picker").forEach(pickerInstance => {
 
-  pickerInstance.dateAdapter = {
+    pickerInstance.dateAdapter = {
 
-    parse(value = "", createDate) {
-      const DATE_FORMAT = /^(\d{2})\/(\d{2})\/(\d{4})$/
-      const matches = value.match(DATE_FORMAT)
-      if (matches) {
-        return createDate(matches[3], matches[2], matches[1])
-      }
-    },
+      parse(value = "", createDate) {
+        const DATE_FORMAT = /^(\d{2})\/(\d{2})\/(\d{4})$/
+        const matches = value.match(DATE_FORMAT)
+        if (matches) {
+          return createDate(matches[3], matches[2], matches[1])
+        }
+      },
 
-    format(date) {
-      const day = ('0' + date.getDate()).slice(-2)
-      const month = ('0' + `${date.getMonth() + 1}`).slice(-2)
-      return `${day}/${month}/${date.getFullYear()}`
-    },
+      format(date) {
+        const day = ('0' + date.getDate()).slice(-2)
+        const month = ('0' + `${date.getMonth() + 1}`).slice(-2)
+        return `${day}/${month}/${date.getFullYear()}`
+      },
 
-  }
-
-  // Automatically insert slashes '/' in date fields.
-  pickerInstance.addEventListener("keyup", event => {
-    // Do nothing when backspace was pressed.
-    if (event.which !== 8) {
-      const numChars = event.target.value.length
-      if (numChars === 2 || numChars === 5) {
-        event.target.value = `${event.target.value}/`
-      }
     }
+
+    // Automatically insert slashes '/' in date fields.
+    pickerInstance.addEventListener("keyup", event => {
+      // Do nothing when backspace was pressed.
+      if (event.which !== 8) {
+        const numChars = event.target.value.length
+        if (numChars === 2 || numChars === 5) {
+          event.target.value = `${event.target.value}/`
+        }
+      }
+    })
+
+    pickerInstance.localization = {
+      buttonLabel: "Choisir une date",
+      placeholder: "JJ/MM/AAAA",
+      selectedDateMessage: "La date sélectionnée est",
+      prevMonthLabel: "Mois précédent",
+      nextMonthLabel: "Mois suivant",
+      monthSelectLabel: "Mois",
+      yearSelectLabel: "Année",
+      closeLabel: "Fermer la fenêtre",
+      calendarHeading: "Choisir une date",
+      dayNames: ["Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi"],
+      monthNames: [
+        "Janvier",
+        "Février",
+        "Mars",
+        "Avril",
+        "Mai",
+        "Juin",
+        "Juillet",
+        "Août",
+        "Septembre",
+        "Octobre",
+        "Novembre",
+        "Décembre",
+      ],
+      monthNamesShort: ["Jan", "Fév", "Mar", "Avr", "Mai", "Jun", "Jui", "Aoû", "Sep", "Oct", "Nov", "Déc"],
+      locale: "fr-FR",
+    }
+
   })
+};
 
-  pickerInstance.localization = {
-    buttonLabel: "Choisir une date",
-    placeholder: "JJ/MM/AAAA",
-    selectedDateMessage: "La date sélectionnée est",
-    prevMonthLabel: "Mois précédent",
-    nextMonthLabel: "Mois suivant",
-    monthSelectLabel: "Mois",
-    yearSelectLabel: "Année",
-    closeLabel: "Fermer la fenêtre",
-    calendarHeading: "Choisir une date",
-    dayNames: ["Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi"],
-    monthNames: [
-      "Janvier",
-      "Février",
-      "Mars",
-      "Avril",
-      "Mai",
-      "Juin",
-      "Juillet",
-      "Août",
-      "Septembre",
-      "Octobre",
-      "Novembre",
-      "Décembre",
-    ],
-    monthNamesShort: ["Jan", "Fév", "Mar", "Avr", "Mai", "Jun", "Jui", "Aoû", "Sep", "Oct", "Nov", "Déc"],
-    locale: "fr-FR",
-  }
+initDuetDatePicker();
 
-})

--- a/itou/static/js/htmx_handlers.js
+++ b/itou/static/js/htmx_handlers.js
@@ -4,6 +4,7 @@
   htmx.on("htmx:afterOnLoad", (e) => {
     const responseStatus = e.detail.xhr.status;
     if (200 <= responseStatus && responseStatus < 300) {
+      initDuetDatePicker();
       // - We're looking for the modal that is supposedly referred by the `htmx-open-modal` data element on the form.
       // - This form is either using `hx-swap=innerHtml` in which case it is `e.detail.elt`
       // - or it uses `outerHtml`, in which case we have to traverse `e.detail.elt` to find our form back.

--- a/itou/static/js/htmx_handlers.js
+++ b/itou/static/js/htmx_handlers.js
@@ -4,7 +4,14 @@
   htmx.on("htmx:afterOnLoad", (e) => {
     const responseStatus = e.detail.xhr.status;
     if (200 <= responseStatus && responseStatus < 300) {
-      $(e.detail.elt.dataset.htmxOpenModal).modal("show");
+      // - We're looking for the modal that is supposedly referred by the `htmx-open-modal` data element on the form.
+      // - This form is either using `hx-swap=innerHtml` in which case it is `e.detail.elt`
+      // - or it uses `outerHtml`, in which case we have to traverse `e.detail.elt` to find our form back.
+      var element = $(e.detail.elt).find("*[data-htmx-open-modal]")[0] || $(e.detail.elt)[0];
+      if (typeof element !== "undefined") {
+        var modal_selector = element.dataset.htmxOpenModal;
+        $(modal_selector).modal("show");
+      }
     }
   });
 

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -9,67 +9,81 @@
         <p class="mb-0">Confirmez votre choix en renseignant quelques informations supplémentaires.</p>
     </div>
 
-    <form method="post" action="" class="mt-5" id="acceptForm">
+    {% block htmx %}
+        <form method="post"
+              action=""
+              hx-post="{{ request.path }}"
+              hx-swap="outerHTML"
+              class="mt-5"
+              id="acceptForm"
+              tabindex="0"
+              aria-labelledby="dialogLabel"
+              aria-hidden="true"
+              {% if modal_shown %}data-htmx-open-modal="#js-confirmation-modal"{% endif %}>
 
-        {% csrf_token %}
+            {% csrf_token %}
 
-        {% if form_address or form_pe_status %}<h3 class="h2">Candidat</h3>{% endif %}
+            {% if form_address or form_pe_status %}<h3 class="h2">Candidat</h3>{% endif %}
 
-        {% if form_pe_status %}
-            {% if not job_application.approval_not_needed %}
-                <div class="alert alert-warning" role="status">
-                    <p class="mb-0">
-                        Pour obtenir un PASS IAE dans les meilleurs délais, assurez-vous de l'exactitude de la date de naissance et du statut Pôle emploi du candidat.
-                    </p>
-                </div>
-            {% endif %}
-            {% bootstrap_form form_pe_status alert_error_type="all" %}
-        {% endif %}
-
-
-        {% if form_user_address %}
-            {% bootstrap_form form_user_address alert_error_type="all" %}
-        {% endif %}
-
-        <div class="mt-5">
-
-            <h3 class="h2">Embauche</h3>
-            {% bootstrap_form form_accept alert_error_type="all" %}
-
-        </div>
-
-        <hr class="my-5">
-        {% buttons %}
-            <div class="text-right mb-4">
-                <a class="btn btn-outline-primary bg-white" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Retour</a>
-                <button type="button" class="btn btn-primary btn-ico" data-toggle="modal" data-target="#confirmModal">
-                    <i class="ri-check-line ri-xl"></i><span class=".btn .btn-ico"></span>Valider l’embauche
-                </button>
-            </div>
-        {% endbuttons %}
-        <div class="modal" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h3 class="modal-title" id="confirmModalLabel">Confirmation de l’embauche</h3>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
-                            <i class="ri-close-line"></i>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            Êtes-vous sûre de vouloir confirmer l’embauche de <strong>{{ job_application.job_seeker.first_name }} {{ job_application.job_seeker.last_name }}</strong> dans la structure suivante ?
+            {% if form_pe_status %}
+                {% if not job_application.approval_not_needed %}
+                    <div class="alert alert-warning" role="status">
+                        <p class="mb-0">
+                            Pour obtenir un PASS IAE dans les meilleurs délais, assurez-vous de l'exactitude de la date de naissance et du statut Pôle emploi du candidat.
                         </p>
-                        <p>{% include "siaes/includes/_siae_info.html" with siae=job_application.to_siae %}</p>
                     </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline-primary" data-dismiss="modal">Retour</button>
-                        <button type="submit" class="btn btn-primary">Confirmer</button>
-                    </div>
+                {% endif %}
+                {% bootstrap_form form_pe_status alert_error_type="all" %}
+            {% endif %}
+
+
+            {% if form_user_address %}
+                {% bootstrap_form form_user_address alert_error_type="all" %}
+            {% endif %}
+
+            <div class="mt-5">
+
+                <h3 class="h2">Embauche</h3>
+                {% bootstrap_form form_accept alert_error_type="all" %}
+
+            </div>
+
+            <hr class="my-5">
+            {% buttons %}
+                <div class="text-right mb-4">
+                    <a class="btn btn-outline-primary bg-white" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Retour</a>
+                    <button type="submit" class="btn btn-primary btn-ico">
+                        <i class="ri-check-line ri-xl"></i><span class=".btn .btn-ico"></span>Valider l’embauche
+                    </button>
+                </div>
+            {% endbuttons %}
+
+        </form>
+    {% endblock %}
+
+    <div class="modal" id="js-confirmation-modal" tabindex="-1" aria-labelledby="confirmation-modal-label" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content modal-centered">
+                <div class="modal-header">
+                    <h3 class="modal-title" id="confirmation-modal-label">Confirmation de l’embauche</h3>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
+                        <i class="ri-close-line"></i>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>
+                        Êtes-vous sûr(e) de vouloir confirmer l’embauche de <strong>{{ job_application.job_seeker.first_name }} {{ job_application.job_seeker.last_name }}</strong> dans la structure suivante ?
+                    </p>
+                    <p>{% include "siaes/includes/_siae_info.html" with siae=job_application.to_siae %}</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-primary" data-dismiss="modal">Retour</button>
+                    <button type="submit" class="btn btn-primary" hx-post={{ request.path }} hx-vals='{"confirmed": "True"}' hx-include="#acceptForm">Confirmer
+                    </button>
                 </div>
             </div>
         </div>
-    </form>
+    </div>
 
 {% endblock %}
 
@@ -78,17 +92,4 @@
     <!-- Needed to use the Datepicker JS widget. -->
     {{ form_accept.media }}
     {% if form_pe_status %}{{ form_pe_status.media }}{% endif %}
-    <script nonce="{{ CSP_NONCE }}">
-        $(function () {
-            $("#acceptForm").on("submit", function (e) {
-                let modal = $("#confirmModal");
-                if (modal.is(":visible")) {
-                    return true;
-                }
-                modal.modal("show");
-                e.preventDefault();
-                return false;
-            });
-        })
-    </script>
 {% endblock %}

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -6,10 +6,12 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
+from django.template.response import TemplateResponse
 from django.urls import reverse, reverse_lazy
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.views.decorators.http import require_http_methods
+from django_htmx.http import HttpResponseClientRedirect
 from django_xworkflows import models as xwf_models
 
 from itou.eligibility.models import EligibilityDiagnosis
@@ -236,7 +238,22 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
     form_accept = AcceptForm(instance=job_application, data=request.POST or None)
     forms.append(form_accept)
 
+    context = {
+        "form_accept": form_accept,
+        "form_user_address": form_user_address,
+        "form_pe_status": form_pe_status,
+        "job_application": job_application,
+    }
+
     if request.method == "POST" and all([form.is_valid() for form in forms]):
+        if request.htmx and not request.POST.get("confirmed"):
+            context["modal_shown"] = True
+            return TemplateResponse(
+                request=request,
+                template=template_name,
+                context=context,
+            )
+
         try:
             with transaction.atomic():
                 if form_pe_status:
@@ -271,10 +288,10 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
                     "<ul>"
                 ),
             )
-            return HttpResponseRedirect(next_url)
+            return HttpResponseClientRedirect(next_url)
         except xwf_models.InvalidTransitionError:
             messages.error(request, "Action déjà effectuée.")
-            return HttpResponseRedirect(next_url)
+            return HttpResponseClientRedirect(next_url)
 
         if job_application.to_siae.is_subject_to_eligibility_rules:
             # Automatic approval delivery mode.
@@ -331,14 +348,8 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
             mark_safe(f"Êtes-vous satisfait des emplois de l'inclusion ? {external_link}"),
         )
 
-        return HttpResponseRedirect(next_url)
+        return HttpResponseClientRedirect(next_url)
 
-    context = {
-        "form_accept": form_accept,
-        "form_user_address": form_user_address,
-        "form_pe_status": form_pe_status,
-        "job_application": job_application,
-    }
     return render(request, template_name, context)
 
 


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/6d2f772966114bc98fefc6ef17df79c0?v=99352c5142224ce8995dcc6ea3a78337&p=13de885a0a174400b746d9c05339ab7f&pm=c**

### Pourquoi ?

Actuellement, la modale de confirmation s'affiche alors qu'elle ne devrait pas. En effet, les formulaires contiennent des erreurs mais ils sont couverts par la modale.

### Comment

L'affichage de la modale est décidé également côté serveur.

### Notes additionnelles

Plusieurs PR suivront :
- utilisation d'un seul ID de modale partout (discuté avec Victor)
- amélioration de HtmxTestClient pour pouvoir l'utiliser dans la même session qu'un TestClient (discuté avec Romain) et remplacement des tests Unittest par Pytest.