### PR TITLE
[Metabase] Fix technique sur le user kind (correction de #2013)

### DIFF
--- a/itou/metabase/tables/job_seekers.py
+++ b/itou/metabase/tables/job_seekers.py
@@ -38,8 +38,8 @@ def get_user_signup_kind(user):
         return "par prescripteur"
     if creator.is_siae_staff:
         return "par employeur"
-    if creator.is_superuser:
-        return "par superuser"
+    if creator.is_staff:
+        return "par administrateur"
     raise ValueError("Unexpected job seeker creator kind")
 
 


### PR DESCRIPTION
Certains utilisateurs is_staff ne sont pas superusers

### Pourquoi ?

Indiquer le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements.

### Comment (optionnel)

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.

