### PR TITLE
Amélioration du message d'erreur pour l'unicité du numéro de sécurité sociale

### DIFF
--- a/itou/users/migrations/0001_initial.py
+++ b/itou/users/migrations/0001_initial.py
@@ -359,6 +359,9 @@ class Migration(migrations.Migration):
                     "nir",
                     models.CharField(
                         blank=True,
+                        error_messages={
+                            "unique": "Ce numéro de sécurité sociale est déjà associé à un autre utilisateur."
+                        },
                         max_length=15,
                         null=True,
                         unique=True,

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -237,6 +237,7 @@ class User(AbstractUser, AddressMixin):
         null=True,
         blank=True,
         unique=True,
+        error_messages={"unique": "Ce numéro de sécurité sociale est déjà associé à un autre utilisateur."},
     )
 
     # The two following Pôle emploi fields are reserved for job seekers.

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -1049,7 +1049,7 @@ class ApplyAsPrescriberTest(S3AccessingTestCase):
         response = self.client.post(next_url)
         [message] = list(get_messages(response.wsgi_request))
         assert message.tags == "error"
-        assert message.message == "Un objet Utilisateur avec ce champ NIR existe déjà."
+        assert message.message == "Ce numéro de sécurité sociale est déjà associé à un autre utilisateur."
         self.assertRedirects(response, reverse("dashboard:index"))
 
         # Remove that extra job seeker and proceed with "normal" flow


### PR DESCRIPTION
### Pourquoi ?

On passe de:

    Un objet Utilisateur avec ce champ NIR existe déjà.

à

    Ce numéro de sécurité sociale est déjà associé à un autre utilisateur.

plus clair.



