### PR TITLE
Amélioration de l'autocompletion des commues pour les fichies salariées (bis)

### DIFF
--- a/itou/www/autocomplete/tests.py
+++ b/itou/www/autocomplete/tests.py
@@ -190,8 +190,12 @@ class CommunesAutocompleteTest(TestCase):
         assert response.status_code == 200
         assert response.json() == []
 
-        response = self.client.get(url, {"term": "64"})
+        response = self.client.get(url, {"term": "ILL"})
         assert response.status_code == 200
         assert response.json() == [
-            {"code": "64483", "department": "064", "value": "SAINT-JEAN-DE-LUZ (064)"},
+            {"code": "59350", "department": "059", "value": "LILLE (059)"},
+            {"code": "37273", "department": "037", "value": "VILLE-AUX-DAMES (037)"},
+            {"code": "07141", "department": "007", "value": "LENTILLERES (007)"},
+            {"code": "13200", "department": "013", "value": "MARSEILLE (013)"},
+            {"code": "83100", "department": "083", "value": "PUGET-VILLE (083)"},
         ]

--- a/itou/www/autocomplete/views.py
+++ b/itou/www/autocomplete/views.py
@@ -98,10 +98,9 @@ def communes_autocomplete(request):
             communes = sorted(
                 active_communes_qs.filter(name__unaccent__icontains=term),
                 # - the results starting by the searched term are favoured (Paris over Cormeil-en-Parisis)
-                # - the shorter city names are then favoured (it seems more natural to our brains)
                 # - then if the length is the same, by alphabetic order
                 # - then if everything is the same (Sainte-Colombe...) by department.
-                key=lambda c: (sanitize(c.name).index(sanitize(term)), len(c.name), c.name, c.department_code),
+                key=lambda c: (sanitize(c.name).index(sanitize(term)), c.name, c.department_code),
             )
 
         communes = [


### PR DESCRIPTION
Carte Notion : https://www.notion.so/plateforme-inclusion/Am-liorer-la-recherche-de-communes-ASP-18be9bbf90d14c45a1913ed8b98efb90

### Pourquoi ?

Prise en compte des retours sur la recette de https://github.com/betagouv/itou/pull/2051
Le problème de code postal n'est en revanche pas présent sur ce formulaire.