### PR TITLE
boost: Afficher "non renseigné" en cas de non-présence d'une information de candidature

### DIFF
--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -6,43 +6,56 @@
     <li>
         Nom : <b>{{ job_application.job_seeker.last_name }}</b>
     </li>
-    {% if job_application.job_seeker.nir %}
-        <li>
-            Numéro de sécurité sociale : <b>{{ job_application.job_seeker.nir|format_nir }}</b>
-        </li>
-    {% endif %}
+    <li>
+        Numéro de sécurité sociale : 
+        {% if job_application.job_seeker.nir %}
+            <b>{{ job_application.job_seeker.nir|format_nir }}</b>
+        {% else %}
+            <span>Non renseigné</span>
+        {% endif %}
+    </li>
     <li>
         Date de naissance : <b>{{ job_application.job_seeker.birthdate|date:"d/m/Y" }}</b>
     </li>
     <li>
-        E-mail :
-        <a href="mailto:{{ job_application.job_seeker.email }}">{{ job_application.job_seeker.email }}</a>
+        E-mail : <a href="mailto:{{ job_application.job_seeker.email }}">{{ job_application.job_seeker.email }}</a>
     </li>
 
-    {% if job_application.job_seeker.phone %}
-        <li>
-            Téléphone :
+    <li>
+        Téléphone : 
+        {% if job_application.job_seeker.phone %}
             <a href="tel:{{ job_application.job_seeker.phone }}">{{ job_application.job_seeker.phone|format_phone }}</a>
-        </li>
-    {% endif %}
+        {% else %}
+            <span>Non renseigné</span>
+        {% endif %}
+    </li>
 
-    {% if job_application.job_seeker.address_on_one_line %}
-        <li>
-            Adresse : <b>{{ job_application.job_seeker.address_on_one_line }}</b>
-        </li>
-    {% endif %}
+    <li>
+        Adresse : 
+        {% if job_application.job_seeker.address_on_one_line %}
+            <b>{{ job_application.job_seeker.address_on_one_line }}</b>
+        {% else %}
+            <span>Non renseignée</span>
+        {% endif %}
+    </li>
 
-    {% if job_application.job_seeker.pole_emploi_id %}
-        <li>
-            Identifiant Pôle emploi : <b>{{ job_application.job_seeker.pole_emploi_id }}</b>
-        </li>
-    {% endif %}
+    <li>
+        Identifiant Pôle emploi : 
+        {% if job_application.job_seeker.pole_emploi_id %}
+            <b>{{ job_application.job_seeker.pole_emploi_id }}</b>
+        {% else %}
+            <span>Non renseigné</span>
+        {% endif %}
+    </li>
 
-    {% if job_application.get_resume_link %}
-        <li>
+    <li>
+        CV : 
+        {% if job_application.get_resume_link %}
             <a href="{{ job_application.get_resume_link }}">Télécharger le CV</a>
-        </li>
-    {% endif %}
+        {% else %}
+            <span>Non renseigné</span>
+        {% endif %}
+    </li>
 </ul>
 {% if job_application.has_editable_job_seeker %}
     <p>


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/En-tant-qu-employeur-ou-prescripteur-je-veux-voir-que-le-CV-ou-le-num-ro-de-t-l-phone-du-candidat-n--884eae0e15b94a6db0163221bd127403**

### Pourquoi ?
Actuellement si les infos sont absentes la ligne entière disparaît. Il est plus explicite d'afficher le label, puis l'info "Non rensigné".


### Captures d'écran (optionnel)
![untitled](https://user-images.githubusercontent.com/88618/210912731-72da7154-967e-4c2f-aadc-549e17d7f416.png)


