### PR TITLE
Création du `ItouProvider` pour Faker afin de remplacer les `RIAE_FS_...` par des `.asp_batch_filename()`

### DIFF
--- a/itou/api/employee_record_api/tests/tests.py
+++ b/itou/api/employee_record_api/tests/tests.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
 from django.utils import timezone
@@ -118,6 +119,7 @@ class EmployeeRecordAPIPermissionsTest(APITestCase):
         self.assertRedirects(response, reverse("account_logout"), status_code=302, target_status_code=200)
 
 
+@pytest.mark.usefixtures("unittest_compatibility")
 class EmployeeRecordAPIFetchListTest(APITestCase):
     @mock.patch(
         "itou.common_apps.address.format.get_geocoding_data",
@@ -147,7 +149,7 @@ class EmployeeRecordAPIFetchListTest(APITestCase):
         # Get list without filtering by status (PROCESSED)
         # note: there is no way to create a processed employee record
         # (and this is perfectly normal)
-        self.employee_record.update_as_sent("RIAE_FS_20210410130000.json", 1)
+        self.employee_record.update_as_sent(self.faker.asp_batch_filename(), 1)
         process_code, process_message = "0000", "La ligne de la fiche salarié a été enregistrée avec succès."
 
         # There should be no result at this point
@@ -183,7 +185,7 @@ class EmployeeRecordAPIFetchListTest(APITestCase):
 
         assert len(result.get("results")) == 0
 
-        employee_record_sent.update_as_sent("RIAE_FS_20210410130001.json", 1)
+        employee_record_sent.update_as_sent(self.faker.asp_batch_filename(), 1)
         response = self.client.get(ENDPOINT_URL + "?status=SENT", format="json")
 
         assert response.status_code == 200
@@ -197,7 +199,7 @@ class EmployeeRecordAPIFetchListTest(APITestCase):
         job_application = JobApplicationWithCompleteJobSeekerProfileFactory(to_siae=self.siae)
         employee_record_rejected = EmployeeRecord.from_job_application(job_application=job_application)
         employee_record_rejected.update_as_ready()
-        employee_record_rejected.update_as_sent("RIAE_FS_20210410130002.json", 1)
+        employee_record_rejected.update_as_sent(self.faker.asp_batch_filename(), 1)
 
         # There should be no result at this point
         response = self.client.get(ENDPOINT_URL + "?status=REJECTED", format="json")
@@ -243,6 +245,7 @@ class EmployeeRecordAPIFetchListTest(APITestCase):
         assert results.get("adresse").get("adrMail") == self.user.email
 
 
+@pytest.mark.usefixtures("unittest_compatibility")
 class EmployeeRecordAPIParametersTest(APITestCase):
     @mock.patch(
         "itou.common_apps.address.format.get_geocoding_data",
@@ -285,7 +288,7 @@ class EmployeeRecordAPIParametersTest(APITestCase):
         )
         employee_record = EmployeeRecord.from_job_application(job_application_2)
         employee_record.update_as_ready()
-        employee_record.update_as_sent("RIAE_FS_20220101000000.json", 1)
+        employee_record.update_as_sent(self.faker.asp_batch_filename(), 1)
 
         member = employee_record.job_application.to_siae.members.first()
         self.client.force_login(member)

--- a/itou/conftest.py
+++ b/itou/conftest.py
@@ -4,7 +4,9 @@ from django.contrib.gis.db.models.fields import get_srid_info
 from django.core import management
 from django.core.cache import cache
 from django.db import connection
+from factory import Faker
 
+from itou.utils import faker_providers
 from itou.utils.htmx.testing import HtmxClient
 from itou.utils.test import NoInlineClient
 
@@ -75,3 +77,14 @@ def django_test_environment_email_fixup(django_test_environment) -> None:
     # django.test.utils.setup_test_environment.
     settings.EMAIL_BACKEND = "itou.utils.tasks.AsyncEmailBackend"
     settings.ASYNC_EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def itou_faker_provider(_session_faker):
+    _session_faker.add_provider(faker_providers.ItouProvider)  # For faker
+    Faker.add_provider(faker_providers.ItouProvider)  # For factory_boy
+
+
+@pytest.fixture(scope="function")
+def unittest_compatibility(request, faker):
+    request.instance.faker = faker

--- a/itou/employee_record/factories.py
+++ b/itou/employee_record/factories.py
@@ -30,6 +30,9 @@ class EmployeeRecordFactory(BareEmployeeRecordFactory):
 
     class Params:
         orphan = factory.Trait(asp_id=0)
+        with_batch_information = factory.Trait(
+            asp_batch_file=factory.Faker("asp_batch_filename"), asp_batch_line_number=factory.Sequence(int)
+        )
 
 
 class EmployeeRecordWithProfileFactory(EmployeeRecordFactory):

--- a/itou/utils/faker_providers.py
+++ b/itou/utils/faker_providers.py
@@ -1,0 +1,8 @@
+import random
+
+from faker.providers import BaseProvider
+
+
+class ItouProvider(BaseProvider):
+    def asp_batch_filename(self) -> str:
+        return f"RIAE_FS_{random.randint(0, 99999999999999)}.json"

--- a/itou/www/employee_record_views/tests/test_disable.py
+++ b/itou/www/employee_record_views/tests/test_disable.py
@@ -1,3 +1,4 @@
+import pytest
 from django.urls import reverse
 from django.utils.html import escape
 
@@ -9,6 +10,7 @@ from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
 from itou.utils.test import TestCase
 
 
+@pytest.mark.usefixtures("unittest_compatibility")
 class DisableEmployeeRecordsTest(TestCase):
     def setUp(self):
         # User must be super user for UI first part (tmp)
@@ -52,8 +54,7 @@ class DisableEmployeeRecordsTest(TestCase):
 
     def test_disable_employee_record_sent(self):
         self.employee_record.update_as_ready()
-        filename = "RIAE_FS_20210410130001.json"
-        self.employee_record.update_as_sent(filename, 1)
+        self.employee_record.update_as_sent(self.faker.asp_batch_filename(), 1)
 
         self.employee_record.refresh_from_db()
         assert self.employee_record.status == Status.SENT
@@ -68,8 +69,7 @@ class DisableEmployeeRecordsTest(TestCase):
 
     def test_disable_employee_record_rejected(self):
         self.employee_record.update_as_ready()
-        filename = "RIAE_FS_20210410130001.json"
-        self.employee_record.update_as_sent(filename, 1)
+        self.employee_record.update_as_sent(self.faker.asp_batch_filename(), 1)
         err_code, err_message = "12", "JSON Invalide"
         self.employee_record.update_as_rejected(err_code, err_message)
 
@@ -88,8 +88,7 @@ class DisableEmployeeRecordsTest(TestCase):
 
     def test_disable_employee_record_completed(self):
         self.employee_record.update_as_ready()
-        filename = "RIAE_FS_20210410130001.json"
-        self.employee_record.update_as_sent(filename, 1)
+        self.employee_record.update_as_sent(self.faker.asp_batch_filename(), 1)
         process_code, process_message = "0000", "La ligne de la fiche salarié a été enregistrée avec succès."
         self.employee_record.update_as_processed(process_code, process_message, "{}")
 

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -1,3 +1,4 @@
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.test import override_settings
 from django.urls import reverse
@@ -12,6 +13,7 @@ from itou.users.enums import LackOfNIRReason
 from itou.utils.test import TestCase
 
 
+@pytest.mark.usefixtures("unittest_compatibility")
 class ListEmployeeRecordsTest(TestCase):
     def setUp(self):
         # User must be super user for UI first part (tmp)
@@ -163,7 +165,7 @@ class ListEmployeeRecordsTest(TestCase):
 
         record = employee_record_factories.EmployeeRecordWithProfileFactory(job_application__to_siae=self.siae)
         record.update_as_ready()
-        record.update_as_sent("RIAE_FS_20210410130002.json", 1)
+        record.update_as_sent(self.faker.asp_batch_filename(), 1)
         record.update_as_rejected("0012", "JSON Invalide")
 
         response = self.client.get(self.url + "?status=REJECTED")

--- a/itou/www/employee_record_views/tests/test_reactivate.py
+++ b/itou/www/employee_record_views/tests/test_reactivate.py
@@ -1,3 +1,4 @@
+import pytest
 from django.urls import reverse
 
 from itou.employee_record.enums import Status
@@ -7,6 +8,7 @@ from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
 from itou.utils.test import TestCase
 
 
+@pytest.mark.usefixtures("unittest_compatibility")
 class ReactivateEmployeeRecordsTest(TestCase):
     def setUp(self):
         # User must be super user for UI first part (tmp)
@@ -19,8 +21,7 @@ class ReactivateEmployeeRecordsTest(TestCase):
 
     def test_reactivate_employee_record(self):
         self.employee_record.update_as_ready()
-        filename = "RIAE_FS_20210410130001.json"
-        self.employee_record.update_as_sent(filename, 1)
+        self.employee_record.update_as_sent(self.faker.asp_batch_filename(), 1)
         process_code, process_message = "0000", "La ligne de la fiche salarié a été enregistrée avec succès."
         self.employee_record.update_as_processed(process_code, process_message, "{}")
         self.employee_record.update_as_disabled()

--- a/itou/www/employee_record_views/tests/test_summary.py
+++ b/itou/www/employee_record_views/tests/test_summary.py
@@ -42,15 +42,15 @@ class SummaryEmployeeRecordsTest(TestCase):
         self.assertNotContains(response, "Horodatage ASP")
 
         self.employee_record.update_as_ready()
-        filename = "RIAE_FS_20210410130000.json"
-        self.employee_record.update_as_sent(filename, 1)
+        self.employee_record.update_as_sent("RIAE_FS_20210410130000.json", 1)
 
         response = self.client.get(self.url)
         self.assertContains(response, "Horodatage ASP")
         self.assertContains(response, "Création : RIAE_FS_20210410130000")
 
-        filename2 = "RIAE_FS_20210510130000.json"
-        EmployeeRecordUpdateNotificationFactory(employee_record=self.employee_record, asp_batch_file=filename2)
+        EmployeeRecordUpdateNotificationFactory(
+            employee_record=self.employee_record, asp_batch_file="RIAE_FS_20210510130000.json"
+        )
         response = self.client.get(self.url)
         self.assertContains(response, "Horodatage ASP")
         self.assertContains(response, "Création : RIAE_FS_20210410130000")


### PR DESCRIPTION
### Pourquoi ?

![gameboyluke-luke](https://user-images.githubusercontent.com/20045330/214860820-c84271da-0686-4718-bd19-5a6dbe961f38.gif)

Mais aussi l'occasion d'ajouter un nouvel outil à notre ceinture afin d'avoir des tests toujours-plus-mieux©®.

### Comment

La fixture pytest `itou_faker_provider` s'occupe d'ajouter le nouveau provider aux instances unique de `Faker` :
- La fixture pytest de _Faker_, j'utilise `_session_faker` car la `faker` utilise un scope `function` contrairement à ce que la documentation indique.
- La déclaration `Faker()` de _factory_boy_ pour l'utiliser dans les factory.

C'est la raison qui fait que j'injecte la fixture pytest dans les `TestCase`, afin de ne pas avoir à répéter l'ajout du provider à chaque instanciation de `Faker()`.

A noter l'utilisation de [`.unique`](https://faker.readthedocs.io/en/master/index.html#unique-values) dans `test_reactivate()` qui est assez pratique je trouve :).