### PR TITLE
[Metabase] Fix technique sur le user kind.

### DIFF
--- a/itou/metabase/tables/job_seekers.py
+++ b/itou/metabase/tables/job_seekers.py
@@ -38,6 +38,8 @@ def get_user_signup_kind(user):
         return "par prescripteur"
     if creator.is_siae_staff:
         return "par employeur"
+    if creator.is_superuser:
+        return "par superuser"
     raise ValueError("Unexpected job seeker creator kind")
 
 


### PR DESCRIPTION
La MAJ Metabase quotidienne casse sur une nouvelle erreur. Cf fil ([lien](https://itou-inclusion.slack.com/archives/CT7986ULC/p1674160204873409))

Bien résumé par la description du commit :

![image](https://user-images.githubusercontent.com/10533583/213677030-dbc56689-043b-42b6-aeda-89694160dbc6.png)

Pour info @tonial et @vperron 

Je merge sans revue car je suis off ce vendredi après-midi et je tiens à débloquer la MAJ pour ce weekend.

