### PR TITLE
Ajout des infos d'horodatage ASP sur les fiches salariés

### DIFF
--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -29,6 +29,17 @@
                         <div>
                             <b>{{ employee_record.get_status_display }}</b> le {{ employee_record.updated_at }}
                         </div>
+                        {% if employee_record.asp_batch_file %}
+                            <div class="mt-3">
+                                <b>Horodatage ASP:</b>
+                            </div>
+                            <div>Création : {{ employee_record.asp_batch_file|remove_json_extension }}</div>
+                            {% for update_notification in employee_record.update_notifications.all %}
+                                {% if update_notification.asp_batch_file %}
+                                    <div>Modification : {{ update_notification.asp_batch_file|remove_json_extension }}</div>
+                                {% endif %}
+                            {% endfor %}
+                        {% endif %}
                     </div>
                     <div class="col-sm-3 text-right">
                         <img src="{% static 'img/employee_record/asp_upload.svg' %}" alt="Transfert ASP">

--- a/itou/utils/templatetags/format_filters.py
+++ b/itou/utils/templatetags/format_filters.py
@@ -75,3 +75,9 @@ def format_approval_number(number, autoescape=True):
     return mark_safe(
         f'<span>{parts[0]}</span><span class="ml-1">{parts[1]}</span><span class="ml-1">{parts[2]}</span>'
     )
+
+
+@register.filter
+@stringfilter
+def remove_json_extension(filename):
+    return filename.removesuffix(".json")


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/En-tant-que-SIAE-je-veux-voir-l-horodatage-de-la-fiche-salari-BOOST-dcac301134084b83b18ed54912a747a0

### Pourquoi ?

Lorsqu’il y a des anomalies d’intégration des fiches salarié, l’ASP demande aux SIAE de fournir l’horodatage

### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.

![Screenshot 2023-01-25 at 14-55-52 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/214582139-b431435f-7783-4a9b-a041-e88a7d77a431.png)
