### PR TITLE
Suppression d'une bannière et d'une vue inutile

### DIFF
--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -26,13 +26,6 @@
             {% if form_address or form_pe_status %}<h3 class="h2">Candidat</h3>{% endif %}
 
             {% if form_pe_status %}
-                {% if not job_application.approval_not_needed %}
-                    <div class="alert alert-warning" role="status">
-                        <p class="mb-0">
-                            Pour obtenir un PASS IAE dans les meilleurs délais, assurez-vous de l'exactitude de la date de naissance et du statut Pôle emploi du candidat.
-                        </p>
-                    </div>
-                {% endif %}
                 {% bootstrap_form form_pe_status alert_error_type="all" %}
             {% endif %}
 

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -103,11 +103,6 @@ urlpatterns = [
     path("<uuid:job_application_id>/siae/transfer", process_views.transfer, name="transfer"),
     # Variant of accept process (employer does not need an approval)
     path(
-        "<uuid:job_application_id>/siae/accept_without_approval",
-        process_views.accept_without_approval,
-        name="accept_without_approval",
-    ),
-    path(
         "<uuid:job_application_id>/siae/edit_contract_start_date",
         edit_views.edit_contract_start_date,
         name="edit_contract_start_date",

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -484,15 +484,3 @@ def eligibility(request, job_application_id, template_name="apply/process_eligib
         "job_seeker": job_application.job_seeker,
     }
     return render(request, template_name, context)
-
-
-@login_required
-def accept_without_approval(request, job_application_id):
-    queryset = JobApplication.objects.siae_member_required(request.user)
-    job_application = get_object_or_404(queryset, id=job_application_id)
-
-    if not job_application.approval_not_needed:
-        job_application.approval_not_needed = True
-        job_application.save()
-
-    return accept(request, job_application_id)


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/1-3-Renseigner-le-NIR-apr-s-l-inscription-du-candidat-En-tant-qu-employeur-j-aimerais-renseigner-l-297c09b3b5844a05b6909a39499016ca

### Pourquoi ?

La suppression de la bannière fait partie du ticket Notion de gestion du NIR (cf Figma)

Au passage en regardant d'où venait le champ `approval_not_needed` conditionnant l'affichage de la bannière je suis tombé sur la vue obsolète `accept_without_approval`.

### Captures d'écran (optionnel)

Avant

![Screenshot 2023-01-04 at 16-06-02 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/210585055-35f83c61-35e2-4583-aef9-a14548319332.png)

Après

![Screenshot 2023-01-04 at 16-06-16 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/210585084-aa1c75b4-22a2-4b63-a25f-7f0c82378d9e.png)


