### PR TITLE
[Metabase] Fix technique des colonnes "ID anonymisé"

### DIFF
--- a/itou/metabase/sql/015_taux_transformation_prescripteurs.sql
+++ b/itou/metabase/sql/015_taux_transformation_prescripteurs.sql
@@ -8,7 +8,9 @@ Nous récupérons aussi différentes informations sur les structures à partir d
 	
 with candidats_p as ( /* Ici on sélectionne les colonnes pertinentes à partir de la table candidats en ne prenant que les auteurs = Prescripteur */
     select  
-	distinct cdd.id as id_candidat, 
+	distinct cdd.id as id_candidat,
+	/* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
+	cdd.id_anonymisé as id_candidat_anonymise, 
 	cdd.actif,   
 	cdd.age,    
 	cdd.date_diagnostic,
@@ -43,7 +45,7 @@ prescripteurs as (
 select /* On selectionne les colonnes finales qui nous intéressent */
     id_candidat,
     /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
-    id_candidat as id_candidat_anonymise,
+    id_candidat_anonymise as id_candidat_anonymise,
     case /* ajout d'une colonne permettant de calculer le taux de candidats acceptées tout en faisant une jointure avec la table candidatures */
         when total_embauches > 0 then concat(cast(id_candidat as varchar), '_accepté')
         else null

--- a/itou/metabase/sql/016_candidatures_recues_par_fiche_de_poste.sql
+++ b/itou/metabase/sql/016_candidatures_recues_par_fiche_de_poste.sql
@@ -16,10 +16,10 @@ select
     c.département_structure,
     c.id as id_candidature,
     /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
-    c.id as id_candidature_anonymisé,
+    c.id_anonymisé as id_candidature_anonymisé,
     c.id_candidat,
     /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
-    c.id_candidat as id_candidat_anonymisé,
+    c.id_candidat_anonymisé as id_candidat_anonymisé,
     c.id_structure,
     c.motif_de_refus,
     c.nom_département_structure,

--- a/itou/metabase/sql/019_candidatures_echelle_locale.sql
+++ b/itou/metabase/sql/019_candidatures_echelle_locale.sql
@@ -85,10 +85,10 @@ select
     état,
     id,
     /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
-    id as id_anonymisé,
+    id_anonymisé,
     id_candidat,
     /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
-    id_candidat as id_candidat_anonymisé,
+    id_candidat_anonymisé,
     candidatures_p.id_structure,
     motif_de_refus,
     candidatures_p.nom_département_structure,

--- a/itou/metabase/sql/020_delai_1ere_candidature_embauche.sql
+++ b/itou/metabase/sql/020_delai_1ere_candidature_embauche.sql
@@ -12,7 +12,9 @@ L'objectif est de calculer le délai entre la 1ère candidature et l'embauche de
 
 with date_1ere_candidature as (
     select 
-        c."id_candidat",
+        c.id_candidat,
+        /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
+        c.id_candidat_anonymisé,
         min(date_candidature) as date_1ere_candidature,
         min(
             case 
@@ -31,7 +33,9 @@ with date_1ere_candidature as (
         where c.origine = 'Prescripteur habilité' /* Modification du filtre initialement fait par Soumia, qui n'était pas bon */
         and c.origine_détaillée  = 'Prescripteur habilité PE'
     group by 
-        c."id_candidat",
+        c.id_candidat,
+        /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
+        c.id_candidat_anonymisé,
         candidats.nom_département,
         date_candidature,
         date_embauche,
@@ -48,7 +52,7 @@ prescripteurs as (
 select 
     id_candidat,
     /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
-    id_candidat as id_candidat_anonymisé,
+    id_candidat_anonymisé,
     nom_département_candidat,
     date_candidature,
     date_embauche,


### PR DESCRIPTION
### Pourquoi ?

Les colonnes "ID anonymisé" (qui ont vocation à être bientôt supprimées) ont l'ID en clair ce qui casse certaines jointures.

Cf https://itou-inclusion.slack.com/archives/CT7986ULC/p1674123224547489

J'ai testé les 4 requêtes SQL manuellement en local, elles semblent ok.

Pour mémoire : lié à ce commit ([lien](https://github.com/betagouv/itou/pull/1978/commits/fd8cf584427c1afe4091b654ff122164a35a8c43)) de cette PR ([lien](https://github.com/betagouv/itou/pull/1978))