### PR TITLE
test: suppression d'un message de dépréciation

### DIFF
--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -324,7 +324,7 @@ class ProcessViewsTest(TestCase):
         response, _ = self.accept_job_application(
             job_application=job_application, post_data=post_data, assert_successful=False
         )
-        self.assertFormError(response, "form_accept", "hiring_start_at", JobApplication.ERROR_START_IN_PAST)
+        self.assertFormError(response.context["form_accept"], "hiring_start_at", JobApplication.ERROR_START_IN_PAST)
 
         # Wrong dates: end < start.
         hiring_start_at = today
@@ -338,7 +338,7 @@ class ProcessViewsTest(TestCase):
         response, _ = self.accept_job_application(
             job_application=job_application, post_data=post_data, assert_successful=False
         )
-        self.assertFormError(response, "form_accept", None, JobApplication.ERROR_END_IS_BEFORE_START)
+        self.assertFormError(response.context["form_accept"], None, JobApplication.ERROR_END_IS_BEFORE_START)
 
         # No address provided.
         job_application = JobApplicationSentByJobSeekerFactory(
@@ -358,9 +358,9 @@ class ProcessViewsTest(TestCase):
         response, _ = self.accept_job_application(
             job_application=job_application, post_data=post_data, assert_successful=False
         )
-        self.assertFormError(response, "form_user_address", "address_line_1", "Ce champ est obligatoire.")
-        self.assertFormError(response, "form_user_address", "city", "Ce champ est obligatoire.")
-        self.assertFormError(response, "form_user_address", "post_code", "Ce champ est obligatoire.")
+        self.assertFormError(response.context["form_user_address"], "address_line_1", "Ce champ est obligatoire.")
+        self.assertFormError(response.context["form_user_address"], "city", "Ce champ est obligatoire.")
+        self.assertFormError(response.context["form_user_address"], "post_code", "Ce champ est obligatoire.")
 
     def test_accept_with_active_suspension(self, *args, **kwargs):
         """Test the `accept` transition with active suspension for active user"""


### PR DESCRIPTION
### Pourquoi ?

Ça prend de la place sur la console (et accessoirement ça ne marchera plus en Django 5)

