### PR TITLE
Détection de candidat existant lors de la création d'un nouveau candidat

### DIFF
--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
@@ -9,4 +9,50 @@
     {% bootstrap_field form.first_name %}
     {% bootstrap_field form.last_name %}
     {% bootstrap_field form.birthdate %} {# TODO: Duet border-color button is not of the correct color #}
+
+    {% if confirmation_needed %}
+        <!-- Modal -->
+        <div class="modal" id="email-confirmation-modal" tabindex="-1" role="dialog" aria-labelledby="email-confirmation-label" aria-modal="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h3 class="modal-title" id="email-confirmation-label">Attention</h3>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
+                            <i class="ri-close-line"></i>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <p>
+                            <strong>
+                                D'après les informations renseignées, il semblerait que ce
+                                candidat soit déjà rattaché à un autre email : {{ redacted_existing_email }}.
+                            </strong>
+                        </p>
+                        <p>
+                            Nous vous invitons à vérifier l'email renseigné précédemment
+                            afin d'éviter la création d'un compte en doublon.
+                        </p>
+                    </div>
+                    <div class="modal-footer">
+                        {# Go to the next step. #}
+                        <button type="submit" name="confirm" value="1" class="btn btn-sm btn-primary">Poursuivre la création du compte</button>
+                        {# Reload this page with a new form. #}
+                        <a href="{% url 'apply:check_email_for_sender' siae_pk=siae.pk %}" name="cancel" value="1" class="btn btn-sm btn-secondary">Modifier l'email du candidat</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block script %}
+    {{ super }}
+    {% if confirmation_needed %}
+        {# Show the confirmation modal after submitting the form. #}
+        <script nonce="{{ CSP_NONCE }}">
+            // Adding the "show" CSS class is not enough and not documented.
+            // A JS initialization is recommended.
+            $("#email-confirmation-modal").modal("show");
+        </script>
+    {% endif %}
 {% endblock %}

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
@@ -34,10 +34,12 @@
                         </p>
                     </div>
                     <div class="modal-footer">
-                        {# Go to the next step. #}
-                        <button type="submit" name="confirm" value="1" class="btn btn-sm btn-primary">Poursuivre la création du compte</button>
-                        {# Reload this page with a new form. #}
-                        <a href="{% url 'apply:check_email_for_sender' siae_pk=siae.pk %}" name="cancel" value="1" class="btn btn-sm btn-secondary">Modifier l'email du candidat</a>
+                        <div class="row">
+                            {# Go to the next step. #}
+                            <button type="submit" name="confirm" value="1" class="btn btn-sm btn-link">Poursuivre la création du compte</button>
+                            {# Reload this page with a new form. #}
+                            <a href="{% url 'apply:check_email_for_sender' siae_pk=siae.pk %}?email={{ email_to_create|urlencode }}" name="cancel" value="1" class="btn btn-sm btn-primary">Modifier l'email du candidat</a>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -46,7 +48,7 @@
 {% endblock %}
 
 {% block script %}
-    {{ super }}
+    {{ block.super }}
     {% if confirmation_needed %}
         {# Show the confirmation modal after submitting the form. #}
         <script nonce="{{ CSP_NONCE }}">

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -54,3 +54,20 @@ def get_email_message(to, context, subject, body, from_email=settings.DEFAULT_FR
 def send_email_messages(email_messages):
     with mail.get_connection() as connection:
         connection.send_messages(email_messages)
+
+
+def redact_email_address(email):
+    def redact_part(part):
+        return part[0] + "*" * (len(part) - 1) if part else ""
+
+    if not email:
+        return ""
+    if "@" not in email:
+        return redact_part(email)
+    user_part, domain_part = email.rsplit("@", 1)
+    redacted_user = redact_part(user_part)
+    if "." in domain_part:
+        redacted_domain = ".".join([redact_part(part) for part in domain_part.rsplit(".", 1)])
+    else:
+        redacted_domain = redact_part(domain_part)
+    return f"{redacted_user}@{redacted_domain}"

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -37,6 +37,7 @@ from itou.users.enums import KIND_JOB_SEEKER, KIND_PRESCRIBER, KIND_SIAE_STAFF, 
 from itou.users.factories import ItouStaffFactory, JobSeekerFactory, PrescriberFactory
 from itou.users.models import User
 from itou.utils import constants as global_constants, pagination
+from itou.utils.emails import redact_email_address
 from itou.utils.models import PkSupportRemark
 from itou.utils.password_validation import CnilCompositionPasswordValidator
 from itou.utils.perms.context_processors import get_current_organization_and_perms
@@ -1216,3 +1217,18 @@ def test_yield_sync_diff():
         "count=1 label=Rome removed by collection",
         "\tREMOVED Vas-y francky (BAZ)",
     ]
+
+
+@pytest.mark.parametrize(
+    "email,expected",
+    [
+        ("", ""),
+        ("test", "t***"),
+        ("test@localhost", "t***@l********"),
+        ("test@example.com", "t***@e******.c**"),
+        ("test.foo@example.com", "t*******@e******.c**"),
+        ("test@beta.gouv.fr", "t***@b********.f*"),
+    ],
+)
+def test_redact_email_adresse(email, expected):
+    assert redact_email_address(email) == expected

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -2329,11 +2329,15 @@ def test_detect_existing_job_seeker(client):
     assertContains(
         response,
         (
-            '<button type="submit" name="confirm" value="1" class="btn btn-sm btn-primary">'
+            '<button type="submit" name="confirm" value="1" class="btn btn-sm btn-link">'
             "Poursuivre la création du compte</button>"
         ),
         html=True,
     )
+    check_email_url = (
+        reverse("apply:check_email_for_sender", kwargs={"siae_pk": siae.pk}) + "?email=wrong-email%40example.com"
+    )
+    assertContains(response, check_email_url)
     # Use the modal button to send confirmation
     response = client.post(next_url, data=post_data | {"confirm": 1})
 
@@ -2346,3 +2350,7 @@ def test_detect_existing_job_seeker(client):
         kwargs={"siae_pk": siae.pk, "session_uuid": job_seeker_session_name},
     )
     assert response.url == next_url
+
+    # If we chose to cancel & go back, we should find our old wrong email in the page
+    response = client.get(check_email_url)
+    assertContains(response, "wrong-email@example.com")

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -316,7 +316,7 @@ class CheckEmailForSenderView(ApplyStepForSenderBaseView):
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
-        self.form = UserExistsForm(data=request.POST or None)
+        self.form = UserExistsForm(initial=request.GET, data=request.POST or None)
 
     def post(self, request, *args, **kwargs):
         can_add_nir = False
@@ -431,6 +431,7 @@ class CreateJobSeekerStep1ForSenderView(CreateJobSeekerForSenderBaseView):
                 # If an existing job seeker matches the info, a confirmation is required
                 context["confirmation_needed"] = True
                 context["redacted_existing_email"] = redact_email_address(existing_job_seeker.email)
+                context["email_to_create"] = self.job_seeker_session.get("user", {}).get("email", "")
 
             if not context["confirmation_needed"]:
                 self.job_seeker_session.set("user", self.job_seeker_session.get("user", {}) | self.form.cleaned_data)


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/En-tant-que-professionnel-qui-postule-pour-un-candidat-je-ne-veux-pas-faire-d-erreur-lorsque-je-rens-fdcd4ff16a6745cb9328e72f5657a732

### Pourquoi ?

Pour limiter les comptes dupliqués de candidats.

### Captures d'écran
![Screenshot 2023-02-01 at 17-55-20 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/216109550-4d207253-78e5-4983-bf8e-9fecd717f021.png)


