### PR TITLE
Ajout d’outils pour formatter le HTML dans les tests

### DIFF
--- a/itou/utils/test.py
+++ b/itou/utils/test.py
@@ -1,4 +1,30 @@
+from bs4 import BeautifulSoup
 from django.test import Client, TestCase as BaseTestCase
+
+
+def format_html(response, **selectors):
+    """
+    Formats an HTML document, ideal for inclusion in the expected outcome of a
+    test.
+
+    Heed the warning from
+    https://www.crummy.com/software/BeautifulSoup/bs4/doc/#pretty-printing :
+
+    > Since it adds whitespace (in the form of newlines), prettify() changes
+      the meaning of an HTML document and should not be used to reformat one.
+      The goal of prettify() is to help you visually understand the structure
+      of the documents you work with.
+
+    Prefer `assertHTMLEqual` and `assertContains(…, html=True)`.
+
+    Nonetheless, this tool cuts boilerplate in capturing response output.
+    """
+    parser = BeautifulSoup(response.content, "html5lib")
+    return [elt.prettify() for elt in parser.find_all(**selectors)]
+
+
+def pprint_html(response, **selectors):
+    print("\n\n".join(format_html(response, **selectors)))
 
 
 class NoInlineClient(Client):

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -2,6 +2,8 @@
 
 pip-tools  # https://github.com/jazzband/pip-tools/
 
+beautifulsoup4  # https://code.launchpad.net/beautifulsoup
+html5lib  # https://github.com/html5lib/html5lib-python
 ipdb  # https://github.com/gotcha/ipdb
 
 # Code quality

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -71,6 +71,7 @@ beautifulsoup4==4.11.1 \
     --hash=sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693
     # via
     #   -r requirements/base.txt
+    #   -r requirements/dev.in
     #   django-bootstrap4
 black==22.12.0 \
     --hash=sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320 \
@@ -467,6 +468,10 @@ html-void-elements==0.1.0 \
 httpcore==0.15.0 \
     --hash=sha256:1105b8b73c025f23ff7c36468e4432226cbb959176eab66864b8e31c4ee27fa6 \
     --hash=sha256:18b68ab86a3ccf3e7dc0f43598eaddcf472b602aba29f9aa6ab85fe2ada3980b
+html5lib==1.1 \
+    --hash=sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d \
+    --hash=sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f
+    # via -r requirements/dev.in
     # via
     #   -r requirements/base.txt
     #   httpx
@@ -1139,6 +1144,7 @@ six==1.16.0 \
     # via
     #   -r requirements/base.txt
     #   cssbeautifier
+    #   html5lib
     #   jsbeautifier
     #   python-dateutil
 sniffio==1.3.0 \
@@ -1232,6 +1238,10 @@ wcwidth==0.2.5 \
     --hash=sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784 \
     --hash=sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83
     # via prompt-toolkit
+webencodings==0.5.1 \
+    --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
+    --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
+    # via html5lib
 wheel==0.38.4 \
     --hash=sha256:965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac \
     --hash=sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8


### PR DESCRIPTION
### Pourquoi ?

Utile pour capturer une partie d’un document HTML, notamment pour inclure du _markup_ dans un format compact et facile à lire dans l’attendu d’un test.