### PR TITLE
Matomo : ajout d'un retry et correction d'un crash si valeurs absentes

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -142,8 +142,9 @@ def get_matomo_dashboard(at: datetime.datetime, options: MatomoFetchOptions):
     }
     segment = options.api_options.get("segment")
     if segment:
-        segment = segment.split("==")[1]
-    print(f"\t> fetching date={at} dashboard='{options.dashboard_name}' segment={segment}")
+        key, value = segment.split("==")
+        options.api_options["segment"] = f"{key}=={urllib.parse.quote(value, safe='')}"
+    print(f"\t> fetching date={at} dashboard='{options.dashboard_name}' {key}={value}")
     column_names = None
     results = []
     for row in matomo_api_call(base_options | options.api_options):

--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -48,6 +48,12 @@ PUBLIC_DASHBOARDS = {
     "statistiques-emplois": "tb 43 - Statistiques des emplois",
     "zoom-employeurs": "tb 54 - Typologie des employeurs",
     "zoom-prescripteurs": "tb 52 - Typologie de prescripteurs",
+    # Note: keep those commented for reference. They're not used anymore but if we ever
+    # need to regenerate values for the Q1 2022 or before, they're going to be required.
+    # "recrutement": "tb 116 - Recrutement",
+    # "criteres": "tb 32 - Acceptés en auto-prescription",
+    # "prescripteurs": "tb 52 - Typologie de prescripteurs",
+    # "employeurs": "tb 54 - Typologie des employeurs",
 }
 
 PRIVATE_DEPARTMENT_DASHBOARDS = {

--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -141,7 +141,7 @@ def get_matomo_dashboard(at: datetime.datetime, options: MatomoFetchOptions):
     column_names = None
     results = []
     for row in matomo_api_call(base_options | options.api_options):
-        if all(x in ["0", "0s", "0%"] for x in row.values()):
+        if all(x in ["0", "0s", "0%", None] for x in row.values()):
             print(f"\t! empty matomo values for date={at} dashboard={options.dashboard_name}")
             return None, None
         row["Date"] = at
@@ -220,7 +220,7 @@ class Command(BaseCommand):
 
         self.stdout.write(f"> about to fetch count={len(api_call_options)} public dashboards from Matomo.")
         column_names, all_rows = multiget_matomo_dashboards(at, api_call_options)
-        if wet_run:
+        if wet_run and column_names:
             update_table_at_date(
                 METABASE_PUBLIC_DASHBOARDS_TABLE_NAME,
                 column_names,
@@ -285,7 +285,7 @@ class Command(BaseCommand):
 
         self.stdout.write(f"> about to fetch count={len(api_call_options)} private dashboards from Matomo.")
         column_names, all_rows = multiget_matomo_dashboards(at, api_call_options)
-        if wet_run:
+        if wet_run and column_names:
             update_table_at_date(
                 METABASE_PRIVATE_DASHBOARDS_TABLE_NAME,
                 column_names,

--- a/itou/metabase/management/test_populate_metabase_matomo.py
+++ b/itou/metabase/management/test_populate_metabase_matomo.py
@@ -59,16 +59,16 @@ def test_matomo_retry(monkeypatch, respx_mock, capsys):
     stdout, _ = capsys.readouterr()
     # sort the output because it's random (ThreadPoolExecutor)
     assert [line[:70] for line in sorted(stdout.splitlines())] == [
-        "\t> fetching date=2022-06-13 dashboard='tb 116 - Recrutement' segment=h",
-        "\t> fetching date=2022-06-13 dashboard='tb 129 - Analyse des publics' s",
+        "\t> fetching date=2022-06-13 dashboard='tb 116 - Recrutement' pageUrl=h",
+        "\t> fetching date=2022-06-13 dashboard='tb 129 - Analyse des publics' p",
         "\t> fetching date=2022-06-13 dashboard='tb 136 - Prescripteurs habilité",
-        "\t> fetching date=2022-06-13 dashboard='tb 140 - ETP conventionnés' seg",
+        "\t> fetching date=2022-06-13 dashboard='tb 140 - ETP conventionnés' pag",
         "\t> fetching date=2022-06-13 dashboard='tb 150 - Fiches de poste en ten",
         "\t> fetching date=2022-06-13 dashboard='tb 32 - Acceptés en auto-prescr",
         "\t> fetching date=2022-06-13 dashboard='tb 43 - Statistiques des emploi",
         "\t> fetching date=2022-06-13 dashboard='tb 52 - Typologie de prescripte",
         "\t> fetching date=2022-06-13 dashboard='tb 54 - Typologie des employeur",
-        "\t> fetching date=2022-06-13 dashboard='tb 90 - Analyse des métiers' se",
+        "\t> fetching date=2022-06-13 dashboard='tb 90 - Analyse des métiers' pa",
         "> about to fetch count=10 public dashboards from Matomo.",
     ] + ["For more information check: https://httpstatuses.com/500"] * 30 + [
         "attempt=1 failed with outcome=Server error '500 Internal Server Error'"
@@ -356,25 +356,25 @@ def test_matomo_empty_output(monkeypatch, respx_mock, capsys):
         "\t! empty matomo values for date=2022-06-13 dashboard=tb 54 - Typologie des employeurs",
         "\t! empty matomo values for date=2022-06-13 dashboard=tb 90 - Analyse des métiers",
         "\t> fetching date=2022-06-13 dashboard='tb 116 - Recrutement' "
-        "segment=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etat-suivi-candidatures/",
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etat-suivi-candidatures/",
         "\t> fetching date=2022-06-13 dashboard='tb 129 - Analyse des publics' "
-        "segment=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyse-des-publics/",
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyse-des-publics/",
         "\t> fetching date=2022-06-13 dashboard='tb 136 - Prescripteurs habilités' "
-        "segment=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/prescripteurs-habilites/",
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/prescripteurs-habilites/",
         "\t> fetching date=2022-06-13 dashboard='tb 140 - ETP conventionnés' "
-        "segment=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etp-conventionnes/",
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etp-conventionnes/",
         "\t> fetching date=2022-06-13 dashboard='tb 150 - Fiches de poste en tension' "
-        "segment=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/postes-en-tension/",
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/postes-en-tension/",
         "\t> fetching date=2022-06-13 dashboard='tb 32 - Acceptés en "
         "auto-prescription' "
-        "segment=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/auto-prescription/",
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/auto-prescription/",
         "\t> fetching date=2022-06-13 dashboard='tb 43 - Statistiques des emplois' "
-        "segment=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/statistiques-emplois/",
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/statistiques-emplois/",
         "\t> fetching date=2022-06-13 dashboard='tb 52 - Typologie de prescripteurs' "
-        "segment=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-prescripteurs/",
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-prescripteurs/",
         "\t> fetching date=2022-06-13 dashboard='tb 54 - Typologie des employeurs' "
-        "segment=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-employeurs/",
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-employeurs/",
         "\t> fetching date=2022-06-13 dashboard='tb 90 - Analyse des métiers' "
-        "segment=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/metiers/",
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/metiers/",
         "> about to fetch count=10 public dashboards from Matomo.",
     ]


### PR DESCRIPTION
### Pourquoi ?

Sentry nous indique deux soucis:
- [ici](https://sentry.io/organizations/itou/issues/3838668440/?project=6247245&query=is%3Aunresolved&referrer=issue-stream)  un crash car on essaie d'écrire une table alors qu'aucune donnée n'a été récupérée
- [ici](https://sentry.io/organizations/itou/issues/3862664998/?project=6247245&query=is%3Aunresolved&referrer=issue-stream) et [là](https://sentry.io/organizations/itou/issues/3848282584/?project=6247245&query=is%3Aunresolved&referrer=issue-stream) parce que il n'a pas réussi à contacter correctement Matomo, faisant crasher l'intégralité du script.

### Comment (optionnel)
On ajoute un retry d'un coté, on corrige le mini bug de l'autre, on teste les deux cas.

