### PR TITLE
Fiches salariées: amélioration de l'affichage des badges

### DIFF
--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -23,24 +23,24 @@
             <div class="col-md-5 text-right">
                 <p class="small mb-0">
                     {% if form.status.value == "SENT" %}
-                        <p class="badge badge-pill badge-warning">
-                            Transmise à l'ASP le&nbsp;<b>{{ employee_record.updated_at }}</b>
+                        <p class="badge badge-pill badge-sm badge-warning">
+                            Transmise à l'ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
                         </p>
                     {% elif form.status.value == "REJECTED" %}
-                        <p class="badge badge-pill badge-danger">
-                            Retour en erreur le&nbsp;<b>{{ employee_record.updated_at }}</b>
+                        <p class="badge badge-pill badge-sm badge-danger">
+                            Retour en erreur le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
                         </p>
                     {% elif form.status.value == "PROCESSED" %}
-                        <p class="badge badge-pill badge-success">
-                            Intégrée ASP le&nbsp;<b>{{ employee_record.updated_at }}</b>
+                        <p class="badge badge-pill badge-sm badge-success">
+                            Intégrée ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
                         </p>
                     {% elif form.status.value == "READY" %}
-                        <p class="badge badge-pill badge-secondary">
-                            Complétée le&nbsp;<b>{{ employee_record.updated_at }}</b>
+                        <p class="badge badge-pill badge-sm badge-secondary">
+                            Complétée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
                         </p>
                     {% elif form.status.value == "DISABLED" %}
-                        <p class="badge badge-pill badge-emploi-lightest">
-                            Désactivée le&nbsp;<b>{{ employee_record.updated_at }}</b>
+                        <p class="badge badge-pill badge-sm badge-emploi-lightest">
+                            Désactivée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
                         </p>
                     {% endif %}
                 </p>

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -2,7 +2,36 @@
 <div class="card my-5">
 
     <div class="card-header">
-        <h3 class="h2">{{ item.job_seeker.get_full_name|title }}</h3>
+        <div class="row">
+            <div class="col-md-7">
+                <h3 class="h2">{{ item.job_seeker.get_full_name|title }}</h3>
+            </div>
+
+            {# Statuses #}
+            <div class="col-md-5 text-right">
+                {% if form.status.value == "SENT" %}
+                    <p class="badge badge-pill badge-sm badge-warning">
+                        Transmise à l'ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+                    </p>
+                {% elif form.status.value == "REJECTED" %}
+                    <p class="badge badge-pill badge-sm badge-danger">
+                        Retour en erreur le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+                    </p>
+                {% elif form.status.value == "PROCESSED" %}
+                    <p class="badge badge-pill badge-sm badge-success">
+                        Intégrée ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+                    </p>
+                {% elif form.status.value == "READY" %}
+                    <p class="badge badge-pill badge-sm badge-secondary">
+                        Complétée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+                    </p>
+                {% elif form.status.value == "DISABLED" %}
+                    <p class="badge badge-pill badge-sm badge-emploi-lightest">
+                        Désactivée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+                    </p>
+                {% endif %}
+            </div>
+        </div>
     </div>
 
     <div class="card-body">
@@ -19,32 +48,6 @@
                 </p>
             </div>
 
-            {# Statuses #}
-            <div class="col-md-5 text-right">
-                <p class="small mb-0">
-                    {% if form.status.value == "SENT" %}
-                        <p class="badge badge-pill badge-sm badge-warning">
-                            Transmise à l'ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
-                        </p>
-                    {% elif form.status.value == "REJECTED" %}
-                        <p class="badge badge-pill badge-sm badge-danger">
-                            Retour en erreur le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
-                        </p>
-                    {% elif form.status.value == "PROCESSED" %}
-                        <p class="badge badge-pill badge-sm badge-success">
-                            Intégrée ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
-                        </p>
-                    {% elif form.status.value == "READY" %}
-                        <p class="badge badge-pill badge-sm badge-secondary">
-                            Complétée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
-                        </p>
-                    {% elif form.status.value == "DISABLED" %}
-                        <p class="badge badge-pill badge-sm badge-emploi-lightest">
-                            Désactivée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
-                        </p>
-                    {% endif %}
-                </p>
-            </div>
         </div>
 
         {# ASP error #}


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/Correction-affichage-du-badge-Int-gr-e-ASP-le-sur-la-liste-des-salari-s-506a580290834eef95b05b22540ec2ef

### Pourquoi ?

C'est plus joli.

### Captures d'écran (optionnel)

Avant:

![Screenshot 2022-12-21 at 17-13-10 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/208951836-c80a70c1-69a6-4ce7-b664-c8aa13bac436.png)

Après:

![Screenshot 2022-12-21 at 17-11-20 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/208951860-3e3aa452-a9d7-4529-9504-aa869d941c2e.png)

