### PR TITLE
Metabase : récupération des visiteurs uniques à partir des tables matomo

### DIFF
--- a/itou/metabase/sql/025_suivi_visiteurs_tous_tb.sql
+++ b/itou/metabase/sql/025_suivi_visiteurs_tous_tb.sql
@@ -1,16 +1,29 @@
+/* Dans cette table nous récupérons les infos des visiteurs uniques de Matomo à partir des tables créées par Victor qui automatisent les requêtes API */
+
 with visiteurs_prives as (
     select
-        svtp."Date" as semaine,  /* Obligé de mettre les titres des colonnes entre "" sinon j'avais un message d'erreur de mon GUI */
+        svtp."Date" as semaine,
+        /* Obligé de mettre les titres des colonnes entre "" sinon j'avais un message d'erreur de mon GUI */
         svtp."Tableau de bord" as tableau_de_bord,
         svtp."Visiteurs uniques" as visiteurs_uniques
-    from suivi_visiteurs_tb_prives svtp 
+    from
+        suivi_visiteurs_tb_prives svtp /* Ancienne table créée par Victor qui débute en 2022 et s'arrête à la semaine du 12/12/22 */
+),
+visiteurs_prives_0 as (
+    select
+        to_date(svtp0."Date", 'YYYY-MM-DD') as semaine,
+        svtp0."Tableau de bord" as tableau_de_bord,
+        to_number(svtp0."Unique visitors", '99') as visiteurs_uniques
+    from
+        suivi_visiteurs_tb_prives_v0 svtp0 /* Nouvelle table créée par Victor qui démarre le 19/12/22 */
 ),
 visiteurs_publics as (
     select
-        vp."Date" as semaine,
-        vp."tableau de bord" as tableau_de_bord,
-        vp."Unique visitors" as visiteurs_uniques
-    from suivi_visiteurs_tb_publics vp 
+        to_date(vp."Date", 'YYYY-MM-DD') as semaine,
+        vp."Tableau de bord" as tableau_de_bord,
+        to_number(vp."Unique visitors", '99') as visiteurs_uniques
+    from
+        suivi_visiteurs_tb_publics_V0 vp /* Nouvelle table créée par Victor qui reprend toutes les infos des visiteurs des TBs publics */
 )
 select
     semaine,
@@ -18,11 +31,21 @@ select
     visiteurs_uniques
 from
     visiteurs_prives
-where semaine is not null       
+where
+    semaine is not null
 union all
-    select
-        semaine,
-        tableau_de_bord,
-        visiteurs_uniques
-    from
-        visiteurs_publics
+select
+    semaine,
+    tableau_de_bord,
+    visiteurs_uniques
+from
+    visiteurs_prives_0
+where
+    semaine is not null
+union all
+select
+    semaine,
+    tableau_de_bord,
+    visiteurs_uniques
+from
+    visiteurs_publics


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Modification de la table pour qu'elle prenne en compte les nouvelles tables crées par Victor

