### PR TITLE
Ajout de la supervision pour les tâches d'envois et de récupération des fiches salariés

### DIFF
--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -12,6 +12,7 @@ from itou.employee_record.exceptions import SerializationError
 from itou.employee_record.mocks.fake_serializers import TestEmployeeRecordBatchSerializer
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch, EmployeeRecordUpdateNotification
 from itou.employee_record.serializers import EmployeeRecordBatchSerializer, EmployeeRecordSerializer
+from itou.utils import sentry
 from itou.utils.iterators import chunks
 
 from ...common_management import EmployeeRecordTransferCommand
@@ -195,6 +196,7 @@ class Command(EmployeeRecordTransferCommand):
 
         return record_errors
 
+    @sentry.Monitor("a4e3c7c8-4d5b-437d-a979-2b8aa7a84634")
     def download(self, conn, dry_run):
         """
         Fetch remote ASP file containing the results of the processing
@@ -255,6 +257,7 @@ class Command(EmployeeRecordTransferCommand):
 
                 conn.remove(file)
 
+    @sentry.Monitor("8654bf02-7d10-463a-8cef-c377a3e01c5c")
     def upload(self, sftp, dry_run):
         """
         Upload a file composed of all ready employee records

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -10,6 +10,7 @@ from itou.employee_record.exceptions import SerializationError
 from itou.employee_record.mocks.fake_serializers import TestEmployeeRecordUpdateNotificationBatchSerializer
 from itou.employee_record.models import EmployeeRecordBatch, EmployeeRecordUpdateNotification
 from itou.employee_record.serializers import EmployeeRecordUpdateNotificationBatchSerializer
+from itou.utils import sentry
 from itou.utils.iterators import chunks
 
 from ...common_management import EmployeeRecordTransferCommand
@@ -152,6 +153,7 @@ class Command(EmployeeRecordTransferCommand):
 
         return record_errors
 
+    @sentry.Monitor("390204fd-95ff-42b0-ae32-8cd39b9c4f9a")
     def download(self, conn: pysftp.Connection, dry_run: bool):
 
         parser = JSONParser()
@@ -205,6 +207,7 @@ class Command(EmployeeRecordTransferCommand):
 
                 conn.remove(file)
 
+    @sentry.Monitor("03ae914a-1908-4b4b-adcf-e5d124bb8242")
     def upload(self, conn: pysftp.Connection, dry_run: bool):
         new_notifications = EmployeeRecordUpdateNotification.objects.new()
 

--- a/itou/utils/sentry.py
+++ b/itou/utils/sentry.py
@@ -1,0 +1,44 @@
+import functools
+
+import httpx
+from django.conf import settings
+
+
+class Monitor:
+    headers = {"Authorization": f"DSN {settings.SENTRY_DSN}"}
+
+    def __init__(self, monitor_id):
+        self.monitor_id = monitor_id
+        self.status = None
+        self.checkin_id = None
+
+    def __call__(self, func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    def __enter__(self):
+        if not settings.SENTRY_DSN:
+            return
+
+        response = httpx.post(
+            f"https://sentry.io/api/0/monitors/{self.monitor_id}/checkins/",
+            headers=self.headers,
+            json={"status": "in_progress"},
+        )
+        response.raise_for_status()
+        self.checkin_id = response.json()["id"]
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if not settings.SENTRY_DSN:
+            return
+
+        response = httpx.put(
+            f"https://sentry.io/api/0/monitors/{self.monitor_id}/checkins/{self.checkin_id}/",
+            headers=self.headers,
+            json={"status": "error" if exc_type else "ok"},
+        )
+        response.raise_for_status()


### PR DESCRIPTION
### Pourquoi ?

Il arrive régulièrement (~1 fois par trimestre) qu'une fiche salarié "se coince" et bloque les échanges, n'ayant pas d'alerte nous nous en rendons compte soit par hasard soit parce que les utilisateurs font un ticket au support qui nous pousse à le découvrir.

### Comment

Utilisation de [Cron Monitoring](https://docs.sentry.io/product/crons/) et des [Alertes](https://docs.sentry.io/product/alerts/) proposées par Sentry