### PR TITLE
ETPs : changements de nomenclatures et ajouts de colonnes

### DIFF
--- a/itou/metabase/sql/026_suivi_etp_realises_v2.sql
+++ b/itou/metabase/sql/026_suivi_etp_realises_v2.sql
@@ -5,7 +5,6 @@ with constantes as (
     from 
         "fluxIAE_EtatMensuelIndiv" as emi
 )
-
 select 
     distinct emi.emi_pph_id as identifiant_salarie, /* ici on considère bien le salarié qu'une fois pour éviter des doublons et donc sur estimer les ETPs */
     emi.emi_afi_id as id_annexe_financiere,
@@ -15,8 +14,8 @@ select
     emi.emi_nb_heures_travail as nombre_heures_travaillees,
     /*Nous calculons directement les ETPs réalisés pour éviter des problèmes de filtres/colonnes/etc sur metabase*/
     /* ETPs réalisés = Nbr heures travaillées / montant d'heures necessaires pour avoir 1 ETP */
-    (emi.emi_nb_heures_travail / firmi.rmi_valeur) as nombre_etp_consommes_reels_mensuels, 
-    (emi.emi_nb_heures_travail / firmi.rmi_valeur) * 12 as nombre_etp_consommes_reels_annuels,
+    (emi.emi_nb_heures_travail / firmi.rmi_valeur) as nombre_etp_consommes_reels_annuels, 
+    (emi.emi_nb_heures_travail / firmi.rmi_valeur) * 12 as nombre_etp_consommes_reels_mensuels,
     emi.emi_afi_id as identifiant_annexe_fin,
     af.af_numero_convention,
     af.af_numero_annexe_financiere,

--- a/itou/metabase/sql/026_suivi_etp_realises_v2.sql
+++ b/itou/metabase/sql/026_suivi_etp_realises_v2.sql
@@ -14,8 +14,8 @@ select
     emi.emi_nb_heures_travail as nombre_heures_travaillees,
     /*Nous calculons directement les ETPs réalisés pour éviter des problèmes de filtres/colonnes/etc sur metabase*/
     /* ETPs réalisés = Nbr heures travaillées / montant d'heures necessaires pour avoir 1 ETP */
-    (emi.emi_nb_heures_travail / firmi.rmi_valeur) as nombre_etp_consommes_reels_annuels, 
-    (emi.emi_nb_heures_travail / firmi.rmi_valeur) * 12 as nombre_etp_consommes_reels_mensuels,
+    (emi.emi_nb_heures_travail / firmi.rmi_valeur) as nombre_etp_consommes_reels_mensuels, 
+    (emi.emi_nb_heures_travail / firmi.rmi_valeur) * 12 as nombre_etp_consommes_reels_annuels,
     emi.emi_afi_id as identifiant_annexe_fin,
     af.af_numero_convention,
     af.af_numero_annexe_financiere,

--- a/itou/metabase/sql/027_suivi_etp_conventionnes_v2.sql
+++ b/itou/metabase/sql/027_suivi_etp_conventionnes_v2.sql
@@ -12,16 +12,16 @@ select
     date_part('year', af.af_date_debut_effet_v2) as annee_af,
     af_date_debut_effet_v2,
     af_date_fin_effet_v2,
+    /* we compute year_diff to anticipate an eventual consideration of the FDI structure, which can have an af that goes over two years */
     (
         date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)
     ) as year_diff,
-    /* we compute year_diff to anticipate an eventual consideration of the FDI structure, which can have an af that goes over two years */
+    /* I need to add 1 to the operation because postgre considers that between january 1st and december 31st of the same year, 11 months have passed not 11,xx nor 12. Thus, the artificial addition of an extra month to round the operation is needed */
     (
         date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)
     ) * 12 + (
         date_part('month', af_date_fin_effet_v2) - date_part('month', af_date_debut_effet_v2)
     ) + 1 as duree_annexe,
-    /* I need to add 1 to the operation because postgre considers that between january 1st and december 31st of the same year, 11 months have passed not 11,xx nor 12. Thus, the artificial addition of an extra month to round the operation is needed */
     af.af_etat_annexe_financiere_code,
     af.af_mesure_dispositif_id,
     af.af_mesure_dispositif_code,

--- a/itou/metabase/sql/027_suivi_etp_conventionnes_v2.sql
+++ b/itou/metabase/sql/027_suivi_etp_conventionnes_v2.sql
@@ -5,17 +5,21 @@ with constantes as
     from 
         "fluxIAE_AnnexeFinanciere_v2"
 )
-
 select
     distinct af.af_id_annexe_financiere as id_annexe_financiere, 
     af.af_numero_convention,
     af.af_numero_annexe_financiere,
     date_part('year', af.af_date_debut_effet_v2) as annee_af,
+    af_date_debut_effet_v2,
+    af_date_fin_effet_v2,
+    (date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)) as year_diff, /* we compute year_diff to anticipate an eventual consideration of the FDI structure, which can have an af that goes over two years */
+    (date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)) * 12 + (date_part('month', af_date_fin_effet_v2) - date_part('month', af_date_debut_effet_v2)) + 1 as duree_annexe, /* I need to add 1 to the operation because postgre considers that between january 1st and december 31st of the same year, 11 months have passed not 11,xx nor 12. Thus, the artificial addition of an extra month to round the operation is needed */
     af.af_etat_annexe_financiere_code,
     af.af_mesure_dispositif_id,
     af.af_mesure_dispositif_code,
     af.af_numero_avenant_modification,
-    af.af_etp_postes_insertion as nombre_etp_conventionnés,
+    af.af_etp_postes_insertion as effectif_mensuel_conventionné,
+    (af.af_etp_postes_insertion *((date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)) * 12 + (date_part('month', af_date_fin_effet_v2) - date_part('month', af_date_debut_effet_v2)))/12) as effectif_annuel_conventionné,
     replace(af.af_mesure_dispositif_code, '_', ' ') as type_structure,
     structure.structure_denomination,
     structure.structure_adresse_admin_commune as commune_structure,

--- a/itou/metabase/sql/027_suivi_etp_conventionnes_v2.sql
+++ b/itou/metabase/sql/027_suivi_etp_conventionnes_v2.sql
@@ -1,25 +1,41 @@
 with constantes as 
 (
-    select 
+    select
         max(date_part('year', af_date_debut_effet_v2)) as annee_en_cours
-    from 
+    from
         "fluxIAE_AnnexeFinanciere_v2"
 )
 select
-    distinct af.af_id_annexe_financiere as id_annexe_financiere, 
+    distinct af.af_id_annexe_financiere as id_annexe_financiere,
     af.af_numero_convention,
     af.af_numero_annexe_financiere,
     date_part('year', af.af_date_debut_effet_v2) as annee_af,
     af_date_debut_effet_v2,
     af_date_fin_effet_v2,
-    (date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)) as year_diff, /* we compute year_diff to anticipate an eventual consideration of the FDI structure, which can have an af that goes over two years */
-    (date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)) * 12 + (date_part('month', af_date_fin_effet_v2) - date_part('month', af_date_debut_effet_v2)) + 1 as duree_annexe, /* I need to add 1 to the operation because postgre considers that between january 1st and december 31st of the same year, 11 months have passed not 11,xx nor 12. Thus, the artificial addition of an extra month to round the operation is needed */
+    (
+        date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)
+    ) as year_diff,
+    /* we compute year_diff to anticipate an eventual consideration of the FDI structure, which can have an af that goes over two years */
+    (
+        date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)
+    ) * 12 + (
+        date_part('month', af_date_fin_effet_v2) - date_part('month', af_date_debut_effet_v2)
+    ) + 1 as duree_annexe,
+    /* I need to add 1 to the operation because postgre considers that between january 1st and december 31st of the same year, 11 months have passed not 11,xx nor 12. Thus, the artificial addition of an extra month to round the operation is needed */
     af.af_etat_annexe_financiere_code,
     af.af_mesure_dispositif_id,
     af.af_mesure_dispositif_code,
     af.af_numero_avenant_modification,
     af.af_etp_postes_insertion as effectif_mensuel_conventionné,
-    (af.af_etp_postes_insertion *((date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)) * 12 + (date_part('month', af_date_fin_effet_v2) - date_part('month', af_date_debut_effet_v2)))/12) as effectif_annuel_conventionné,
+    (
+        af.af_etp_postes_insertion *(
+            (
+                date_part('year', af_date_fin_effet_v2) - date_part('year', af_date_debut_effet_v2)
+            ) * 12 + (
+                date_part('month', af_date_fin_effet_v2) - date_part('month', af_date_debut_effet_v2)
+            )+ 1
+        )/ 12
+    ) as effectif_annuel_conventionné,
     replace(af.af_mesure_dispositif_code, '_', ' ') as type_structure,
     structure.structure_denomination,
     structure.structure_adresse_admin_commune as commune_structure,
@@ -40,5 +56,7 @@ left join
     af.af_id_structure = structure.structure_id_siae
 where
     date_part('year', af.af_date_debut_effet_v2) >= annee_en_cours - 2
-    and af.af_etat_annexe_financiere_code in ('VALIDE', 'PROVISOIRE', 'CLOTURE')
+    and af.af_etat_annexe_financiere_code in (
+        'VALIDE', 'PROVISOIRE', 'CLOTURE'
+    )
     and af_mesure_dispositif_code not like '%FDI%'

--- a/itou/metabase/sql/028_suivi_consommation_etp_V2.sql
+++ b/itou/metabase/sql/028_suivi_consommation_etp_V2.sql
@@ -1,71 +1,97 @@
 /* Cette table nous permet de suivre la consommation d'etp par structures, par rapport à leur conventionnement */
 with calcul_etp as (
-select 
-    distinct(etp.id_annexe_financiere), /* Utilisation de l'ID de l'annexe financière -> ID unique contrairement à la convention et l'af */
-    etp.af_numero_annexe_financiere,
-    etp.af_numero_convention,
-    annee_af,
-    dernier_mois_saisi_asp,
-    sum(nombre_etp_consommes_reels_mensuels) as total_etp_mensuels_realises,
-    sum(nombre_etp_consommes_reels_annuels) as total_etp_annuels_realises,
-    /* les deux conditions si dessus sont identiques, sauf que pour l'une on considère les ETPs mensuels et l'autre les annuels */
-    case 
-        /* Sur les deux lignes du dessous on sélectionne le dernier mois saisi pour avoir une moyenne mensuelle des ETPs consommés sur les années précédentes */
-        when (max(annee_af) = date_part ('year', current_date )- 1) then (sum(nombre_etp_consommes_reels_mensuels) / max(date_part('month',etp_c.date_saisie)))  
-        when (max(annee_af) = date_part('year', current_date )- 2) then (sum(nombre_etp_consommes_reels_mensuels) / max(date_part('month',etp_c.date_saisie)))
-        /* Ici on lui demande de seulement prendre en compte les mois écoulés pour l'année en cours (donc en mars il divisera le total par 3) */
-        else sum(nombre_etp_consommes_reels_mensuels) filter (where annee_af = (date_part('year', current_date))) 
-                / (max(date_part('month',etp_c.date_saisie)) filter (where annee_af = (date_part('year', current_date))))
+    select
+        distinct(etp.id_annexe_financiere),
+        /* Utilisation de l'ID de l'annexe financière -> ID unique contrairement à la convention et l'af */
+        etp.af_numero_annexe_financiere,
+        etp.af_numero_convention,
+        annee_af,
+        dernier_mois_saisi_asp,
+        sum(nombre_etp_consommes_reels_mensuels) as total_etp_mensuels_realises,
+        sum(nombre_etp_consommes_reels_annuels) as total_etp_annuels_realises,
+        /* les deux conditions si dessus sont identiques, sauf que pour l'une on considère les ETPs mensuels et l'autre les annuels */
+        case
+            /* Sur les deux lignes du dessous on sélectionne le dernier mois saisi pour avoir une moyenne mensuelle des ETPs consommés sur les années précédentes */
+            when (
+                max(annee_af) = date_part ('year', current_date) - 1
+            ) then (
+                sum(nombre_etp_consommes_reels_mensuels) / max(date_part('month', etp_c.date_saisie))
+            )
+            when (
+                max(annee_af) = date_part('year', current_date) - 2
+            ) then (
+                sum(nombre_etp_consommes_reels_mensuels) / max(date_part('month', etp_c.date_saisie))
+            )
+            /* Ici on lui demande de seulement prendre en compte les mois écoulés pour l'année en cours (donc en mars il divisera le total par 3) */
+            else sum(nombre_etp_consommes_reels_mensuels) filter (
+                where
+                    annee_af = (date_part('year', current_date))
+            ) / (
+                max(date_part('month', etp_c.date_saisie)) filter (
+                    where
+                        annee_af = (date_part('year', current_date))
+                )
+            )
         end moyenne_nb_etp_mensuels_depuis_debut_annee,
-    case 
-        when (max(annee_af) = date_part ('year', current_date )- 1) then (sum(nombre_etp_consommes_reels_annuels) / max(date_part('month',etp_c.date_saisie)))
-        when (max(annee_af) = date_part('year', current_date )- 2) then (sum(nombre_etp_consommes_reels_annuels) / max(date_part('month',etp_c.date_saisie)))
-        else sum(nombre_etp_consommes_reels_annuels) filter (where annee_af = (date_part('year', current_date))) 
-                / (max(date_part('month',etp_c.date_saisie)) filter (where annee_af = (date_part('year', current_date))))
+        case
+            when (
+                max(annee_af) = date_part ('year', current_date) - 1
+            ) then (
+                sum(nombre_etp_consommes_reels_annuels) / max(date_part('month', etp_c.date_saisie))
+            )
+            when (
+                max(annee_af) = date_part('year', current_date) - 2
+            ) then (
+                sum(nombre_etp_consommes_reels_annuels) / max(date_part('month', etp_c.date_saisie))
+            )
+            else sum(nombre_etp_consommes_reels_annuels) filter (
+                where
+                    annee_af = (date_part('year', current_date))
+            ) / (
+                max(date_part('month', etp_c.date_saisie)) filter (
+                    where
+                        annee_af = (date_part('year', current_date))
+                )
+            )
         end moyenne_nb_etp_annuels_depuis_debut_annee,
-    effectif_mensuel_conventionné, 
-    effectif_annuel_conventionné,
-    max(date_part('month',etp_c.date_saisie)) as mois_max,
-    etp.type_structure,
-    etp.structure_denomination,
-    etp.code_departement_af,
-    etp.nom_departement_af,
-    etp.nom_region_af
-from
-    suivi_etp_conventionnes_v2 etp
-left join suivi_etp_realises_v2 etp_c 
-    on
-    etp.id_annexe_financiere = etp_c.id_annexe_financiere
-    and
-    etp.af_numero_convention = etp_c.af_numero_convention
-    and
-    etp.af_numero_annexe_financiere = etp_c.af_numero_annexe_financiere
-    and
-    date_part('year',etp_c.date_saisie) = annee_af /* bien penser à joindre sur l'année pour éviter que l'on se retrouve avec années de conventionnement qui correspondent pas */
-right join suivi_saisies_dans_asp sasp 
-	on etp.id_annexe_financiere = sasp.af_id_annexe_financiere
-group by
-	dernier_mois_saisi_asp,
-    etp.id_annexe_financiere,
-    etp.af_numero_convention,
-    etp.af_numero_annexe_financiere,
-    effectif_mensuel_conventionné,
-    effectif_annuel_conventionné,
-    annee_af,
-    etp.type_structure,
-    etp.structure_denomination,
-    etp.code_departement_af,
-    etp.nom_departement_af,
-    etp.nom_region_af
+        effectif_mensuel_conventionné,
+        effectif_annuel_conventionné,
+        max(date_part('month', etp_c.date_saisie)) as mois_max,
+        etp.type_structure,
+        etp.structure_denomination,
+        etp.code_departement_af,
+        etp.nom_departement_af,
+        etp.nom_region_af
+    from
+        suivi_etp_conventionnes_v2 etp
+        left join suivi_etp_realises_v2 etp_c on etp.id_annexe_financiere = etp_c.id_annexe_financiere
+        and etp.af_numero_convention = etp_c.af_numero_convention
+        and etp.af_numero_annexe_financiere = etp_c.af_numero_annexe_financiere
+        and date_part('year', etp_c.date_saisie) = annee_af
+        /* bien penser à joindre sur l'année pour éviter que l'on se retrouve avec années de conventionnement qui correspondent pas */
+        right join suivi_saisies_dans_asp sasp on etp.id_annexe_financiere = sasp.af_id_annexe_financiere
+    group by
+        dernier_mois_saisi_asp,
+        etp.id_annexe_financiere,
+        etp.af_numero_convention,
+        etp.af_numero_annexe_financiere,
+        effectif_mensuel_conventionné,
+        effectif_annuel_conventionné,
+        annee_af,
+        etp.type_structure,
+        etp.structure_denomination,
+        etp.code_departement_af,
+        etp.nom_departement_af,
+        etp.nom_region_af
 )
-select 
+select
     *,
-    case 
+    case
         /* On calcule la moyenne des etp consommés depuis le début de l'année et on la compare avec le nombre d'etp 
-        conventionnés */
+                conventionnés */
         when moyenne_nb_etp_mensuels_depuis_debut_annee < effectif_mensuel_conventionné then 'sous-consommation'
         when moyenne_nb_etp_mensuels_depuis_debut_annee > effectif_mensuel_conventionné then 'sur-consommation'
         else 'conforme'
     end consommation_ETP
-from 
+from
     calcul_etp

--- a/itou/metabase/sql/028_suivi_consommation_etp_V2.sql
+++ b/itou/metabase/sql/028_suivi_consommation_etp_V2.sql
@@ -7,9 +7,9 @@ with calcul_etp as (
         etp.af_numero_convention,
         annee_af,
         dernier_mois_saisi_asp,
+        /* les deux conditions si dessus sont identiques, sauf que pour l'une on considère les ETPs mensuels et l'autre les annuels */
         sum(nombre_etp_consommes_reels_mensuels) as total_etp_mensuels_realises,
         sum(nombre_etp_consommes_reels_annuels) as total_etp_annuels_realises,
-        /* les deux conditions si dessus sont identiques, sauf que pour l'une on considère les ETPs mensuels et l'autre les annuels */
         case
             /* Sur les deux lignes du dessous on sélectionne le dernier mois saisi pour avoir une moyenne mensuelle des ETPs consommés sur les années précédentes */
             when (

--- a/itou/metabase/sql/028_suivi_consommation_etp_V2.sql
+++ b/itou/metabase/sql/028_suivi_consommation_etp_V2.sql
@@ -5,9 +5,10 @@ select
     etp.af_numero_annexe_financiere,
     etp.af_numero_convention,
     annee_af,
-    sum(nombre_etp_consommes_reels_mensuels) as total_etp_annuels_realises,
-    sum(nombre_etp_consommes_reels_annuels) as total_etp_mensuels_realises,
-    /* les deux conditions si dessous sont identiques, sauf que pour l'une on considère les ETPs mensuels et l'autre les annuels */
+    dernier_mois_saisi_asp,
+    sum(nombre_etp_consommes_reels_mensuels) as total_etp_mensuels_realises,
+    sum(nombre_etp_consommes_reels_annuels) as total_etp_annuels_realises,
+    /* les deux conditions si dessus sont identiques, sauf que pour l'une on considère les ETPs mensuels et l'autre les annuels */
     case 
         /* Sur les deux lignes du dessous on sélectionne le dernier mois saisi pour avoir une moyenne mensuelle des ETPs consommés sur les années précédentes */
         when (max(annee_af) = date_part ('year', current_date )- 1) then (sum(nombre_etp_consommes_reels_mensuels) / max(date_part('month',etp_c.date_saisie)))  
@@ -15,14 +16,15 @@ select
         /* Ici on lui demande de seulement prendre en compte les mois écoulés pour l'année en cours (donc en mars il divisera le total par 3) */
         else sum(nombre_etp_consommes_reels_mensuels) filter (where annee_af = (date_part('year', current_date))) 
                 / (max(date_part('month',etp_c.date_saisie)) filter (where annee_af = (date_part('year', current_date))))
-        end moyenne_nb_etp_annuels_depuis_debut_annee,
+        end moyenne_nb_etp_mensuels_depuis_debut_annee,
     case 
         when (max(annee_af) = date_part ('year', current_date )- 1) then (sum(nombre_etp_consommes_reels_annuels) / max(date_part('month',etp_c.date_saisie)))
         when (max(annee_af) = date_part('year', current_date )- 2) then (sum(nombre_etp_consommes_reels_annuels) / max(date_part('month',etp_c.date_saisie)))
         else sum(nombre_etp_consommes_reels_annuels) filter (where annee_af = (date_part('year', current_date))) 
                 / (max(date_part('month',etp_c.date_saisie)) filter (where annee_af = (date_part('year', current_date))))
-        end moyenne_nb_etp_mensuels_depuis_debut_annee,
-    (etp.nombre_etp_conventionnés) as etp_conventionnés, 
+        end moyenne_nb_etp_annuels_depuis_debut_annee,
+    effectif_mensuel_conventionné, 
+    effectif_annuel_conventionné,
     max(date_part('month',etp_c.date_saisie)) as mois_max,
     etp.type_structure,
     etp.structure_denomination,
@@ -40,11 +42,15 @@ left join suivi_etp_realises_v2 etp_c
     etp.af_numero_annexe_financiere = etp_c.af_numero_annexe_financiere
     and
     date_part('year',etp_c.date_saisie) = annee_af /* bien penser à joindre sur l'année pour éviter que l'on se retrouve avec années de conventionnement qui correspondent pas */
+right join suivi_saisies_dans_asp sasp 
+	on etp.id_annexe_financiere = sasp.af_id_annexe_financiere
 group by
+	dernier_mois_saisi_asp,
     etp.id_annexe_financiere,
     etp.af_numero_convention,
     etp.af_numero_annexe_financiere,
-    etp_conventionnés,
+    effectif_mensuel_conventionné,
+    effectif_annuel_conventionné,
     annee_af,
     etp.type_structure,
     etp.structure_denomination,
@@ -57,8 +63,8 @@ select
     case 
         /* On calcule la moyenne des etp consommés depuis le début de l'année et on la compare avec le nombre d'etp 
         conventionnés */
-        when moyenne_nb_etp_mensuels_depuis_debut_annee < etp_conventionnés then 'sous-consommation'
-        when moyenne_nb_etp_mensuels_depuis_debut_annee > etp_conventionnés then 'sur-consommation'
+        when moyenne_nb_etp_mensuels_depuis_debut_annee < effectif_mensuel_conventionné then 'sous-consommation'
+        when moyenne_nb_etp_mensuels_depuis_debut_annee > effectif_mensuel_conventionné then 'sur-consommation'
         else 'conforme'
     end consommation_ETP
 from 

--- a/itou/metabase/sql/029_suivi_consommation_mensuelle_etp_V2.sql
+++ b/itou/metabase/sql/029_suivi_consommation_mensuelle_etp_V2.sql
@@ -8,7 +8,7 @@ select
     sum(nombre_etp_consommes_reels_annuels) as total_etp_annuels_realises,
     etp.effectif_mensuel_conventionné,
     case 
-        when etp.nombre_etp_conventionnés <> 0 then sum(nombre_etp_consommes_reels_annuels)/etp.effectif_mensuel_conventionné*100      
+        when etp.nombre_etp_conventionnés <> 0 then sum(nombre_etp_consommes_reels_mensuels)/etp.effectif_mensuel_conventionné*100      
         else 0
     end taux_de_realisation,
     max(date_part('month',etp_c.date_saisie)) as mois_max,

--- a/itou/metabase/sql/029_suivi_consommation_mensuelle_etp_V2.sql
+++ b/itou/metabase/sql/029_suivi_consommation_mensuelle_etp_V2.sql
@@ -4,11 +4,11 @@ select
     etp.af_numero_convention,
     date_saisie,
     annee_af,
-    sum(nombre_etp_consommes_reels_mensuels) as total_etp_annuels_realises,
-    sum(nombre_etp_consommes_reels_annuels) as total_etp_mensuels_realises,
-    (etp.nombre_etp_conventionnés) as etp_conventionnés,
+    sum(nombre_etp_consommes_reels_mensuels) as total_etp_mensuels_realises,
+    sum(nombre_etp_consommes_reels_annuels) as total_etp_annuels_realises,
+    etp.effectif_mensuel_conventionné,
     case 
-        when etp.nombre_etp_conventionnés <> 0 then sum(nombre_etp_consommes_reels_annuels)/etp.nombre_etp_conventionnés*100      
+        when etp.nombre_etp_conventionnés <> 0 then sum(nombre_etp_consommes_reels_annuels)/etp.effectif_mensuel_conventionné*100      
         else 0
     end taux_de_realisation,
     max(date_part('month',etp_c.date_saisie)) as mois_max,
@@ -32,7 +32,7 @@ group by
     etp.id_annexe_financiere,
     etp.af_numero_convention,
     etp.af_numero_annexe_financiere,
-    etp_conventionnés,
+    effectif_mensuel_conventionné,
     date_saisie,
     annee_af,
     etp.type_structure,


### PR DESCRIPTION
**Carte Notion : **  [Suivi opérationnel des effectifs mensuels exprimés en ETP](https://www.notion.so/plateforme-inclusion/Cr-er-un-tableau-de-bord-du-suivi-op-rationnel-des-effectifs-mensuels-exprim-s-en-ETPs-a2cd262583194ed9b6c3734d9c7a937c)

### Pourquoi ?

Changement de titres de colonnes pour coller aux définitions établies par Aurélie + ajout du calcul des ETPs conventionnés mensuels
