### PR TITLE
Permettre à `clone_orphan_employee_records.py` de fonctionner pour les SIAE ayant plusieurs mesures

### DIFF
--- a/itou/approvals/test_notify_pole_emploi.py
+++ b/itou/approvals/test_notify_pole_emploi.py
@@ -172,7 +172,7 @@ class ApprovalNotifyPoleEmploiIntegrationTest(TestCase):
         )
         respx.post("https://pe.fake/maj-pass-iae/v1/passIAE/miseAjour").respond(200, json=API_MAJPASS_RESULT_ERROR)
         job_seeker = JobSeekerFactory()
-        siae = SiaeFactory(kind="FOOBAR")  # unknown kind
+        siae = SiaeFactory(kind="FOO")  # unknown kind
         approval = ApprovalFactory(user=job_seeker)
         JobApplicationFactory(to_siae=siae, approval=approval, state=JobApplicationWorkflow.STATE_ACCEPTED)
         approval.notify_pole_emploi(at=now)
@@ -190,7 +190,7 @@ class ApprovalNotifyPoleEmploiIntegrationTest(TestCase):
         )
         respx.post("https://pe.fake/maj-pass-iae/v1/passIAE/miseAjour").respond(200, json=API_MAJPASS_RESULT_ERROR)
         job_seeker = JobSeekerFactory()
-        siae = SiaeFactory(kind="FOOBAR")  # unknown kind
+        siae = SiaeFactory(kind="FOO")  # unknown kind
         approval = ApprovalFactory(user=job_seeker)
         JobApplicationFactory(to_siae=siae, approval=approval, state=JobApplicationWorkflow.STATE_POSTPONED)
         approval.notify_pole_emploi(at=now)

--- a/itou/employee_record/factories.py
+++ b/itou/employee_record/factories.py
@@ -23,7 +23,9 @@ class EmployeeRecordFactory(BareEmployeeRecordFactory):
     (no job seeker profile linked => not updatable)
     """
 
-    job_application = factory.SubFactory(JobApplicationWithApprovalNotCancellableFactory)
+    job_application = factory.SubFactory(
+        JobApplicationWithApprovalNotCancellableFactory, to_siae__use_employee_record=True
+    )
     asp_id = factory.SelfAttribute(".job_application.to_siae.convention.asp_id")
     approval_number = factory.SelfAttribute(".job_application.approval.number")
     siret = factory.SelfAttribute(".job_application.to_siae.siret")

--- a/itou/employee_record/management/commands/clone_orphan_employee_records.py
+++ b/itou/employee_record/management/commands/clone_orphan_employee_records.py
@@ -28,9 +28,7 @@ class Command(BaseCommand):
 
     @transaction.atomic()
     def handle(self, old_asp_id, new_asp_id, wet_run=False, **options):
-        try:
-            siaes_models.SiaeConvention.objects.get(asp_id=new_asp_id)
-        except siaes_models.SiaeConvention.DoesNotExist:
+        if not siaes_models.SiaeConvention.objects.filter(asp_id=new_asp_id).exists():
             self.stderr.write(f"No convention exists with {new_asp_id=}!")
             return
 

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -430,9 +430,7 @@ class EmployeeRecord(models.Model):
         if not self.is_orphan:
             raise CloningError(f"This employee record is not an orphan, {self.asp_id=}")
 
-        try:
-            convention = SiaeConvention.objects.get(asp_id=asp_id)
-        except SiaeConvention.DoesNotExist:
+        if not SiaeConvention.objects.filter(asp_id=asp_id).exists():
             raise CloningError(f"Unable to find SIAE convention for asp_id: {asp_id}")
 
         # Cleanup clone fields
@@ -440,7 +438,7 @@ class EmployeeRecord(models.Model):
             status=Status.NEW,
             job_application=self.job_application,
             approval_number=self.approval_number,
-            asp_id=convention.asp_id,
+            asp_id=asp_id,
             siret=EmployeeRecord.siret_from_asp_source(self.job_application.to_siae),
             asp_processing_label=f"{self.ASP_CLONE_MESSAGE} (pk origine: {self.pk})",
         )

--- a/itou/employee_record/tests/test_clone_orphan_employee_records.py
+++ b/itou/employee_record/tests/test_clone_orphan_employee_records.py
@@ -3,6 +3,8 @@ import io
 import pytest
 from django.core.management import call_command
 
+from itou.siaes import enums as siaes_enums, models as siaes_models
+
 from .. import factories
 from ..management.commands import clone_orphan_employee_records
 
@@ -56,6 +58,39 @@ def test_management_command_wet_run(command):
     assert command.stdout.getvalue().split("\n") == [
         f"Cloning employee_record.pk={employee_record.pk}...",
         f"  Cloning was successful, employee_record_clone.pk={employee_record.pk + 3}",
+        "",
+    ]
+
+
+def test_management_command_when_the_new_asp_id_is_used_by_multiple_convention(command):
+    employee_record = factories.EmployeeRecordFactory(
+        orphan=True,
+        job_application__to_siae__kind=siaes_enums.SiaeKind.EI,
+    )
+    old_asp_id, new_asp_id = employee_record.asp_id, employee_record.job_application.to_siae.convention.asp_id
+    factories.EmployeeRecordFactory(
+        job_application__to_siae__kind=siaes_enums.SiaeKind.ACI,
+        job_application__to_siae__convention__asp_id=new_asp_id,
+    )
+
+    # SiaeConventionFactory() use the `django_get_or_create` option to match the ("asp_id", "kind")` unique
+    # constraint, and in this test case we need to be sure that more than one convention share the same asp_id.
+    assert siaes_models.SiaeConvention.objects.filter(asp_id=new_asp_id).count() == 2
+
+    command.handle(
+        old_asp_id=old_asp_id,
+        new_asp_id=new_asp_id,
+    )
+
+    assert command.stderr.getvalue().split("\n") == [
+        f"Clone orphans employee records from old_asp_id={old_asp_id} to new_asp_id={new_asp_id}",
+        "1 employee records will be cloned",
+        "Option --wet-run was not used so nothing will be cloned.",
+        "Done!",
+        "",
+    ]
+    assert command.stdout.getvalue().split("\n") == [
+        f"Cloning employee_record.pk={employee_record.pk}...",
         "",
     ]
 

--- a/itou/siaes/factories.py
+++ b/itou/siaes/factories.py
@@ -101,7 +101,7 @@ class SiaeFactory(factory.django.DjangoModelFactory):
     post_code = factory.Faker("postalcode")
     city = factory.Faker("city", locale="fr_FR")
     source = models.Siae.SOURCE_ASP
-    convention = factory.SubFactory(SiaeConventionFactory)
+    convention = factory.SubFactory(SiaeConventionFactory, kind=factory.SelfAttribute("..kind"))
     department = factory.LazyAttribute(lambda o: department_from_postcode(o.post_code))
 
 


### PR DESCRIPTION
### Pourquoi ?

L'`asp_id` n'est pas unique par `SiaeConvention()` ce qui peux donc générer ce genre d'erreur :
```
itou.siaes.models.SiaeConvention.MultipleObjectsReturned: get() returned more than one SiaeConvention -- it returned 2!
```

### Comment

Normalement tout est expliqué dans le commit.


