### PR TITLE
metabase: Correction du freeze de la commande check_inconsistencies

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -333,8 +333,9 @@ class Command(BaseCommand):
             )
             .all()
         )
+        job_seekers_table = job_seekers.get_table()
 
-        populate_table(job_seekers.TABLE, batch_size=1000, querysets=[queryset])
+        populate_table(job_seekers_table, batch_size=1000, querysets=[queryset])
 
     def populate_rome_codes(self):
         queryset = Rome.objects.all()

--- a/itou/metabase/management/test_populate_metabase_emplois.py
+++ b/itou/metabase/management/test_populate_metabase_emplois.py
@@ -141,7 +141,8 @@ def test_populate_job_seekers():
         created_at=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc),
     )
 
-    num_queries = 1  # Count rows
+    num_queries = 1  # Get administrative criteria
+    num_queries += 1  # Count rows
     num_queries += 1  # Select all elements ids (chunked_queryset)
     num_queries += 1  # Select last pk for current chunck
     num_queries += 1  # Select job seekers chunck (with annotations)


### PR DESCRIPTION
Le queryset appelé est tellement large que la commande ne termine jamais.
Corriger en s'appuyant sur les travaux d'antoine pour en faire un fix immédiat, et le tester.

Au passage ne pas faire de retry sur ce check, ça n'a pas de sens.