### PR TITLE
Exclure les agréments PE des évaluations a posteriori

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -186,6 +186,7 @@ class EvaluationCampaign(models.Model):
                 eligibility_diagnosis__author_siae=F("to_siae"),
                 hiring_start_at__gte=self.evaluated_period_start_at,
                 hiring_start_at__lte=self.evaluated_period_end_at,
+                approval__number__startswith=settings.ASP_ITOU_PREFIX,
             )
         )
 

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -213,6 +213,13 @@ class TestEvaluationCampaignManagerEligibleJobApplication:
         diag.save()
         assert [] == list(evaluation_campaign.eligible_job_applications())
 
+    def test_approval_does_not_start_with_itou_prefix(self, campaign_eligible_job_app_objects):
+        evaluation_campaign = EvaluationCampaignFactory()
+        approval = campaign_eligible_job_app_objects["approval"]
+        approval.number = "0123456789"
+        approval.save()
+        assert [] == list(evaluation_campaign.eligible_job_applications())
+
 
 class EvaluationCampaignManagerTest(TestCase):
     def test_first_active_campaign(self):


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/Contr-le-posteriori-Limiter-la-selections-des-SIAE-aux-pass-99999XXXXXXXX-d06aad2f980b41b8aae2d4273e4455c9**

### Pourquoi ?
La plupart des tests n’auraient pas remarqué les erreurs, car la candidature n’était pas éligible.

### Comment ?
Utiliser une candidature éligible et vérifier que chaque changement la disqualifie.