### PR TITLE
Suppression du badge du nombre de postes ouverts si le recrutement est fermé

### DIFF
--- a/itou/templates/siaes/includes/_job_description_details.html
+++ b/itou/templates/siaes/includes/_job_description_details.html
@@ -1,8 +1,10 @@
 {% include "siaes/includes/_siae_info.html" %}
 
-<p class="badge badge-pill badge-success mb-4">
-    {{ job.open_positions }} poste{{ job.open_positions|pluralize }} ouvert{{ job.open_positions|pluralize }} au recrutement
-</p>
+{% if job.is_active %}
+    <p class="badge badge-pill badge-success mb-4">
+        {{ job.open_positions }} poste{{ job.open_positions|pluralize }} ouvert{{ job.open_positions|pluralize }} au recrutement
+    </p>
+{% endif %}
 
 <h2 class="mb-4">{{ job.display_name }}</h2>
 

--- a/itou/www/siaes_views/tests/tests_views.py
+++ b/itou/www/siaes_views/tests/tests_views.py
@@ -533,6 +533,7 @@ class JobDescriptionCardViewTest(TestCase):
         siae = SiaeWithMembershipAndJobsFactory()
         job_description = siae.job_description_through.first()
         job_description.description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        job_description.open_positions = 1234
         job_description.save()
         url = reverse("siaes_views:job_description_card", kwargs={"job_description_id": job_description.pk})
         response = self.client.get(url)
@@ -542,6 +543,16 @@ class JobDescriptionCardViewTest(TestCase):
         self.assertContains(response, job_description.description)
         self.assertContains(response, escape(job_description.display_name))
         self.assertContains(response, escape(siae.display_name))
+        OPEN_POSITION_TEXT = "1234 postes ouverts au recrutement"
+        self.assertContains(response, OPEN_POSITION_TEXT)
+
+        job_description.is_active = False
+        job_description.save()
+        response = self.client.get(url)
+        self.assertContains(response, job_description.description)
+        self.assertContains(response, escape(job_description.display_name))
+        self.assertContains(response, escape(siae.display_name))
+        self.assertNotContains(response, OPEN_POSITION_TEXT)
 
 
 class ShowAndSelectFinancialAnnexTest(TestCase):


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/BUG-Le-badge-X-postes-ouverts-au-recrutement-s-affiche-m-me-si-le-recrutement-est-ferm-b9cf85af217b4f5682bc61a1ff83de91

### Pourquoi ?

Si le recrutement est fermé, il n'y a pas de poste ouvert.

