### PR TITLE
Changement de représentation pour la qualité de vie du support

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -47,7 +47,7 @@ class JobApplicationInline(admin.StackedInline):
         to_siae_link = reverse("admin:siaes_siae_change", args=[obj.to_siae.pk])
         return format_html(
             f"<a href='{to_siae_link}'>{obj.to_siae.display_name}</a> "
-            f"(SIRET : {obj.to_siae.siren} {obj.to_siae.siret_nic})"
+            f"— SIRET : {obj.to_siae.siren}{obj.to_siae.siret_nic}"
         )
 
     # Custom read-only fields as workaround :

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -289,7 +289,7 @@ class User(AbstractUser, AddressMixin):
     objects = ItouUserManager()
 
     def __str__(self):
-        return f"{self.get_full_name()} ({self.email})"
+        return f"{self.get_full_name()} — {self.email}"
 
     def clean(self):
         """


### PR DESCRIPTION
### Pourquoi ?

Copier-coller un texte entouré de parenthèses demande de bien viser.
L’email serait plus facile à copier s’il était séparé par un tiret.
Aussi, le SIRET d’une SIAE pourrait être sélectionné par un double clic
s’il n’avait pas d’espaces, et s’il n’était pas entouré de parenthèses.