### PR TITLE
Ajout du type d'utilisateur dans l'admin

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -140,7 +140,7 @@ class ItouUserAdmin(UserAdmin):
         "first_name",
         "last_name",
         "birthdate",
-        "is_staff",
+        "kind",
         "identity_provider",
         "is_created_by_a_proxy",
         "has_verified_email",

--- a/itou/users/migrations/0009_alter_user_kind.py
+++ b/itou/users/migrations/0009_alter_user_kind.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                     ("itou_staff", "administrateur"),
                 ],
                 max_length=20,
-                verbose_name="Type d'utilisateur",
+                verbose_name="Type",
             ),
         ),
     ]

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -216,7 +216,7 @@ class User(AbstractUser, AddressMixin):
     )
     phone = models.CharField(verbose_name="Téléphone", max_length=20, blank=True)
 
-    kind = models.CharField(max_length=20, verbose_name="Type d'utilisateur", choices=UserKind.choices, blank=False)
+    kind = models.CharField(max_length=20, verbose_name="Type", choices=UserKind.choices, blank=False)
 
     asp_uid = models.TextField(
         verbose_name="ID unique envoyé à l'ASP",


### PR DESCRIPTION
### Pourquoi ?

C'est une information plus complète que "is_staff" qui correspond au type administrateur
