### PR TITLE
Exporter en XSLX au lieu de CSV

### DIFF
--- a/itou/approvals/tests/test_management_commands.py
+++ b/itou/approvals/tests/test_management_commands.py
@@ -1,6 +1,7 @@
 import datetime
 import io
 
+import openpyxl
 from django.core import management
 from freezegun import freeze_time
 
@@ -28,37 +29,28 @@ class ExportPEApiRejectionsTestCase(TestCase):
         )
         stdout = io.StringIO()
         management.call_command("export_pe_api_rejections", stdout=stdout, stderr=io.StringIO())
-        assert open("exports/2022-09-13-00-00-00-export_pe_api_rejections.csv").read() == "\n".join(
+        workbook = openpyxl.load_workbook("exports/2022-09-13-00-00-00-export_pe_api_rejections.xlsx")
+        assert [[cell.value or "" for cell in row] for row in workbook.active.rows] == [
             [
-                ",".join(
-                    [
-                        "numero",
-                        "date_notification",
-                        "code_echec",
-                        "nir",
-                        "pole_emploi_id",
-                        "nom_naissance",
-                        "prenom",
-                        "date_naissance",
-                        "siae_departement",
-                    ]
-                ),
-                ",".join(
-                    map(
-                        str,
-                        [
-                            approval.number,
-                            "2022-08-31 00:00:00+00:00",
-                            "FOOBAR",
-                            approval.user.nir,
-                            approval.user.pole_emploi_id,
-                            '"Pers,e"',
-                            '"Jul""ie"',
-                            approval.user.birthdate,
-                            42,
-                        ],
-                    )
-                ),
-                "",  # Trailing newline
-            ]
-        )
+                "numero",
+                "date_notification",
+                "code_echec",
+                "nir",
+                "pole_emploi_id",
+                "nom_naissance",
+                "prenom",
+                "date_naissance",
+                "siae_departement",
+            ],
+            [
+                approval.number,
+                "2022-08-31 00:00:00+00:00",
+                "FOOBAR",
+                approval.user.nir,
+                approval.user.pole_emploi_id,
+                "Pers,e",
+                'Jul"ie',
+                str(approval.user.birthdate),
+                "42",
+            ],
+        ]

--- a/itou/scripts/management/commands/export_approvals.py
+++ b/itou/scripts/management/commands/export_approvals.py
@@ -8,7 +8,7 @@ class Command(BaseCommand):
     Export all valid approvals (PASS IAE, not Pole emploi) to an Excel file.
 
     This file is:
-    * named 'export_pass_iae_MMDDYYY_HHMINSEC.xslx' (datetime of export)
+    * named 'export_pass_iae_MMDDYYY_HHMINSEC.xlsx' (datetime of export)
     * put in the 'exports' folder
 
     There is no optional argument at the moment.

--- a/itou/scripts/management/commands/export_auto_prescriptions.py
+++ b/itou/scripts/management/commands/export_auto_prescriptions.py
@@ -1,7 +1,5 @@
-import os
 from datetime import date
 
-from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db.models import F
 
@@ -9,10 +7,10 @@ from itou.common_apps.address.departments import DEPARTMENTS
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.enums import SiaeKind
 from itou.users.enums import KIND_SIAE_STAFF
-from itou.utils.export import generate_excel_sheet
+from itou.utils.management_commands import XlsxExportMixin
 
 
-class Command(BaseCommand):
+class Command(XlsxExportMixin, BaseCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
 
@@ -38,47 +36,45 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Found {queryset.count()} auto prescriptions")
 
-        path = f"{settings.EXPORT_DIR}/auto_prescriptions_{start_at_min}_{start_at_max}.xlsx"
-        os.makedirs(settings.EXPORT_DIR, exist_ok=True)
-        with open(path, "wb") as xlsxfile:
-            workbook = generate_excel_sheet()(
-                [
-                    "ID établissement",
-                    "SIRET établissement",
-                    "SIRET à la signature",
-                    "Type établissement",
-                    "Nom établissement",
-                    "Département établissement",
-                    "Nom département établissement",
-                    "Nom région établissement",
-                    "Numéro pass",
-                    "Date début pass",
-                    "Date fin pass",
-                    "ID candidat",
-                    "Prénom candidat",
-                    "Nom candidat",
-                    "Date d'embauche",
-                ],
-                [
-                    [
-                        ja.to_siae.pk,
-                        ja.to_siae.siret,
-                        ja.to_siae.convention.siret_signature,
-                        ja.to_siae.kind,
-                        ja.to_siae.name,
-                        ja.to_siae.department,
-                        DEPARTMENTS.get(ja.to_siae.department, "Département inconnu"),
-                        ja.to_siae.region,
-                        ja.approval.number,
-                        ja.approval.start_at,
-                        ja.approval.end_at,
-                        ja.job_seeker.pk,
-                        ja.job_seeker.first_name,
-                        ja.job_seeker.last_name,
-                        ja.hiring_start_at,
-                    ]
-                    for ja in queryset.iterator()
-                ],
-            )
-            workbook.save(xlsxfile)
-        self.stdout.write(f"XLSX file created `{path}`")
+        filename = f"auto_prescriptions_{start_at_min}_{start_at_max}.xlsx"
+
+        headers = [
+            "ID établissement",
+            "SIRET établissement",
+            "SIRET à la signature",
+            "Type établissement",
+            "Nom établissement",
+            "Département établissement",
+            "Nom département établissement",
+            "Nom région établissement",
+            "Numéro pass",
+            "Date début pass",
+            "Date fin pass",
+            "ID candidat",
+            "Prénom candidat",
+            "Nom candidat",
+            "Date d'embauche",
+        ]
+
+        data = [
+            [
+                ja.to_siae.pk,
+                ja.to_siae.siret,
+                ja.to_siae.convention.siret_signature,
+                ja.to_siae.kind,
+                ja.to_siae.name,
+                ja.to_siae.department,
+                DEPARTMENTS.get(ja.to_siae.department, "Département inconnu"),
+                ja.to_siae.region,
+                ja.approval.number,
+                ja.approval.start_at,
+                ja.approval.end_at,
+                ja.job_seeker.pk,
+                ja.job_seeker.first_name,
+                ja.job_seeker.last_name,
+                ja.hiring_start_at,
+            ]
+            for ja in queryset.iterator()
+        ]
+
+        self.export_to_xlsx(filename, headers, data)

--- a/itou/scripts/management/commands/export_auto_prescriptions.py
+++ b/itou/scripts/management/commands/export_auto_prescriptions.py
@@ -1,7 +1,7 @@
-import csv
-import datetime
 import os
+from datetime import date
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db.models import F
 
@@ -9,11 +9,17 @@ from itou.common_apps.address.departments import DEPARTMENTS
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.enums import SiaeKind
 from itou.users.enums import KIND_SIAE_STAFF
+from itou.utils.export import generate_excel_sheet
 
 
 class Command(BaseCommand):
-    def handle(self, **kwargs):
-        writer = csv.writer(self.stdout, lineterminator=os.linesep)
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+
+        parser.add_argument(dest="start_at_min", type=date.fromisoformat, help="Approval start_at from date")
+        parser.add_argument(dest="start_at_max", type=date.fromisoformat, help="Approval start_at to date")
+
+    def handle(self, start_at_min, start_at_max, **kwargs):
         queryset = (
             JobApplication.objects.exclude(approval=None)
             .select_related(
@@ -26,47 +32,53 @@ class Command(BaseCommand):
                 to_siae__kind__in=[SiaeKind.ACI, SiaeKind.EI, SiaeKind.ETTI, SiaeKind.AI],
                 eligibility_diagnosis__author_kind=KIND_SIAE_STAFF,
                 eligibility_diagnosis__author_siae=F("to_siae"),
-                approval__start_at__range=[datetime.date(2022, 1, 1), datetime.date(2022, 10, 1)],
+                approval__start_at__range=[start_at_min, start_at_max],
             )
         )
 
-        writer.writerow(
-            [
-                "ID établissement",
-                "SIRET établissement",
-                "SIRET à la signature",
-                "Type établissement",
-                "Nom établissement",
-                "Département établissement",
-                "Nom département établissement",
-                "Nom région établissement",
-                "Numéro pass",
-                "Date début pass",
-                "Date fin pass",
-                "ID candidat",
-                "Prénom candidat",
-                "Nom candidat",
-                "Date d'embauche",
-            ],
-        )
+        self.stdout.write(f"Found {queryset.count()} auto prescriptions")
 
-        for ja in queryset.iterator():
-            writer.writerow(
+        path = f"{settings.EXPORT_DIR}/auto_prescriptions_{start_at_min}_{start_at_max}.xlsx"
+        os.makedirs(settings.EXPORT_DIR, exist_ok=True)
+        with open(path, "wb") as xlsxfile:
+            workbook = generate_excel_sheet()(
                 [
-                    ja.to_siae.pk,
-                    ja.to_siae.siret,
-                    ja.to_siae.convention.siret_signature,
-                    ja.to_siae.kind,
-                    ja.to_siae.name,
-                    ja.to_siae.department,
-                    DEPARTMENTS.get(ja.to_siae.department, "Département inconnu"),
-                    ja.to_siae.region,
-                    ja.approval.number,
-                    ja.approval.start_at,
-                    ja.approval.end_at,
-                    ja.job_seeker.pk,
-                    ja.job_seeker.first_name,
-                    ja.job_seeker.last_name,
-                    ja.hiring_start_at,
+                    "ID établissement",
+                    "SIRET établissement",
+                    "SIRET à la signature",
+                    "Type établissement",
+                    "Nom établissement",
+                    "Département établissement",
+                    "Nom département établissement",
+                    "Nom région établissement",
+                    "Numéro pass",
+                    "Date début pass",
+                    "Date fin pass",
+                    "ID candidat",
+                    "Prénom candidat",
+                    "Nom candidat",
+                    "Date d'embauche",
+                ],
+                [
+                    [
+                        ja.to_siae.pk,
+                        ja.to_siae.siret,
+                        ja.to_siae.convention.siret_signature,
+                        ja.to_siae.kind,
+                        ja.to_siae.name,
+                        ja.to_siae.department,
+                        DEPARTMENTS.get(ja.to_siae.department, "Département inconnu"),
+                        ja.to_siae.region,
+                        ja.approval.number,
+                        ja.approval.start_at,
+                        ja.approval.end_at,
+                        ja.job_seeker.pk,
+                        ja.job_seeker.first_name,
+                        ja.job_seeker.last_name,
+                        ja.hiring_start_at,
+                    ]
+                    for ja in queryset.iterator()
                 ],
             )
+            workbook.save(xlsxfile)
+        self.stdout.write(f"XLSX file created `{path}`")

--- a/itou/scripts/management/commands/update_nir_from_pass.py
+++ b/itou/scripts/management/commands/update_nir_from_pass.py
@@ -44,7 +44,7 @@ class Command(DeprecatedLoggerMixin, BaseCommand):
         django-admin update_nir_from_pass --file-path=path/to/file.xlsx
     """
 
-    help = "Deduplicate job seekers."
+    help = "Update NIR from PASS"
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -18,15 +18,42 @@
 
         <div class="table-responsive">
             <table class="table table-striped table-bordered">
-                <caption>Liste des candidatures reçues par mois</caption>
+                <caption>Liste des candidatures reçues</caption>
                 <thead>
                     <tr>
-                        <th scope="col">Mois</th>
+                        <th scope="col">Contenu du fichier</th>
                         <th scope="col">Nombre de candidatures</th>
-                        <th scope="col">Télécharger (.csv)</th>
+                        <th scope="col">Télécharger (.xlsx)</th>
                     </tr>
                 </thead>
                 <tbody>
+                    <tr>
+                        <td>Toutes les candidatures</td>
+                        <td>{{ total_job_applications }}</td>
+                        <td>
+                            {% if export_for == "siae" %}
+                                <i class="ri-download-line mr-1"></i>
+                                <a class="matomo-event text-decoration-none"
+                                   data-matomo-category="candidatures"
+                                   data-matomo-action="exports"
+                                   data-matomo-option="export-siae"
+                                   title="Télécharger cet export SIAE"
+                                   href="{% url 'apply:list_for_siae_exports_download' %}">
+                                    Télécharger
+                                </a>
+                            {% else %}
+                                <i class="ri-download-line mr-1"></i>
+                                <a class="matomo-event text-decoration-none"
+                                   data-matomo-category="candidatures"
+                                   data-matomo-action="exports"
+                                   data-matomo-option="export-prescripteur"
+                                   title="Télécharger cet export prescripteur"
+                                   href="{% url 'apply:list_for_prescriber_exports_download' %}">
+                                    Télécharger
+                                </a>
+                            {% endif %}
+                        </td>
+                    </tr>
                     {% for month in job_applications_by_month %}
                         <tr>
                             <td>{{ month.month|date:"F Y"|capfirst }}</td>
@@ -48,7 +75,7 @@
                                        data-matomo-category="candidatures"
                                        data-matomo-action="exports"
                                        data-matomo-option="export-prescripteur"
-                                       title="Télécharger cet export prescriteur"
+                                       title="Télécharger cet export prescripteur"
                                        href="{% url 'apply:list_for_prescriber_exports_download' month_identifier=month.month|date:"Y-m" %}">
                                         Télécharger
                                     </a>

--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -13,12 +12,11 @@ from tqdm import tqdm
 from itou.job_applications.enums import SenderKind
 from itou.job_applications.models import JobApplication
 from itou.users.models import User
-from itou.utils.export import generate_excel_sheet
-from itou.utils.management_commands import DeprecatedLoggerMixin
+from itou.utils.management_commands import DeprecatedLoggerMixin, XlsxExportMixin
 from itou.utils.urls import get_absolute_url
 
 
-class Command(DeprecatedLoggerMixin, BaseCommand):
+class Command(XlsxExportMixin, DeprecatedLoggerMixin, BaseCommand):
     """
     Deduplicate job seekers.
 
@@ -279,9 +277,5 @@ class Command(DeprecatedLoggerMixin, BaseCommand):
 
     def to_xlsx(self, filename, fieldnames, data):
         log_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        path = f"{settings.EXPORT_DIR}/{log_datetime}-{filename}-{settings.ITOU_ENVIRONMENT.lower()}.xlsx"
-        os.makedirs(settings.EXPORT_DIR, exist_ok=True)
-        with open(path, "wb") as xlsxfile:
-            workbook = generate_excel_sheet(fieldnames, data)
-            workbook.save(xlsxfile)
-        self.stdout.write(f"XLSX file created `{path}`")
+        filename = f"{log_datetime}-{filename}-{settings.ITOU_ENVIRONMENT.lower()}.xlsx"
+        self.export_to_xlsx(filename, fieldnames, data)

--- a/itou/users/tests/test_management_commands.py
+++ b/itou/users/tests/test_management_commands.py
@@ -1,7 +1,5 @@
 import datetime
 import io
-import os
-import unittest
 
 from django.contrib.auth.models import Group
 from django.core.management import call_command
@@ -14,7 +12,6 @@ from itou.users.models import User
 from itou.utils.test import TestCase
 
 
-@unittest.skipUnless(os.getenv("CI", False), "It is a long management command and normally not subject to change!")
 class DeduplicateJobSeekersManagementCommandsTest(TestCase):
     """
     Test the deduplication of several users.
@@ -64,7 +61,7 @@ class DeduplicateJobSeekersManagementCommandsTest(TestCase):
         assert 1 == user3.eligibility_diagnoses.count()
 
         # Merge all users into `user1`.
-        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True, wet_run=True)
+        call_command("deduplicate_job_seekers", verbosity=0, no_xlsx=True, wet_run=True)
 
         # If only one NIR exists for all the duplicates, it should
         # be reassigned to the target account.
@@ -125,7 +122,7 @@ class DeduplicateJobSeekersManagementCommandsTest(TestCase):
         ApprovalFactory(user=user1)
 
         # Merge all users into `user1`.
-        call_command("deduplicate_job_seekers", verbosity=0, no_csv=True, wet_run=True)
+        call_command("deduplicate_job_seekers", verbosity=0, no_xlsx=True, wet_run=True)
 
         assert 3 == user1.job_applications.count()
 

--- a/itou/utils/export.py
+++ b/itou/utils/export.py
@@ -1,0 +1,42 @@
+import io
+
+import openpyxl
+import xlsx_streaming
+from django import http
+from django.utils import timezone
+
+
+def generate_excel_sheet(headers, rows):
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+
+    sheet.append(headers)
+    for row in rows:
+        sheet.append(row)
+    dimension = sheet.calculate_dimension()
+    sheet.auto_filter.ref = dimension
+
+    return workbook
+
+
+def _generate_excel_template(headers):
+    template = generate_excel_sheet(
+        headers,
+        [["Default" for _header in headers]],  # Force the type of each column to text
+    )
+    return io.BytesIO(openpyxl.writer.excel.save_virtual_workbook(template))
+
+
+def to_streaming_response(queryset, filename, headers, serializer, with_time=False):
+    """Generate a HTTP Streaming response with a XLSX file"""
+
+    xlsx_streaming.set_export_timezone(timezone.get_default_timezone())
+    openxml_mimetype = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    template = _generate_excel_template(headers)
+    stream = xlsx_streaming.stream_queryset_as_xlsx(queryset, template, serializer=serializer)
+    response = http.StreamingHttpResponse(stream, content_type=openxml_mimetype)
+    if with_time:
+        now = timezone.now().isoformat(timespec="seconds").replace(":", "-")
+        filename = f"{filename}-{now}"
+    response["Content-Disposition"] = f'attachment; filename="{filename}.xlsx"'
+    return response

--- a/itou/utils/management_commands.py
+++ b/itou/utils/management_commands.py
@@ -1,4 +1,9 @@
 import logging
+import os
+
+from django.conf import settings
+
+from itou.utils.export import generate_excel_sheet
 
 
 class DeprecatedLoggerMixin:
@@ -21,3 +26,17 @@ class DeprecatedLoggerMixin:
         self.logger.setLevel(logging.INFO)
         if verbosity is not None and verbosity >= 1:
             self.logger.setLevel(logging.DEBUG)
+
+
+class XlsxExportMixin:
+    """
+    A mixin with xslx export shortcup
+    """
+
+    def export_to_xlsx(self, filename, headers, data):
+        path = f"{settings.EXPORT_DIR}/{filename}"
+        os.makedirs(settings.EXPORT_DIR, exist_ok=True)
+        with open(path, "wb") as xlsxfile:
+            workbook = generate_excel_sheet(headers, data)
+            workbook.save(xlsxfile)
+        self.stdout.write(f"XLSX file created `{path}`")

--- a/itou/utils/testing.py
+++ b/itou/utils/testing.py
@@ -1,5 +1,7 @@
 import importlib
+import io
 
+import openpyxl
 from django.test.utils import TestContextDecorator
 
 
@@ -15,3 +17,12 @@ class reload_module(TestContextDecorator):
     def disable(self):
         for key, value in self._original_values.items():
             setattr(self._module, key, value)
+
+
+def get_rows_from_streaming_response(response):
+    """Helper to read streamed XLSX files in tests"""
+
+    content = b"".join(response.streaming_content)
+    workbook = openpyxl.load_workbook(io.BytesIO(content))
+    worksheet = workbook.active
+    return [[cell.value or "" for cell in row] for row in worksheet.rows]

--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -507,6 +507,7 @@ class ProcessListPrescriberTest(ProcessListTest):
         response = self.client.get(self.prescriber_exports_url)
 
         assert 200 == response.status_code
+        assertContains(response, "Toutes les candidatures")
 
     def test_list_for_prescriber_exports_download_view(self):
         """
@@ -631,6 +632,7 @@ class ProcessListExportsPrescriberTest(ProcessListTest):
         response = self.client.get(self.prescriber_exports_url)
 
         assert 200 == response.status_code
+        assertContains(response, "Toutes les candidatures")
 
     def test_list_for_prescriber_exports_as_siae_view(self):
         """
@@ -656,6 +658,7 @@ class ProcessListExportsSiaeTest(ProcessListTest):
         response = self.client.get(self.siae_exports_url)
 
         assert 200 == response.status_code
+        assertContains(response, "Toutes les candidatures")
 
     def test_list_for_siae_exports_as_prescriber_view(self):
         """
@@ -676,6 +679,18 @@ class ProcessListExportsDownloadPrescriberTest(ProcessListTest):
     def test_list_for_prescriber_exports_download_view(self):
         """
         Connect as Thibault to download a XLSX export of available job applications
+        """
+        self.client.force_login(self.thibault_pe)
+        download_url = reverse("apply:list_for_prescriber_exports_download")
+
+        response = self.client.get(download_url)
+
+        assert 200 == response.status_code
+        assert "spreadsheetml" in response.get("Content-Type")
+
+    def test_list_for_prescriber_exports_download_view_by_month(self):
+        """
+        Connect as Thibault to download a CSV export of available job applications
         """
         self.client.force_login(self.thibault_pe)
 
@@ -716,6 +731,18 @@ class ProcessListExportsDownloadSiaeTest(ProcessListTest):
     def test_list_for_siae_exports_download_view(self):
         """
         Connect as Thibault to download a XLSX export of available job applications
+        """
+        self.client.force_login(self.eddie_hit_pit)
+        download_url = reverse("apply:list_for_siae_exports_download")
+
+        response = self.client.get(download_url)
+
+        assert 200 == response.status_code
+        assert "spreadsheetml" in response.get("Content-Type")
+
+    def test_list_for_siae_exports_download_view_by_month(self):
+        """
+        Connect as Thibault to download a CSV export of available job applications
         """
         self.client.force_login(self.eddie_hit_pit)
 

--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -524,7 +524,7 @@ class ProcessListPrescriberTest(ProcessListTest):
         response = self.client.get(download_url)
 
         assert 200 == response.status_code
-        assert "text/csv" in response.get("Content-Type")
+        assert "spreadsheetml" in response.get("Content-Type")
 
     def test_view__filtered_by_state(self):
         """
@@ -675,7 +675,7 @@ class ProcessListExportsSiaeTest(ProcessListTest):
 class ProcessListExportsDownloadPrescriberTest(ProcessListTest):
     def test_list_for_prescriber_exports_download_view(self):
         """
-        Connect as Thibault to download a CSV export of available job applications
+        Connect as Thibault to download a XLSX export of available job applications
         """
         self.client.force_login(self.thibault_pe)
 
@@ -689,11 +689,11 @@ class ProcessListExportsDownloadPrescriberTest(ProcessListTest):
         response = self.client.get(download_url)
 
         assert 200 == response.status_code
-        assert "text/csv" in response.get("Content-Type")
+        assert "spreadsheetml" in response.get("Content-Type")
 
     def test_list_for_siae_exports_download_view(self):
         """
-        Connect as Thibault and attempt to download a CSV export of available job applications from SIAE
+        Connect as Thibault and attempt to download a XLSX export of available job applications from SIAE
         """
         self.client.force_login(self.thibault_pe)
 
@@ -715,7 +715,7 @@ class ProcessListExportsDownloadPrescriberTest(ProcessListTest):
 class ProcessListExportsDownloadSiaeTest(ProcessListTest):
     def test_list_for_siae_exports_download_view(self):
         """
-        Connect as Thibault to download a CSV export of available job applications
+        Connect as Thibault to download a XLSX export of available job applications
         """
         self.client.force_login(self.eddie_hit_pit)
 
@@ -727,11 +727,11 @@ class ProcessListExportsDownloadSiaeTest(ProcessListTest):
         response = self.client.get(download_url)
 
         assert 200 == response.status_code
-        assert "text/csv" in response.get("Content-Type")
+        assert "spreadsheetml" in response.get("Content-Type")
 
     def test_list_for_prescriber_exports_download_view(self):
         """
-        Connect as SIAE and attempt to download a CSV export of available job applications from prescribers
+        Connect as SIAE and attempt to download a XLSX export of available job applications from prescribers
         """
         self.client.force_login(self.eddie_hit_pit)
 

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -96,12 +96,22 @@ urlpatterns = [
     path("prescriber/list", list_views.list_for_prescriber, name="list_for_prescriber"),
     path("prescriber/list/exports", list_views.list_for_prescriber_exports, name="list_for_prescriber_exports"),
     path(
+        "prescriber/list/exports/download",
+        list_views.list_for_prescriber_exports_download,
+        name="list_for_prescriber_exports_download",
+    ),
+    path(
         "prescriber/list/exports/download/<str:month_identifier>",
         list_views.list_for_prescriber_exports_download,
         name="list_for_prescriber_exports_download",
     ),
     path("siae/list", list_views.list_for_siae, name="list_for_siae"),
     path("siae/list/exports", list_views.list_for_siae_exports, name="list_for_siae_exports"),
+    path(
+        "siae/list/exports/download",
+        list_views.list_for_siae_exports_download,
+        name="list_for_siae_exports_download",
+    ),
     path(
         "siae/list/exports/download/<str:month_identifier>",
         list_views.list_for_siae_exports_download,

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -1,9 +1,8 @@
 from django.contrib.auth.decorators import login_required, user_passes_test
-from django.http import HttpResponse
 from django.shortcuts import render
 from django.utils.text import slugify
 
-from itou.job_applications.csv_export import generate_csv_export
+from itou.job_applications.export import stream_xlsx_export
 from itou.utils.pagination import pager
 from itou.utils.perms.prescriber import get_all_available_job_applications_as_prescriber
 from itou.utils.perms.siae import get_current_siae_or_404
@@ -105,14 +104,7 @@ def list_for_prescriber_exports_download(request, month_identifier):
     year, month = month_identifier.split("-")
     job_applications = job_applications.created_on_given_year_and_month(year, month).with_list_related_data()
 
-    filename = f"candidatures-{month_identifier}.csv"
-
-    response = HttpResponse(content_type="text/csv", charset="utf-8")
-    response["Content-Disposition"] = f'attachment; filename="{filename}"'
-
-    generate_csv_export(job_applications, response)
-
-    return response
+    return stream_xlsx_export(job_applications, f"candidatures-{month_identifier}")
 
 
 @login_required
@@ -175,11 +167,5 @@ def list_for_siae_exports_download(request, month_identifier):
     siae = get_current_siae_or_404(request)
     job_applications = siae.job_applications_received.not_archived()
     job_applications = job_applications.created_on_given_year_and_month(year, month).with_list_related_data()
-    filename = f"candidatures-{slugify(siae.display_name)}-{month_identifier}.csv"
 
-    response = HttpResponse(content_type="text/csv", charset="utf-8")
-    response["Content-Disposition"] = f'attachment; filename="{filename}"'
-
-    generate_csv_export(job_applications, response)
-
-    return response
+    return stream_xlsx_export(job_applications, f"candidatures-{slugify(siae.display_name)}-{month_identifier}")

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -80,6 +80,9 @@ httpx  # https://github.com/encode/httpx/
 paramiko==2.8.1  # https://github.com/paramiko/paramiko
 pysftp==0.2.9  # https://bitbucket.org/dundeemt/pysftp/src/master/
 
+# Stream XLSX files
+xlsx_streaming  # https://github.com/Polyconseil/xlsx_streaming
+
 # Add Content Security Policy headers
 django-csp
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -662,6 +662,10 @@ xlrd==2.0.1 \
     # via
     #   -r requirements/base.in
     #   tablib
+xlsx-streaming==1.1.0 \
+    --hash=sha256:6c1a040ccbebbe7ea1d5d54180ae9b2972112f74303c13fc266812cd98c8b826 \
+    --hash=sha256:c12d21653d2d77ead622b49deb30c8a5921ff3be6c1e4ac2540a8ead8c64f7b7
+    # via -r requirements/base.in
 xlwt==1.3.0 \
     --hash=sha256:a082260524678ba48a297d922cc385f58278b8aa68741596a87de01a9c628b2e \
     --hash=sha256:c59912717a9b28f1a3c2a98fd60741014b06b043936dcecbc113eaaada156c88
@@ -670,3 +674,6 @@ xworkflows==1.1.0 \
     --hash=sha256:8e3a9f6e9de6bcd779335f2ce4f87445ad8047771be9c6c96e347fb8622e2f27 \
     --hash=sha256:943571904066e03946016c5710cfea97847c1931c2e07bdd61827a01bce38d80
     # via django-xworkflows
+zipstream==1.1.4 \
+    --hash=sha256:2ef24b9150c93429b172750c4890b5ab28c1317892e11727afeff986ad2a3506
+    # via xlsx-streaming

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1318,6 +1318,10 @@ xlrd==2.0.1 \
     # via
     #   -r requirements/base.txt
     #   tablib
+xlsx-streaming==1.1.0 \
+    --hash=sha256:6c1a040ccbebbe7ea1d5d54180ae9b2972112f74303c13fc266812cd98c8b826 \
+    --hash=sha256:c12d21653d2d77ead622b49deb30c8a5921ff3be6c1e4ac2540a8ead8c64f7b7
+    # via -r requirements/base.txt
 xlwt==1.3.0 \
     --hash=sha256:a082260524678ba48a297d922cc385f58278b8aa68741596a87de01a9c628b2e \
     --hash=sha256:c59912717a9b28f1a3c2a98fd60741014b06b043936dcecbc113eaaada156c88
@@ -1330,3 +1334,8 @@ xworkflows==1.1.0 \
     # via
     #   -r requirements/base.txt
     #   django-xworkflows
+zipstream==1.1.4 \
+    --hash=sha256:2ef24b9150c93429b172750c4890b5ab28c1317892e11727afeff986ad2a3506
+    # via
+    #   -r requirements/base.txt
+    #   xlsx-streaming


### PR DESCRIPTION
https://www.notion.so/Export-XLSX-au-lieu-de-CSV-ac904d6d521b4076b9b3c5ee8b874ca9

### Pourquoi ?

On est en ~2022~2023 et on ne veut pas traiter des problèmes d’import de fichier au support

- [x] Convertir les exports en XSLX (voir détail plus bas)
- [x] revoir la façon donc on permet d'exporter les candidatures

Liste des exports :
- :heavy_check_mark:  Candidatures
- :heavy_check_mark:  Siae_evalusation (admin)

Pour les exports des management commands, je ne sais pas si c'est très utile de le faire....
Est-ce que ce sont est exports qui servent à donner à des utilisateurs après ou juste pour des besoins de dev / interne?
- :heavy_check_mark: export_pe_api_rejections
- :x: update_nir_from_pe_data (logs)
- :heavy_check_mark:  update_refused_prescriber_organizations_kind
- :heavy_check_mark:  export_auto_prescriptions
- :x: geolocate_jobseeker_addresses (usage interne)
- :x: update_nir_from_pass (logs)
- :x: update_pe_approvals_from_asp_data (logs)
- :heavy_check_mark: deduplicate_job_seekers
- :grey_question:  extract_c2_users
