### PR TITLE
users: prevent useless SQL query in is_handled_by_proxy

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -560,7 +560,7 @@ class User(AbstractUser, AddressMixin):
 
     @property
     def is_handled_by_proxy(self):
-        if self.is_job_seeker and self.created_by and not self.last_login:
+        if self.is_job_seeker and self.created_by_id and not self.last_login:
             return True
         return False
 


### PR DESCRIPTION
### Pourquoi ?

Pour toujours plus de vitesse (et surtout moins de requêtes SQL).

