### PR TITLE
Masquer le badge de type de contrat si le champ n’est pas rempli

### DIFF
--- a/itou/templates/siaes/includes/_siae_jobdescription.html
+++ b/itou/templates/siaes/includes/_siae_jobdescription.html
@@ -25,7 +25,9 @@
             </span>
         </div>
         <div class="mt-lg-0 ml-auto d-flex flex-column align-items-end justify-content-center">
-            <span class="badge badge-xs badge-pill badge-accent-02-light text-primary">{{ job.display_contract_type }}</span>
+            {% if job.display_contract_type %}
+                <span class="badge badge-xs badge-pill badge-accent-02-light text-primary">{{ job.display_contract_type }}</span>
+            {% endif %}
             {% if job.hours_per_week %}
                 <span class="badge badge-xs badge-pill badge-accent-02-light text-primary mt-1">
                     {{ job.hours_per_week }}h/semaine


### PR DESCRIPTION
### Captures d'écran

#### Avant
![Screenshot from 2023-01-04 16-30-34](https://user-images.githubusercontent.com/2758243/210590367-f7b908b3-bdd6-4883-b7da-d39618209e37.png)

#### Après
![Screenshot from 2023-01-04 16-30-24](https://user-images.githubusercontent.com/2758243/210590385-12ec55e9-9915-4d65-a4cc-1e3678669549.png)