### PR TITLE
Transitionne toutes SIAE en phase contradictoire

### DIFF
--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
@@ -11,29 +11,48 @@
     </div>
     <div class="col-md-4 text-right">
         <p class="small mb-0">
-            {% if state == "SUBMITTED" and reviewed_at %}
-                <p class="badge badge-pill badge-pilotage float-right">Nouveaux justificatifs à traiter</p>
-            {% elif state == "SUBMITTED" %}
-                <p class="badge badge-pill badge-pilotage float-right">À traiter</p>
-            {% elif state == "REFUSED_2" or evaluated_siae.evaluation_is_final and state == "REFUSED" %}
-                {# Final refusal #}
-                <p class="badge badge-pill badge-danger float-right">Problème constaté</p>
-            {% elif not evaluated_siae.reviewed_at and state == "REFUSED" %}
-                {% comment %}
-                    Show “Problème constaté” until the review is submitted, which starts the “phase contradictoire”
-                    (tracked by the reviewed_at field).
-                     After review, refused job applications fall through to “Phase contradictoire - En attente”.
-                {% endcomment %}
-                <p class="badge badge-pill badge-danger float-right">Problème constaté</p>
-            {% elif state == "ACCEPTED" %}
-                <p class="badge badge-pill badge-success float-right">Validé</p>
-            {% elif state == "UPLOADED" %}
-                <p class="badge badge-pill badge-pilotage float-right">Justificatifs téléversés</p>
+            {% if evaluated_siae.evaluation_is_final %}
+                {% if state == "PENDING" %}
+                    <p class="badge badge-pill badge-danger float-right">Non téléversés</p>
+                {% elif state == "PROCESSING" %}
+                    <p class="badge badge-pill badge-warning float-right">Téléversement incomplet</p>
+                {% elif state == "UPLOADED" %}
+                    <p class="badge badge-pill badge-warning float-right">Justificatifs téléversés</p>
+                {% elif state == "SUBMITTED" %}
+                    <p class="badge badge-pill badge-info-light text-primary float-right">Justificatifs non contrôlés</p>
+                {% elif state == "ACCEPTED" %}
+                    <p class="badge badge-pill badge-success float-right">Validé</p>
+                {% elif state == "REFUSED" or state == "REFUSED_2" %}
+                    <p class="badge badge-pill badge-danger float-right">Problème constaté</p>
+                {% endif %}
             {% else %}
-                <p class="badge badge-pill badge-emploi float-right">
-                    {% if evaluated_siae.reviewed_at %}Phase contradictoire -{% endif %}
-                    En attente
-                </p>
+                {% if state == "PENDING" or state == "PROCESSING" %}
+                    <p class="badge badge-pill badge-emploi float-right">En attente</p>
+                {% elif state == "UPLOADED" %}
+                    <p class="badge badge-pill badge-pilotage float-right">Justificatifs téléversés</p>
+                {% elif state == "SUBMITTED" %}
+                    <p class="badge badge-pill badge-pilotage float-right">
+                        {% if reviewed_at %}
+                            Nouveaux justificatifs à traiter
+                        {% else %}
+                            À traiter
+                        {% endif %}
+                    </p>
+                {% elif state == "ACCEPTED" %}
+                    <p class="badge badge-pill badge-success float-right">Validé</p>
+                {% elif state == "REFUSED" %}
+                    {% if reviewed_at %}
+                        <p class="badge badge-pill badge-emploi float-right">Phase contradictoire - En attente</p>
+                    {% else %}
+                        {% comment %}
+                        Show “Problème constaté” until the review is submitted, which starts the “phase contradictoire”
+                        (tracked by the reviewed_at field).
+                        {% endcomment %}
+                        <p class="badge badge-pill badge-danger float-right">Problème constaté</p>
+                    {% endif %}
+                {% elif state == "REFUSED_2" %}
+                    <p class="badge badge-pill badge-danger float-right">Problème constaté</p>
+                {% endif %}
             {% endif %}
         </p>
     </div>

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
@@ -35,6 +35,12 @@
                                 <b class="text-danger">négatif</b>.
                             </div>
                         {% endif %}
+                    {% elif accepted_by_default %}
+                        <div class="alert alert-warning">
+                            {{ evaluated_siae|capfirst }} a soumis des justificatifs, mais leur contrôle n’a pas été
+                            validé avant la fin de la phase amiable, le résultat du contrôle est
+                            <b class="text-success">positif</b>.
+                        </div>
                     {% endif %}
 
                     <h3 class="h3">

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -145,6 +145,14 @@ def institution_evaluated_siae_detail(
         "campaign_closed_before_final_evaluation": (
             evaluation_campaign.ended_at and not evaluated_siae.final_reviewed_at
         ),
+        "accepted_by_default": (
+            evaluated_siae.final_reviewed_at
+            and evaluated_siae.state == evaluation_enums.EvaluatedSiaeState.ACCEPTED
+            and any(
+                evaluated_jobapp.compute_state() != evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
+                for evaluated_jobapp in evaluated_siae.evaluated_job_applications.all()
+            )
+        ),
     }
     return render(request, template_name, context)
 


### PR DESCRIPTION
Lié à https://www.notion.so/En-tant-que-SIAE-qui-a-soumis-ses-justificatifs-en-phase-2-mais-qui-n-ont-pas-t-contr-l-s-temps--a0c3feddc60046aeb1807fe8a3fff1d5?d=744125640d614733b763ef4159de741f

### Pourquoi ?

Auparavant, le système ignorait les SIAE qui avaient envoyés des documents lors du passage en phase contradictoire, ce qui pénalisait les SIAE ayant envoyé leurs justificatifs sans qu’ils ne soient revus par la DDETS.

Maintenant, en l’absence de réponse de la DDETS, les SIAE ayant soumis leurs documents avant la fin de la phase amiable obtiennent un contrôle positif lors du passage en phase contradictoire. Le principe général de l’administration s’applique : l’absence de réponse dans les délais impartis implique consentement.

### Comment ?

Pour clarifier ce nouveau comportement du système, un message explique qu’en l’absence de revue à la fin de la phase contradictoire, le système a accepté les justificatifs de la SIAE.

Un nouveau statut “Justificatifs non contrôlés” a été ajouté pour indiquer cet état.

### Captures d’écran
![image](https://user-images.githubusercontent.com/2758243/218853947-0b2c437c-7934-475c-8610-5c5871256f53.png)
