### PR TITLE
Installer l’objet POLE EMPLOI SIAE avec post_migrate

### DIFF
--- a/itou/siaes/apps.py
+++ b/itou/siaes/apps.py
@@ -1,0 +1,26 @@
+from django.apps import AppConfig
+from django.db import models
+
+from itou.siaes import enums
+
+
+class SiaesAppConfig(AppConfig):
+    name = "itou.siaes"
+    verbose_name = "SIAE"
+
+    def ready(self):
+        super().ready()
+        models.signals.post_migrate.connect(create_pole_emploi_siae, sender=self)
+
+
+def create_pole_emploi_siae(*args, **kwargs):
+    from itou.siaes.models import Siae
+
+    Siae._base_manager.get_or_create(
+        siret=enums.POLE_EMPLOI_SIRET,
+        defaults={
+            "name": "POLE EMPLOI",
+            "kind": enums.SIAE_KIND_RESERVED,
+            "source": enums.SIAE_SOURCE_ADMIN_CREATED,
+        },
+    )

--- a/itou/siaes/migrations/0001_initial.py
+++ b/itou/siaes/migrations/0001_initial.py
@@ -12,20 +12,6 @@ from django.db import migrations, models
 import itou.utils.validators
 
 
-def create_pole_emploi_siae(apps, _schema_editor):
-    from itou.siaes import enums
-
-    Siae = apps.get_model("siaes", "Siae")
-    Siae.objects.get_or_create(
-        siret=enums.POLE_EMPLOI_SIRET,
-        defaults={
-            "name": "POLE EMPLOI",
-            "kind": enums.SIAE_KIND_RESERVED,
-            "source": enums.SIAE_SOURCE_ADMIN_CREATED,
-        },
-    )
-
-
 class Migration(migrations.Migration):
 
     initial = True
@@ -605,5 +591,4 @@ class Migration(migrations.Migration):
                 name="source_id_kind_unique_without_null_values",
             ),
         ),
-        migrations.RunPython(create_pole_emploi_siae, migrations.RunPython.noop, elidable=True),
     ]


### PR DESCRIPTION
Le `TransactionTestCase` utilise `TRUNCATE` sur les tables, et ne réinstalle
pas l’objet spécial POLE EMPLOI SIAE.