### PR TITLE
Forcer le champ `asp_uid` à `None` si ce n'est compte n'est pas un compte candidat

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -217,9 +217,6 @@ class User(AbstractUser, AddressMixin):
 
     kind = models.CharField(max_length=20, verbose_name="Type d'utilisateur", choices=UserKind.choices, blank=False)
 
-    # TODO(rsebille): Replace the use of a signal by using an uuid4() as default value.
-    #  I am not do it _right now_ because we need to make sure the format will work on ASP side,
-    #  and even if it works we will need the field to store the ID already sent.
     asp_uid = models.TextField(
         verbose_name="ID unique envoyé à l'ASP",
         help_text="Si vide, une valeur sera assignée automatiquement.",
@@ -352,6 +349,9 @@ class User(AbstractUser, AddressMixin):
         super().save(*args, **kwargs)
 
         if self.is_job_seeker and not self.asp_uid:
+            # TODO(rsebille): Replace this by using an uuid4() as default value.
+            #  I am not do it _right now_ because we need to make sure the format will work on ASP side,
+            #  and even if it works we will need the field to store the ID already sent.
             self.asp_uid = salted_hmac(key_salt="job_seeker.id", value=self.id).hexdigest()[:30]
             super().save(update_fields=["asp_uid"])
 

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -330,6 +330,11 @@ class User(AbstractUser, AddressMixin):
             raise ValidationError(self.ERROR_BIRTH_COMMUNE_WITH_FOREIGN_COUNTRY)
 
     def save(self, *args, **kwargs):
+        if not self.is_job_seeker:
+            self.asp_uid = None  # Needs to be done before the call to .validate_unique()
+        if self.is_job_seeker and not self.asp_uid and self.id:  # When .kind changes
+            self.asp_uid = salted_hmac(key_salt="job_seeker.id", value=self.id).hexdigest()[:30]
+
         # Update department from postal code (if possible).
         self.department = department_from_postcode(self.post_code)
         self.validate_unique()

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+import itertools
 import json
 import uuid
 from unittest import mock
@@ -1188,15 +1189,37 @@ class LatestApprovalTestCase(TestCase):
 )
 @override_settings(SECRET_KEY="test")
 def test_user_asp_uid(factory, expected):
-    user = factory.build(pk=42)
+    user = factory.build(pk=42, asp_uid="")
 
-    assert user.asp_uid is None
+    assert user.asp_uid == ""
     user.save()
 
     if expected is None:
         assert user.asp_uid is None
     else:
         assert user.asp_uid == expected
+
+
+@pytest.mark.parametrize("from_kind,to_kind", itertools.combinations(UserKind, 2))
+@override_settings(SECRET_KEY="test")
+def test_user_asp_uid_when_its_kind_changes(from_kind, to_kind):
+    user = UserFactory(pk=42, asp_uid="", kind=from_kind)
+    print(user.pk)
+
+    if user.is_job_seeker:
+        assert user.asp_uid == "08b4e9f755a688b554a6487d96d2a0"
+    else:
+        assert user.asp_uid is None
+
+    user.kind = to_kind
+    user.save()
+
+    print(user.pk)
+
+    if user.is_job_seeker:
+        assert user.asp_uid == "08b4e9f755a688b554a6487d96d2a0"
+    else:
+        assert user.asp_uid is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Pourquoi ?

La clause d'unicité du champs était déclenchée car le formulaire de l'admin enregistrais `""` pour ce champ.