### PR TITLE
metabase.organizations/siaes: Cesser d'annoter les membres

### DIFF
--- a/itou/metabase/tables/siaes.py
+++ b/itou/metabase/tables/siaes.py
@@ -71,7 +71,7 @@ TABLE.add_columns(
             "name": "total_membres",
             "type": "integer",
             "comment": "Nombre de comptes employeur rattachés à la structure",
-            "fn": lambda o: o.members_count,
+            "fn": lambda o: o.members.count(),
         },
         {
             "name": "total_candidatures",

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -159,7 +159,9 @@ def get_establishment_last_login_date_column():
             "name": "date_dernière_connexion",
             "type": "date",
             "comment": "Date de dernière connexion utilisateur",
-            "fn": lambda o: o.members_last_login,
+            "fn": lambda o: max([u.last_login for u in o.members.all() if u.last_login], default=None)
+            if o.members.exists()
+            else None,
         },
     ]
 
@@ -170,8 +172,10 @@ def get_establishment_is_active_column():
             "name": "active",
             "type": "boolean",
             "comment": "Dernière connexion dans les 7 jours",
-            "fn": lambda o: o.members_last_login > timezone.now() - timezone.timedelta(days=7)
-            if o.members_last_login
+            "fn": lambda o: any(
+                [u.last_login > timezone.now() - timezone.timedelta(days=7) for u in o.members.all() if u.last_login]
+            )
+            if o.members.exists()
             else False,
         },
     ]


### PR DESCRIPTION
On espère un gain de performance certain en prod.
Actuellement 1500 secondes, on espère passer sous la minute. A vérifier et compter dans les logs ensuite (retour sur la PR)