### PR TITLE
Exclure les SIAE dont le contrôle est terminé du rappel en phase contradictoire

### DIFF
--- a/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
+++ b/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
@@ -38,7 +38,8 @@ class Command(BaseCommand):
         for campaign in campaigns.filter(evaluations_asked_at__date__lte=evaluations_asked_before):
             emails = []
             evaluated_siaes = (
-                campaign.evaluated_siaes.exclude(
+                campaign.evaluated_siaes.filter(final_reviewed_at=None)
+                .exclude(
                     Exists(
                         EvaluatedAdministrativeCriteria.objects.filter(
                             evaluated_job_application__evaluated_siae=OuterRef("pk"),


### PR DESCRIPTION
### Pourquoi ?

Aujourd’hui, 255 administrateurs de SIAE qui avaient terminé leur campagne de contrôle a posteriori avec un résultat positif, ont reçu un rappel d’envoyer leurs documents justificatifs avant la fin de la campagne, sans quoi ils seraient sanctionnés. 😵