### PR TITLE
Ajout d'une page pour créer / accéder à son token d'API

### DIFF
--- a/itou/api/applicants_api/views.py
+++ b/itou/api/applicants_api/views.py
@@ -22,7 +22,7 @@ class ApplicantsView(generics.ListAPIView):
 
     Pour l'obtention d'un jeton, veuillez utiliser **les identifiants d'un compte administrateur de la structure.**
 
-    Voir le endpoint `auth-token` pour obtenir un jeton.
+    Voir le endpoint `token-auth` pour obtenir un jeton.
 
     Ce compte ne doit être *uniquement membre* de la structure dont on souhaite récupérer la liste de candidats.
 

--- a/itou/api/employee_record_api/viewsets.py
+++ b/itou/api/employee_record_api/viewsets.py
@@ -88,7 +88,9 @@ class EmployeeRecordViewSet(AbstractEmployeeRecordViewSet):
     # Permissions
 
     L'utilisation externe de cette API nécessite l'utilisation d'un token d'autorisation
-    (voir le endpoint `auth-token`).
+
+    Ce token peut être généré, et récupéré depuis votre tableau de bord sur le site des emplois.
+    Cliquez sur "Mon espace" puis "Token d'API"
 
     L'API peut également être utilisée dans un navigateur :
 

--- a/itou/api/token_auth/tests.py
+++ b/itou/api/token_auth/tests.py
@@ -1,0 +1,29 @@
+from django.urls import reverse
+from rest_framework.authtoken.models import Token
+
+from itou.users.factories import DEFAULT_PASSWORD, SiaeStaffFactory
+
+
+def test_token_auth_with_login_password(client):
+    user = SiaeStaffFactory()
+    assert Token.objects.count() == 0
+
+    url = reverse("v1:token-auth")
+    response = client.post(url, data={"username": user.email, "password": DEFAULT_PASSWORD})
+
+    token = Token.objects.get()
+    assert response.json() == {"token": token.key}
+
+
+def test_token_auth_with_token(client):
+    user = SiaeStaffFactory()
+    token = Token(user=user)
+    assert Token.objects.count() == 0
+
+    url = reverse("v1:token-auth")
+    response = client.post(url, data={"username": "__token__", "password": token.key})
+    assert response.status_code == 400
+
+    token.save()
+    response = client.post(url, data={"username": "__token__", "password": token.key})
+    assert response.json() == {"token": token.key}

--- a/itou/api/token_auth/views.py
+++ b/itou/api/token_auth/views.py
@@ -1,0 +1,20 @@
+from rest_framework import serializers
+from rest_framework.authtoken import views as drf_authtoken_views
+from rest_framework.authtoken.models import Token
+from rest_framework.response import Response
+
+
+TOKEN_ID_STR = "__token__"
+
+
+class ObtainAuthToken(drf_authtoken_views.ObtainAuthToken):
+    def post(self, request, *args, **kwargs):
+        if request.data.get("username") == TOKEN_ID_STR:
+            try:
+                token = Token.objects.get(key=request.data.get("password"))
+                return Response({"token": token.key})
+            except Token.DoesNotExist:
+                msg = "Impossible de se connecter avec le token fourni."
+                raise serializers.ValidationError(msg, code="authorization")
+
+        return super().post(request, *args, **kwargs)

--- a/itou/api/urls.py
+++ b/itou/api/urls.py
@@ -1,7 +1,6 @@
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView
 from rest_framework import routers
-from rest_framework.authtoken import views as auth_views
 
 from itou.api.data_inclusion_api.views import DataInclusionStructureView
 
@@ -12,6 +11,7 @@ from .employee_record_api.viewsets import (
     EmployeeRecordViewSet,
 )
 from .siae_api.viewsets import SiaeViewSet
+from .token_auth.views import ObtainAuthToken
 
 
 # High level app for API
@@ -31,7 +31,7 @@ router.register(r"siaes", SiaeViewSet, basename="siaes")
 
 urlpatterns = [
     # TokenAuthentication endpoint to get token from login/password.
-    path("token-auth/", auth_views.obtain_auth_token, name="token-auth"),
+    path("token-auth/", ObtainAuthToken.as_view(), name="token-auth"),
     # Needed for Browseable API (dev)
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     # OpenAPI

--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -1,0 +1,71 @@
+{% extends "layout/content_small.html" %}
+{% load bootstrap4 %}
+
+{% block title %}Accès aux APIs {{ block.super }}{% endblock %}
+
+{% block content %}
+    <h1 class="h1-hero-c1">Accès aux APIs</h1>
+
+    <div class="card-deck mt-3">
+
+        <div class="card">
+            <div class="card-body">
+                <div class="col-12">
+                    <p>
+                        Une API (application programming interface ou « interface de programmation d'application ») est une interface logicielle qui permet de « connecter » le site des emplois de l'inclusion à un autre logiciel ou service afin d'échanger des données et des fonctionnalités.
+                    </p>
+                    <p>
+                        En tant qu’administrateur des structures suivantes, vous avez accès à l’API Fiches salarié (<a href="https://emplois.inclusion.beta.gouv.fr/api/v1/redoc/#tag/employee-records" target="_blank">voir la documentation ici</a>):
+                    </p>
+                    <ul>
+                        {% for siae_name in siaes_names %}<li>{{ siae_name }}</li>{% endfor %}
+                    </ul>
+                    <p>
+                        Pour vous connecter à l'API vous devez utiliser l'identifiant "{{ login_string }}" et comme mot de passe le token suivant.
+                    </p>
+                </div>
+                {% if not token %}
+                    <form method="post" action="{% url 'dashboard:api_token' %}">
+                        {% csrf_token %}
+
+                        <div class="col-12">
+                            <div class="form-row align-items-center">
+                                <div class="form-group mb-0 col-12 col-lg order-2">
+                                    <span class="align-middle">Vous n'avez pas encore de token d'API</span>
+                                </div>
+                                <div class="form-group mb-0 col-6 col-lg-auto order-1 order-lg-2">
+                                    <button class="btn btn-primary">Créer un token d'API</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            {% else %}
+                <div class="col-12">
+                    <div class="form-row align-items-center">
+                        <div class="form-group mb-0 col-8">
+                            Votre token d'API est :
+                            <span id="token">{{ token.key }}</span>
+                        </div>
+                        <div class="form-group mb-0 col-4 text-right">
+                            <button class="btn btn-primary" id="copy-token">
+                                <i class="ri-file-copy-line mr-2 ri-lg"></i>Copier le token
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    </div>
+</div>
+</div>
+
+<script nonce="{{ CSP_NONCE }}">
+    var copyToken = document.getElementById('copy-token')
+    copyToken.addEventListener("click", function select(event){
+        var token = document.getElementById('token') ;
+        navigator.clipboard.writeText(token.innerText);
+    });
+</script>
+
+{% endblock %}

--- a/itou/templates/layout/_nav_btn_items.html
+++ b/itou/templates/layout/_nav_btn_items.html
@@ -123,6 +123,14 @@
                 <li>
                     <div class="dropdown-divider"></div>
                 </li>
+                {% if user_is_siae_admin %}
+                    <li>
+                        <a class="dropdown-item text-primary" href="{% url 'dashboard:api_token' %}">Accès aux APIs</a>
+                    </li>
+                    <li>
+                        <div class="dropdown-divider"></div>
+                    </li>
+                {% endif %}
                 <li>
                     <form method="post" action="{% url 'account_logout' %}">
                         {% csrf_token %}

--- a/itou/www/dashboard/urls.py
+++ b/itou/www/dashboard/urls.py
@@ -8,6 +8,7 @@ app_name = "dashboard"
 
 urlpatterns = [
     path("", views.dashboard, name="index"),
+    path("token_api", views.api_token, name="api_token"),
     path("edit_user_email", views.edit_user_email, name="edit_user_email"),
     path("edit_user_info", views.edit_user_info, name="edit_user_info"),
     path("edit_user_notifications", views.edit_user_notifications, name="edit_user_notifications"),


### PR DESCRIPTION
Carte Notion : https://www.notion.so/plateforme-inclusion/Acc-s-l-API-avec-un-compte-Inclusion-Connect-7f56844b0f624e06b746fa4030f3937c

### Pourquoi ?

Une fois passé à inclusion connect, il est impossible d'agir sur son mot de passe pour le changer et donc accéder à l'api de génération de token

### Captures d'écran

![image](https://user-images.githubusercontent.com/7632730/227959837-145dccd0-4188-4082-92e6-73048fe20dcb.png)

![image](https://user-images.githubusercontent.com/7632730/227959885-b90de1d5-e322-483d-a33f-dad49c56ef5b.png)
