### PR TITLE
Ajout d'une bannière promotionnelle pour Inclusion Connect

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -179,6 +179,36 @@
                 </div>
             </div>
         </section>
+    {% elif ic_activate_url %}
+        {# Une p-inclusion-connect class somewhere #}
+        <div class="container mt-2">
+            <div class="row">
+                <div class="col-8">
+                    <div class="d-flex flex-column flex-md-row">
+                        <div class="w-100">
+                            <span class="badge badge-pill badge-sm badge-important-lightest text-important mb-2">A découvrir</span>
+                            <p class="h2 mb-2">Inclusion Connect : Un accès unique à tous vos services !</p>
+                            <p class="mb-2">
+                                Simplifiez la connexion : accédez aux différents services partenaires avec <b>le même identifiant et le même mot de passe.</b>
+                            </p>
+
+                            <a class="btn btn-primary btn-ico" href="{{ ic_activate_url }}" title="Activer Inclusion Connect">
+                                <span>Activer Inclusion Connect</span>
+                            </a>
+
+                            <a class="ml-4 text-decoration-none"
+                               href="https://plateforme-inclusion.notion.site/Un-compte-unique-pour-mes-services-num-riques-ded9135197654da590f5dde41d8bb68b"
+                               title="Plus d'infos concernant Inclusion Connect"
+                               rel="noopener"
+                               target="_blank">
+                                <span>Plus d'infos</span>
+                                <i class="ri-external-link-line ri-lg"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     {% endif %}
 {% endblock %}
 
@@ -207,10 +237,16 @@
         </p>
     {% endif %}
 
-    {% if current_siae %}<p class="text-muted">SIRET {{ current_siae.siret|format_siret }}</p>{% endif %}
+    {% if current_siae %}
+        <p class="text-muted">
+            SIRET {{ current_siae.siret|format_siret }}
+        </p>
+    {% endif %}
 
     {% if current_prescriber_organization and current_prescriber_organization.siret %}
-        <p class="text-muted">SIRET {{ current_prescriber_organization.siret|format_siret }}</p>
+        <p class="text-muted">
+            SIRET {{ current_prescriber_organization.siret|format_siret }}
+        </p>
     {% endif %}
 
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 mt-3">


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/242f90ec76d9411b848830197dd7e949?v=0992cca6c85448ebb13ce1e8a5b3c7eb&p=675e67fb58b64f56a4d8e97f1ef63eca&pm=c **

### Pourquoi ?

C'est cool pour faire la promo de IC.

### Comment (optionnel)
Cf le ticket.

On ne peut pas terminer le ticket sans avoir le code de Antoine fusionné, ie [cette PR](https://github.com/betagouv/itou/pull/2011).

Le lien utilisera:
```
params = {
    "user_kind": user.kind,
    "user_email": user.email,
    "previous_url": self.request.get_full_path(), # a tweaker peut être
}
f"{reverse('inclusion_connect:activate_account')}?{urlencode(params)}"
```