### PR TITLE
Tableau de bord: ajout d'un bandeau pour les SIAE avec une convention active mais sans annexe financière

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -33,6 +33,16 @@
         </div>
     {% endif %}
 
+    {# Information pour les employeurs en cas d'absence d'annexe financière #}
+    {% if show_previous_year_financial_annex_info %}
+        <div class="alert alert-info">
+            <p class="mb-0">
+                La fin de validité des annexes financières de l'année précédente n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.
+            </p>
+            <p class="mb-0">Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
+        </div>
+    {% endif %}
+
     {# Alerte pour les prescripteurs en cas d'absence ou de mauvais score de geocoding. #}
     {# Seuls les prescripteurs habilités apparaissent dans le moteur de recherche. #}
     {% if current_prescriber_organization and current_prescriber_organization.is_authorized and not current_prescriber_organization.has_reliable_coords %}

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -340,6 +340,26 @@ class DashboardViewTest(TestCase):
         response = self.client.get(reverse("dashboard:index"))
         self.assertContains(response, "Contrôle a posteriori")
 
+    def test_dashboard_siae_convention_without_financial_annex(self):
+        siae = SiaeFactory(with_membership=True)
+        user = siae.members.first()
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertNotContains(response, "La fin de validité des annexes financières")
+
+        # Remove active annexes
+        siae.convention.financial_annexes.all().delete()
+
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertContains(response, "La fin de validité des annexes financières")
+
+        siae.kind = SiaeKind.EITI  # This kind cannot use employee records
+        siae.save()
+
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertNotContains(response, "La fin de validité des annexes financières")
+
     def test_dora_card_is_not_shown_for_job_seeker(self):
         user = JobSeekerFactory()
         self.client.force_login(user)

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -18,7 +18,7 @@ from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 from itou.siae_evaluations.constants import CAMPAIGN_VIEWABLE_DURATION
 from itou.siae_evaluations.models import EvaluatedSiae, EvaluationCampaign
-from itou.siaes.models import Siae
+from itou.siaes.models import Siae, SiaeFinancialAnnex
 from itou.utils import constants as global_constants
 from itou.utils.perms.institution import get_current_institution_or_404
 from itou.utils.perms.prescriber import get_current_org_or_404
@@ -41,6 +41,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
     active_campaigns = []
     campaign_in_progress = False
     evaluated_siae_notifications = EvaluatedSiae.objects.none()
+    show_previous_year_financial_annex_info = False
 
     # `current_org` can be a Siae, a PrescriberOrganization or an Institution.
     current_org = None
@@ -84,6 +85,20 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         num_rejected_employee_records = (
             EmployeeRecord.objects.for_siae(current_org).filter(status=Status.REJECTED).count()
         )
+        if (
+            current_org.can_use_employee_record
+            and current_org.convention
+            and current_org.convention.is_active
+            and not current_org.convention.financial_annexes.filter(
+                state__in=SiaeFinancialAnnex.STATES_ACTIVE, end_at__gt=timezone.now()
+            ).exists()
+        ):
+            # We have a SIAE that uses employee record, has an active convention
+            # but is missing its financial annex:
+            # the ASP data is certainly late, like at every beginning of the year
+            # Let's inform our user that they can still use their employee record
+            # to avoid support tickets.
+            show_previous_year_financial_annex_info = True
 
     if request.user.is_prescriber:
         try:
@@ -118,6 +133,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "evaluated_siae_notifications": evaluated_siae_notifications,
         "precriber_kind_pe": PrescriberOrganizationKind.PE,
         "precriber_kind_dept": PrescriberOrganizationKind.DEPT,
+        "show_previous_year_financial_annex_info": show_previous_year_financial_annex_info,
         "show_dora_banner": (
             any([request.user.is_siae_staff, request.user.is_prescriber])
             and current_org


### PR DESCRIPTION
### Pourquoi ?

L'absence d'annexe financière est "normale" en début d'année. L'ajout de ce bandeau devrait servir à éviter quelques tickets au support.

### Captures d'écran (optionnel)

![Screenshot 2023-01-18 at 12-10-24 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/213176536-6af9df3d-568a-4ffd-a00e-6f39ac65e597.png)


