### PR TITLE
Renommer Scan.clamav_infected → infected

### DIFF
--- a/itou/antivirus/admin.py
+++ b/itou/antivirus/admin.py
@@ -23,19 +23,19 @@ class SuspiciousFilter(admin.SimpleListFilter):
 
 @admin.register(Scan)
 class ScanAdmin(admin.ModelAdmin):
-    list_display = ["file_id", "suspicious", "clamav_infected", "clamav_signature", "clamav_completed_at"]
+    list_display = ["file_id", "suspicious", "infected", "clamav_signature", "clamav_completed_at"]
     readonly_fields = ["clamav_completed_at", "clamav_signature"]
-    fields = ["clamav_completed_at", "clamav_signature", "clamav_infected", "comment"]
-    list_filter = [SuspiciousFilter, "clamav_infected", "clamav_completed_at"]
+    fields = ["clamav_completed_at", "clamav_signature", "infected", "comment"]
+    list_filter = [SuspiciousFilter, "infected", "clamav_completed_at"]
     search_fields = ["file__key", "clamav_signature"]
 
     @admin.display(boolean=True, description="à vérifier", ordering="suspicious")
     def suspicious(self, obj):
-        return bool(obj.clamav_infected is None and obj.clamav_signature)
+        return bool(obj.infected is None and obj.clamav_signature)
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        is_suspicious = Case(When(Q(clamav_infected=None) & ~Q(clamav_signature=""), then=True))
+        is_suspicious = Case(When(Q(infected=None) & ~Q(clamav_signature=""), then=True))
         return qs.annotate(suspicious=is_suspicious).order_by(F("suspicious").desc(nulls_last=True), "file_id")
 
     def has_add_permission(self, request):

--- a/itou/antivirus/management/commands/scan_s3_files.py
+++ b/itou/antivirus/management/commands/scan_s3_files.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
                             file=file,
                             clamav_completed_at=now,
                             # On conflict, the virus field is not updated. Assume legitimate files.
-                            clamav_infected=file.key in viruses_keys,
+                            infected=file.key in viruses_keys,
                         )
                         for file in files
                     ],

--- a/itou/antivirus/migrations/0002_scan_delete_filescanreport.py
+++ b/itou/antivirus/migrations/0002_scan_delete_filescanreport.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
                 ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
                 ("clamav_signature", models.TextField()),
                 ("clamav_completed_at", models.DateTimeField(null=True, verbose_name="analyse ClamAV le")),
-                ("clamav_infected", models.BooleanField(null=True, verbose_name="fichier infecté selon ClamAV")),
+                ("clamav_infected", models.BooleanField(null=True, verbose_name="fichier infecté")),
                 ("comment", models.TextField(blank=True, verbose_name="commentaire")),
                 ("file", models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to="files.file")),
             ],

--- a/itou/antivirus/migrations/0003_rename_clamav_infected_scan_infected.py
+++ b/itou/antivirus/migrations/0003_rename_clamav_infected_scan_infected.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("antivirus", "0002_scan_delete_filescanreport"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="scan",
+            old_name="clamav_infected",
+            new_name="infected",
+        ),
+    ]

--- a/itou/antivirus/models.py
+++ b/itou/antivirus/models.py
@@ -8,7 +8,7 @@ class Scan(models.Model):
     file = models.OneToOneField(File, on_delete=models.CASCADE)
     clamav_signature = models.TextField()
     clamav_completed_at = models.DateTimeField(null=True, verbose_name="analyse ClamAV le")
-    clamav_infected = models.BooleanField(null=True, verbose_name="fichier infecté selon ClamAV")
+    infected = models.BooleanField(null=True, verbose_name="fichier infecté")
     comment = models.TextField(blank=True, verbose_name="commentaire")
 
     class Meta:
@@ -17,6 +17,6 @@ class Scan(models.Model):
 
     def __str__(self):
         text = f"{capfirst(self._meta.verbose_name)} {self.file_id}"
-        if self.clamav_infected:
+        if self.infected:
             text = f"[VIRUS] {text}"
         return text


### PR DESCRIPTION
### Pourquoi ?

Le champ stocke l’information de si le fichier est vraiment infecté selon un humain. Lorsque ClamAV détecte une signature de virus, elle est stockée dans le champ `clamav_signature`.