### PR TITLE
matomo: Modifier l'heure de synchronisation

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -11,7 +11,7 @@
   "5 * * * * $ROOT/clevercloud/run_management_command.sh update_siaes_job_app_score",
   "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
   "0 0 15 * * $ROOT/clevercloud/run_management_command.sh sync_romes_and_appellations --wet-run",
-  "0 2 * * 1 $ROOT/clevercloud/crons/populate_metabase_matomo.sh",
+  "0 6 * * 1 $ROOT/clevercloud/crons/populate_metabase_matomo.sh",
   "30 20 * * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --daily",
   "0 0 2 * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --monthly",
   "5 * * * * $ROOT/clevercloud/run_management_command.sh sync_pec_offers --wet-run"


### PR DESCRIPTION
By experience, midnight seems to be a bad choice and Matromo tends stop answering. I don't have the details of what's happening but it's very possible that maintenance or consolidation operations happen around that time.

I tried very successfully the same operation in the middle of the night, so this mitigation seems to be a simple way to be more successful.


