### PR TITLE
R&D : Essayer de se reconnecter à la database en cas de connexion périmée

### DIFF
--- a/itou/metabase/conftest.py
+++ b/itou/metabase/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+from django.db import connection
+
+from itou.metabase import db
+
+
+@pytest.fixture(name="metabase")
+def metabase_fixture(monkeypatch):
+    class FakeMetabase:
+        """
+        This fake metabase database allows us to benefit from all
+        the Django heavy lifting that is done with creating the database,
+        wrap everything in a transaction, etc.
+
+        This makes us write the metabase tables in the main test database.
+
+        FIXME(vperron): This is very basic for now. It still does not handle
+        initial table creation, there might be table name collision or other
+        issues. Let's fix them as they arise.
+        """
+
+        def __init__(self):
+            self.cursor = None
+
+        def __enter__(self):
+            self.cursor = connection.cursor().cursor
+            return self.cursor, connection
+
+        def __exit__(self, exc_type, exc_value, exc_traceback):
+            if self.cursor:
+                self.cursor.close()
+
+    monkeypatch.setattr(db, "MetabaseDatabaseCursor", FakeMetabase)

--- a/itou/metabase/management/test_populate_metabase_matomo.py
+++ b/itou/metabase/management/test_populate_metabase_matomo.py
@@ -6,37 +6,6 @@ from django.db import connection
 from django.test import override_settings
 from freezegun import freeze_time
 
-from itou.metabase import db
-
-
-@pytest.fixture(name="metabase")
-def metabase_fixture(monkeypatch):
-    class FakeMetabase:
-        """
-        This fake metabase database allows us to benefit from all
-        the Django heavy lifting that is done with creating the database,
-        wrap everything in a transaction, etc.
-
-        This makes us write the metabase tables in the main test database.
-
-        FIXME(vperron): This is very basic for now. It still does not handle
-        initial table creation, there might be table name collision or other
-        issues. Let's fix them as they arise.
-        """
-
-        def __init__(self):
-            self.cursor = None
-
-        def __enter__(self):
-            self.cursor = connection.cursor().cursor
-            return self.cursor, connection
-
-        def __exit__(self, exc_type, exc_value, exc_traceback):
-            if self.cursor:
-                self.cursor.close()
-
-    monkeypatch.setattr(db, "MetabaseDatabaseCursor", FakeMetabase)
-
 
 MATOMO_HEADERS = (
     "Unique visitors,Visits,Users,Actions,Maximum actions in one visit,Bounces,"

--- a/itou/metabase/tests/test_populate_metabase_emplois.py
+++ b/itou/metabase/tests/test_populate_metabase_emplois.py
@@ -1,0 +1,37 @@
+import pytest
+from django.db import connection
+
+
+class ForceConnectedTransaction:
+    """This context manager could come in handy in our long-standing workers,
+    by calling it before an operation that could potentially be a little long.
+
+    We get InterfaceError: "connection already closed" in some of our workers
+    and by default, Django does not rconnect in such cases.
+
+    This is a draft of a tool that would help us reconnect before any operation
+    starts, even though it does not protect us from very random disconnections
+    and does not retry failed operations. Is not there, somewhere, a special
+    database conenctor that could do that ?
+    """
+
+    def __enter__(self):
+        if not connection.is_usable():
+            connection.connect()
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        pass
+
+
+@pytest.mark.usefixtures("metabase")
+@pytest.mark.django_db()
+def test_interface_error():
+    connection.close()
+    assert not connection.is_usable()
+
+    with ForceConnectedTransaction():
+        assert connection.is_usable()
+
+    # unfortunately, if the assertions do pass, the test fails in an error (not a failure)
+    # bacause pytest-django tries to tear down ad database that is in a weird state according
+    # to it. I did not crack this issue just yet :/


### PR DESCRIPTION
CF le second commit. 

En court : certains de nos scripts crashent car la connexion à la database a coupé entre temlps et l'objet `connection` est invalide, on ne peut plus rien en tirer. Dans ces cas-là, Django ne se reconnecte pas et ça ne sert à rien de retenter, on ne peut plus que crasher.

Peut-on tuner les paramètres d'accès à la database ? Existe-t-il un `ReconnectingConnector` ? Je fais ici une tentative mais peu couronnée de succès, je vais avoir besoin de vos lumières - je sens que ce n'est pas la bonne approche.

Cf [cette discussion](https://itou-inclusion.slack.com/archives/CT7986ULC/p1671913804233089) sur Slack aussi.
[L'erreur Sentry](https://sentry.io/organizations/itou/issues/3834583158/?alert_rule_id=10485625&alert_timestamp=1671913909725&alert_type=email&environment=production&project=6247245&referrer=alert_email).
La [feature request](https://code.djangoproject.com/ticket/24810) dans Django.