### PR TITLE
CSP: add object-src directive

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -629,6 +629,9 @@ CSP_CONNECT_SRC = [
     "wss://*.hotjar.com",
     "https://translate.googleapis.com",  # Allow google translate
 ]
+CSP_WORKER_SRC = [
+    "'self' blob:",  # Redoc seems to use blob:https://emplois.inclusion.beta.gouv.fr/some-ran-dom-uu-id
+]
 if S3_STORAGE_ENDPOINT_DOMAIN:
     CSP_CONNECT_SRC += [
         f"https://{S3_STORAGE_ENDPOINT_DOMAIN}",


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/BUG-la-page-documentation-API-ne-fonctionne-plus-depuis-google-chrome-c2c80e0a86754df9aad1e8518eaef2b5

### Pourquoi ?

On a une erreur CSP:
`Failed to construct 'Worker': Access to the script at 'blob:https://emplois.inclusion.beta.gouv.fr/3e5d929e-9e5b-4c36-b483-ee07254ec18e' is denied by the document's Content Security Policy.`

sur la page https://emplois.inclusion.beta.gouv.fr/api/v1/redoc/


