### PR TITLE
Corrige l’ancrage des métiers sur la page de description des SIAE

### DIFF
--- a/itou/templates/siaes/card.html
+++ b/itou/templates/siaes/card.html
@@ -102,7 +102,7 @@
 {% endblock %}
 
 {% block post_content %}
-    <section class="s-tabs-01 mt-0 pt-0">
+    <section id="metiers" class="s-tabs-01 mt-0 pt-0">
         <div class="s-tabs-01__container container">
             <div class="s-tabs-01__row row">
                 <div class="s-tabs-01__col col-12">


### PR DESCRIPTION
Regression introduite avec 30331edeed8d6aa1b0e1b7363bc274c2d5ad24e9.

https://itou-inclusion.slack.com/archives/C01181Y04LT/p1674569058030759