### PR TITLE
[Metabase] Recensement et création à vide de toutes les tables non versionnées

### DIFF
--- a/itou/metabase/db.py
+++ b/itou/metabase/db.py
@@ -163,10 +163,6 @@ def create_unversioned_tables_if_needed():
                 "longitude" numeric(9,6)
             );
 
-            CREATE TABLE IF NOT EXISTS "constantes" (
-                "annee_en_cours" float8
-            );
-
             CREATE TABLE IF NOT EXISTS "sa_ept" (
                 "etablissement_public_territorial" varchar(255),
                 "commune" varchar(255),

--- a/itou/metabase/tables/selected_jobs.py
+++ b/itou/metabase/tables/selected_jobs.py
@@ -1,7 +1,7 @@
 from itou.metabase.tables.utils import MetabaseTable, hash_content
 
 
-TABLE = MetabaseTable(name="fiches_de_poste_par_candidature_v2")
+TABLE = MetabaseTable(name="fiches_de_poste_par_candidature")
 TABLE.add_columns(
     [
         {


### PR DESCRIPTION
### Pourquoi ?

En local dev en partant d'une db vierge, même après avoir fait les trois populates (emplois/fluxiae/matomo), le `build_final_tables` casse sur un tas de tables manquantes. Cela empêche de tester l'ensemble des requêtes SQL en local après un changement.

Ces tables manquantes sont des tables "non versionnées" (c.a.d. dont la création n'est codée nulle part dans le présent repo) qui ont été créées manuellement (dette technique).

Fil complet ([lien](https://itou-inclusion.slack.com/archives/CT7986ULC/p1673626720113039))

### Comment

- En crééant toutes ces tables avec la bonne structure mais aucune donnée. Au moins cela débloque l'ensemble des requêtes SQL et on la visibilité de l'ensemble de ces tables qu'on peut maintenant discuter au cas par cas. C'est un premier pas.
- En passant j'ai levé un loup sur la table `fiches_de_poste_par_candidature_v2` qui est renommée en `fiches_de_poste_par_candidature` pour que les scripts s'appuient bien dessus.

