### PR TITLE
Marquer la migration siaes.0064_fill_siae_job_app_score elidable

### DIFF
--- a/itou/siaes/migrations/0064_fill_siae_job_app_score.py
+++ b/itou/siaes/migrations/0064_fill_siae_job_app_score.py
@@ -18,4 +18,10 @@ class Migration(migrations.Migration):
         ("siaes", "0063_siae_job_app_score"),
     ]
 
-    operations = [migrations.RunPython(_fill_siae_job_app_score, reverse_code=migrations.RunPython.noop)]
+    operations = [
+        migrations.RunPython(
+            _fill_siae_job_app_score,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        )
+    ]


### PR DESCRIPTION
### Pourquoi ?

Facilite le _squash_ des migrations.