### PR TITLE
Contrôle a posteriori : Afficher des statistiques sur la page de sanction

### DIFF
--- a/itou/templates/siae_evaluations/institution_evaluated_siae_notify.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_notify.html
@@ -1,20 +1,25 @@
 {% extends "layout/content.html" %}
 
 {% load bootstrap4 %}
+{% load str_filters %}
 
 {% block title %}Notifier la sanction du contrôle pour {{ evaluated_siae }}{{ block.super }}{% endblock %}
 
 {% block content %}
-    <div class="row justify-content-center">
-        <div class="col-lg-8 col-md-10 col-12">
+    <h1>
+        Notifier la sanction du contrôle pour <span class="text-muted">{{ evaluated_siae }}</span>
+    </h1>
+    <div class="row justify-content-between">
+        <section class="col-lg-6 col-12 order-2 order-md-1 card c-card">
             <div class="row mt-3">
-                <div class="col-12">
-                    <h1>
-                        Notifier la sanction du contrôle pour <span class="text-muted">{{ evaluated_siae }}</span>
-                    </h1>
-                    <h2>
-                        Résultat de la campagne : <b class="text-danger">Négatif</b>
-                    </h2>
+                <div class="card-body">
+                    <h2>Quelle raison justifie ce résultat ?</h2>
+                    <hr>
+                    <p>
+                        <b>
+                            Résultat de cette campagne de contrôle : <span class="text-danger">Négatif</span>
+                        </b>
+                    </p>
                     {% bootstrap_form_errors form type="all" %}
                     <form method="post">
                         {% csrf_token %}
@@ -28,6 +33,43 @@
                     </form>
                 </div>
             </div>
-        </div>
+        </section>
+        <article class="col-12 col-lg-5 order-1 mb-sm-4 card c-card has-links-inside">
+            <div class="card-header">
+                <h2>Données</h2>
+            </div>
+            <div class="card-body">
+                <h3>Campagne en cours</h3>
+                <ul>
+                    <li>{{ refused_percent|floatformat:"0" }} % justificatifs refusés lors de votre contrôle</li>
+                    {% if expected_crits_count %}
+                        <li>
+                            {{ not_submitted_percent|floatformat:"0" }} % justificatifs non soumis par la SIAE (dont {{ uploaded_count }} téléversé{{ uploaded_count|pluralizefr }} sur {{ expected_crits_count }} attendu{{ expected_crits_count|pluralizefr }})
+                        </li>
+                    {% endif %}
+                </ul>
+                <a target="_blank" href="{% url 'siae_evaluations_views:institution_evaluated_siae_detail' evaluated_siae_pk=evaluated_siae.pk %}">Revoir
+                    {% if job_apps_count == 1 %}
+                        l’auto-prescription
+                    {% else %}
+                        les {{ job_apps_count }} auto-prescriptions
+                    {% endif %}
+                    <i class="ri-external-link-line"></i></a>
+                <h3 class="mt-5">Historique des campagnes de contrôle</h3>
+                <ul class="list-unstyled">
+                    {% for old_evaluated_siae in evaluation_history %}
+                        <li>
+                            Période du {{ old_evaluated_siae.evaluation_campaign.evaluated_period_start_at|date:"d/m/Y" }} au {{ old_evaluated_siae.evaluation_campaign.evaluated_period_end_at|date:"d/m/Y" }} :
+                            {% if old_evaluated_siae.state == "ACCEPTED" %}
+                                <b class="text-success">Positif</b>
+                            {% else %}
+                                <b class="text-danger">Négatif</b>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+                <p>2021 : Campagne non concernée par les sanctions</p>
+            </div>
+        </article>
     </div>
 {% endblock %}


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/2-4-Pack-Sanctions-En-tant-que-DDETS-je-peux-consulter-le-d-tail-du-r-sultat-n-gatif-de-la-SIAE-et-431c34731f224be48e5d637e447661f5**

### Pourquoi ?

Aide à la décision pour les DDETS.

### Captures d'écran

![image](https://user-images.githubusercontent.com/2758243/215702691-70db7c15-0310-427b-acb6-bd6d16daea0b.png)