### PR TITLE
Parcours de vérification des informations candidat: correction d'un bug sur la session de candidature

### DIFF
--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -2102,6 +2102,17 @@ class UpdateJobSeekerViewTestCase(TestCase):
         self.job_seeker.save(update_fields=["last_login"])
         self._check_only_administrative_allowed(self.siae.members.first())
 
+    def test_without_apply_session(self):
+        self.client.force_login(self.siae.members.first())
+        for url in [
+            self.step_1_url,
+            self.step_2_url,
+            self.step_3_url,
+            self.step_end_url,
+        ]:
+            response = self.client.get(url)
+            assert response.status_code == 403
+
 
 class UpdateJobSeekerStep3ViewTestCase(TestCase):
     def test_job_seeker_with_profile_has_check_boxes_ticked_in_step3(self):

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -918,6 +918,8 @@ class ApplicationEndView(ApplyStepBaseView):
 
 
 class UpdateJobSeekerBaseView(ApplyStepBaseView):
+    required_session_namespaces = ["apply_session"]
+
     def __init__(self):
         super().__init__()
         self.job_seeker_session = None


### PR DESCRIPTION
https://sentry.io/organizations/itou/issues/3865301686/?project=6164438

### Pourquoi ?

On ne devrait pas pouvoir arriver sur cette vue sans session mais comme les sessions expirent mais pas les onglets, tout est possible.


