### PR TITLE
Cacher les informations personnelles aux orienteurs

### DIFF
--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -1,10 +1,11 @@
 {% load format_filters %}
+{% load str_filters %}
 <ul>
     <li>
-        Prénom : <b>{{ job_application.job_seeker.first_name }}</b>
+        Prénom : <b>{{ job_application.job_seeker.first_name|mask_unless:can_view_personal_information }}</b>
     </li>
     <li>
-        Nom : <b>{{ job_application.job_seeker.last_name }}</b>
+        Nom : <b>{{ job_application.job_seeker.last_name|mask_unless:can_view_personal_information }}</b>
     </li>
     <li>
         Numéro de sécurité sociale : 
@@ -14,48 +15,50 @@
             <span>Non renseigné</span>
         {% endif %}
     </li>
-    <li>
-        Date de naissance : <b>{{ job_application.job_seeker.birthdate|date:"d/m/Y" }}</b>
-    </li>
-    <li>
-        E-mail : <a href="mailto:{{ job_application.job_seeker.email }}">{{ job_application.job_seeker.email }}</a>
-    </li>
+    {% if can_view_personal_information %}
+        <li>
+            Date de naissance : <b>{{ job_application.job_seeker.birthdate|date:"d/m/Y" }}</b>
+        </li>
+        <li>
+            E-mail : <a href="mailto:{{ job_application.job_seeker.email }}">{{ job_application.job_seeker.email }}</a>
+        </li>
 
-    <li>
-        Téléphone : 
-        {% if job_application.job_seeker.phone %}
-            <a href="tel:{{ job_application.job_seeker.phone }}">{{ job_application.job_seeker.phone|format_phone }}</a>
-        {% else %}
-            <span>Non renseigné</span>
-        {% endif %}
-    </li>
+        <li>
+            Téléphone : 
+            {% if job_application.job_seeker.phone %}
+                <a href="tel:{{ job_application.job_seeker.phone }}">{{ job_application.job_seeker.phone|format_phone }}</a>
+            {% else %}
+                <span>Non renseigné</span>
+            {% endif %}
+        </li>
 
-    <li>
-        Adresse : 
-        {% if job_application.job_seeker.address_on_one_line %}
-            <b>{{ job_application.job_seeker.address_on_one_line }}</b>
-        {% else %}
-            <span>Non renseignée</span>
-        {% endif %}
-    </li>
+        <li>
+            Adresse : 
+            {% if job_application.job_seeker.address_on_one_line %}
+                <b>{{ job_application.job_seeker.address_on_one_line }}</b>
+            {% else %}
+                <span>Non renseignée</span>
+            {% endif %}
+        </li>
 
-    <li>
-        Identifiant Pôle emploi : 
-        {% if job_application.job_seeker.pole_emploi_id %}
-            <b>{{ job_application.job_seeker.pole_emploi_id }}</b>
-        {% else %}
-            <span>Non renseigné</span>
-        {% endif %}
-    </li>
+        <li>
+            Identifiant Pôle emploi : 
+            {% if job_application.job_seeker.pole_emploi_id %}
+                <b>{{ job_application.job_seeker.pole_emploi_id }}</b>
+            {% else %}
+                <span>Non renseigné</span>
+            {% endif %}
+        </li>
 
-    <li>
-        CV : 
-        {% if job_application.get_resume_link %}
-            <a href="{{ job_application.get_resume_link }}">Télécharger le CV</a>
-        {% else %}
-            <span>Non renseigné</span>
-        {% endif %}
-    </li>
+        <li>
+            CV : 
+            {% if job_application.get_resume_link %}
+                <a href="{{ job_application.get_resume_link }}">Télécharger le CV</a>
+            {% else %}
+                <span>Non renseigné</span>
+            {% endif %}
+        </li>
+    {% endif %}
 </ul>
 {% if job_application.has_editable_job_seeker %}
     <p>

--- a/itou/templates/apply/includes/list_card_header.html
+++ b/itou/templates/apply/includes/list_card_header.html
@@ -1,6 +1,8 @@
+{% load str_filters %}
+
 <div class="card-header">
     <p>
-        <b>{{ job_application.job_seeker.get_full_name }}</b>
+        <b>{{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}</b>
 
         <small>chez</small>
 

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -1,9 +1,10 @@
 {% extends "layout/content_small.html" %}
+{% load str_filters %}
 
 {% block title %}
     Candidature
     -
-    {{ job_application.job_seeker.get_full_name }}
+    {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}
     {{ block.super }}
 {% endblock %}
 
@@ -11,7 +12,7 @@
 
     <h1 class="h1-hero-c1">
         Candidature de
-        <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span>
+        <span class="text-muted">{{ job_application.job_seeker.get_full_name|title|mask_unless:can_view_personal_information }}</span>
     </h1>
     <p>{% include "apply/includes/state_badge.html" with job_application=job_application %}</p>
 

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -200,9 +200,12 @@ class ProcessViewsTest(TestCase):
         self.assertContains(response, format_nir(job_application.job_seeker.nir))
         self.assertContains(response, "Prénom : <b>S…</b>", html=True)
         self.assertContains(response, "Nom : <b>U…</b>", html=True)
+        self.assertContains(response, '<span class="text-muted">S… U…</span>', html=True)
         self.assertNotContains(response, job_application.job_seeker.email)
         self.assertNotContains(response, job_application.job_seeker.phone)
         self.assertNotContains(response, job_application.job_seeker.post_code)
+        self.assertNotContains(response, "Supersecretname")
+        self.assertNotContains(response, "Unknown")
 
     def test_process(self, *args, **kwargs):
         """Ensure that the `process` transition is triggered."""

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -14,6 +14,11 @@ from itou.www.apply.forms import (
 )
 
 
+def _add_user_can_view_personal_information(job_applications, can_view):
+    for job_application in job_applications:
+        job_application.user_can_view_personal_information = can_view(job_application.job_seeker)
+
+
 @login_required
 @user_passes_test(lambda u: u.is_job_seeker, login_url="/", redirect_field_name=None)
 def list_for_job_seeker(request, template_name="apply/list_for_job_seeker.html"):
@@ -31,6 +36,9 @@ def list_for_job_seeker(request, template_name="apply/list_for_job_seeker.html")
         filters_counter = filters_form.get_qs_filters_counter(qs_filters)
 
     job_applications_page = pager(job_applications, request.GET.get("page"), items_per_page=10)
+
+    # The candidate has obviously access to its personal info
+    _add_user_can_view_personal_information(job_applications_page, lambda ja: True)
 
     context = {
         "job_applications_page": job_applications_page,
@@ -60,6 +68,7 @@ def list_for_prescriber(request, template_name="apply/list_for_prescriber.html")
         filters_counter = filters_form.get_qs_filters_counter(qs_filters)
 
     job_applications_page = pager(job_applications, request.GET.get("page"), items_per_page=10)
+    _add_user_can_view_personal_information(job_applications_page, request.user.can_view_personal_information)
 
     context = {
         "job_applications_page": job_applications_page,
@@ -128,6 +137,9 @@ def list_for_siae(request, template_name="apply/list_for_siae.html"):
         filters_counter = filters_form.get_qs_filters_counter(qs_filters)
 
     job_applications_page = pager(job_applications, request.GET.get("page"), items_per_page=10)
+
+    # SIAE members have access to personal info
+    _add_user_can_view_personal_information(job_applications_page, lambda ja: True)
 
     context = {
         "siae": siae,

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -74,6 +74,7 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
     back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("apply:list_for_siae"))
 
     context = {
+        "can_view_personal_information": True,  # SIAE members have access to personal info
         "eligibility_diagnosis": job_application.get_eligibility_diagnosis(),
         "expired_eligibility_diagnosis": expired_eligibility_diagnosis,
         "job_application": job_application,
@@ -117,6 +118,7 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
     back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("apply:list_for_prescriber"))
 
     context = {
+        "can_view_personal_information": request.user.can_view_personal_information(job_application.job_seeker),
         "eligibility_diagnosis": job_application.get_eligibility_diagnosis(),
         "job_application": job_application,
         "transition_logs": transition_logs,

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -175,6 +175,7 @@ def refuse(request, job_application_id, template_name="apply/process_refuse.html
     context = {
         "form": form,
         "job_application": job_application,
+        "can_view_personal_information": True,  # SIAE members have access to personal info
     }
     return render(request, template_name, context)
 
@@ -207,6 +208,7 @@ def postpone(request, job_application_id, template_name="apply/process_postpone.
     context = {
         "form": form,
         "job_application": job_application,
+        "can_view_personal_information": True,  # SIAE members have access to personal info
     }
     return render(request, template_name, context)
 
@@ -246,6 +248,7 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
         "form_user_address": form_user_address,
         "form_pe_status": form_pe_status,
         "job_application": job_application,
+        "can_view_personal_information": True,  # SIAE members have access to personal info
     }
 
     if request.method == "POST" and all([form.is_valid() for form in forms]):
@@ -380,6 +383,7 @@ def cancel(request, job_application_id, template_name="apply/process_cancel.html
         return HttpResponseRedirect(next_url)
 
     context = {
+        "can_view_personal_information": True,  # SIAE members have access to personal info
         "job_application": job_application,
     }
     return render(request, template_name, context)
@@ -486,6 +490,7 @@ def eligibility(request, job_application_id, template_name="apply/process_eligib
 
     context = {
         "job_application": job_application,
+        "can_view_personal_information": True,  # SIAE members have access to personal info
         "form_administrative_criteria": form_administrative_criteria,
         "form_confirm_eligibility": form_confirm_eligibility,
         "job_seeker": job_application.job_seeker,

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -63,6 +63,7 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["can_view_personal_information"] = True  # SIAE members have access to personal info
         context["approval_can_be_suspended_by_siae"] = self.object.can_be_suspended_by_siae(self.siae)
         context["hire_by_other_siae"] = not self.object.user.last_hire_was_made_by_siae(self.siae)
         context["approval_can_be_prolonged_by_siae"] = self.object.can_be_prolonged_by_siae(self.siae)


### PR DESCRIPTION
### Pourquoi ?

Actuellement un orienteur peut créer une candidature pour n'importe quel NIR et accéder ensuite à ses informations personnelles.

