### PR TITLE
Ajout de <hr> à l’encart données des sanctions contrôle a posteriori

### DIFF
--- a/itou/templates/siae_evaluations/institution_evaluated_siae_notify.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_notify.html
@@ -37,6 +37,7 @@
         <article class="col-12 col-lg-5 order-1 mb-sm-4 card c-card has-links-inside">
             <div class="card-header">
                 <h2>Données</h2>
+                <hr class="mt-5">
             </div>
             <div class="card-body">
                 <h3>Campagne en cours</h3>
@@ -55,7 +56,8 @@
                         les {{ job_apps_count }} auto-prescriptions
                     {% endif %}
                     <i class="ri-external-link-line"></i></a>
-                <h3 class="mt-5">Historique des campagnes de contrôle</h3>
+                <hr class="my-5">
+                <h3>Historique des campagnes de contrôle</h3>
                 <ul class="list-unstyled">
                     {% for old_evaluated_siae in evaluation_history %}
                         <li>

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -1234,7 +1234,7 @@ class InstitutionEvaluatedSiaeNotifyViewTest(TestCase):
         self.assertContains(
             response,
             """
-            <h3 class="mt-5">
+            <h3>
              Historique des campagnes de contrôle
             </h3>
             <ul class="list-unstyled">
@@ -1387,7 +1387,7 @@ class InstitutionEvaluatedSiaeNotifyViewTest(TestCase):
         self.assertContains(
             response,
             """
-            <h3 class="mt-5">
+            <h3>
              Historique des campagnes de contrôle
             </h3>
             <ul class="list-unstyled">


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/il-manque-les-deux-s-parateurs-horizontaux-213286b81c904d41aa772de537d102d9**

### Captures d'écran

![image](https://user-images.githubusercontent.com/2758243/216065634-9316510f-4c57-42a5-b9d2-8f26fbaa0441.png)
