### PR TITLE
Modèle `Users` : Ajout du champs `asp_uid` afin de remplacer la propriété `jobseeker_hash_id`

### DIFF
--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -90,7 +90,7 @@
                 <div class="h5">
                     {% if form.status.value == "NEW" %}
                         <p class="mb-0">
-                            Vous trouverez ici les candidatures validées à partir desquelles vous devez créér de
+                            Vous trouverez ici les candidatures validées à partir desquelles vous devez créer de
                             nouvelles fiches salarié.
                         </p>
                     {% elif form.status.value == "READY" %}

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -186,9 +186,11 @@ class ItouUserAdmin(UserAdmin):
     search_fields = UserAdmin.search_fields + (
         "pk",
         "nir",
+        "asp_uid",
     )
     readonly_fields = (
         "pk",
+        "asp_uid",
         "jobseeker_hash_id",
         "identity_provider",
         "address_in_qpv",
@@ -200,6 +202,7 @@ class ItouUserAdmin(UserAdmin):
             {
                 "fields": (
                     "pk",
+                    "asp_uid",
                     "jobseeker_hash_id",
                     "title",
                     "birthdate",

--- a/itou/users/management/commands/fill_user_asp_uid.py
+++ b/itou/users/management/commands/fill_user_asp_uid.py
@@ -1,0 +1,21 @@
+from django.core.management.base import BaseCommand
+
+from itou.users.models import User
+
+
+BATCH_SIZE = 5000
+
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        to_update = []
+
+        for user in User.objects.filter(is_job_seeker=True, asp_uid=None).only("pk").iterator(BATCH_SIZE):
+            user.asp_uid = user.jobseeker_hash_id
+            to_update.append(user)
+
+            if len(to_update) >= BATCH_SIZE:
+                User.objects.bulk_update(to_update, ["asp_uid"], batch_size=BATCH_SIZE)
+                to_update = []
+
+        User.objects.bulk_update(to_update, ["asp_uid"], batch_size=BATCH_SIZE)

--- a/itou/users/migrations/0006_user_asp_uid.py
+++ b/itou/users/migrations/0006_user_asp_uid.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0005_alter_user_last_checked_at"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="asp_uid",
+            field=models.TextField(
+                blank=True, max_length=30, null=True, unique=True, verbose_name="ID unique envoyé à l'ASP"
+            ),
+        ),
+    ]


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/Comment-g-rer-le-doublon-ASP-quand-on-a-plus-le-doublon-chez-nous-95592f7f625142b98fa4a2264a8195e6

### Pourquoi ?

La propriété `jobseeker_hash_id` n'est actuellement utilisé que dans nos échanges avec l'ASP et en particulier dans les fiches salariés en tant que `IdItou`.

Deux problématiques on été identifiées : 
1. Lors d'échange avec l'ASP nous souhaitons pouvoir rechercher un utilisateur par cet ID, qui est le seul identifiant technique commun, ce qui est impossible avec une propriété.
2. Dans le cas d'un doublon utilisateurs :
  a. Si l'utilisateur a déjà été envoyé vers l'ASP mais que l'on a supprimé celui-ci chez nous alors il est plus simple de juste changer cette valeur dans l'utilisateur existant.
  b. Si nous avons encore les deux utilisateurs mais que celui connus de l'ASP est moins remplis que l'autre alors permuter cette valeur va éviter de longue et fastidieuse opérations manuelles, donc possiblement des erreurs, de notre coté.

### Comment

- Création d'un champs `asp_uid` puis migration de données afin de le remplir par le contenu de `jobseeker_hash_id`.
- Pour les nouveaux utilisateurs c'est un signal qui fait cette opération, ouvert à toute suggestion ou alternative sur le sujet ;). A terme le but serait d'utiliser un `uuid.uuid4()` comme valeur par défaut pour virer le signal, mais il faut confirmer que cela ne va pas poser problème du coté de l'ASP.
- Une autre PR s'occupera de remplacer les utilisations de `jobseeker_hash_id` par `asp_uid`.

