### PR TITLE
Ajout d’un garde à EvaluatedJobApplication.state

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -721,6 +721,7 @@ class EvaluatedJobApplication(models.Model):
             for eval_admin_crit in self.evaluated_administrative_criteria.all()
         ):
             return evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
+        raise TypeError(f"Unknown state for “{self}”")
 
     @property
     def should_select_criteria(self):

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -452,7 +452,9 @@ class EvaluationCampaignManagerTest(TestCase):
         assert 2 == EvaluatedSiae.objects.filter(reviewed_at__isnull=True).count()
 
         # make the SIAE in another state
-        evaluated_administrative_criterion.review_state = "FOOBAR"
+        evaluated_administrative_criterion.review_state = (
+            evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
+        )
         evaluated_administrative_criterion.save(update_fields=["review_state"])
         del evaluated_siae.state
         assert evaluation_enums.EvaluatedSiaeState.SUBMITTED != evaluated_siae.state


### PR DESCRIPTION
### Pourquoi ?

Éviter de tomber dans un cas non prévu de manière silencieuse.