### PR TITLE
Amélioration des performances de la liste des nouvelles fiches salariés

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -397,8 +397,8 @@ class JobApplicationQuerySet(models.QuerySet):
         return (
             self.filter(pk__in=eligible_job_applications.values("id"))
             .exclude(approval__number__in=approvals_to_exclude)
-            .select_related("to_siae", "to_siae__convention", "approval", "job_seeker")
-            .prefetch_related("employee_record", "approval__suspension_set", "approval__prolongation_set")
+            .select_related("approval", "job_seeker")
+            .prefetch_related("employee_record")
             .order_by("-hiring_start_at")
         )
 

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -177,6 +177,18 @@ class ListEmployeeRecordsTest(TestCase):
             self.url + "?order=-name", job_applicationZ.job_seeker, job_applicationA.job_seeker
         )
 
+        # Count queries
+        num_queries = 1  # Get django session
+        num_queries += 3  # Get current user and siae
+        num_queries += 1  # Select employee_records status count
+        num_queries += 1  # Get Siae Convention
+        num_queries += 1  # Select ordered job applications
+        num_queries += 1  # Select EmployeeRecords
+        num_queries += 1  # Select siae members
+        num_queries += 1  # Get user social_account
+        with self.assertNumQueries(num_queries):
+            self.client.get(self.url)
+
     def test_rejected_employee_records_sorted(self):
         self.client.force_login(self.user)
 


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Problème de performance sur cette page : 
https://sentry.io/organizations/itou/performance/les-emplois-prod:278ac935105b4c5ba33ba5e955b518a6/?project=6164438&query=transaction.duration%3A%3C15m+http.method%3AGET&referrer=performance-transaction-summary&statsPeriod=7d&transaction=%2Femployee_record%2Flist&unselectedSeries=p100%28%29

### Comment ?

- Correction d'une requête en 1+N 
- Suppression du doublon de requêtes pour compter les JobApplications