### PR TITLE
static: remplacement de $(document).ready par htmx.onLoad

### DIFF
--- a/itou/static/js/city_autocomplete_field.js
+++ b/itou/static/js/city_autocomplete_field.js
@@ -1,10 +1,9 @@
-$(document).ready(() => {
-
-  let citySearchInput = $('.js-city-autocomplete-input')
-  let hiddenCityInput = $('.js-city-autocomplete-hidden')
-  let searchButton = $('.js-search-button')
-  let loading = $('.js-city-autocomplete-loading')
-  let noLoading = $('.js-city-autocomplete-no-loading')
+htmx.onLoad((target) => {
+  let citySearchInput = $('.js-city-autocomplete-input', target)
+  let hiddenCityInput = $('.js-city-autocomplete-hidden', target)
+  let searchButton = $('.js-search-button', target)
+  let loading = $('.js-city-autocomplete-loading', target)
+  let noLoading = $('.js-city-autocomplete-no-loading', target)
 
   let autoSubmitOnEnterPressed = citySearchInput.data('autosubmit-on-enter-pressed')
 

--- a/itou/static/js/commune_autocomplete_field.js
+++ b/itou/static/js/commune_autocomplete_field.js
@@ -1,11 +1,10 @@
+htmx.onLoad((target) => {
 
-$(document).ready(() => {
-
-  let communeSearchInput = $('.js-commune-autocomplete-input')
-  let hiddenCommuneInput = $('.js-commune-autocomplete-hidden')
-  let searchButton = $('.js-search-button')
-  let loading = $('.js-commune-autocomplete-loading')
-  let noLoading = $('.js-commune-autocomplete-no-loading')
+  let communeSearchInput = $('.js-commune-autocomplete-input', target)
+  let hiddenCommuneInput = $('.js-commune-autocomplete-hidden', target)
+  let searchButton = $('.js-search-button', target)
+  let loading = $('.js-commune-autocomplete-loading', target)
+  let noLoading = $('.js-commune-autocomplete-no-loading', target)
 
   let autoSubmitOnEnterPressed = communeSearchInput.data('autosubmit-on-enter-pressed')
 

--- a/itou/static/js/job_autocomplete.js
+++ b/itou/static/js/job_autocomplete.js
@@ -1,9 +1,9 @@
-$(document).ready(() => {
+htmx.onLoad((target) => {
 
-  let jobAppellationSearchInput = $('.js-job-autocomplete-input')
-  let jobAppellationCodeInput = $('.js-job-autocomplete-hidden')
-  let loading = $('.js-job-autocomplete-loading')
-  let noLoading = $('.js-job-autocomplete-no-loading')
+  let jobAppellationSearchInput = $('.js-job-autocomplete-input', target)
+  let jobAppellationCodeInput = $('.js-job-autocomplete-hidden', target)
+  let loading = $('.js-job-autocomplete-loading', target)
+  let noLoading = $('.js-job-autocomplete-no-loading', target)
   let autoSubmitOnEnterPressed = jobAppellationSearchInput.data('autosubmit-on-enter-pressed')
 
   function clearInput() {

--- a/itou/static/js/matomo.js
+++ b/itou/static/js/matomo.js
@@ -1,4 +1,4 @@
-$(document).ready(() => {
+htmx.onLoad((target) => {
 
     /********************************************************************
        Send an event to Matomo on click.
@@ -6,7 +6,7 @@ $(document).ready(() => {
        <a href="#" class="matomo-event" data-matomo-category="MyCategory"
        data-matomo-action="MyAction" data-matomo-option="MyOption" >
     ********************************************************************/
-    $(".matomo-event").on("click", function() {
+    $(".matomo-event", target).on("click", function() {
         var category = $(this).data("matomo-category");
         var action = $(this).data("matomo-action");
         var option = $(this).data("matomo-option");

--- a/itou/static/js/prevent_multiple_submit.js
+++ b/itou/static/js/prevent_multiple_submit.js
@@ -1,4 +1,4 @@
-$(document).ready(() => {
+htmx.onLoad((target) => {
 
   // Prevent multiple submit client side.
   // Never trust the client: validation must also happen server side.
@@ -8,7 +8,7 @@ $(document).ready(() => {
   // state of the button when clicking "Previous" in the browser, eventually
   // disabling moving forward afterwards !
 
-  $('form.js-prevent-multiple-submit').on('submit', function () {
+  $('form.js-prevent-multiple-submit', target).on('submit', function () {
       $(':submit', this).on('click', function () {
           return false
       })

--- a/itou/static/js/split_nir.js
+++ b/itou/static/js/split_nir.js
@@ -2,8 +2,8 @@
 
 "use strict";
 
-$(document).ready(() => {
-  let form = $(".js-format-nir");
+htmx.onLoad((target) => {
+  let form = $(".js-format-nir", target);
   let input = form.find("input[name='nir']").first();
 
   function formatNir(nir) {

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -1,9 +1,9 @@
-$(document).ready(() => {
-    $(".js-prevent-default").on("click", (event) => {
+htmx.onLoad((target) => {
+    $(".js-prevent-default", target).on("click", (event) => {
         event.preventDefault();
     });
 
-    $(".js-display-if-javascript-enabled").css("display", "block");
+    $(".js-display-if-javascript-enabled", target).css("display", "block");
 
     /**
      * JS to disable the submit button of the form when it's not valid
@@ -17,7 +17,7 @@ $(document).ready(() => {
         }
     }
 
-    $(".js-enable-submit-when-valid").each(function () {
+    $(".js-enable-submit-when-valid", target).each(function () {
         let form = $(this)
         // Check the validity when something (possibly) change in the form.
         form.on("change reset duetChange", (e) => {
@@ -42,7 +42,7 @@ $(document).ready(() => {
     swap_elements.addClass('d-none').removeClass('d-block')
     swap_element_with.addClass('d-block').removeClass('d-none')
   }
-  $(".js-swap-elements").each(function () {
+  $(".js-swap-elements", target).each(function () {
     $(this).find("[data-swap-element]").each(function () {
       $(this).click(swapElements)
     })
@@ -51,9 +51,9 @@ $(document).ready(() => {
   /**
    * JS to manage shroud
    */
-  $("[data-shroud-input]").prop("disabled", true)
-  $(".js-shroud").find("[data-shroud-input]").prop("disabled", false)
-  $("[data-shroud-clear]").each(function () {
+  $("[data-shroud-input]", target).prop("disabled", true)
+  $(".js-shroud", target).find("[data-shroud-input]").prop("disabled", false)
+  $("[data-shroud-clear]", target).each(function () {
     $(this).click(function() {
       $(".js-shroud").removeClass("js-shroud")
       $("[data-shroud-input]").prop("disabled", true)


### PR DESCRIPTION
### Pourquoi ?

Pour gérer le cas de nouveaux éléments DOM créé par htmx (un form swappé par exemple) afin que les champs continuent d'avoir le comportement souhaité.

### Comment (optionnel)

On souhaite utiliser le target pour s'assurer qu'on ne rajoute des callbacks que sur les nouveaux éléments dans le cas où htmx ne recharge qu'une partie de la page.

