### PR TITLE
Ajout de la reprise de stock AI quand nécessaire

### DIFF
--- a/itou/metabase/sql/015_taux_transformation_prescripteurs.sql
+++ b/itou/metabase/sql/015_taux_transformation_prescripteurs.sql
@@ -1,52 +1,57 @@
-	
 /* 
 	 
 L'objectif est de créer une table agrégée sur les candidats et leur candidatures qui ne contient que les préscripteurs comme auteurs de diagnostics. 
 Nous récupérons aussi différentes informations sur les structures à partir de la table organisation afin de mettre en place des filtres + précis
 	
 */
-	
-with candidats_p as ( /* Ici on sélectionne les colonnes pertinentes à partir de la table candidats en ne prenant que les auteurs = Prescripteur */
-    select  
-	distinct cdd.id as id_candidat,
-	/* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
-	cdd.id_anonymisé as id_candidat_anonymise, 
-	cdd.actif,   
-	cdd.age,    
-	cdd.date_diagnostic,
-	case /* On soustrait 6 mois à la date de diagnostic pour déterminer s'il est toujours en cours ou pas */
-    	    when date_diagnostic >= date_trunc('month', CURRENT_DATE) - INTERVAL '5 months' then 'Oui' 
-    	    else 'non'
-	end diagnostic_valide,
-	cdd.département as departement_candidat,
-	cdd.nom_département as nom_departement_candidat,
-	cdd.région as region_candidat,
-	cdd.type_auteur_diagnostic,
-	cdd.sous_type_auteur_diagnostic, 
-	cdd.nom_auteur_diagnostic,
-	cdd.id_auteur_diagnostic_prescripteur as id_org_prescripteur,
-	cdd.total_candidatures, 
-	cdd.total_diagnostics,
-	cdd.total_embauches,
-	cdd.type_inscription,
-	cdd.injection_ai,
-	cdd.pe_inscrit
+with candidats_p as (
+    /* Ici on sélectionne les colonnes pertinentes à partir de la table candidats en ne prenant que les auteurs = Prescripteur */
+    select
+        distinct cdd.id as id_candidat,
+        /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
+        cdd.id_anonymisé as id_candidat_anonymise,
+        cdd.actif,
+        cdd.age,
+        cdd.date_diagnostic,
+        case
+            /* On soustrait 6 mois à la date de diagnostic pour déterminer s'il est toujours en cours ou pas */
+            when date_diagnostic >= date_trunc('month', CURRENT_DATE) - interval '5 months' then 'Oui'
+            else 'non'
+        end diagnostic_valide,
+        cdd.département as departement_candidat,
+        cdd.nom_département as nom_departement_candidat,
+        cdd.région as region_candidat,
+        cdd.type_auteur_diagnostic,
+        cdd.sous_type_auteur_diagnostic,
+        cdd.nom_auteur_diagnostic,
+        cdd.id_auteur_diagnostic_prescripteur as id_org_prescripteur,
+        cdd.total_candidatures,
+        cdd.total_diagnostics,
+        cdd.total_embauches,
+        cdd.type_inscription,
+        cdd.injection_ai,
+        cdd.pe_inscrit
     from
-	public.candidats as cdd /* cdd pour CanDiDats */
-    where type_auteur_diagnostic = ('Prescripteur')
+        public.candidats as cdd /* cdd pour CanDiDats */
+    where
+        type_auteur_diagnostic = ('Prescripteur')
 ),
 prescripteurs as (
-    select 
+    select
         id,
-        nom_département as nom_département_prescripteur, /* Ajout du département du prescripteur pour les TBs privés */
+        nom_département as nom_département_prescripteur,
+        /* Ajout du département du prescripteur pour les TBs privés */
         région as nom_région_prescripteur
-    from organisations o 
+    from
+        organisations o
 )
-select /* On selectionne les colonnes finales qui nous intéressent */
+select
+    /* On selectionne les colonnes finales qui nous intéressent */
     id_candidat,
     /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
     id_candidat_anonymise as id_candidat_anonymise,
-    case /* ajout d'une colonne permettant de calculer le taux de candidats acceptées tout en faisant une jointure avec la table candidatures */
+    case
+        /* ajout d'une colonne permettant de calculer le taux de candidats acceptées tout en faisant une jointure avec la table candidatures */
         when total_embauches > 0 then concat(cast(id_candidat as varchar), '_accepté')
         else null
     end candidature_acceptée,
@@ -58,40 +63,41 @@ select /* On selectionne les colonnes finales qui nous intéressent */
     nom_departement_candidat,
     region_candidat,
     type_auteur_diagnostic,
-    case /* Modification des noms pour plus de clarté */
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur AFPA' then 'AFPA - Agence nationale pour la formation professionnelle des adultes'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur ASE' then 'ASE - Aide sociale à l''enfance'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur Autre' then 'Autre' 
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAARUD' then 'CAARUD - Centre d''accueil et d''accompagnement à la réduction de risques pour usagers de drogues'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CADA' then 'CADA - Centre d''accueil de demandeurs d''asile'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAF' then 'CAF - Caisse d''allocations familiales'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAP_EMPLOI' then 'CAP emploi'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAVA' then 'ACAVA - Centre d''adaptation à la vie active'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CCAS' then 'CCAS - Centre communal d''action sociale ou centre intercommunal d''action sociale'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CHRS' then 'CHRS - Centre d''hébergement et de réinsertion sociale'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CHU' then 'CHU - Centre d''hébergement d''urgence'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CIDFF' then 'CIDFF - Centre d''information sur les droits des femmes et des familles'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CPH' then 'CPH - Centre provisoire d''hébergement'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CSAPA' then 'CSAPA - Centre de soins, d''accompagnement et de prévention en addictologie'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur DEPT' then 'Service social du conseil départemental'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur E2C' then 'E2C - École de la deuxième chance'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur EPIDE' then 'EPIDE - Établissement pour l''insertion dans l''emploi'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur HUDA' then 'HUDA - Hébergement d''urgence pour demandeurs d''asile'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur ML' then 'Mission Locale'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur MSA' then 'MSA - Mutualité Sociale Agricole'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur None' then 'Autre'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur OACAS' then 'OACAS - Structure porteuse d''un agrément national organisme d''accueil communautaire et d''activité solidaire'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur ODC' then 'Organisation délégataire d''un CD'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur OIL' then 'Opérateur d''intermédiation locative'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PE' then 'Pôle emploi'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PENSION' then 'Pension de famille / résidence accueil'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PIJ_BIJ' then 'PIJ-BIJ - Point/Bureau information jeunesse'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PJJ' then 'PJJ - Protection judiciaire de la jeunesse'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PLIE' then 'PLIE - Plan local pour l''insertion et l''emploi'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PREVENTION' then 'Service ou club de prévention'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur RS_FJT' then 'Résidence sociale / FJT - Foyer de Jeunes Travailleurs'
-	when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur SPIP' then 'SPIP - Service pénitentiaire d''insertion et de probation'
-    end type_auteur_diagnostic_detaille, 
+    case
+        /* Modification des noms pour plus de clarté */
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur AFPA' then 'AFPA - Agence nationale pour la formation professionnelle des adultes'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur ASE' then 'ASE - Aide sociale à l''enfance'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur Autre' then 'Autre'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAARUD' then 'CAARUD - Centre d''accueil et d''accompagnement à la réduction de risques pour usagers de drogues'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CADA' then 'CADA - Centre d''accueil de demandeurs d''asile'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAF' then 'CAF - Caisse d''allocations familiales'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAP_EMPLOI' then 'CAP emploi'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAVA' then 'ACAVA - Centre d''adaptation à la vie active'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CCAS' then 'CCAS - Centre communal d''action sociale ou centre intercommunal d''action sociale'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CHRS' then 'CHRS - Centre d''hébergement et de réinsertion sociale'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CHU' then 'CHU - Centre d''hébergement d''urgence'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CIDFF' then 'CIDFF - Centre d''information sur les droits des femmes et des familles'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CPH' then 'CPH - Centre provisoire d''hébergement'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CSAPA' then 'CSAPA - Centre de soins, d''accompagnement et de prévention en addictologie'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur DEPT' then 'Service social du conseil départemental'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur E2C' then 'E2C - École de la deuxième chance'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur EPIDE' then 'EPIDE - Établissement pour l''insertion dans l''emploi'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur HUDA' then 'HUDA - Hébergement d''urgence pour demandeurs d''asile'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur ML' then 'Mission Locale'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur MSA' then 'MSA - Mutualité Sociale Agricole'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur None' then 'Autre'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur OACAS' then 'OACAS - Structure porteuse d''un agrément national organisme d''accueil communautaire et d''activité solidaire'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur ODC' then 'Organisation délégataire d''un CD'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur OIL' then 'Opérateur d''intermédiation locative'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PE' then 'Pôle emploi'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PENSION' then 'Pension de famille / résidence accueil'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PIJ_BIJ' then 'PIJ-BIJ - Point/Bureau information jeunesse'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PJJ' then 'PJJ - Protection judiciaire de la jeunesse'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PLIE' then 'PLIE - Plan local pour l''insertion et l''emploi'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PREVENTION' then 'Service ou club de prévention'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur RS_FJT' then 'Résidence sociale / FJT - Foyer de Jeunes Travailleurs'
+        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur SPIP' then 'SPIP - Service pénitentiaire d''insertion et de probation'
+    end type_auteur_diagnostic_detaille,
     nom_auteur_diagnostic,
     id_org_prescripteur,
     nom_département_prescripteur,
@@ -102,7 +108,8 @@ select /* On selectionne les colonnes finales qui nous intéressent */
     type_inscription,
     pe_inscrit,
     injection_ai
-from 
+from
     candidats_p
-    	left join prescripteurs
-            on prescripteurs.id = candidats_p.id_org_prescripteur
+left join prescripteurs
+            on
+    prescripteurs.id = candidats_p.id_org_prescripteur

--- a/itou/metabase/sql/015_taux_transformation_prescripteurs.sql
+++ b/itou/metabase/sql/015_taux_transformation_prescripteurs.sql
@@ -33,7 +33,7 @@ with candidats_p as ( /* Ici on sélectionne les colonnes pertinentes à partir 
 	cdd.pe_inscrit
     from
 	public.candidats as cdd /* cdd pour CanDiDats */
-    where type_auteur_diagnostic = ('Prescripteur') and injection_ai = 0
+    where type_auteur_diagnostic = ('Prescripteur')
 ),
 prescripteurs as (
     select 

--- a/itou/metabase/sql/018_nombre_candidatures_par_structure.sql
+++ b/itou/metabase/sql/018_nombre_candidatures_par_structure.sql
@@ -22,7 +22,7 @@ with z_candidatures as (
 	c.nom_org_prescripteur	
     from 
 	public.candidatures c 
-    where injection_ai = 0 and type_structure IN ('AI', 'ACI', 'EI', 'EITI', 'ETTI') 
+    where type_structure IN ('AI', 'ACI', 'EI', 'EITI', 'ETTI') 
     group by 
 	état,
 	c.date_candidature,

--- a/itou/metabase/sql/018_nombre_candidatures_par_structure.sql
+++ b/itou/metabase/sql/018_nombre_candidatures_par_structure.sql
@@ -4,67 +4,69 @@ L'objectif est de créer une table agrégée avec le nombre de candidatures et l
 selon l'état de la candidature, la structure, le type de structure, l'orgine de la candidature et le prescripteur
 
 */
-
 with z_candidatures as (
-    select 
+    select
         c.état,
-	c.date_candidature,
-	count(c.état) as nombre_de_candidatures,
-	c.id_structure, 
-	c.type_structure, 
-	c.nom_structure,
-	c.injection_ai,
-	c.origine,
-	c.origine_détaillée,
-	c.département_structure,
-	c.nom_département_structure,
-	c.région_structure,
-	c.nom_org_prescripteur	
-    from 
-	public.candidatures c 
-    where type_structure IN ('AI', 'ACI', 'EI', 'EITI', 'ETTI') 
-    group by 
-	état,
-	c.date_candidature,
-	id_structure,
-	type_structure,
-	nom_structure,
-	injection_ai,
-	origine,
-	origine_détaillée,
-	département_structure,
-	nom_département_structure,
-	région_structure,
-	nom_org_prescripteur
+        c.date_candidature,
+        count(c.état) as nombre_de_candidatures,
+        c.id_structure,
+        c.type_structure,
+        c.nom_structure,
+        c.injection_ai,
+        c.origine,
+        c.origine_détaillée,
+        c.département_structure,
+        c.nom_département_structure,
+        c.région_structure,
+        c.nom_org_prescripteur
+    from
+        public.candidatures c
+    where
+        type_structure in (
+            'AI', 'ACI', 'EI', 'EITI', 'ETTI'
+        )
+    group by
+        état,
+        c.date_candidature,
+        id_structure,
+        type_structure,
+        nom_structure,
+        injection_ai,
+        origine,
+        origine_détaillée,
+        département_structure,
+        nom_département_structure,
+        région_structure,
+        nom_org_prescripteur
 ),
-z_prop_candidatures as ( 					
-    select 
-	état,
-	sum(nombre_de_candidatures) as total_candidatures,
-	id_structure 	
-    from 
-	z_candidatures
-    group by 
-	état,
-	id_structure
+z_prop_candidatures as (
+    select
+        état,
+        sum(nombre_de_candidatures) as total_candidatures,
+        id_structure
+    from
+        z_candidatures
+    group by
+        état,
+        id_structure
 ),
-z_ttes_candidatures as ( 
-    select 
-	sum(nombre_de_candidatures) as somme_candidatures,
-	id_structure
-    from 
-	z_candidatures
-    group by 
-	id_structure 
+z_ttes_candidatures as (
+    select
+        sum(nombre_de_candidatures) as somme_candidatures,
+        id_structure
+    from
+        z_candidatures
+    group by
+        id_structure
 )
-select 
+select
     z_candidatures.état,
     z_candidatures.date_candidature,
     z_candidatures.nombre_de_candidatures,
     z_prop_candidatures.total_candidatures,
     z_ttes_candidatures.somme_candidatures,
-  /* calcul de la proportion de candidatures en % */
-    z_candidatures.nombre_de_candidatures/z_prop_candidatures.total_candidatures as taux_de_candidatures,  
+    /* calcul de la proportion de candidatures en % */
+    z_candidatures.nombre_de_candidatures / z_prop_candidatures.total_candidatures as taux_de_candidatures,
     z_candidatures.nom_structure,
     z_candidatures.type_structure,
     z_candidatures.origine,
@@ -79,9 +81,13 @@ select
     z_candidatures.injection_ai
 from
     z_candidatures
-	left join z_prop_candidatures 
-		on z_candidatures.état = z_prop_candidatures.état and z_candidatures.id_structure =  z_prop_candidatures.id_structure
-	left join z_ttes_candidatures
-		on z_candidatures.id_structure = z_ttes_candidatures.id_structure 
-	left join public.structures s 
-		on z_candidatures.id_structure = s.id
+left join z_prop_candidatures 
+		on
+    z_candidatures.état = z_prop_candidatures.état
+    and z_candidatures.id_structure = z_prop_candidatures.id_structure
+left join z_ttes_candidatures
+		on
+    z_candidatures.id_structure = z_ttes_candidatures.id_structure
+left join public.structures s 
+		on
+    z_candidatures.id_structure = s.id

--- a/itou/metabase/sql/021_tx_candidats_acceptes_par_prescripteurs.sql
+++ b/itou/metabase/sql/021_tx_candidats_acceptes_par_prescripteurs.sql
@@ -4,12 +4,13 @@ select
     count(distinct(id_candidat)) filter (where(état = 'Candidature acceptée')) as nombre_candidats_acceptés,
     count(distinct(id_candidat)) as nombre_candidats,
     count(distinct(id)) filter (where(état = 'Candidature acceptée')) as nombre_candidatures_acceptées,
-    count(distinct(id)) as nombre_candidatures
+    count(distinct(id)) as nombre_candidatures,
+    injection_ai
 from 
     candidatures
 where 
     lower(origine_détaillée) like 'prescripteur%'
-    and injection_ai = 0
 group by 
     origine_détaillée, 
-    date_candidature
+    date_candidature,
+    injection_ai 

--- a/itou/metabase/sql/021_tx_candidats_acceptes_par_prescripteurs.sql
+++ b/itou/metabase/sql/021_tx_candidats_acceptes_par_prescripteurs.sql
@@ -1,16 +1,26 @@
-select 
-    origine_détaillée, 
-    date_candidature, 
-    count(distinct(id_candidat)) filter (where(état = 'Candidature acceptée')) as nombre_candidats_acceptés,
+select
+    origine_détaillée,
+    date_candidature,
+    count(distinct(id_candidat)) filter (
+    where
+        (
+            état = 'Candidature acceptée'
+        )
+    ) as nombre_candidats_acceptés,
     count(distinct(id_candidat)) as nombre_candidats,
-    count(distinct(id)) filter (where(état = 'Candidature acceptée')) as nombre_candidatures_acceptées,
+    count(distinct(id)) filter (
+    where
+        (
+            état = 'Candidature acceptée'
+        )
+    ) as nombre_candidatures_acceptées,
     count(distinct(id)) as nombre_candidatures,
     injection_ai
-from 
+from
     candidatures
-where 
+where
     lower(origine_détaillée) like 'prescripteur%'
-group by 
-    origine_détaillée, 
+group by
+    origine_détaillée,
     date_candidature,
-    injection_ai 
+    injection_ai

--- a/itou/metabase/sql/022_delai_recrutement.sql
+++ b/itou/metabase/sql/022_delai_recrutement.sql
@@ -2,31 +2,32 @@
  L'objectif est de suivre le délai de recrutement des candidats en IAE.
  Statistiques d'impact des emplois de l'inclusion : maintenir un délai de recrutement inférieur à 30 jours 
 */
-
 with premiere_candidature as (
-    select 
+    select
         id_candidat,
-        min(date_candidature) as min_date_candidature 
-    from 
-        candidatures 
-    group by 
-        id_candidat  ) 
-select     
-    distinct (c.id_candidat) as identifiant_candidat, 
+        min(date_candidature) as min_date_candidature
+    from
+        candidatures
+    group by
+        id_candidat
+)
+select
+    distinct (c.id_candidat) as identifiant_candidat,
     pc.min_date_candidature,
     min(date_embauche) as min_date_embauche,
     min(date_embauche) - pc.min_date_candidature as delai_recrutement_jours,
     injection_ai
-from 
+from
     candidatures c
 left join 
     premiere_candidature pc
-    on c.id_candidat = pc.id_candidat
-where 
+    on
+    c.id_candidat = pc.id_candidat
+where
     date_embauche is not null
-    and état = 'Candidature acceptée' 
+    and état = 'Candidature acceptée'
     and origine != 'Employeur'
-group by 
-    c.id_candidat, 
+group by
+    c.id_candidat,
     pc.min_date_candidature,
-    injection_ai 
+    injection_ai

--- a/itou/metabase/sql/022_delai_recrutement.sql
+++ b/itou/metabase/sql/022_delai_recrutement.sql
@@ -15,7 +15,8 @@ select
     distinct (c.id_candidat) as identifiant_candidat, 
     pc.min_date_candidature,
     min(date_embauche) as min_date_embauche,
-    min(date_embauche) - pc.min_date_candidature as delai_recrutement_jours
+    min(date_embauche) - pc.min_date_candidature as delai_recrutement_jours,
+    injection_ai
 from 
     candidatures c
 left join 
@@ -27,4 +28,5 @@ where
     and origine != 'Employeur'
 group by 
     c.id_candidat, 
-    pc.min_date_candidature
+    pc.min_date_candidature,
+    injection_ai 


### PR DESCRIPTION
**Carte Notion : ** [ici](https://www.notion.so/Reprise-de-stock-AI-V-rifier-les-scripts-sql-pour-int-grer-les-reprises-de-stock-5c89efd36077487a9b05e8ff6b9e03e4)

### Pourquoi ?

Dans le cadre de la fiabilisation des données nous avons décidé d'ajouter la reprise de stock AI dans nos tableaux de bord. Il a donc fallu reprendre les scripts sql ou cette dernière était manquante
+ modifications dans l'indentation des scripts 



