### PR TITLE
Déplacer les emails du contrôle a posteriori dans un module

### DIFF
--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -1,0 +1,165 @@
+from django.conf import settings
+from django.urls import reverse
+
+from itou.utils import constants as global_constants
+from itou.utils.emails import get_email_message
+
+
+class CampaignEmailFactory:
+    def __init__(self, evaluation_campaign):
+        self.evaluation_campaign = evaluation_campaign
+        self.recipients = evaluation_campaign.institution.active_members.values_list("email", flat=True)
+
+    def ratio_to_select(self, ratio_selection_end_at):
+        context = {
+            "ratio_selection_end_at": ratio_selection_end_at,
+            "dashboard_url": f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{reverse('dashboard:index')}",
+        }
+        subject = "siae_evaluations/email/to_institution_ratio_to_select_subject.txt"
+        body = "siae_evaluations/email/to_institution_ratio_to_select_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def selected_siae(self):
+        context = {
+            "end_date": self.evaluation_campaign.adversarial_stage_start_date,
+            "evaluated_period_start_at": self.evaluation_campaign.evaluated_period_start_at,
+            "evaluated_period_end_at": self.evaluation_campaign.evaluated_period_end_at,
+        }
+        subject = "siae_evaluations/email/to_institution_selected_siae_subject.txt"
+        body = "siae_evaluations/email/to_institution_selected_siae_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def forced_to_adversarial_stage(self, evaluated_siaes):
+        context = {"evaluated_siaes": evaluated_siaes}
+        subject = "siae_evaluations/email/to_institution_siaes_forced_to_adversarial_stage_subject.txt"
+        body = "siae_evaluations/email/to_institution_siaes_forced_to_adversarial_stage_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+
+class InstitutionEmailFactory:
+    def __init__(self, evaluated_siae):
+        self.evaluated_siae = evaluated_siae
+        self.recipients = evaluated_siae.evaluation_campaign.institution.active_members.values_list("email", flat=True)
+
+    def submitted_by_siae(self):
+        context = {
+            "siae": self.evaluated_siae.siae,
+            "dashboard_url": f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{reverse('dashboard:index')}",
+        }
+        subject = "siae_evaluations/email/to_institution_submitted_by_siae_subject.txt"
+        body = "siae_evaluations/email/to_institution_submitted_by_siae_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+
+class SIAEEmailFactory:
+    def __init__(self, evaluated_siae):
+        self.evaluated_siae = evaluated_siae
+        self.recipients = evaluated_siae.siae.active_admin_members.values_list("email", flat=True)
+
+    def selected(self):
+        evaluated_siae_url = reverse(
+            "siae_evaluations_views:siae_job_applications_list",
+            kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
+        )
+        context = {
+            "campaign": self.evaluated_siae.evaluation_campaign,
+            "siae": self.evaluated_siae.siae,
+            "end_date": self.evaluated_siae.evaluation_campaign.adversarial_stage_start_date,
+            "url": (f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}" + evaluated_siae_url),
+        }
+        subject = "siae_evaluations/email/to_siae_selected_subject.txt"
+        body = "siae_evaluations/email/to_siae_selected_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def reviewed(self, adversarial=False):
+        context = {
+            "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
+            "siae": self.evaluated_siae.siae,
+            "adversarial": adversarial,
+        }
+        subject = "siae_evaluations/email/to_siae_reviewed_subject.txt"
+        body = "siae_evaluations/email/to_siae_reviewed_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def notify_before_adversarial_stage(self):
+        job_app_list_url = reverse(
+            "siae_evaluations_views:siae_job_applications_list",
+            kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
+        )
+        context = {
+            "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
+            "siae": self.evaluated_siae.siae,
+            "evaluated_job_app_list_url": f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{job_app_list_url}",
+            "itou_community_url": global_constants.ITOU_COMMUNITY_URL,
+        }
+        subject = "siae_evaluations/email/to_siae_notify_before_adversarial_stage_subject.txt"
+        body = "siae_evaluations/email/to_siae_notify_before_adversarial_stage_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def adversarial_stage(self):
+        context = {
+            "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
+            "siae": self.evaluated_siae.siae,
+        }
+        subject = "siae_evaluations/email/to_siae_adversarial_stage_subject.txt"
+        body = "siae_evaluations/email/to_siae_adversarial_stage_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def forced_to_adversarial_stage(self):
+        auto_prescription_url = reverse(
+            "siae_evaluations_views:siae_job_applications_list",
+            kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
+        )
+        context = {
+            "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
+            "siae": self.evaluated_siae.siae,
+            "auto_prescription_url": f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{auto_prescription_url}",
+        }
+        subject = "siae_evaluations/email/to_siae_forced_to_adversarial_stage_subject.txt"
+        body = "siae_evaluations/email/to_siae_forced_to_adversarial_stage_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def notify_before_campaign_close(self):
+        job_app_list_url = reverse(
+            "siae_evaluations_views:siae_job_applications_list",
+            kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
+        )
+        context = {
+            "adversarial_stage_start": self.evaluated_siae.evaluation_campaign.adversarial_stage_start_date,
+            "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
+            "siae": self.evaluated_siae.siae,
+            "evaluated_job_app_list_url": f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}{job_app_list_url}",
+            "itou_community_url": global_constants.ITOU_COMMUNITY_URL,
+        }
+        subject = "siae_evaluations/email/to_siae_notify_before_campaign_close_subject.txt"
+        body = "siae_evaluations/email/to_siae_notify_before_campaign_close_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def refused(self):
+        context = {
+            "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
+            "siae": self.evaluated_siae.siae,
+        }
+        subject = "siae_evaluations/email/to_siae_refused_subject.txt"
+        body = "siae_evaluations/email/to_siae_refused_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def refused_no_proofs(self):
+        context = {
+            "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
+            "siae": self.evaluated_siae.siae,
+        }
+        subject = "siae_evaluations/email/to_siae_refused_no_proofs_subject.txt"
+        body = "siae_evaluations/email/to_siae_refused_no_proofs_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def sanctioned(self):
+        dashboard_url = reverse("dashboard:index")
+        context = {
+            "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
+            "siae": self.evaluated_siae.siae,
+            "dashboard_url": (f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}" + dashboard_url),
+        }
+        subject = "siae_evaluations/email/to_siae_sanctioned_subject.txt"
+        body = "siae_evaluations/email/to_siae_sanctioned_body.txt"
+        return get_email_message(self.recipients, context, subject, body)

--- a/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
+++ b/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
@@ -3,6 +3,7 @@ from django.core.management import BaseCommand
 from django.db.models import Exists, F, OuterRef, Q
 from django.utils import timezone
 
+from itou.siae_evaluations.emails import SIAEEmailFactory
 from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria, EvaluationCampaign
 from itou.utils.emails import send_email_messages
 
@@ -26,7 +27,7 @@ class Command(BaseCommand):
                 .select_related("evaluation_campaign__institution", "siae__convention")
             )
             for evaluated_siae in evaluated_siaes:
-                emails.append(evaluated_siae.get_email_to_siae_notify_before_adversarial_stage())
+                emails.append(SIAEEmailFactory(evaluated_siae).notify_before_adversarial_stage())
             if emails:
                 send_email_messages(emails)
                 evaluated_siaes.update(reminder_sent_at=timezone.now())
@@ -51,7 +52,7 @@ class Command(BaseCommand):
                 .select_related("evaluation_campaign__institution", "siae__convention")
             )
             for evaluated_siae in evaluated_siaes:
-                emails.append(evaluated_siae.get_email_to_siae_notify_before_campaign_close())
+                emails.append(SIAEEmailFactory(evaluated_siae).notify_before_campaign_close())
             if emails:
                 send_email_messages(emails)
                 evaluated_siaes.update(reminder_sent_at=timezone.now())

--- a/itou/siae_evaluations/tests/test_emails.py
+++ b/itou/siae_evaluations/tests/test_emails.py
@@ -1,0 +1,125 @@
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.urls import reverse
+from django.utils import dateformat, timezone
+
+from itou.institutions.factories import InstitutionWith2MembershipFactory
+from itou.siae_evaluations.emails import CampaignEmailFactory, InstitutionEmailFactory, SIAEEmailFactory
+from itou.siae_evaluations.factories import EvaluatedSiaeFactory, EvaluationCampaignFactory
+from itou.siaes.factories import SiaeFactory, SiaeWith2MembershipsFactory
+
+
+class TestInstitutionEmailFactory:
+    def test_ratio_to_select(self):
+        institution = InstitutionWith2MembershipFactory()
+        evaluation_campaign = EvaluationCampaignFactory(institution=institution)
+
+        date = timezone.localdate()
+        email = CampaignEmailFactory(evaluation_campaign).ratio_to_select(date)
+
+        assert email.to == list(u.email for u in institution.active_members)
+        assert reverse("dashboard:index") in email.body
+        assert (
+            f"Le choix du taux de SIAE à contrôler est possible jusqu’au {dateformat.format(date, 'd E Y')}"
+            in email.body
+        )
+        assert f"avant le {dateformat.format(date, 'd E Y')}" in email.subject
+
+    def test_selected(self):
+        siae = SiaeWith2MembershipsFactory()
+        evaluated_siae = EvaluatedSiaeFactory(siae=siae, evaluation_campaign__evaluations_asked_at=timezone.now())
+        email = SIAEEmailFactory(evaluated_siae).selected()
+
+        assert email.to == list(u.email for u in evaluated_siae.siae.active_admin_members)
+        assert email.subject == (
+            "Contrôle a posteriori sur vos embauches réalisées "
+            + f"du {dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_start_at, 'd E Y')} "
+            + f"au {dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_end_at, 'd E Y')}"
+        )
+        assert siae.name in email.body
+        assert siae.kind in email.body
+        assert siae.convention.siret_signature in email.body
+        assert dateformat.format(timezone.now() + relativedelta(weeks=6), "d E Y") in email.body
+
+    def test_selected_siae(self):
+        fake_now = timezone.now()
+        institution = InstitutionWith2MembershipFactory()
+        evaluation_campaign = EvaluationCampaignFactory(institution=institution, evaluations_asked_at=fake_now)
+
+        email = CampaignEmailFactory(evaluation_campaign).selected_siae()
+        assert email.to == list(u.email for u in institution.active_members)
+        assert dateformat.format(fake_now + relativedelta(weeks=6), "d E Y") in email.body
+        assert dateformat.format(evaluation_campaign.evaluated_period_start_at, "d E Y") in email.body
+        assert dateformat.format(evaluation_campaign.evaluated_period_end_at, "d E Y") in email.body
+
+    def test_submitted_by_siae(self):
+        institution = InstitutionWith2MembershipFactory()
+        evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign__institution=institution)
+        email = InstitutionEmailFactory(evaluated_siae).submitted_by_siae()
+
+        assert evaluated_siae.siae.kind in email.subject
+        assert evaluated_siae.siae.name in email.subject
+        assert evaluated_siae.siae.kind in email.body
+        assert evaluated_siae.siae.name in email.body
+        assert email.from_email == settings.DEFAULT_FROM_EMAIL
+        assert len(email.to) == len(institution.active_members)
+
+
+class TestSIAEEmails:
+    def test_reviewed(self):
+        siae = SiaeFactory(with_membership=True)
+        evaluated_siae = EvaluatedSiaeFactory(siae=siae)
+        email = SIAEEmailFactory(evaluated_siae).reviewed()
+
+        assert email.from_email == settings.DEFAULT_FROM_EMAIL
+        assert len(email.to) == len(evaluated_siae.siae.active_admin_members)
+        assert email.to[0] == evaluated_siae.siae.active_admin_members.first().email
+        assert evaluated_siae.siae.kind in email.subject
+        assert evaluated_siae.siae.name in email.subject
+        assert str(evaluated_siae.siae.id) in email.subject
+        assert evaluated_siae.siae.kind in email.body
+        assert evaluated_siae.siae.name in email.body
+        assert str(evaluated_siae.siae.id) in email.body
+        assert evaluated_siae.evaluation_campaign.institution.name in email.body
+        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_start_at, "d E Y") in email.body
+        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_end_at, "d E Y") in email.body
+        assert "la conformité des justificatifs que vous avez" in email.body
+
+        email = SIAEEmailFactory(evaluated_siae).reviewed(adversarial=True)
+        assert "la conformité des nouveaux justificatifs que vous avez" in email.body
+
+    def test_refused(self):
+        siae = SiaeFactory(with_membership=True)
+        evaluated_siae = EvaluatedSiaeFactory(siae=siae)
+        email = SIAEEmailFactory(evaluated_siae).refused()
+
+        assert email.from_email == settings.DEFAULT_FROM_EMAIL
+        assert len(email.to) == len(evaluated_siae.siae.active_admin_members)
+        assert email.to[0] == evaluated_siae.siae.active_admin_members.first().email
+        assert evaluated_siae.siae.kind in email.subject
+        assert evaluated_siae.siae.name in email.subject
+        assert str(evaluated_siae.siae.id) in email.subject
+        assert evaluated_siae.siae.kind in email.body
+        assert evaluated_siae.siae.name in email.body
+        assert str(evaluated_siae.siae.id) in email.body
+        assert evaluated_siae.evaluation_campaign.institution.name in email.body
+        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_start_at, "d E Y") in email.body
+        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_end_at, "d E Y") in email.body
+
+    def test_adversarial_stage(self):
+        siae = SiaeFactory(with_membership=True)
+        evaluated_siae = EvaluatedSiaeFactory(siae=siae)
+        email = SIAEEmailFactory(evaluated_siae).adversarial_stage()
+
+        assert email.from_email == settings.DEFAULT_FROM_EMAIL
+        assert len(email.to) == len(evaluated_siae.siae.active_admin_members)
+        assert email.to[0] == evaluated_siae.siae.active_admin_members.first().email
+        assert evaluated_siae.siae.kind in email.subject
+        assert evaluated_siae.siae.name in email.subject
+        assert str(evaluated_siae.siae.id) in email.subject
+        assert evaluated_siae.siae.kind in email.body
+        assert evaluated_siae.siae.name in email.body
+        assert str(evaluated_siae.siae.id) in email.body
+        assert evaluated_siae.evaluation_campaign.institution.name in email.body
+        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_start_at, "d E Y") in email.body
+        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_end_at, "d E Y") in email.body

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -3,12 +3,10 @@ from unittest import mock
 
 import pytest
 from dateutil.relativedelta import relativedelta
-from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
-from django.urls import reverse
-from django.utils import dateformat, timezone
+from django.utils import timezone
 
 from itou.approvals.factories import ApprovalFactory
 from itou.eligibility.enums import AdministrativeCriteriaLevel, AuthorKind
@@ -558,50 +556,6 @@ class EvaluationCampaignManagerTest(TestCase):
         assert len(mail.outbox) == 1
 
 
-class EvaluationCampaignEmailMethodsTest(TestCase):
-    def test_get_email_to_institution_ratio_to_select(self):
-        institution = InstitutionWith2MembershipFactory()
-        evaluation_campaign = EvaluationCampaignFactory(institution=institution)
-
-        date = timezone.localdate()
-        email = evaluation_campaign.get_email_to_institution_ratio_to_select(date)
-
-        assert email.to == list(u.email for u in institution.active_members)
-        assert reverse("dashboard:index") in email.body
-        assert (
-            f"Le choix du taux de SIAE à contrôler est possible jusqu’au {dateformat.format(date, 'd E Y')}"
-            in email.body
-        )
-        assert f"avant le {dateformat.format(date, 'd E Y')}" in email.subject
-
-    def test_get_email_to_siae_selected(self):
-        siae = SiaeWith2MembershipsFactory()
-        evaluated_siae = EvaluatedSiaeFactory(siae=siae, evaluation_campaign__evaluations_asked_at=timezone.now())
-        email = evaluated_siae.get_email_to_siae_selected()
-
-        assert email.to == list(u.email for u in evaluated_siae.siae.active_admin_members)
-        assert email.subject == (
-            "Contrôle a posteriori sur vos embauches réalisées "
-            + f"du {dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_start_at, 'd E Y')} "
-            + f"au {dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_end_at, 'd E Y')}"
-        )
-        assert siae.name in email.body
-        assert siae.kind in email.body
-        assert siae.convention.siret_signature in email.body
-        assert dateformat.format(timezone.now() + relativedelta(weeks=6), "d E Y") in email.body
-
-    def test_get_email_to_institution_selected_siae(self):
-        fake_now = timezone.now()
-        institution = InstitutionWith2MembershipFactory()
-        evaluation_campaign = EvaluationCampaignFactory(institution=institution, evaluations_asked_at=fake_now)
-
-        email = evaluation_campaign.get_email_to_institution_selected_siae()
-        assert email.to == list(u.email for u in institution.active_members)
-        assert dateformat.format(fake_now + relativedelta(weeks=6), "d E Y") in email.body
-        assert dateformat.format(evaluation_campaign.evaluated_period_start_at, "d E Y") in email.body
-        assert dateformat.format(evaluation_campaign.evaluated_period_end_at, "d E Y") in email.body
-
-
 class EvaluatedSiaeQuerySetTest(TestCase):
     def test_for_siae(self):
         siae1 = SiaeFactory()
@@ -1025,76 +979,6 @@ class EvaluatedSiaeModelTest(TestCase):
         evaluated_siae.review()
         evaluated_siae.refresh_from_db()
         assert evaluated_siae.reviewed_at is not None
-
-    def test_get_email_to_institution_submitted_by_siae(self):
-        institution = InstitutionWith2MembershipFactory()
-        evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign__institution=institution)
-        email = evaluated_siae.get_email_to_institution_submitted_by_siae()
-
-        assert evaluated_siae.siae.kind in email.subject
-        assert evaluated_siae.siae.name in email.subject
-        assert evaluated_siae.siae.kind in email.body
-        assert evaluated_siae.siae.name in email.body
-        assert email.from_email == settings.DEFAULT_FROM_EMAIL
-        assert len(email.to) == len(institution.active_members)
-
-    def test_get_email_to_siae_reviewed(self):
-        siae = SiaeFactory(with_membership=True)
-        evaluated_siae = EvaluatedSiaeFactory(siae=siae)
-        email = evaluated_siae.get_email_to_siae_reviewed()
-
-        assert email.from_email == settings.DEFAULT_FROM_EMAIL
-        assert len(email.to) == len(evaluated_siae.siae.active_admin_members)
-        assert email.to[0] == evaluated_siae.siae.active_admin_members.first().email
-        assert evaluated_siae.siae.kind in email.subject
-        assert evaluated_siae.siae.name in email.subject
-        assert str(evaluated_siae.siae.id) in email.subject
-        assert evaluated_siae.siae.kind in email.body
-        assert evaluated_siae.siae.name in email.body
-        assert str(evaluated_siae.siae.id) in email.body
-        assert evaluated_siae.evaluation_campaign.institution.name in email.body
-        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_start_at, "d E Y") in email.body
-        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_end_at, "d E Y") in email.body
-        assert "la conformité des justificatifs que vous avez" in email.body
-
-        email = evaluated_siae.get_email_to_siae_reviewed(adversarial=True)
-        assert "la conformité des nouveaux justificatifs que vous avez" in email.body
-
-    def test_get_email_to_siae_refused(self):
-        siae = SiaeFactory(with_membership=True)
-        evaluated_siae = EvaluatedSiaeFactory(siae=siae)
-        email = evaluated_siae.get_email_to_siae_refused()
-
-        assert email.from_email == settings.DEFAULT_FROM_EMAIL
-        assert len(email.to) == len(evaluated_siae.siae.active_admin_members)
-        assert email.to[0] == evaluated_siae.siae.active_admin_members.first().email
-        assert evaluated_siae.siae.kind in email.subject
-        assert evaluated_siae.siae.name in email.subject
-        assert str(evaluated_siae.siae.id) in email.subject
-        assert evaluated_siae.siae.kind in email.body
-        assert evaluated_siae.siae.name in email.body
-        assert str(evaluated_siae.siae.id) in email.body
-        assert evaluated_siae.evaluation_campaign.institution.name in email.body
-        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_start_at, "d E Y") in email.body
-        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_end_at, "d E Y") in email.body
-
-    def test_get_email_to_siae_adversarial_stage(self):
-        siae = SiaeFactory(with_membership=True)
-        evaluated_siae = EvaluatedSiaeFactory(siae=siae)
-        email = evaluated_siae.get_email_to_siae_adversarial_stage()
-
-        assert email.from_email == settings.DEFAULT_FROM_EMAIL
-        assert len(email.to) == len(evaluated_siae.siae.active_admin_members)
-        assert email.to[0] == evaluated_siae.siae.active_admin_members.first().email
-        assert evaluated_siae.siae.kind in email.subject
-        assert evaluated_siae.siae.name in email.subject
-        assert str(evaluated_siae.siae.id) in email.subject
-        assert evaluated_siae.siae.kind in email.body
-        assert evaluated_siae.siae.name in email.body
-        assert str(evaluated_siae.siae.id) in email.body
-        assert evaluated_siae.evaluation_campaign.institution.name in email.body
-        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_start_at, "d E Y") in email.body
-        assert dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_end_at, "d E Y") in email.body
 
 
 class EvaluatedJobApplicationModelTest(TestCase):

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -12,6 +12,7 @@ from django.views import generic
 from django.views.decorators.http import require_POST
 
 from itou.siae_evaluations import enums as evaluation_enums
+from itou.siae_evaluations.emails import InstitutionEmailFactory, SIAEEmailFactory
 from itou.siae_evaluations.models import (
     EvaluatedAdministrativeCriteria,
     EvaluatedJobApplication,
@@ -191,7 +192,7 @@ class InstitutionEvaluatedSiaeNotifyView(LoginRequiredMixin, generic.UpdateView)
 
     def form_valid(self, form):
         messages.success(self.request, f"{self.object} a bien été notifiée de la sanction.")
-        email = self.object.get_email_to_siae_sanctioned()
+        email = SIAEEmailFactory(self.object).sanctioned()
         send_email_messages([email])
         return super().form_valid(form)
 
@@ -531,7 +532,7 @@ def siae_submit_proofs(request, evaluated_siae_pk):
 
         # note vincentporte : misconception. This view should be called with one evaluated_siae
         # check this impact when calling this view with evaluated_siae.pk in params
-        send_email_messages([evaluated_siae.get_email_to_institution_submitted_by_siae()])
+        send_email_messages([InstitutionEmailFactory(evaluated_siae).submitted_by_siae()])
 
         messages.success(
             request,


### PR DESCRIPTION
### Pourquoi ?

Éviter des centaines de lignes de codes pas très intéressantes ni très liées au modèle.