### PR TITLE
populate_metabase_emplois: Ajout du label à l'export des analytics

### DIFF
--- a/itou/metabase/management/test_populate_metabase_emplois.py
+++ b/itou/metabase/management/test_populate_metabase_emplois.py
@@ -23,9 +23,9 @@ from itou.users.factories import JobSeekerFactory, PrescriberFactory, SiaeStaffF
 @pytest.mark.usefixtures("metabase")
 def test_populate_metabase_analytics():
     date_maj = datetime.date.today() + datetime.timedelta(days=-1)
-    data0 = DatumFactory(code="FOO-BAR", bucket="2021-12-31")
-    data1 = DatumFactory(code="FOO-MAN", bucket="2020-10-17")
-    data2 = DatumFactory(code="FOO-DUR", bucket="2022-08-16")
+    data0 = DatumFactory(code="ER-101", bucket="2021-12-31")
+    data1 = DatumFactory(code="ER-102", bucket="2020-10-17")
+    data2 = DatumFactory(code="ER-102-3436", bucket="2022-08-16")
     management.call_command("populate_metabase_emplois", mode="analytics")
     with connection.cursor() as cursor:
         cursor.execute("SELECT * FROM c1_analytics_v0 ORDER BY date")
@@ -33,23 +33,26 @@ def test_populate_metabase_analytics():
         assert rows == [
             (
                 str(data1.pk),
-                "FOO-MAN",
+                "ER-102",
                 datetime.date(2020, 10, 17),
                 data1.value,
+                "FS avec une erreur au premier retour",
                 date_maj,
             ),
             (
                 str(data0.pk),
-                "FOO-BAR",
+                "ER-101",
                 datetime.date(2021, 12, 31),
                 data0.value,
+                "FS intégrées (0000) au premier retour",
                 date_maj,
             ),
             (
                 str(data2.pk),
-                "FOO-DUR",
+                "ER-102-3436",
                 datetime.date(2022, 8, 16),
                 data2.value,
+                "FS avec une erreur 3436 au premier retour",
                 date_maj,
             ),
         ]

--- a/itou/metabase/tables/analytics.py
+++ b/itou/metabase/tables/analytics.py
@@ -1,4 +1,8 @@
+from itou.analytics.models import DatumCode
 from itou.metabase.tables.utils import MetabaseTable
+
+
+DATUM_CHOICES = dict(DatumCode.choices)
 
 
 AnalyticsTable = MetabaseTable(name="c1_analytics_v0")
@@ -23,5 +27,6 @@ AnalyticsTable.add_columns(
             "comment": "Valeur de la mesure",
             "fn": lambda o: o.value,
         },
+        {"name": "type_detail", "type": "varchar", "comment": "Type détaillé", "fn": lambda o: DATUM_CHOICES[o.code]},
     ]
 )


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/Ajout-d-une-colonne-Type-detailled-sur-la-table-C1-Analytics-V0-5d7257aed90e42c08db617b1ab943bfe**

### Pourquoi ?
Evite un AR dans le code aux data analysts pour savoir à quoi correspond un code de donnée.
