### PR TITLE
Retrait du commentaire non clair “Point of no return“

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -575,7 +575,7 @@ class CreateJobSeekerStepEndForSenderView(CreateJobSeekerForSenderBaseView):
                 user.save()
 
             self.apply_session.set("job_seeker_pk", profile.user.pk)
-            self.job_seeker_session.delete()  # Point of no return
+            self.job_seeker_session.delete()
             url = reverse("apply:application_jobs", kwargs={"siae_pk": self.siae.pk})
         return HttpResponseRedirect(url)
 
@@ -1181,7 +1181,7 @@ class UpdateJobSeekerStepEndView(UpdateJobSeekerBaseView):
             )
         else:
             self.profile.save()
-            self.job_seeker_session.delete()  # Point of no return
+            self.job_seeker_session.delete()
             url = reverse("apply:application_jobs", kwargs={"siae_pk": self.siae.pk})
         return HttpResponseRedirect(url)
 


### PR DESCRIPTION
La suppression du `SessionNamespace` ne fait que modifier la session, et la modification n’est enregistrée que si la vue se termine bien. Autrement, Django ne modifie pas la session et les données sont préservées.