### PR TITLE
[Metabase] Ajout du champ `candidatures.date_début_contrat`

### DIFF
--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -140,6 +140,12 @@ TABLE.add_columns(
             "fn": lambda o: o.created_at,
         },
         {
+            "name": "date_début_contrat",
+            "type": "date",
+            "comment": "Date de début du contrat",
+            "fn": lambda o: o.hiring_start_at,
+        },
+        {
             "name": "état",
             "type": "varchar",
             "comment": "Etat de la candidature",


### PR DESCRIPTION
### Pourquoi ?

Pour débloquer une étude urgente pour le Ministère du Travail. Cf fil ([lien](https://itou-inclusion.slack.com/archives/CT7986ULC/p1673550096493869)).

Pas de revue car trivial *et* urgent.

