### PR TITLE
admin: cacher les boutons valider ou refuser une habilitation au CRI

### DIFF
--- a/itou/templates/admin/prescribers/change_form.html
+++ b/itou/templates/admin/prescribers/change_form.html
@@ -3,14 +3,14 @@
 {% block submit_buttons_bottom %}
 
     {# Whatever the state, the super user has access to refuse and validate actions #}
-    {% if original.has_pending_authorization or user.is_superuser %}
+    {% if perms.prescribers.change_prescriberorganization and original.has_pending_authorization or user.is_superuser %}
 
         <div class="submit-row">
             <input class="danger with-confirm" type="submit" value="Refuser l'habilitation" name="_authorization_action_refuse">
             <input class="default with-confirm" type="submit" value="Valider l'habilitation" name="_authorization_action_validate">
         </div>
 
-    {% elif original.has_refused_authorization and not user.is_superuser %}
+    {% elif perms.prescribers.change_prescriberorganization and original.has_refused_authorization and not user.is_superuser %}
         {# Allow to validate an authorization after an error in a refusal. #}
 
         <div class="submit-row">


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/C1-Probl-me-r-soudre-le-CRI-a-acc-s-la-commande-valider-ou-refuser-une-habilitation-a19e6b85cded499aa1d5130e7f27b8a8

### Pourquoi ?

Ils ne sont pas censés effectuer cette action (et n'ont pas les droits pour).



