### PR TITLE
Notifier les DDETS quand les SIAE attendent les sanctions

### DIFF
--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 
 from itou.utils import constants as global_constants
 from itou.utils.emails import get_email_message
+from itou.utils.urls import get_absolute_url
 
 
 class CampaignEmailFactory:
@@ -33,6 +34,19 @@ class CampaignEmailFactory:
         context = {"evaluated_siaes": evaluated_siaes}
         subject = "siae_evaluations/email/to_institution_siaes_forced_to_adversarial_stage_subject.txt"
         body = "siae_evaluations/email/to_institution_siaes_forced_to_adversarial_stage_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
+    def close(self):
+        context = {
+            "evaluated_siaes_list_url": get_absolute_url(
+                reverse(
+                    "siae_evaluations_views:institution_evaluated_siae_list",
+                    kwargs={"evaluation_campaign_pk": self.evaluation_campaign.pk},
+                )
+            )
+        }
+        subject = "siae_evaluations/email/to_institution_campaign_close_subject.txt"
+        body = "siae_evaluations/email/to_institution_campaign_close_body.txt"
         return get_email_message(self.recipients, context, subject, body)
 
 

--- a/itou/templates/siae_evaluations/email/to_institution_campaign_close_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_campaign_close_body.txt
@@ -1,0 +1,12 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+Suite au dernier contrôle a posteriori, une ou plusieurs SIAE de votre département ont obtenu un résultat négatif.
+Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
+
+Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
+{{ evaluated_siaes_list_url }}
+
+Cordialement,
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/to_institution_campaign_close_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_campaign_close_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+[Contrôle a posteriori] Notification des sanctions
+{% endblock %}


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/1-4-Pack-sanctions-En-tant-que-DDETS-je-prends-connaissance-de-l-ouverture-de-la-phase-des-sanctio-2e9646d5e4be4c04bebedbba90f70497**

### Pourquoi ?

Prévenir les DDETS qu’elles doivent enregistrer la ou les sanctions prévues à l’encontre des SIAE qui ont obtenu un résultat négatif.