### PR TITLE
Promouvoir DORA : bandeau et bloc dans le tableau de bord

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -107,28 +107,61 @@
 {% endblock %}
 
 {% block pre_content %}
-    {# Mise en avant temporaire de Dora. #}
-    {% if user.is_prescriber or user.is_siae_staff %}
+    {# Mise en avant de Dora. #}
+    {% if show_dora_banner %}
         <section class="s-banner-01 pt-3 pb-0">
             <div class="s-banner-01__container container">
                 <div class="s-banner-01__row row">
                     <div class="s-banner-01__col col-12">
                         <div class="d-flex flex-column flex-md-row">
-                            <div class="text-center text-md-left mt-3">
-                                <a href="https://dora.fabrique.social.gouv.fr/contribuer?utm_source=lesemplois&utm_medium=banniere&utm_campaign=dashboard" target="_blank">
-                                    <img src="{% static 'img/logo_dora.svg' %}" alt="DORA : recensement et mise à jour de l’offre d’insertion" width="140">
-                                </a>
-                            </div>
                             <div class="w-100 mt-3 pl-0 pl-md-3">
-                                <p class="h3 mb-2">
-                                    Participez au référencement de l’offre d’insertion de votre territoire en renseignant les services que vous utilisez au quotidien.
-                                </p>
-                                <p class="mb-0 text-right">
-                                    <a href="https://dora.fabrique.social.gouv.fr/contribuer?utm_source=lesemplois&utm_medium=banniere&utm_campaign=dashboard" rel="noopener" target="_blank" class="btn btn-sm btn-outline-primary btn-ico">
-                                        <span>Je contribue</span>
-                                        <i class="ri-external-link-line ri-lg"></i>
-                                    </a>
-                                </p>
+                                {% if user.is_prescriber %}
+                                    <p class="h3 mb-2">Consultez l’offre de service de vos partenaires</p>
+                                    <p>
+                                        DORA vous aide dans la levée des freins périphériques bloquant le retour à l'emploi des bénéficiaires en facilitant l’identification des services d’insertion adaptés.
+                                    </p>
+                                    <p class="mb-0">
+                                        <a class="btn btn-primary btn-ico"
+                                           href="https://dora.fabrique.social.gouv.fr/?utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
+                                           title="Consulter les services (ouverture dans un nouvel onglet)"
+                                           rel="noopener"
+                                           target="_blank">
+                                            <span>Consulter les services</span>
+                                            <i class="ri-external-link-line ri-lg"></i>
+                                        </a>
+                                        <a class="btn btn-link btn-ico"
+                                           href="https://dora.fabrique.social.gouv.fr/contribuer?utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
+                                           title="Suggérer les services de vos partenaires (ouverture dans un nouvel onglet)"
+                                           rel="noopener"
+                                           target="_blank">
+                                            <span>Suggérer les services de vos partenaires</span>
+                                            <i class="ri-external-link-line ri-lg"></i>
+                                        </a>
+                                    </p>
+                                {% elif user.is_siae_staff %}
+                                    <p class="h3 mb-2">Donnez de la visibilité à votre offre d’insertion</p>
+                                    <p>
+                                        DORA est une cartographie numérique de l'offre d'insertion nationale. Rendez vos services visibles sur votre territoire et sur tous les sites partenaires, grâce à notre démarche collective d'ouverture des données.
+                                    </p>
+                                    <p class="mb-0">
+                                        <a class="btn btn-primary btn-ico"
+                                           href="https://dora.fabrique.social.gouv.fr/auth/rattachement?siret={{ current_org.siret }}&utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
+                                           title="Référencer un service (ouverture dans un nouvel onglet)"
+                                           rel="noopener"
+                                           target="_blank">
+                                            <span>Référencer un service</span>
+                                            <i class="ri-external-link-line ri-lg"></i>
+                                        </a>
+                                        <a class="btn btn-link btn-ico"
+                                           href="https://dora.fabrique.social.gouv.fr/?utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
+                                           title="Découvrir DORA (ouverture dans un nouvel onglet)"
+                                           rel="noopener"
+                                           target="_blank">
+                                            <span>Découvrir DORA</span>
+                                            <i class="ri-external-link-line ri-lg"></i>
+                                        </a>
+                                    </p>
+                                {% endif %}
                             </div>
                         </div>
                     </div>
@@ -211,6 +244,10 @@
 
         {% if can_view_stats_ddets and active_campaigns %}
             {% include "dashboard/includes/labor_inspector_evaluation_campains_card.html" %}
+        {% endif %}
+
+        {% if user.is_siae_staff or user.is_prescriber %}
+            {% include "dashboard/includes/dora_card.html" with siret=current_org.siret tracker="utm_source=LesEmplois&utm_medium=blocLesEmplois&utm_campaign=dashboard" %}
         {% endif %}
     </div>
 

--- a/itou/templates/dashboard/includes/dora_card.html
+++ b/itou/templates/dashboard/includes/dora_card.html
@@ -1,0 +1,32 @@
+<div class="col mb-3 mb-md-5">
+    <div class="card c-card c-card--plateforme h-100 w-100 has-links-inside">
+        <p class="h4 card-header">
+            DORA <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
+        </p>
+        <div class="card-body">
+            <ul class="list-unstyled">
+                <li class="card-text mb-3">
+                    <i class="ri-global-line ri-lg mr-1"></i>
+                    <a href="https://dora.fabrique.social.gouv.fr/?{{ tracker }}" rel="noopener" target="_blank" title="Consulter les services d'insertion de votre territoire (ouverture dans un nouvel onglet)">
+                        Consulter les services d'insertion de votre territoire
+                    </a>
+                    <i class="ri-external-link-line ri-lg mr-1"></i>
+                </li>
+                <li class="card-text mb-3">
+                    <i class="ri-file-add-line ri-lg mr-1"></i>
+                    <a href="https://dora.fabrique.social.gouv.fr/auth/rattachement?siret={{ siret }}&{{ tracker }}" rel="noopener" target="_blank" title="Référencer vos services (ouverture dans un nouvel onglet)">
+                        Référencer vos services
+                    </a>
+                    <i class="ri-external-link-line ri-lg mr-1"></i>
+                </li>
+                <li class="card-text mb-3">
+                    <i class="ri-file-transfer-line ri-lg mr-1"></i>
+                    <a href="https://dora.fabrique.social.gouv.fr/contribuer?{{ tracker }}" rel="noopener" target="_blank" title="Suggérer un service partenaire (ouverture dans un nouvel onglet)">
+                        Suggérer un service partenaire
+                    </a>
+                    <i class="ri-external-link-line ri-lg mr-1"></i>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -340,6 +340,76 @@ class DashboardViewTest(TestCase):
         response = self.client.get(reverse("dashboard:index"))
         self.assertContains(response, "Contrôle a posteriori")
 
+    def test_dora_card_is_not_shown_for_job_seeker(self):
+        user = JobSeekerFactory()
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertNotContains(response, "DORA")
+
+    def test_dora_card_is_shown_for_siae(self):
+        siae = SiaeFactory(with_membership=True)
+        self.client.force_login(siae.members.first())
+
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertContains(response, "DORA")
+        self.assertContains(response, "Consulter les services d'insertion de votre territoire")
+        self.assertContains(response, "Référencer vos services")
+        self.assertContains(response, "Suggérer un service partenaire")
+
+    def test_dora_card_is_shown_for_prescriber(self):
+        prescriber_organization = prescribers_factories.PrescriberOrganizationWithMembershipFactory()
+        self.client.force_login(prescriber_organization.members.first())
+
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertContains(response, "DORA")
+        self.assertContains(response, "Consulter les services d'insertion de votre territoire")
+        self.assertContains(response, "Référencer vos services")
+        self.assertContains(response, "Suggérer un service partenaire")
+
+    def test_dora_banner_is_not_shown_for_job_seeker(self):
+        user = JobSeekerFactory()
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertNotContains(response, "Consultez l’offre de service de vos partenaires")
+        self.assertNotContains(response, "Donnez de la visibilité à votre offre d’insertion")
+
+    def test_dora_banner_is_shown_for_siae(self):
+        for department in ["08", "60", "91", "974"]:
+            with self.subTest(department=department):
+                siae = SiaeFactory(with_membership=True, department=department)
+                self.client.force_login(siae.members.first())
+
+                response = self.client.get(reverse("dashboard:index"))
+                self.assertContains(response, "Donnez de la visibilité à votre offre d’insertion")
+
+    def test_dora_banner_is_shown_for_prescriber(self):
+        for department in ["08", "60", "91", "974"]:
+            with self.subTest(department=department):
+                prescriber_organization = prescribers_factories.PrescriberOrganizationWithMembershipFactory(
+                    department=department,
+                )
+                self.client.force_login(prescriber_organization.members.first())
+
+                response = self.client.get(reverse("dashboard:index"))
+                self.assertContains(response, "Consultez l’offre de service de vos partenaires")
+
+    def test_dora_banner_is_not_shown_for_other_department(self):
+        siae = SiaeFactory(with_membership=True, department="01")
+        self.client.force_login(siae.members.first())
+
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertNotContains(response, "Donnez de la visibilité à votre offre d’insertion")
+
+        prescriber_organization = prescribers_factories.PrescriberOrganizationWithMembershipFactory(
+            department="01",
+        )
+        self.client.force_login(prescriber_organization.members.first())
+
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertNotContains(response, "Consultez l’offre de service de vos partenaires")
+
     def test_dashboard_prescriber_suspend_link(self):
 
         user = JobSeekerFactory()

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -97,6 +97,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         campaign_in_progress = any(campaign.ended_at is None for campaign in active_campaigns)
 
     context = {
+        "current_org": current_org,
         "job_applications_categories": job_applications_categories,
         # FIXME(vperron): I think there's a rising need for a revamped permission system.
         "can_create_siae_antenna": request.user.can_create_siae_antenna(parent_siae=current_org),
@@ -117,6 +118,11 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "evaluated_siae_notifications": evaluated_siae_notifications,
         "precriber_kind_pe": PrescriberOrganizationKind.PE,
         "precriber_kind_dept": PrescriberOrganizationKind.DEPT,
+        "show_dora_banner": (
+            any([request.user.is_siae_staff, request.user.is_prescriber])
+            and current_org
+            and current_org.department in ["08", "60", "91", "974"]
+        ),
     }
 
     return render(request, template_name, context)


### PR DESCRIPTION
**Cartes Notion :**
- https://www.notion.so/1-2-Promouvoir-DORA-Bandeau-d-information-en-haut-du-tableau-de-bord-Limit-aux-territoires-d-XP-73603d4018894239b47370dcef091ee2
- https://www.notion.so/2-2-Promouvoir-DORA-Nouveau-bloc-Services-pour-Dora-f66a731a66864b9ab34783b2ec417a3a

### Pourquoi ?

Augmenter l’acquisition de nouveaux utilisateurs pour DORA

### Comment (optionnel)

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran (optionnel)

Employeur :
![image](https://user-images.githubusercontent.com/20045330/209525813-b2a1967f-d71b-446a-9a24-0e6391ea5996.png)
Prescripteur :
![image](https://user-images.githubusercontent.com/20045330/209526071-456fce2b-4675-4fc9-8fe1-8b1b6a2d4ea2.png)
