### PR TITLE
[Metabase] Ajout des tables du CAP

### DIFF
--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -25,6 +25,7 @@ mkdir -p $OUTPUT_PATH
         django-admin populate_metabase_emplois --mode=job_applications
         django-admin populate_metabase_emplois --mode=selected_jobs
         django-admin populate_metabase_emplois --mode=approvals
+        django-admin populate_metabase_emplois --mode=evaluation_campaigns
         django-admin populate_metabase_emplois --mode=final_tables
         django-admin populate_metabase_emplois --mode=data_inconsistencies
         django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"

--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -25,7 +25,10 @@ mkdir -p $OUTPUT_PATH
         django-admin populate_metabase_emplois --mode=job_applications
         django-admin populate_metabase_emplois --mode=selected_jobs
         django-admin populate_metabase_emplois --mode=approvals
+        django-admin populate_metabase_emplois --mode=institutions
         django-admin populate_metabase_emplois --mode=evaluation_campaigns
+        django-admin populate_metabase_emplois --mode=evaluated_siaes
+        django-admin populate_metabase_emplois --mode=evaluated_job_applications
         django-admin populate_metabase_emplois --mode=final_tables
         django-admin populate_metabase_emplois --mode=data_inconsistencies
         django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -42,6 +42,7 @@ from itou.metabase.db import build_final_tables, populate_table
 from itou.metabase.tables import (
     analytics,
     approvals,
+    evaluation_campaigns,
     insee_codes,
     job_applications,
     job_descriptions,
@@ -53,6 +54,7 @@ from itou.metabase.tables import (
 )
 from itou.metabase.tables.utils import get_active_siae_pks
 from itou.prescribers.models import PrescriberOrganization
+from itou.siae_evaluations.models import EvaluationCampaign
 from itou.siaes.models import Siae, SiaeJobDescription
 from itou.users.enums import UserKind
 from itou.users.models import User
@@ -78,6 +80,7 @@ class Command(BaseCommand):
             "job_applications": self.populate_job_applications,
             "selected_jobs": self.populate_selected_jobs,
             "approvals": self.populate_approvals,
+            "evaluation_campaigns": self.populate_evaluation_campaigns,
             "rome_codes": self.populate_rome_codes,
             "insee_codes": self.populate_insee_codes,
             "insee_codes_vs_post_codes": self.populate_insee_codes_vs_post_codes,
@@ -284,6 +287,10 @@ class Command(BaseCommand):
         ).all()
 
         populate_table(approvals.TABLE, batch_size=1000, querysets=[queryset1, queryset2])
+
+    def populate_evaluation_campaigns(self):
+        queryset = EvaluationCampaign.objects.all()
+        populate_table(evaluation_campaigns.TABLE, batch_size=1000, querysets=[queryset])
 
     def populate_job_seekers(self):
         """

--- a/itou/metabase/management/test_populate_metabase_emplois.py
+++ b/itou/metabase/management/test_populate_metabase_emplois.py
@@ -24,7 +24,7 @@ from itou.users.factories import JobSeekerFactory, PrescriberFactory, SiaeStaffF
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.usefixtures("metabase")
-def test_populate_metabase_analytics():
+def test_populate_analytics():
     date_maj = datetime.date.today() + datetime.timedelta(days=-1)
     data0 = DatumFactory(code="ER-101", bucket="2021-12-31")
     data1 = DatumFactory(code="ER-102", bucket="2020-10-17")
@@ -347,7 +347,7 @@ def test_check_inconsistencies(capsys):
 @freeze_time("2023-02-02")
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.usefixtures("metabase")
-def test_populate_metabase_approvals():
+def test_populate_approvals():
     approval = ApprovalFactory()
     pe_approval = PoleEmploiApprovalFactory()
 

--- a/itou/metabase/tables/evaluated_job_applications.py
+++ b/itou/metabase/tables/evaluated_job_applications.py
@@ -1,0 +1,21 @@
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.siae_evaluations.models import EvaluatedJobApplication
+
+
+def get_field(name):
+    return EvaluatedJobApplication._meta.get_field(name)
+
+
+TABLE = MetabaseTable(name="cap_candidatures")
+TABLE.add_columns(
+    [
+        get_column_from_field(get_field("id"), name="id"),
+        get_column_from_field(get_field("evaluated_siae_id"), name="id_cap_structure"),
+        {
+            "name": "état",
+            "type": "varchar",
+            "comment": "Etat du contrôle de la candidature",
+            "fn": lambda o: o.state,
+        },
+    ]
+)

--- a/itou/metabase/tables/evaluated_siaes.py
+++ b/itou/metabase/tables/evaluated_siaes.py
@@ -1,0 +1,23 @@
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.siae_evaluations.models import EvaluatedSiae
+
+
+def get_field(name):
+    return EvaluatedSiae._meta.get_field(name)
+
+
+TABLE = MetabaseTable(name="cap_structures")
+TABLE.add_columns(
+    [
+        get_column_from_field(get_field("id"), name="id"),
+        get_column_from_field(get_field("siae_id"), name="id_structure"),
+        {
+            "name": "état",
+            "type": "varchar",
+            "comment": "Etat du contrôle de la structure",
+            "fn": lambda o: o.state,
+        },
+        get_column_from_field(get_field("reviewed_at"), name="date_contrôle"),
+        get_column_from_field(get_field("final_reviewed_at"), name="date_définitive_contrôle"),
+    ]
+)

--- a/itou/metabase/tables/evaluation_campaigns.py
+++ b/itou/metabase/tables/evaluation_campaigns.py
@@ -1,0 +1,19 @@
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.siae_evaluations.models import EvaluationCampaign
+
+
+def get_field(name):
+    return EvaluationCampaign._meta.get_field(name)
+
+
+TABLE = MetabaseTable(name="cap_campagnes")
+TABLE.add_columns(
+    [
+        get_column_from_field(get_field("id"), name="id"),
+        get_column_from_field(get_field("name"), name="nom"),
+        get_column_from_field(get_field("institution_id"), name="id_institution"),
+        get_column_from_field(get_field("evaluated_period_start_at"), name="date_début"),
+        get_column_from_field(get_field("evaluated_period_end_at"), name="date_fin"),
+        get_column_from_field(get_field("chosen_percent"), name="pourcentage_sélection"),
+    ]
+)

--- a/itou/metabase/tables/institutions.py
+++ b/itou/metabase/tables/institutions.py
@@ -1,0 +1,19 @@
+from itou.institutions.models import Institution
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_department_and_region_columns
+
+
+def get_field(name):
+    return Institution._meta.get_field(name)
+
+
+TABLE = MetabaseTable(name="institutions")
+TABLE.add_columns(
+    [
+        get_column_from_field(get_field("id"), name="id"),
+        get_column_from_field(get_field("kind"), name="type"),
+    ]
+    + get_department_and_region_columns()
+    + [
+        get_column_from_field(get_field("name"), name="nom"),
+    ]
+)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Import-des-tables-contr-le-du-contr-le-posteriori-23f28d51d1684fa1ba389eb7d8d399dc**

### Quatre tables au menu pour cette première étape

(CAP = Contrôle a posteriori)

- institutions
- cap_campagnes
- cap_structures
- cap_candidatures

### Pourquoi ?

Pour permettre l'élaboration de KPI et TB pour le C1.



