### PR TITLE
[FS] Amélioration du message confusant à propos des FS complétées en attente d'envoi

### DIFF
--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -87,15 +87,18 @@
                 </div>
 
                 {# Messages #}
-                <div class="h5">
+                <article>
                     {% if form.status.value == "NEW" %}
                         <p class="mb-0">
-                            Vous trouverez ici les candidatures validées à partir desquelles vous devez créer de
-                            nouvelles fiches salarié.
+                            Vous trouverez ici les candidatures validées <b>à partir desquelles vous devez créer de
+                            nouvelles fiches salarié</b>.
                         </p>
                     {% elif form.status.value == "READY" %}
-                        <p class="mb-0">Vous trouverez ici les fiches salarié complétées en attente de l’envoi à l’ASP,</p>
-                        <p class="mb-0">qui a lieu automatiquement à intervalles réguliers.</p>
+                        <p class="mb-0">
+                            Vous trouverez ici les fiches salarié complétées
+                            <b>en attente d’envoi à l’ASP, qui a lieu
+                            automatiquement à intervalles réguliers</b>.
+                        </p>
                         <p class="mb-0">
                             À ce stade, seule la visualisation des informations de la fiche est
                             possible.
@@ -126,7 +129,7 @@
                             "Nouvelle".
                         </p>
                     {% endif %}
-                </div>
+                </article>
                 {% if need_manual_regularization %}
                     <div class="alert alert-warning my-5">
                         <div class="row">

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -94,14 +94,13 @@
                             nouvelles fiches salarié.
                         </p>
                     {% elif form.status.value == "READY" %}
-                        <p class="mb-0">
-                            Vous trouverez ici les fiches salarié complétées et en attente d'envoi à
-                            l'ASP.
-                        </p>
+                        <p class="mb-0">Vous trouverez ici les fiches salarié complétées en attente de l’envoi à l’ASP,</p>
+                        <p class="mb-0">qui a lieu automatiquement à intervalles réguliers.</p>
                         <p class="mb-0">
                             À ce stade, seule la visualisation des informations de la fiche est
                             possible.
                         </p>
+                        <p class="mb-0">Merci de votre patience.</p>
                     {% elif form.status.value == "SENT" %}
                         <p class="mb-0">Vous trouverez ici les fiches salarié complétées et envoyées à l'ASP.</p>
                         <p class="mb-0">


### PR DESCRIPTION
### Pourquoi ?

Certains employeurs (groupe Actual) remontent le fait qu'une FS complétée ne s'envoit pas comme un bug. Ils ne comprennent pas qu'il suffit d'attendre quelques heures pour un envoi automatique. Ils pensent qu'ils ont encore une action à faire, ce qui n'est pas le cas.

Cf fil ([lien](https://itou-inclusion.slack.com/archives/C01AQKD7MAN/p1673021278502709))

### Avant

![image](https://user-images.githubusercontent.com/10533583/214265103-b58b8b86-a1e3-4a0c-9d19-f25be1a445d6.png)

### Après

![image](https://user-images.githubusercontent.com/10533583/214266418-3d652f92-bb42-4da8-b11c-1d2dca159b13.png)



