### PR TITLE
imports ASP: Première tentative d'automatisation

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -12,6 +12,7 @@
   "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
   "0 0 15 * * $ROOT/clevercloud/run_management_command.sh sync_romes_and_appellations --wet-run",
   "0 6 * * 1 $ROOT/clevercloud/crons/populate_metabase_matomo.sh",
+  "0 6 * * 2 $ROOT/clevercloud/crons/populate_metabase_fluxiae.sh",
   "30 20 * * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --daily",
   "0 0 2 * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --monthly",
   "5 * * * * $ROOT/clevercloud/run_management_command.sh sync_pec_offers --wet-run",

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -69,7 +69,6 @@ from itou.metabase.db import build_final_tables
 # Another way to do it would be to rationalize our import (to Itou) & export (to Metabase) logic.
 from itou.siaes.management.commands._import_siae.utils import get_fluxiae_df, get_fluxiae_referential_filenames
 from itou.utils.python import timeit
-from itou.utils.slack import send_slack_message
 
 
 class Command(BaseCommand):
@@ -87,10 +86,6 @@ class Command(BaseCommand):
 
     @timeit
     def populate_metabase_fluxiae(self):
-        send_slack_message(
-            ":rocket: Début de la mise à jour hebdomadaire de Metabase avec les dernières données FluxIAE :rocket:"
-        )
-
         self.populate_fluxiae_referentials()
 
         self.populate_fluxiae_view(vue_name="fluxIAE_AnnexeFinanciere")
@@ -108,11 +103,6 @@ class Command(BaseCommand):
         self.populate_fluxiae_view(vue_name="fluxIAE_Structure")
 
         build_final_tables()
-
-        send_slack_message(
-            ":white_check_mark: Fin de la mise à jour hebdomadaire de Metabase avec les"
-            " dernières données FluxIAE :white_check_mark:"
-        )
 
     def handle(self, **options):
         self.populate_metabase_fluxiae()


### PR DESCRIPTION
Nous avons désormais une machine dédiée aux tâches périodiques. Je pense qu'il est temps de planter la graine de la fin de "supportix-as-a-cron" ^^

**Explications du commit en anglais ci-dessous**
- We add a script in the clevercloud/ folder.
- The script is scheduled to be run avery tuesday morning (we usually receive the ASP files during the Monday)
- The output is the same as before, everything is stored in our FS bucket.
- Slack notifications are sent thanks to the management command that is responsible for it; we get notified if the files are missing.

We did not separate the populate_fluxiae and import_asp scripts for now since they both rely on the same input data that has to be destroyed after use.

This can be the opening of a discussion where we might want to split those scripts and settle on a different management of the fluxIAE files.

This could pave the way to:
- scripts that accept input files as arguments with a record of which file has been processed when
- ASP files being kept a bit longer but marked as processed (and in which fashion) or not, another task taking care of removing them later
- tests for import_siae, import_ea_eatt, populate_fluxiae will be easier to write and made exhaustive
