### PR TITLE
feat: update ui for siae results tabs

### DIFF
--- a/itou/templates/search/includes/siaes_search_filters.html
+++ b/itou/templates/search/includes/siaes_search_filters.html
@@ -1,51 +1,63 @@
 {% load bootstrap4 %}
-<div class="card mt-4">
-    <a id="js-search-filter-button"
-       class="btn btn-primary-outline btn-sm btn-ico d-block d-md-none"
-       href="#search-filter-form"
-       data-toggle="collapse"
-       role="button"
-       aria-expanded="false"
-       aria-controls="search-filter-form">
-        <span>Filtrer les résultats</span>
+
+<aside class="c-aside-filters">
+    <a class="c-aside-filters__btn__collapse" data-toggle="collapse" href="#search-filter-form" aria-expanded="false" aria-controls="search-filter-form">
         <i class="ri-filter-line"></i>
+        <span>Filtres des résultats</span>
     </a>
-    <div id="search-filter-form" class="card-body collapse show">
-        {% bootstrap_field form.distance form_group_class="form-group" label_class="h3 font-weight-bold text-muted" %}
+    <div class="c-aside-filters__card collapse" id="search-filter-form">
+        <div class="c-aside-filters__card__body">
+            <fieldset>
+                {% bootstrap_field form.distance form_group_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+            </fieldset>
 
-        {% if form.departments %}
+            {% if form.departments %}
+                <hr>
+                <fieldset>
+                    {% bootstrap_field form.departments form_group_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+                </fieldset>
+            {% endif %}
+
+            {# getattr and list still painful in Django template #}
+            {% if form.districts_13 %}
+                <hr>
+                <fieldset>
+                    {% bootstrap_field form.districts_13 form_group_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+                </fieldset>
+            {% endif %}
+
+            {% if form.districts_69 %}
+                <hr>
+                <fieldset>
+                    {% bootstrap_field form.districts_69 form_group_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+                </fieldset>
+            {% endif %}
+
+            {% if form.districts_75 %}
+                <hr>
+                <fieldset>
+                    {% bootstrap_field form.districts_75 form_group_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+                </fieldset>
+            {% endif %}
+
             <hr>
-            {% bootstrap_field form.departments form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
-        {% endif %}
+            <fieldset>
+                {% bootstrap_field form.kinds form_group_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+            </fieldset>
 
-        {# getattr and list still painful in Django template #}
-        {% if form.districts_13 %}
-            <hr>
-            {% bootstrap_field form.districts_13 form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
-        {% endif %}
+            {% if form.contract_types %}
+                <hr>
+                <fieldset>
+                    {% bootstrap_field form.contract_types form_group_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+                </fieldset>
+            {% endif %}
 
-        {% if form.districts_69 %}
-            <hr>
-            {% bootstrap_field form.districts_69 form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
-        {% endif %}
-
-        {% if form.districts_75 %}
-            <hr>
-            {% bootstrap_field form.districts_75 form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
-        {% endif %}
-
-        <hr>
-        {% bootstrap_field form.kinds form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
-
-        {% if form.contract_types %}
-            <hr>
-            {% bootstrap_field form.contract_types form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
-        {% endif %}
-
-        {% if form.domains %}
-            <hr>
-            {% bootstrap_field form.domains form_group_class="form-group mt-2" label_class="h3 font-weight-bold text-muted" %}
-        {% endif %}
-
+            {% if form.domains %}
+                <hr>
+                <fieldset>
+                    {% bootstrap_field form.domains form_group_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+                </fieldset>
+            {% endif %}
+        </div>
     </div>
-</div>
+</aside>

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -9,96 +9,106 @@
     {{ block.super }}
 {% endblock %}
 
+{% block content_container_css_classes %}s-tabs-01 p-0{% endblock %}
+{% block content %}
+    <div class="s-tabs-01__row row">
+        <div class="s-tabs-01__col col-12">
+            <form id="search-form" method="get" action="" class="d-block w-100 mb-3 mb-md-5">
+                {% include "search/includes/siaes_search_form.html" with form=form %}
+                {% if form.is_valid %}
+                    <h1 class="h2">
+                        Emplois inclusifs à <strong>{{ distance }} km</strong> du centre de <strong>{{ city }}</strong>
+                    </h1>
+                {% endif %}
+                <ul class="s-tabs-01__nav nav nav-tabs">
+                    <li class="nav-item" role="presentation">
+                        <a class="matomo-event nav-link {% if request.resolver_match.view_name == "search:siaes_results" %}active{% endif %}"
+                           data-matomo-category="candidature"
+                           data-matomo-action="clic"
+                           data-matomo-option="clic-onglet-employeur"
+                           href="{% url "search:siaes_results" %}?{{ filters_query_string }}">
+                            <i class="ri-hotel-line ri-xl font-weight-normal mr-1"></i>
+                            <span>Employeurs</span>
+                            {% if siaes_count %}
+                                <span class="d-inline d-lg-none ml-1">({{ siaes_count }})</span>
+                                <span class="d-none d-lg-inline ml-1">({{ siaes_count }} résultat{{ siaes_count|pluralize }})</span>
+                            {% endif %}
+                        </a>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <a class="matomo-event nav-link {% if request.resolver_match.view_name == "search:job_descriptions_results" %}active{% endif %}"
+                           data-matomo-category="candidature"
+                           data-matomo-action="clic"
+                           data-matomo-option="clic-onglet-fichesdeposte"
+                           href="{% url "search:job_descriptions_results" %}?{{ filters_query_string }}">
+                            <i class="ri-briefcase-4-line ri-xl font-weight-normal mr-1"></i>
+                            <span class="d-inline d-lg-none">Postes</span>
+                            <span class="d-none d-lg-inline">Postes ouverts au recrutement</span>
+                            {% if job_descriptions_count %}
+                                <span class="d-inline d-lg-none ml-1">({{ job_descriptions_count }})</span>
+                                <span class="d-none d-lg-inline ml-1">
+                                    ({{ job_descriptions_count }} résultat{{ job_descriptions_count|pluralize }})
+                                </span>
+                            {% endif %}
+                            <div class="d-none d-lg-block">
+                                <span class="badge badge-xs badge-pill badge-important ml-2 text-white">Nouveau</span>
+                            </div>
+                        </a>
+                    </li>
+                    <li class="nav-item-dropdown dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" role="button" id="sTabs01DropdownMoreLink" data-toggle="dropdown" aria-expanded="false"><i class="ri-more-line"></i></a>
+                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="sTabs01DropdownMoreLink"></div>
+                    </li>
+                </ul>
+                <div class="tab-content">
+                    <div class="tab-pane fade show active">
+                        <div class="row">
+                            <div class="col-12 col-md-4">{% include "search/includes/siaes_search_filters.html" with form=form %}</div>
+                            <div class="col-12 col-md-8">
+                                {% for item in results_page %}
+                                    {% if request.resolver_match.view_name == "search:siaes_results" %}
+                                        {% include "siaes/includes/_card_siae.html" with siae=item %}
+                                    {% else %}
+                                        {% include "siaes/includes/_card_jobdescription.html" with job_description=item %}
+                                    {% endif %}
+                                {% empty %}
+                                    <div class="c-card card mb-3 mb-md-4">
+                                        <div class="card-body">
+                                            <p>Aucun résultat avec les filtres actuels.</p>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+
+                                {% include "includes/pagination.html" with page=results_page %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}
+
 {% block script %}
     {{ block.super }}
     <script nonce="{{ CSP_NONCE }}">
         $("#search-filter-form :input").change(function() {
             $("#search-form").submit();
         });
-        // If the Filtres button is present, the associated card should be collapsed on display.
-        if ($("#js-search-filter-button").is(":visible")) {
-            // The button should be always visible now (on windows resize)
-            $("#js-search-filter-button").removeClass("d-md-none");
-            $('#search-filter-form').collapse();
-        }
+
+        // Show or Hide the search-filter-form sidebar based on responsive breakpoint
+        var breakpointMD = getComputedStyle(document.documentElement).getPropertyValue("--breakpoint-md");
+        $(window).on("load resize", function() {
+            if (window.matchMedia("(min-width: "+breakpointMD+")").matches) {
+                $("#search-filter-form").collapse("show");
+            } else {
+                $("#search-filter-form").collapse("hide");
+            }
+        });
+
         $("#siae-number-results").focus();
         // FIXME(vperron): Remove this after March 2023; especially it might break the display if the number
         // or order of the contract types filter changes.
-        $("#id_contract_types > div:nth-child(12) > label:nth-child(1)").append('<span class="badge badge-base badge-xs badge-pill badge-important ml-1 text-white">Nouveau</span>');
+        $("#id_contract_types > div:nth-child(12) > label:nth-child(1)").append('<span class="badge badge-xs badge-pill badge-important ml-2 text-white">Nouveau</span>');
     </script>
-{% endblock %}
-
-{% block content %}
-    <section class="s-tabs-01 mx-md-1 mx-lg-2">
-        <form id="search-form" method="get" action="" class="d-block mb-5">
-            {% include "search/includes/siaes_search_form.html" with form=form %}
-
-            {% if form.is_valid %}
-                <h2 class="h2">
-                    Emplois inclusifs à <strong>{{ distance }} km</strong> du centre de <strong>{{ city }}</strong>
-                </h2>
-            {% endif %}
-
-            <ul class="nav nav-tabs nav-tabs--emploi">
-                <li class="nav-item">
-                    <a class="matomo-event nav-link {% if request.resolver_match.view_name == "search:siaes_results" %}active{% endif %}"
-                       data-matomo-category="candidature"
-                       data-matomo-action="clic"
-                       data-matomo-option="clic-onglet-employeur"
-                       href="{% url "search:siaes_results" %}?{{ filters_query_string }}">
-                        <i class="ri-hotel-line ri-xl mr-1"></i>
-                        Employeurs
-                        {% if siaes_count %}
-                            <span class="d-lg-none d-xl-none ml-1">({{ siaes_count }})</span>
-                            <span class="d-none d-lg-inline ml-1">({{ siaes_count }} résultat{{ siaes_count|pluralize }})</span>
-                        {% endif %}
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a class="matomo-event nav-link {% if request.resolver_match.view_name == "search:job_descriptions_results" %}active{% endif %}"
-                       data-matomo-category="candidature"
-                       data-matomo-action="clic"
-                       data-matomo-option="clic-onglet-fichesdeposte"
-                       href="{% url "search:job_descriptions_results" %}?{{ filters_query_string }}">
-                        <i class="ri-briefcase-4-line ri-xl mr-1"></i>
-                        <span class="d-lg-none d-xl-none">Postes</span>
-                        <span class="d-none d-lg-inline">Postes ouverts au recrutement</span>
-                        {% if job_descriptions_count %}
-                            <span class="d-lg-none d-xl-none ml-1">({{ job_descriptions_count }})</span>
-                            <span class="d-none d-lg-inline ml-1">
-                                ({{ job_descriptions_count }} résultat{{ job_descriptions_count|pluralize }})
-                            </span>
-                        {% endif %}
-                        <div class="d-none d-lg-block">
-                            <span class="badge badge-base badge-xs badge-pill badge-important ml-1 text-white">Nouveau</span>
-                        </div>
-                    </a>
-                </li>
-            </ul>
-
-            <div class="tab-content py-1">
-                <div class="row px-lg-2">
-                    <div class="col-12 col-md-4">{% include "search/includes/siaes_search_filters.html" with form=form %}</div>
-                    <div class="col-12 col-md-8">
-                        {% for item in results_page %}
-                            {% if request.resolver_match.view_name == "search:siaes_results" %}
-                                {% include "siaes/includes/_card_siae.html" with siae=item %}
-                            {% else %}
-                                {% include "siaes/includes/_card_jobdescription.html" with job_description=item %}
-                            {% endif %}
-                        {% empty %}
-                            <div class="card my-4">
-                                <div class="card-body">
-                                    <p>Aucun résultat avec les filtres actuels.</p>
-                                </div>
-                            </div>
-                        {% endfor %}
-
-                        {% include "includes/pagination.html" with page=results_page %}
-                    </div>
-                </div>
-            </div>
-        </form>
-    </section>
-
 {% endblock %}

--- a/itou/templates/siaes/includes/_card_siae.html
+++ b/itou/templates/siaes/includes/_card_siae.html
@@ -1,6 +1,6 @@
 {% comment %} takes argument siae <Siae>{% endcomment %}
-<div class="card c-card has-links-inside my-4">
-    <div class="bg-light p-3 p-md-4">
+<div class="card c-card has-links-inside mb-3 mb-md-4">
+    <div class="card-header bg-light pb-3">
         <p class="d-flex flex-wrap fs-sm mb-2">
             <span class="flex-grow-1 text-primary">
                 {% if siae.is_opcs %}
@@ -13,14 +13,14 @@
                 <span class="badge badge-base badge-pill badge-xs badge-accent-01-lighter text-accent-01"><b>Priorité aux bénéficiaires de la RQTH</b></span>
             {% endif %}
         </p>
-        <h3 class="h2 mb-2">
+        <h3 class="mb-2">
             <a class="matomo-event" href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}" data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-structure">{{ siae.display_name }}</a>
             {# Display non-user-edited name too, but only if it's not the same text #}
             {% if siae.brand and siae.brand|lower != siae.name|lower %}
                 <small class="text-muted">({{ siae.name|title }})</small>
             {% endif %}
         </h3>
-        <h4 class="h5 mb-2 text-muted">{{ siae.address_on_one_line }}</h4>
+        <p class="font-weight-bold mb-2 text-muted">{{ siae.address_on_one_line }}</p>
         <p class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center mb-0">
             <span class="align-self-start">
                 <span class="badge badge-sm badge-pill badge-primary">à {{ siae.distance|floatformat:"-1"|default:"12" }} km</span>
@@ -44,7 +44,7 @@
             {% endif %}
         </p>
     </div>
-    <div class="card-body p-3 p-md-4">
+    <div class="card-body">
         {% if siae.block_job_applications %}
             <p class="mb-0">
                 <i>Cet employeur ne traite plus de nouvelles candidatures pour le moment</i>


### PR DESCRIPTION
**Carte Notion:** https://www.notion.so/Am-lioration-de-l-int-gration-de-la-section-des-onglets-dans-les-r-sultats-de-recherche-c4087c0c8aca4ea7b8c5147d12c2a13d

### Pourquoi ?

Amélioration de l'ui des onglets avec résultats des recherches en respectant la mise en forme du thème et pour faire fonctionner le masquage des onglets trop longs en mobile. Au passage, amélioration de l'accessibilité

### Comment (optionnel)

Modification du DOM et classes css dans les templates

