### PR TITLE
Implementation d’une surveillance des tâches planifiées

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -347,17 +347,17 @@ API_EMAIL_CONTACT = os.getenv("API_EMAIL_CONTACT", "api@inclusion.beta.gouv.fr")
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@inclusion.beta.gouv.fr")
 
 
-_sentry_dsn = os.getenv("SENTRY_DSN")
+SENTRY_DSN = os.getenv("SENTRY_DSN")
 try:
     _sentry_traces_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", ""))
 except ValueError:
     _sentry_traces_sample_rate = 0
 
 
-if _sentry_dsn:
+if SENTRY_DSN:
     from ._sentry import sentry_init
 
-    sentry_init(dsn=_sentry_dsn, traces_sample_rate=_sentry_traces_sample_rate)
+    sentry_init(dsn=SENTRY_DSN, traces_sample_rate=_sentry_traces_sample_rate)
 
 SHOW_TEST_ACCOUNTS_BANNER = ITOU_ENVIRONMENT in ("DEMO", "REVIEW-APP")
 


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/Surveiller-les-crons-avec-UptimeRobot-58916e8ebc6b46e0aac17f146c4de22a**

### Pourquoi ?

La machine exécutant les tâches planifiées était en panne durant plusieurs jours, et l’équipe de dev a mis longtemps à le remarquer.

### Comment ?

Avec Sentry.

Cette première étape vérifie qu’au moins une tâche planifiée est exécutée. Il n’y a pas d’API Sentry pour enregistrer les crons, ce qui décourage la surveillance toutes les tâches.
Actuellement, lorsque les tâches ne tournent pas, le système continue de rendre service aux utilisateurs, simplement les synchronisations avec les autres services ne fonctionne pas, et les données affichées sont moins récentes. Revenir à l’état normal demande simplement de relancer les tâches. Ce n’est pas la peine de surveiller chaque tâche pour le moment.