### PR TITLE
Boost février

### DIFF
--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -1456,7 +1456,7 @@ class ProlongationNotificationsTest(TestCase):
         assert title(prolongation.declared_by.get_full_name()) in email.body
 
         assert prolongation.declared_by_siae.display_name in email.body
-        assert prolongation.approval.number_with_spaces in email.body
+        assert prolongation.approval.number in email.body
         assert title(prolongation.approval.user.first_name) in email.body
         assert title(prolongation.approval.user.last_name) in email.body
         assert global_constants.ITOU_EMAIL_PROLONGATION in email.body

--- a/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
+++ b/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
@@ -5,7 +5,7 @@ Bonjour,
 
 {{ prolongation.declared_by.get_full_name|title }} de la structure {{ prolongation.declared_by_siae.display_name }} a déclaré avoir obtenu votre accord pour prolonger un PASS IAE :
 
-- Numéro de PASS : {{ prolongation.approval.number_with_spaces }}
+- Numéro de PASS : {{ prolongation.approval.number }}
 - Prénom : {{ prolongation.approval.user.first_name|title }}
 - Nom : {{ prolongation.approval.user.last_name|title }}
 - Début de la prolongation : {{ prolongation.start_at|date:"d/m/Y" }}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -44,7 +44,10 @@ class UserExistsForm(forms.Form):
                 error = "Vous ne pouvez pas postuler pour cet utilisateur car son compte a été désactivé."
                 raise forms.ValidationError(error)
             if not self.user.is_job_seeker:
-                error = "Vous ne pouvez pas postuler pour cet utilisateur car il n'est pas demandeur d'emploi."
+                error = (
+                    "Vous ne pouvez pas postuler pour cet utilisateur car"
+                    "cet e-mail est déjà rattaché à un prescripteur ou à un employeur."
+                )
                 raise forms.ValidationError(error)
         return email
 


### PR DESCRIPTION
**Cartes Notion : **
- https://www.notion.so/plateforme-inclusion/Zammad-prolongation-Afficher-n-PASS-sans-espace-ae08f1a64ec3463a90052812231dfa80
- https://www.notion.so/plateforme-inclusion/Modifier-un-message-d-alerte-confus-ad2f65a1487b459e9201fc75aee94387

### Pourquoi ?

- E-mail de confirmation de candidature envoyé au prescripteur : affichage du numéro de PASS IAE sans espace.
- Modification d'un message d'alerte.

### Comment (optionnel)

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.

