### PR TITLE
metabase: add new table with jobs associated to job_applications

### DIFF
--- a/itou/metabase/sql/032_metier_candidatures.sql
+++ b/itou/metabase/sql/032_metier_candidatures.sql
@@ -1,7 +1,8 @@
 select
     id_candidat,
     id_candidature,
-    id_fiche_de_poste id_structure,
+    id_fiche_de_poste,
+    id_structure,
     nom_structure,
     département_structure,
     nom_département_structure,
@@ -14,12 +15,13 @@ select
     date_embauche,
     état,
     département_employeur,
-    nom_département_employeur domaine_professionnel,
+    nom_département_employeur,
+    domaine_professionnel,
     grand_domaine,
     crdp.code_rome,
     nom_rome
 from
     candidatures_echelle_locale cel
-    inner join fiches_de_poste_par_candidature_v2 fdpc on fdpc.id_candidature = cel.id
+    inner join fiches_de_poste_par_candidature fdpc on fdpc.id_candidature = cel.id
     inner join fiches_de_poste fdp on fdpc.id_fiche_de_poste = fdp.id
     inner join code_rome_domaine_professionnel crdp on fdp.code_rome = crdp.code_rome

--- a/itou/metabase/sql/032_metier_candidatures.sql
+++ b/itou/metabase/sql/032_metier_candidatures.sql
@@ -1,0 +1,25 @@
+select
+    id_candidat,
+    id_candidature,
+    id_fiche_de_poste id_structure,
+    nom_structure,
+    département_structure,
+    nom_département_structure,
+    type_structure,
+    origine,
+    origine_détaillée,
+    type_auteur_diagnostic_detaille,
+    région_structure,
+    date_candidature,
+    date_embauche,
+    état,
+    département_employeur,
+    nom_département_employeur domaine_professionnel,
+    grand_domaine,
+    crdp.code_rome,
+    nom_rome
+from
+    candidatures_echelle_locale cel
+    inner join fiches_de_poste_par_candidature_v2 fdpc on fdpc.id_candidature = cel.id
+    inner join fiches_de_poste fdp on fdpc.id_fiche_de_poste = fdp.id
+    inner join code_rome_domaine_professionnel crdp on fdp.code_rome = crdp.code_rome


### PR DESCRIPTION
Carte Notion : https://www.notion.so/plateforme-inclusion/Fiabilisation-donn-es-candidature-vs-donn-es-fiche-de-poste-bbb5709d60de499ea06b7f8372a15995

### Pourquoi ?

Pour ajouter l'analyse des métiers associés aux candidatures.

### Comment (optionnel)

Ajout d'une table qui associe les fiches de postes et métiers associés aux candidatures.



