### PR TITLE
stats: Ajout d'un tableau de bord DIHAL

### DIFF
--- a/itou/institutions/enums.py
+++ b/itou/institutions/enums.py
@@ -5,4 +5,5 @@ class InstitutionKind(models.TextChoices):
     DDETS = ("DDETS", "Direction départementale de l'emploi, du travail et des solidarités")
     DREETS = ("DREETS", "Direction régionale de l'économie, de l'emploi, du travail et des solidarités")
     DGEFP = ("DGEFP", "Délégation générale à l'emploi et à la formation professionnelle")
+    DIHAL = ("DIHAL", "Délégation interministérielle à l'hébergement et à l'accès au logement")
     OTHER = ("Autre", "Autre")

--- a/itou/institutions/migrations/0001_initial.py
+++ b/itou/institutions/migrations/0001_initial.py
@@ -180,6 +180,7 @@ class Migration(migrations.Migration):
                                 "Direction régionale de l'économie, de l'emploi, du travail et des solidarités",
                             ),
                             ("DGEFP", "Délégation générale à l'emploi et à la formation professionnelle"),
+                            ("DIHAL", "Délégation interministérielle à l'hébergement et à l'accès au logement"),
                             ("Autre", "Autre"),
                         ],
                         default="Autre",

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -69,6 +69,12 @@
                         <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données du contrôle a posteriori (version bêta)</a>
                     </li>
                 {% endif %}
+                {% if can_view_stats_dihal %}
+                    <li class="card-text mb-3">
+                        <i class="ri-line-chart-line ri-lg mr-1"></i>
+                        <a href="{% url 'stats:stats_dihal_state' %}">Voir les données des prescriptions</a>
+                    </li>
+                {% endif %}
                 <li class="card-text mb-3">
                     <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)">
                         Accéder aux tableaux de bord publics

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -612,6 +612,7 @@ class User(AbstractUser, AddressMixin):
             or self.can_view_stats_ddets(current_org=current_org)
             or self.can_view_stats_dreets(current_org=current_org)
             or self.can_view_stats_dgefp(current_org=current_org)
+            or self.can_view_stats_dihal(current_org=current_org)
         )
 
     def _can_view_stats_siae(self, current_org):
@@ -734,6 +735,13 @@ class User(AbstractUser, AddressMixin):
             self.is_labor_inspector
             and isinstance(current_org, Institution)
             and current_org.kind == InstitutionKind.DGEFP
+        )
+
+    def can_view_stats_dihal(self, current_org):
+        return (
+            self.is_labor_inspector
+            and isinstance(current_org, Institution)
+            and current_org.kind == InstitutionKind.DIHAL
         )
 
     def update_external_data_source_history_field(self, provider, field, value) -> bool:

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -88,6 +88,9 @@ METABASE_DASHBOARDS = {
     "stats_dgefp_af": {
         "dashboard_id": 142,
     },
+    "stats_dihal_state": {
+        "dashboard_id": 235,
+    },
 }
 
 

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -12,6 +12,7 @@ from freezegun import freeze_time
 from itou.approvals.factories import ApprovalFactory
 from itou.employee_record.enums import Status
 from itou.employee_record.factories import EmployeeRecordFactory
+from itou.institutions.enums import InstitutionKind
 from itou.institutions.factories import InstitutionMembershipFactory
 from itou.job_applications.factories import JobApplicationFactory, JobApplicationSentByPrescriberFactory
 from itou.job_applications.notifications import (
@@ -178,6 +179,13 @@ class DashboardViewTest(TestCase):
                     self.assertContains(response, "Créer/rejoindre une autre structure")
                 else:
                     self.assertNotContains(response, "Créer/rejoindre une autre structure")
+
+    def test_dashboard_dihal_institution_access(self):
+        membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DIHAL)
+        self.client.force_login(membershipfactory.user)
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertContains(response, "Voir les données des prescriptions")
+        self.assertContains(response, reverse("stats:stats_dihal_state"))
 
     def test_dashboard_siae_evaluations_institution_access(self):
         membershipfactory = InstitutionMembershipFactory()

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -93,6 +93,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
 
     context = {
         "job_applications_categories": job_applications_categories,
+        # FIXME(vperron): I think there's a rising need for a revamped permission system.
         "can_create_siae_antenna": request.user.can_create_siae_antenna(parent_siae=current_org),
         "can_show_financial_annexes": can_show_financial_annexes,
         "can_show_employee_records": can_show_employee_records,
@@ -104,6 +105,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_view_stats_ddets": request.user.can_view_stats_ddets(current_org=current_org),
         "can_view_stats_dreets": request.user.can_view_stats_dreets(current_org=current_org),
         "can_view_stats_dgefp": request.user.can_view_stats_dgefp(current_org=current_org),
+        "can_view_stats_dihal": request.user.can_view_stats_dihal(current_org=current_org),
         "num_rejected_employee_records": num_rejected_employee_records,
         "active_campaigns": active_campaigns,
         "campaign_in_progress": campaign_in_progress,

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -32,4 +32,6 @@ urlpatterns = [
     path("dgefp/iae", views.stats_dgefp_iae, name="stats_dgefp_iae"),
     path("dgefp/diagnosis_control", views.stats_dgefp_diagnosis_control, name="stats_dgefp_diagnosis_control"),
     path("dgefp/af", views.stats_dgefp_af, name="stats_dgefp_af"),
+    # Institution stats - DIHAL - nation level.
+    path("dihal/state", views.stats_dihal_state, name="stats_dihal_state"),
 ]

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -424,3 +424,14 @@ def stats_dgefp_af(request):
         "page_title": "Annexes financières actives",
     }
     return render_stats(request=request, context=context)
+
+
+@login_required
+def stats_dihal_state(request):
+    current_org = get_current_institution_or_404(request)
+    if not request.user.can_view_stats_dihal(current_org=current_org):
+        raise PermissionDenied
+    context = {
+        "page_title": "Suivi des prescriptions",
+    }
+    return render_stats(request=request, context=context, params={})


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/TB-DIHAL-d-ployer-le-TB-81ff15c839a141ef9cf4b30243c2454f**

### Pourquoi ?

Il s'agit dune demande de la DIHAL.

### Comment (optionnel)
Comme le reste. La gestion des permissions d'accès aux Stats me semble chargée, mais je ne vois pas de moyen simple, rapide et explicite de faire mieux, il y a pour l'instant un peu trop d'exceptions partout. Ce n'est pas très joli mais à part ça on n'a pas beaucoup de problèmes qui en découlent.

Deux choses cependant:
- il y a zéro tests sur les accès, il faudrait essayer d'en ajouter (comme ici) à chaque modification.
- a minima les `can_view_stats` sur User et l'injection de chaque droit dans le contexte devrait être plus "automatique": un systeme par tags (`custom_permissions = [("read", "stats", {"cd89", "cd56", "dgefp"}), ...]`) permettrait cela mais rendrait plus complexe son exploitation (template tags custom, etc)

Recette: se connecter avec le compte test+dreets@inclusion.beta.gouv.fr et choisir l'institution "DIHAL".