### PR TITLE
Retourner la liste de villes crées avec create_test_cities

### DIFF
--- a/itou/cities/factories.py
+++ b/itou/cities/factories.py
@@ -21,7 +21,7 @@ def create_test_cities(selected_departments, num_per_department=None):
             line["coords"] = GEOSGeometry(f"{line['coords']}")
             department_map[current_dpt].append(City(**line))
     cities = sum(department_map.values(), [])
-    City.objects.bulk_create(cities)
+    return City.objects.bulk_create(cities)
 
 
 def create_city_saint_andre():

--- a/itou/common_apps/address/tests/tests.py
+++ b/itou/common_apps/address/tests/tests.py
@@ -5,7 +5,6 @@ from django import forms
 from django.contrib.gis.geos import Point
 
 from itou.cities.factories import create_test_cities
-from itou.cities.models import City
 from itou.common_apps.address.departments import department_from_postcode
 from itou.common_apps.address.forms import MandatoryAddressFormMixin, OptionalAddressFormMixin
 from itou.common_apps.address.models import lat_lon_to_coords
@@ -143,8 +142,7 @@ class UtilsOptionalAddressFormMixinTest(TestCase):
         The city name should be fetched from the slug.
         """
 
-        create_test_cities(["67"], num_per_department=1)
-        city = City.objects.first()
+        [city] = create_test_cities(["67"], num_per_department=1)
 
         form_data = {
             "city_slug": city.slug,
@@ -172,9 +170,7 @@ class UtilsOptionalAddressFormMixinTest(TestCase):
         If an instance is passed, `city` and `city_slug` should be prepopulated.
         """
 
-        create_test_cities(["57"], num_per_department=1)
-
-        city = City.objects.first()
+        [city] = create_test_cities(["57"], num_per_department=1)
 
         user = JobSeekerFactory()
         user.address_line_1 = "11 rue des pixels cassés"

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -9,7 +9,6 @@ from django.utils.http import urlencode
 from itou.approvals.factories import PoleEmploiApprovalFactory, SuspensionFactory
 from itou.approvals.models import Approval, Suspension
 from itou.cities.factories import create_test_cities
-from itou.cities.models import City
 from itou.eligibility.enums import AuthorKind
 from itou.eligibility.factories import EligibilityDiagnosisFactory
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
@@ -271,8 +270,8 @@ class ProcessViewsTest(TestCase):
         assert job_application.state.is_postponed
 
     def test_accept(self, *args, **kwargs):
-        create_test_cities(["54", "57"], num_per_department=2)
-        city = City.objects.first()
+        cities = create_test_cities(["54", "57"], num_per_department=2)
+        city = cities[0]
         today = timezone.localdate()
 
         job_seeker = JobSeekerWithAddressFactory(city=city.name)
@@ -389,8 +388,8 @@ class ProcessViewsTest(TestCase):
 
     def test_accept_with_active_suspension(self, *args, **kwargs):
         """Test the `accept` transition with active suspension for active user"""
-        create_test_cities(["54", "57"], num_per_department=2)
-        city = City.objects.first()
+        cities = create_test_cities(["54", "57"], num_per_department=2)
+        city = cities[0]
         today = timezone.localdate()
         # the old job of job seeker
         job_seeker_user = JobSeekerWithAddressFactory()
@@ -456,8 +455,7 @@ class ProcessViewsTest(TestCase):
         """
         Test the "manual approval delivery mode" path of the view.
         """
-        create_test_cities(["57"], num_per_department=1)
-        city = City.objects.first()
+        [city] = create_test_cities(["57"], num_per_department=1)
 
         job_application = JobApplicationSentByJobSeekerFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING,
@@ -492,8 +490,8 @@ class ProcessViewsTest(TestCase):
         assert job_application.approval_delivery_mode == job_application.APPROVAL_DELIVERY_MODE_MANUAL
 
     def test_accept_and_update_hiring_start_date_of_two_job_applications(self, *args, **kwargs):
-        create_test_cities(["54", "57"], num_per_department=2)
-        city = City.objects.first()
+        cities = create_test_cities(["54", "57"], num_per_department=2)
+        city = cities[0]
         job_seeker = JobSeekerWithAddressFactory()
         base_for_post_data = {
             "address_line_1": job_seeker.address_line_1,
@@ -588,9 +586,8 @@ class ProcessViewsTest(TestCase):
         assert job_app_starting_later.approval.start_at == job_app_starting_earlier.hiring_start_at
 
     def test_accept_with_double_user(self, *args, **kwargs):
-
-        create_test_cities(["54"], num_per_department=1)
-        city = City.objects.first()
+        cities = create_test_cities(["54"], num_per_department=1)
+        city = cities[0]
 
         siae = SiaeFactory(with_membership=True)
         job_seeker = JobSeekerWithAddressFactory(city=city.name)
@@ -775,8 +772,8 @@ class ProcessViewsTest(TestCase):
     def test_accept_after_cancel(self, *args, **kwargs):
         # A canceled job application is not linked to an approval
         # unless the job seeker has an accepted job application.
-        create_test_cities(["54", "57"], num_per_department=2)
-        city = City.objects.first()
+        cities = create_test_cities(["54", "57"], num_per_department=2)
+        city = cities[0]
         job_seeker = JobSeekerWithAddressFactory(city=city.name)
         job_application = JobApplicationSentByJobSeekerFactory(
             state=JobApplicationWorkflow.STATE_CANCELLED, job_seeker=job_seeker

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -12,7 +12,6 @@ from pytest_django.asserts import assertRedirects
 from itou.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
 from itou.asp.models import AllocationDuration, EducationLevel, RSAAllocation
 from itou.cities.factories import create_city_in_zrr, create_test_cities
-from itou.cities.models import City
 from itou.eligibility.factories import EligibilityDiagnosisFactory
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.geo.factories import ZRRFactory
@@ -344,8 +343,7 @@ class ApplyAsJobSeekerTest(S3AccessingTestCase):
 
 class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
     def setUp(self):
-        create_test_cities(["67"], num_per_department=1)
-        self.city = City.objects.first()
+        [self.city] = create_test_cities(["67"], num_per_department=1)
 
     @property
     def default_session_data(self):
@@ -885,8 +883,8 @@ class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
 
 class ApplyAsPrescriberTest(S3AccessingTestCase):
     def setUp(self):
-        create_test_cities(["67"], num_per_department=10)
-        self.city = City.objects.first()
+        cities = create_test_cities(["67"], num_per_department=10)
+        self.city = cities[0]
 
     @property
     def default_session_data(self):
@@ -1278,8 +1276,7 @@ class ApplyAsPrescriberNirExceptionsTest(S3AccessingTestCase):
 
 class ApplyAsSiaeTest(S3AccessingTestCase):
     def setUp(self):
-        create_test_cities(["67"], num_per_department=1)
-        self.city = City.objects.first()
+        [self.city] = create_test_cities(["67"], num_per_department=1)
 
     @property
     def default_session_data(self):
@@ -1795,8 +1792,7 @@ class UpdateJobSeekerViewTestCase(TestCase):
         cls.step_end_url = reverse(
             "apply:update_job_seeker_step_end", kwargs={"siae_pk": cls.siae.pk, "job_seeker_pk": cls.job_seeker.pk}
         )
-        create_test_cities(["67"], num_per_department=1)
-        cls.city = City.objects.first()
+        [cls.city] = create_test_cities(["67"], num_per_department=1)
 
         cls.INFO_MODIFIABLE_PAR_CANDIDAT_UNIQUEMENT = "Informations modifiables par le candidat uniquement"
         cls.job_seeker_session_key = f"job_seeker-{cls.job_seeker.pk}"

--- a/itou/www/signup/tests/test_job_seeker.py
+++ b/itou/www/signup/tests/test_job_seeker.py
@@ -8,7 +8,6 @@ from django.test import override_settings
 from django.urls import reverse
 
 from itou.cities.factories import create_test_cities
-from itou.cities.models import City
 from itou.openid_connect.france_connect import constants as fc_constants
 from itou.openid_connect.france_connect.tests import FC_USERINFO, mock_oauth_dance
 from itou.users.enums import UserKind
@@ -22,7 +21,7 @@ from itou.www.signup.forms import JobSeekerSituationForm
 
 class JobSeekerSignupTest(TestCase):
     def setUp(self):
-        create_test_cities(["67"], num_per_department=1)
+        [self.city] = create_test_cities(["67"], num_per_department=1)
 
     def test_job_seeker_signup_situation(self):
         """
@@ -94,8 +93,7 @@ class JobSeekerSignupTest(TestCase):
 
         address_line_1 = "Test adresse"
         address_line_2 = "Test adresse complémentaire"
-        city = City.objects.first()
-        post_code = city.post_codes[0]
+        post_code = self.city.post_codes[0]
 
         post_data = {
             "first_name": "John",
@@ -106,8 +104,8 @@ class JobSeekerSignupTest(TestCase):
             "address_line_1": address_line_1,
             "address_line_2": address_line_2,
             "post_code": post_code,
-            "city_name": city.name,
-            "city": city.slug,
+            "city_name": self.city.name,
+            "city": self.city.slug,
         }
 
         response = self.client.post(url, data=post_data)
@@ -145,8 +143,7 @@ class JobSeekerSignupTest(TestCase):
 
         address_line_1 = "Test adresse"
         address_line_2 = "Test adresse complémentaire"
-        city = City.objects.first()
-        post_code = city.post_codes[0]
+        post_code = self.city.post_codes[0]
 
         post_data = {
             "first_name": "John",
@@ -157,8 +154,8 @@ class JobSeekerSignupTest(TestCase):
             "address_line_1": address_line_1,
             "address_line_2": address_line_2,
             "post_code": post_code,
-            "city_name": city.name,
-            "city": city.slug,
+            "city_name": self.city.name,
+            "city": self.city.slug,
         }
 
         response = self.client.post(url, data=post_data)
@@ -182,8 +179,7 @@ class JobSeekerSignupTest(TestCase):
 
         address_line_1 = "Test adresse"
         address_line_2 = "Test adresse complémentaire"
-        city = City.objects.first()
-        post_code = city.post_codes[0]
+        post_code = self.city.post_codes[0]
 
         post_data = {
             "first_name": "John",
@@ -194,8 +190,8 @@ class JobSeekerSignupTest(TestCase):
             "address_line_1": address_line_1,
             "address_line_2": address_line_2,
             "post_code": post_code,
-            "city_name": city.name,
-            "city": city.slug,
+            "city_name": self.city.name,
+            "city": self.city.slug,
         }
 
         response = self.client.post(url, data=post_data)


### PR DESCRIPTION
### Pourquoi ?

Évite une requête SQL, façonner les outils à notre usage.