### PR TITLE
Synchronisation des analytics C1 avec Metabase

### DIFF
--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -17,6 +17,7 @@ mkdir -p $OUTPUT_PATH
 (
     if [[ "$1" == "--daily" ]]; then
         django-admin send_slack_message ":rocket: lancement mise à jour de données C1 -> Metabase"
+        django-admin populate_metabase_emplois --mode=analytics
         django-admin populate_metabase_emplois --mode=siaes
         django-admin populate_metabase_emplois --mode=job_descriptions
         django-admin populate_metabase_emplois --mode=organizations

--- a/itou/metabase/conftest.py
+++ b/itou/metabase/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+from django.db import connection
+
+from itou.metabase import db
+
+
+@pytest.fixture(name="metabase")
+def metabase_fixture(monkeypatch):
+    class FakeMetabase:
+        """
+        This fake metabase database allows us to benefit from all
+        the Django heavy lifting that is done with creating the database,
+        wrap everything in a transaction, etc.
+
+        This makes us write the metabase tables in the main test database.
+
+        FIXME(vperron): This is very basic for now. It still does not handle
+        initial table creation, there might be table name collision or other
+        issues. Let's fix them as they arise.
+        """
+
+        def __init__(self):
+            self.cursor = None
+
+        def __enter__(self):
+            self.cursor = connection.cursor().cursor
+            return self.cursor, connection
+
+        def __exit__(self, exc_type, exc_value, exc_traceback):
+            if self.cursor:
+                self.cursor.close()
+
+    monkeypatch.setattr(db, "MetabaseDatabaseCursor", FakeMetabase)

--- a/itou/metabase/db.py
+++ b/itou/metabase/db.py
@@ -1,14 +1,17 @@
 """
 Helper methods for manipulating tables used by both populate_metabase_emplois and populate_metabase_fluxiae scripts.
 """
+import gc
 import logging
 import os
 
 import psycopg2
 from django.conf import settings
-from psycopg2 import sql
+from django.utils import timezone
+from psycopg2 import extras as psycopg2_extras, sql
 from psycopg2.extras import LoggingConnection, LoggingCursor
 
+from itou.metabase.utils import chunked_queryset, compose, convert_boolean_to_int
 from itou.utils.python import timeit
 
 
@@ -129,7 +132,114 @@ def build_final_tables():
     for filename in sorted([f for f in os.listdir(path) if f.endswith(".sql")]):
         print(f"Running {filename} ...")
         table_name = "_".join(filename.split(".")[0].split("_")[1:])
-        with open(os.path.join(path, filename)) as file:
+        with open(os.path.join(path, filename), encoding="utf-8") as file:
             sql_request = file.read()
         build_custom_table(table_name=table_name, sql_request=sql_request)
         print("Done.")
+
+
+def populate_table(table, batch_size, querysets=None, extra_object=None):
+    """
+    About commits: a single final commit freezes the itou-metabase-db temporarily, making
+    our GUI unable to connect to the db during this commit.
+
+    This is why we instead do small and frequent commits, so that the db stays available
+    throughout the script.
+
+    Note that psycopg2 will always automatically open a new transaction when none is open.
+    Thus it will open a new one after each such commit.
+    """
+
+    table_name = table.name
+    new_table_name = get_new_table_name(table_name)
+    old_table_name = get_old_table_name(table_name)
+
+    def drop_old_and_new_tables():
+        with MetabaseDatabaseCursor() as (cur, conn):
+            cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(new_table_name)))
+            cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(old_table_name)))
+            conn.commit()
+
+    drop_old_and_new_tables()
+
+    total_rows = sum([queryset.count() for queryset in querysets])
+
+    table.add_columns(
+        [
+            {
+                "name": "date_mise_à_jour_metabase",
+                "type": "date",
+                "comment": "Date de dernière mise à jour de Metabase",
+                # As metabase daily updates run typically every night after midnight, the last day with
+                # complete data is yesterday, not today.
+                "fn": lambda o: timezone.now() + timezone.timedelta(days=-1),
+            },
+        ]
+    )
+
+    # Transform boolean fields into 0-1 integer fields as
+    # metabase cannot sum or average boolean columns ¯\_(ツ)_/¯
+    for c in table.columns:
+        if c["type"] == "boolean":
+            c["type"] = "integer"
+            c["fn"] = compose(convert_boolean_to_int, c["fn"])
+
+    print(f"Injecting {total_rows} rows with {len(table.columns)} columns into table {table_name}:")
+
+    create_table(new_table_name, [(c["name"], c["type"]) for c in table.columns])
+
+    with MetabaseDatabaseCursor() as (cur, conn):
+
+        def inject_chunk(table_columns, chunk, new_table_name):
+            insert_query = sql.SQL("insert into {new_table_name} ({fields}) values %s").format(
+                new_table_name=sql.Identifier(new_table_name),
+                fields=sql.SQL(",").join(
+                    [sql.Identifier(c["name"]) for c in table_columns],
+                ),
+            )
+            dataset = [[c["fn"](o) for c in table_columns] for o in chunk]
+            psycopg2_extras.execute_values(cur, insert_query, dataset, template=None)
+            conn.commit()
+
+        # Add comments on table columns.
+        for c in table.columns:
+            assert set(c.keys()) == {"name", "type", "comment", "fn"}
+            column_name = c["name"]
+            column_comment = c["comment"]
+            comment_query = sql.SQL("comment on column {new_table_name}.{column_name} is {column_comment}").format(
+                new_table_name=sql.Identifier(new_table_name),
+                column_name=sql.Identifier(column_name),
+                column_comment=sql.Literal(column_comment),
+            )
+            cur.execute(comment_query)
+
+        conn.commit()
+
+        if extra_object:
+            inject_chunk(table_columns=table.columns, chunk=[extra_object], new_table_name=new_table_name)
+
+        written_rows = 0
+        for queryset in querysets:
+            # Insert rows by batch of batch_size.
+            # A bigger number makes the script faster until a certain point,
+            # but it also increases RAM usage.
+            for chunk_qs in chunked_queryset(queryset, chunk_size=batch_size):
+                inject_chunk(table_columns=table.columns, chunk=chunk_qs, new_table_name=new_table_name)
+                written_rows += chunk_qs.count()
+                print(f"count={written_rows} of total={total_rows} written")
+
+            # Trigger garbage collection to optimize memory use.
+            gc.collect()
+
+        # Swap new and old table nicely to minimize downtime.
+        cur.execute(
+            sql.SQL("ALTER TABLE IF EXISTS {} RENAME TO {}").format(
+                sql.Identifier(table_name), sql.Identifier(old_table_name)
+            )
+        )
+        cur.execute(
+            sql.SQL("ALTER TABLE {} RENAME TO {}").format(sql.Identifier(new_table_name), sql.Identifier(table_name))
+        )
+        conn.commit()
+
+    drop_old_and_new_tables()

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -37,6 +37,7 @@ from itou.jobs.models import Rome
 from itou.metabase.dataframes import get_df_from_rows, store_df
 from itou.metabase.db import build_final_tables, populate_table
 from itou.metabase.tables import (
+    analytics,
     approvals,
     insee_codes,
     job_applications,
@@ -47,7 +48,7 @@ from itou.metabase.tables import (
     selected_jobs,
     siaes,
 )
-from itou.metabase.tables.utils import MetabaseTable, get_active_siae_pks
+from itou.metabase.tables.utils import get_active_siae_pks
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.models import Siae, SiaeJobDescription
 from itou.users.models import User
@@ -84,32 +85,7 @@ class Command(BaseCommand):
         parser.add_argument("--mode", action="store", dest="mode", type=str, choices=self.MODE_TO_OPERATION.keys())
 
     def populate_analytics(self):
-        AnalyticsTable = MetabaseTable(name="c1_analytics_v0")
-        AnalyticsTable.add_columns(
-            [
-                {"name": "id", "type": "varchar", "comment": "ID du point de mesure", "fn": lambda o: o.pk},
-                {
-                    "name": "type",
-                    "type": "varchar",
-                    "comment": "Type de mesure",
-                    "fn": lambda o: o.code,
-                },
-                {
-                    "name": "date",
-                    "type": "date",
-                    "comment": "Date associée à la mesure",
-                    "fn": lambda o: o.bucket,
-                },
-                {
-                    "name": "value",
-                    "type": "integer",
-                    "comment": "Valeur de la mesure",
-                    "fn": lambda o: o.value,
-                },
-            ]
-        )
-
-        populate_table(AnalyticsTable, batch_size=10_000, querysets=[Datum.objects.all()])
+        populate_table(analytics.AnalyticsTable, batch_size=10_000, querysets=[Datum.objects.all()])
 
     def populate_siaes(self):
         ONE_MONTH_AGO = timezone.now() - timezone.timedelta(days=30)

--- a/itou/metabase/management/test_populate_metabase_emplois.py
+++ b/itou/metabase/management/test_populate_metabase_emplois.py
@@ -1,0 +1,43 @@
+import datetime
+
+import pytest
+from django.core import management
+from django.db import connection
+
+from itou.analytics.factories import DatumFactory
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.usefixtures("metabase")
+def test_populate_metabase_analytics():
+    date_maj = datetime.date.today() + datetime.timedelta(days=-1)
+    data0 = DatumFactory(code="FOO-BAR", bucket="2021-12-31")
+    data1 = DatumFactory(code="FOO-MAN", bucket="2020-10-17")
+    data2 = DatumFactory(code="FOO-DUR", bucket="2022-08-16")
+    management.call_command("populate_metabase_emplois", mode="analytics")
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT * FROM c1_analytics_v0 ORDER BY date")
+        rows = cursor.fetchall()
+        assert rows == [
+            (
+                str(data1.pk),
+                "FOO-MAN",
+                datetime.date(2020, 10, 17),
+                data1.value,
+                date_maj,
+            ),
+            (
+                str(data0.pk),
+                "FOO-BAR",
+                datetime.date(2021, 12, 31),
+                data0.value,
+                date_maj,
+            ),
+            (
+                str(data2.pk),
+                "FOO-DUR",
+                datetime.date(2022, 8, 16),
+                data2.value,
+                date_maj,
+            ),
+        ]

--- a/itou/metabase/management/test_populate_metabase_matomo.py
+++ b/itou/metabase/management/test_populate_metabase_matomo.py
@@ -6,37 +6,6 @@ from django.db import connection
 from django.test import override_settings
 from freezegun import freeze_time
 
-from itou.metabase import db
-
-
-@pytest.fixture(name="metabase")
-def metabase_fixture(monkeypatch):
-    class FakeMetabase:
-        """
-        This fake metabase database allows us to benefit from all
-        the Django heavy lifting that is done with creating the database,
-        wrap everything in a transaction, etc.
-
-        This makes us write the metabase tables in the main test database.
-
-        FIXME(vperron): This is very basic for now. It still does not handle
-        initial table creation, there might be table name collision or other
-        issues. Let's fix them as they arise.
-        """
-
-        def __init__(self):
-            self.cursor = None
-
-        def __enter__(self):
-            self.cursor = connection.cursor().cursor
-            return self.cursor, connection
-
-        def __exit__(self, exc_type, exc_value, exc_traceback):
-            if self.cursor:
-                self.cursor.close()
-
-    monkeypatch.setattr(db, "MetabaseDatabaseCursor", FakeMetabase)
-
 
 MATOMO_HEADERS = (
     "Unique visitors,Visits,Users,Actions,Maximum actions in one visit,Bounces,"

--- a/itou/metabase/tables/analytics.py
+++ b/itou/metabase/tables/analytics.py
@@ -1,0 +1,27 @@
+from itou.metabase.tables.utils import MetabaseTable
+
+
+AnalyticsTable = MetabaseTable(name="c1_analytics_v0")
+AnalyticsTable.add_columns(
+    [
+        {"name": "id", "type": "varchar", "comment": "ID du point de mesure", "fn": lambda o: o.pk},
+        {
+            "name": "type",
+            "type": "varchar",
+            "comment": "Type de mesure",
+            "fn": lambda o: o.code,
+        },
+        {
+            "name": "date",
+            "type": "date",
+            "comment": "Date associée à la mesure",
+            "fn": lambda o: o.bucket,
+        },
+        {
+            "name": "value",
+            "type": "integer",
+            "comment": "Valeur de la mesure",
+            "fn": lambda o: o.value,
+        },
+    ]
+)

--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -16,6 +16,7 @@ def get_permissions_dict():
     # and tooling will help us with refactoring, dead code and models, etc.
     import allauth.account.models as account_models
 
+    import itou.analytics.models as analytics_models
     import itou.approvals.models as approvals_models
     import itou.asp.models as asp_models
     import itou.cities.models as cities_models
@@ -33,6 +34,7 @@ def get_permissions_dict():
     return {
         "itou-admin": {
             account_models.EmailAddress: PERMS_ADD,
+            analytics_models.Datum: PERMS_READ,
             approvals_models.Approval: PERMS_ALL,
             approvals_models.PoleEmploiApproval: PERMS_READ,
             approvals_models.Suspension: PERMS_ALL,

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -165,6 +165,7 @@ class TestSyncPermsTestCase(TestCase):
             "add_emailaddress",
             "change_emailaddress",
             "view_emailaddress",
+            "view_datum",
             "add_approval",
             "change_approval",
             "delete_approval",


### PR DESCRIPTION
**Carte Notion :  https://www.notion.so/C1-kpi-16-Taux-de-transmissions-des-fiches-salari-s-r-ussies-au-premier-envoi-statut-int-gr-e-2a532dc2089b42e2bdfced8f66ab3827**

### Pourquoi ?
Les derniers développements de Romain concernant l'app Analytics permettent d'extraire des données historisées, en particulier sur l'évolution des fiches de poste.
Extraire ces données vers Metabase permettra de les exploiter.

### Comment (optionnel)
Ajouter cet export à la liste des données exportées par le cron.
On en profite pour introduire un premier test _end to end_ du cron !
