### PR TITLE
dependabot: augementation de la limite de PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,5 @@ updates:
     # Only allow updates to the lockfile for pip and
     # ignore any version updates that affect the manifest
     versioning-strategy: lockfile-only
+    # Allow up to 10 concurrent open PRs
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### Pourquoi ?

On a plus de 45 dépendances (en comptant celle de dev) qui ne sont pas à jour.
La limite par défaut est de 5 PRs par semaine ce qui laisse peu d'espoir d'avoir un jour une stack totalement à jour.

