### PR TITLE
Correction pour le message d'information des fiches salariés d'actualisation

### DIFF
--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -101,7 +101,7 @@
 
         {# Actions #}
         {% if form.status.value == "NEW" %}
-            {% if item.has_outdated_date %}
+            {% if item.has_suspension or item.has_prolongation %}
                 <div class="alert alert-warning mt-4" role="status">
                     <div class="row">
                         <div class="col-auto pr-0">


### PR DESCRIPTION
**Carte Notion :** Ticket support

### Pourquoi ?

Le gabarit `list_item.html` n'a pas été ajusté suite à 0635f3e31.

### Captures d'écran (optionnel)

Actuellement :
![image](https://user-images.githubusercontent.com/20045330/212941361-5c584b2f-fffd-4a74-ad6e-4f1dc570a725.png)
Attendu :
![image](https://user-images.githubusercontent.com/20045330/212941081-c076e554-ef5f-4168-8cac-f434dc46d9bd.png)
