### PR TITLE
[Admin] Plus de granularité pour le message d'un champ des PASS IAE et des Fiches Salariés

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -69,6 +69,9 @@ class JobApplicationInline(admin.StackedInline):
         if not obj.create_employee_record:
             return "Création désactivée"
 
+        if JobApplication.objects.eligible_as_employee_record(siae=obj.to_siae).filter(pk=obj.pk).exists():
+            return "En attente de création"
+
         return "-"
 
 

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -847,7 +847,7 @@ class CustomApprovalAdminViewsTest(TestCase):
                 if not job_application.to_siae.can_use_employee_record:
                     assert msg == "La SIAE n'utilise pas les fiches salariés"
                 else:
-                    assert msg == "-"
+                    assert msg == "En attente de création"
 
 
 class SuspensionQuerySetTest(TestCase):

--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -158,11 +158,11 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
         return mark_safe(f'<a href="{url}">Profil salarié ID:{job_seeker.pk}</a>')
 
     def asp_processing_type(self, obj):
-        return (
-            "Intégrée automatiquement par script (doublon ASP)"
-            if obj.processed_as_duplicate
-            else "Intégration ASP normale"
-        )
+        if obj.processed_as_duplicate:
+            return "Intégrée automatiquement par script (doublon ASP)"
+        if obj.asp_processing_code:
+            return "Intégration ASP normale"
+        return "-"
 
     asp_processing_type.short_description = "Type d'intégration"
     job_seeker_link.short_description = "Salarié"


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/ADMIN-Page-PASS-IAE-L-information-sur-le-statut-de-la-fiche-salari-n-est-pas-toujours-fiable-59cf47653dd641ba834ef79c0e7e13c1 + remontée du support

### Pourquoi ?

Commit 1 : Ne pas créer de confusion parce qu'on affiche une phrase qui est là uniquement car c'est un cas par défaut.
Commit 2 : Remettre l'information "FS en attente de création" directement dans l'admin (plutôt que de devoir regarder sur le tableau de bord de l'employeur), enlevé par 592e23f63 car on ne disais pas la vérité dans les cas problématiques.