### PR TITLE
Gestion de la date d'acception (`accepted_at`) des candidatures du stock AI

### DIFF
--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 import factory
 import factory.fuzzy
 from dateutil.relativedelta import relativedelta
+from django.conf import settings
 
 from itou.approvals.factories import ApprovalFactory
 from itou.eligibility.factories import EligibilityDiagnosisFactory
@@ -21,6 +22,7 @@ from itou.users.factories import (
     JobSeekerProfileWithHexaAddressFactory,
     JobSeekerWithMockedAddressFactory,
     PrescriberFactory,
+    UserFactory,
 )
 
 
@@ -49,6 +51,12 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
             ),
             sender=factory.LazyAttribute(lambda obj: obj.sender_prescriber_organization.members.first()),
             sender_kind=SenderKind.PRESCRIBER,
+        )
+        is_from_ai_stock = factory.Trait(
+            approval_manually_delivered_by=factory.SubFactory(
+                UserFactory, email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL
+            ),
+            created_at=settings.AI_EMPLOYEES_STOCK_IMPORT_DATE,
         )
 
     job_seeker = factory.SubFactory(JobSeekerFactory)

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -170,6 +170,12 @@ class JobApplicationQuerySet(models.QuerySet):
         )
         return self.annotate(
             accepted_at=Case(
+                # Mega Super duper special case to handle job applications created to generate AI's PASS IAE
+                When(
+                    approval_manually_delivered_by__email=settings.AI_EMPLOYEES_STOCK_DEVELOPER_EMAIL,
+                    created_at=settings.AI_EMPLOYEES_STOCK_IMPORT_DATE,
+                    then=F("hiring_start_at"),
+                ),
                 When(created_from_pe_approval=True, then=F("created_at")),
                 # A job_application created at the accepted status, still accepted
                 When(
@@ -179,6 +185,7 @@ class JobApplicationQuerySet(models.QuerySet):
                     then=F("created_at"),
                 ),
                 When(created_from_pe_approval=False, then=created_at_from_transition),
+                output_field=models.DateTimeField(),
             )
         )
 

--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -572,6 +572,13 @@ class JobApplicationQuerySetTest(TestCase):
         job_application = JobApplication.objects.with_accepted_at().first()
         self.assertEqual(job_application.accepted_at, job_application.created_at)
 
+    def test_with_accepted_at_for_ai_stock(self):
+        JobApplicationFactory(is_from_ai_stock=True)
+
+        job_application = JobApplication.objects.with_accepted_at().first()
+        assert job_application.accepted_at.date() == job_application.hiring_start_at
+        assert job_application.accepted_at != settings.AI_EMPLOYEES_STOCK_IMPORT_DATE
+
 
 class JobApplicationNotificationsTest(TestCase):
     @classmethod


### PR DESCRIPTION
### Pourquoi ?

La version actuelle de `.with_accepted_at()` tombais dans son deuxième `When` et utilisais donc `created_at`, sauf que si une SIAE avait embauchée la personne avant la création des candidatures du stock AI alors elle n'était pas considéré comme le dernier employeur donc impossible pour elle de prolonger ou suspendre alors qu'elle est effectivement le dernier employeur.

Ce cas est probablement minime mais la correction n'était pas énorme non plus, autant la faire et ne plus risquer de tomber dessus, surtout qu'il est plus logique d'utiliser `hiring_start_at` que `created_at` (qui à une valeur fixe) pour ces candidatures.

### Comment

Idéalement je pense qu'il aurais fallu en profiter pour convertir `is_from_ai_stock` d'une propriété à un champs physique (avec peut-être un nom plus générique pour le réutiliser un autre jour :shrug:) et ainsi faciliter et uniformiser les requêtes et le code, peut-être un autre jour :grin:.