### PR TITLE
users: drop is_peamu property

### DIFF
--- a/itou/users/adapter.py
+++ b/itou/users/adapter.py
@@ -5,6 +5,7 @@ from django.utils.http import urlencode
 
 from itou.openid_connect.france_connect.constants import FRANCE_CONNECT_SESSION_STATE, FRANCE_CONNECT_SESSION_TOKEN
 from itou.openid_connect.inclusion_connect.constants import INCLUSION_CONNECT_SESSION_KEY
+from itou.users.enums import IdentityProvider
 from itou.utils.urls import get_absolute_url, get_safe_url
 
 
@@ -52,8 +53,8 @@ class UserAdapter(DefaultAccountAdapter):
             fc_base_logout_url = reverse("france_connect:logout")
             redirect_url = f"{fc_base_logout_url}?{urlencode(params)}"
         # PE Connect
-        peamu_id_token = getattr(request.user, "peamu_id_token", None)
-        if peamu_id_token:
+        if getattr(request.user, "kind", None) == IdentityProvider.PE_CONNECT:
+            peamu_id_token = self.socialaccount_set.filter(provider="peamu").get().extra_data["id_token"]
             hp_url = get_absolute_url(reverse("home:hp"))
             params = {"id_token_hint": peamu_id_token, "redirect_uri": hp_url}
             redirect_url = f"{settings.PEAMU_AUTH_BASE_URL}/compte/deconnexion?{urlencode(params)}"

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -565,12 +565,6 @@ class User(AbstractUser, AddressMixin):
         return False
 
     @cached_property
-    def peamu_id_token(self):
-        if self.identity_provider != IdentityProvider.PE_CONNECT:
-            return None
-        return self.socialaccount_set.filter(provider="peamu").get().extra_data["id_token"]
-
-    @cached_property
     def is_prescriber_with_org(self):
         return self.is_prescriber and self.prescribermembership_set.filter(is_active=True).exists()
 

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -434,7 +434,7 @@ class User(AbstractUser, AddressMixin):
 
     @property
     def has_sso_provider(self):
-        return self.identity_provider != IdentityProvider.DJANGO or self.is_peamu
+        return self.identity_provider != IdentityProvider.DJANGO
 
     @cached_property
     def has_verified_email(self):
@@ -565,14 +565,8 @@ class User(AbstractUser, AddressMixin):
         return False
 
     @cached_property
-    def is_peamu(self):
-        social_accounts = self.socialaccount_set.all()
-        # We have to do all this in python to benefit from prefetch_related.
-        return len([sa for sa in social_accounts if sa.provider == "peamu"]) >= 1
-
-    @cached_property
     def peamu_id_token(self):
-        if not self.is_peamu:
+        if self.identity_provider != IdentityProvider.PE_CONNECT:
             return None
         return self.socialaccount_set.filter(provider="peamu").get().extra_data["id_token"]
 

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -236,8 +236,7 @@ class ModelTest(TestCase):
         job_seeker = JobSeekerFactory(identity_provider=IdentityProvider.INCLUSION_CONNECT)
         assert job_seeker.has_sso_provider
 
-        job_seeker = JobSeekerFactory()
-        job_seeker.socialaccount_set.create(provider="peamu")
+        job_seeker = JobSeekerFactory(identity_provider=IdentityProvider.PE_CONNECT)
         assert job_seeker.has_sso_provider
 
     def test_update_external_data_source_history_field(self):

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 
+from itou.users.enums import IdentityProvider
 from itou.utils import constants as global_constants
 
 
@@ -144,7 +145,11 @@ def user_to_account_type(user):
     if user.is_job_seeker:
         return {
             "account_type": "job_seeker",
-            "account_sub_type": "job_seeker_with_peconnect" if user.is_peamu else "job_seeker_without_peconnect",
+            "account_sub_type": (
+                "job_seeker_with_peconnect"
+                if user.identity_provider == IdentityProvider.PE_CONNECT
+                else "job_seeker_without_peconnect"
+            ),
         }
     elif user.is_siae_staff:
         return {

--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -187,7 +187,6 @@ class ProcessListSiaeTest(ProcessListTest):
             + 1  # get list of sender org (distinct sender_prescriber_organization_id)
             + 3  # count, list & prefetch of job application
             + 1  # check user membership again
-            + 1  # weird fetch social account
             + 3  # update session
         ):
             response = self.client.get(self.siae_base_url)
@@ -609,7 +608,6 @@ def test_list_for_unauthorized_prescriber_view(client):
         + 1  # get list of siaes (distinct)
         + 3  # count, list & prefetch of job application
         + 1  # check user membership again
-        + 1  # weird fetch social account
         + 3  # update session
     ):
         response = client.get(url)

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -258,7 +258,6 @@ class ListEmployeeRecordsTest(TestCase):
         num_queries += 1  # Select ordered job applications
         num_queries += 1  # Select EmployeeRecords
         num_queries += 1  # Select siae members
-        num_queries += 1  # Get user social_account
         with self.assertNumQueries(num_queries):
             self.client.get(self.url)
 

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -580,7 +580,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
             + 1  # fetch evaluation campaign
             + 3  # fetch evaluated_siae and its prefetch_related eval_job_app & eval_admin_crit
             + 1  # one again institution membership
-            + 1  # social account
             + 3  # savepoint, update session, release savepoint
         ):
             response = self.client.get(url)
@@ -1141,7 +1140,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
             + 3  # fetch institution membership & institution x 2 !should be fixed!
             + 6  # fetch evaluated_siae and its prefetch_related
             + 1  # one again institution membership
-            + 1  # social account
             + 3  # savepoint, update session, release savepoint
         ):
             response = self.client.get(url)
@@ -1787,7 +1785,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
             + 3  # fetch institution membership & institution x 2 !should be fixed!
             + 6  # fetch evaluated_siae and its prefetch_related
             + 1  # one again institution membership
-            + 1  # social account
             + 3  # savepoint, update session, release savepoint
             + 5  # issue with evaluated_job_application.evaluated_siae.state
         ):

--- a/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
@@ -91,7 +91,7 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
             + 1  # fetch evaluated siae
             + 2  # fetch evaluatedjobapplication and its prefetched evaluatedadministrativecriteria
             + 1  # aggregate min evaluation_campaign notification date
-            + 2  # weird fetch siae membership and social account
+            + 1  # weird fetch siae membership
             # NOTE(vperron): the prefecth is necessary to check the SUBMITTABLE state of the evaluated siae
             # We do those requests "two times" but at least it's now accurate information, and we get
             # the EvaluatedJobApplication list another way so that we can select_related on them.

--- a/itou/www/siaes_views/tests/tests_job_description_views.py
+++ b/itou/www/siaes_views/tests/tests_job_description_views.py
@@ -426,7 +426,6 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             + 1  # fetch siaes infos
             + 1  # fetch prescribers_prescribermembership/organization
             + 1  # fetch jobappelation
-            + 1  # weird fetch social account
             + 1  # fetch other job infos
         ):
             response = self.client.get(self.url)


### PR DESCRIPTION
### Pourquoi ?

On privilégie le champ `identity_provider` pour identifier les utilisateurs de PE Connect.


