### PR TITLE
Amélioration du rendu de DuetDatePickerWidget

### DIFF
--- a/itou/templates/utils/widgets/duet_date_picker_widget.html
+++ b/itou/templates/utils/widgets/duet_date_picker_widget.html
@@ -1,15 +1,1 @@
-<duet-date-picker
-identifier="{{ widget.attrs.id }}"
-{% if widget.attrs.required %}required{% endif %}
-{% if widget.attrs.disabled %}disabled{% endif %}
-name="{{ widget.name }}"
-{% if widget.attrs.min %}min="{{ widget.attrs.min }}"{% endif %}
-{% if widget.attrs.max %}max="{{ widget.attrs.max }}"{% endif %}
-{% if widget.value != None %}value="{{ widget.value }}"{% endif %}
-{% comment %}
-    Force the display of `.invalid-feedback` for Duet Date Picker with Bootstrap 4.
-    See also `itou.css`.
-    https://getbootstrap.com/docs/4.6/components/forms/#server-side
-{% endcomment %}
-{% if widget.attrs.class %}class="{{ widget.attrs.class }}"{% endif %}
-/>
+<duet-date-picker name="{{ widget.name }}" {% if widget.value != None %}value="{{ widget.value }}" {% endif %}{% include "django/forms/widgets/attrs.html" %} />

--- a/itou/utils/widgets.py
+++ b/itou/utils/widgets.py
@@ -48,6 +48,10 @@ class DuetDatePickerWidget(forms.DateInput):
         # Remove the `form-control` class inserted by `django-bootstrap4` to avoid
         # breaking the layout.
         attrs["class"] = attrs.get("class", "").replace("form-control", "").strip()
+        try:
+            attrs["identifier"] = attrs.pop("id")
+        except KeyError:
+            pass
         return attrs
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,4 @@ ignore="H006,H014,H017,H023,H030,H031,T002,T003"
 custom_blocks="buttons,endbuttons"
 max_attribute_length=200
 preserve_blank_lines=true
+extend_exclude = "itou/templates/utils/widgets/duet_date_picker_widget.html"


### PR DESCRIPTION
### Pourquoi ?

- Afficher tous les attributs du widget (ex `aria-label`)
- Cohérence avec les widgets de Django
- Forcer l’utilisation de `identifier` et non `id` pour le widget