### PR TITLE
Nettoyage après l’activation de la CSP

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -107,7 +107,6 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 
 DJANGO_MIDDLEWARES = [
-    "csp.contrib.rate_limiting.RateLimitedCSPMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -118,6 +117,7 @@ DJANGO_MIDDLEWARES = [
 ]
 
 THIRD_PARTY_MIDDLEWARES = [
+    "csp.middleware.CSPMiddleware",
     "django_htmx.middleware.HtmxMiddleware",
     "hijack.middleware.HijackUserMiddleware",
 ]
@@ -634,4 +634,3 @@ if S3_STORAGE_ENDPOINT_DOMAIN:
     ]
 CSP_INCLUDE_NONCE_IN = ["script-src", "script-src-elem"]
 CSP_REPORT_URI = os.getenv("CSP_REPORT_URI", None)
-CSP_REPORT_PERCENTAGE = float(os.getenv("CSP_REPORT_PERCENTAGE", 1))


### PR DESCRIPTION
### Pourquoi ?

Utilisation de l’intergiciel officiel.

`CSP_REPORT_PERCENTAGE` n’est pas utilisé lorsque `CSP_REPORT_URI` n’est pas défini.
https://github.com/mozilla/django-csp/blob/e209183b0956bfe2cef562bece18a6a526479c80/docs/reports.rst#throttling-the-number-of-reports
Inutile depuis f78c015eea060d773fd69245509b7c4879c4df89.