### PR TITLE
Correction de 1790 suspensions qui finissent dans trop longtemps

### DIFF
--- a/itou/scripts/management/commands/update_suspensions_end_at.py
+++ b/itou/scripts/management/commands/update_suspensions_end_at.py
@@ -1,43 +1,43 @@
 import io
-from datetime import datetime as dt
+from datetime import date, datetime, timedelta
 
 import pandas
-from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import F
 from django.utils import timezone
 
 from itou.approvals.models import Approval, Suspension
 
 
-FIRST_SCRIPT_RUNNING_DATE = timezone.make_aware(dt(2023, 2, 1, 17, 44))
+FIRST_SCRIPT_RUNNING_DATE = datetime(2023, 2, 1, 16, 44, tzinfo=timezone.utc)
 MONTHS_OF_PROLONGATION = 24
 
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument("--wet-run", action="store_true", dest="wet_run")
         parser.add_argument(
-            "--file-path",
             dest="file_path",
-            required=True,
             action="store",
             help="Path of the ASP CSV file to deduplicate",
         )
+        parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 
     def clean_file(self, file_path):
-        with open(file_path, newline="", encoding="utf-8") as input_file:
+        with open(file_path) as input_file:
             output_file = io.StringIO()
             for line in input_file:
-                if not line.strip("\n").startswith("\t! skipping "):
+                if not line.startswith("\t! skipping "):
                     output_file.write(line)
         output_file.seek(0)
         return output_file
 
+    @transaction.atomic()
     def handle(self, file_path, wet_run=False, **options):
-        max_threshold = dt.today() + relativedelta(months=Suspension.MAX_DURATION_MONTHS)
-        suspensions = Suspension.objects.filter(end_at__gte=max_threshold)
-        self.stdout.write(f"Problematic suspensions found in database: {suspensions.count()}.")
+        max_threshold = timedelta(365 * Suspension.MAX_DURATION_MONTHS / 12)
+        suspensions = Suspension.objects.filter(end_at__gt=F("start_at") + max_threshold)
+        self.stdout.write(f"Problematic suspensions found in database: {suspensions.count()}")
 
         csv_file = self.clean_file(file_path)
         colnames = ["approval_number", "suspension_start_at", "suspension_end_at"]
@@ -53,11 +53,11 @@ class Command(BaseCommand):
 
         # Just for the records as we only have one.
         # Should be treated manually.
-        excluded_suspensions = suspensions.exclude(approval__number__in=unique_approval_numbers_from_file)
-        for suspension in excluded_suspensions:
+        suspensions_not_in_file = suspensions.exclude(approval__number__in=unique_approval_numbers_from_file)
+        for suspension in suspensions_not_in_file:
             self.stdout.write(
-                "Suspension not in log file. "
-                f"Pk: {suspension.pk}, start_at: {suspension.start_at}, end_at: {suspension.end_at}"
+                "Suspension not in log file : "
+                f"pk={suspension.pk} start_at={suspension.start_at} end_at={suspension.end_at}"
             )
 
         suspensions = suspensions.filter(approval__number__in=unique_approval_numbers_from_file)
@@ -67,55 +67,80 @@ class Command(BaseCommand):
         # Generated dataframe:
         #               approval_number  size
         #        35509  9999922919054    4
-        df = df.groupby(by="approval_number", as_index=False).size().sort_values("size")
+        df_gouped = df.groupby(by="approval_number", as_index=False).size().sort_values("size")
+        # Only keep lines with more the one value
+        df_gouped = df_gouped[df_gouped["size"] > 1]
+        self.stdout.write(f"Anomalies found in input file: {len(df_gouped)}")
 
+        self.stdout.write("")
+        self.stdout.write("Start processing")
+        self.stdout.write("========================================")
         updated_suspensions_counter = 0
-        skipped_suspensions_no_duplicate_counter = 0
         skipped_suspensions_other_reason_counter = 0
-        for _, row in df.iterrows():
-            # Only approvals with several suspensions have caused troubles.
-            if row["size"] == 1:
-                skipped_suspensions_no_duplicate_counter += 1
-                continue
-
+        for _, row in df_gouped.iterrows():
             try:
                 approval = Approval.objects.get(number=row["approval_number"])
             except Approval.DoesNotExist:
-                self.stdout.write(f"Skipping approval not found: {row['approval_number']}")
+                self.stdout.write(f"Skipping approval not found: approval={row['approval_number']}")
                 skipped_suspensions_other_reason_counter += 1
                 continue
 
             last_suspension = approval.suspension_set.order_by("end_at").last()
+            theorical_suspension_end = max(df[df["approval_number"] == approval.number]["suspension_end_at"])
             # Don't update suspensions updated by a user after the first script ran.
-            if last_suspension.updated_at and last_suspension.updated_at > FIRST_SCRIPT_RUNNING_DATE:
+            if str(last_suspension.end_at) != theorical_suspension_end:
+                updated_at = last_suspension.updated_at.date() if last_suspension.updated_at else "None"
                 self.stdout.write(
                     "Skipping suspension updated after script ran: "
-                    f"{last_suspension.pk}, start_at: {last_suspension.start_at}, end_at: {last_suspension.end_at}, "
-                    f"updated_at: {last_suspension.updated_at.date()}"
+                    f"pk={last_suspension.pk} start_at={last_suspension.start_at} end_at={last_suspension.end_at} "
+                    f"updated_at={updated_at}"
                 )
                 skipped_suspensions_other_reason_counter += 1
+                if last_suspension.end_at > Suspension.get_max_end_at(last_suspension.start_at):
+                    self.stdout.write(">  Still to long though !")
                 continue
 
-            last_suspension.end_at -= relativedelta(months=MONTHS_OF_PROLONGATION * (row["size"] - 1))
+            previous_end_at = last_suspension.end_at
+            last_suspension.end_at = date.fromisoformat(
+                min(df[df["approval_number"] == approval.number]["suspension_end_at"])
+            )
+
             try:
                 last_suspension.clean()
+                if last_suspension.end_at != Suspension.get_max_end_at(last_suspension.start_at):
+                    self.stdout.write(
+                        f"Updated suspension isn't 36 month long. Is it normal ? "
+                        f"pk={last_suspension.pk} start_at={last_suspension.start_at} end_at={last_suspension.end_at} "
+                    )
                 updated_suspensions_counter += 1
             except ValidationError as error:
                 self.stdout.write("; ".join(error.messages))
                 self.stdout.write(
                     (
-                        f">  Skipping because of validation error! Suspension: {last_suspension.pk}, "
-                        f"Approval number: {row['approval_number']}"
+                        f">  Skipping because of validation error! Suspension pk={last_suspension.pk} "
+                        f"approval={row['approval_number']} start_at={last_suspension.start_at} "
+                        f"end_at={last_suspension.end_at}"
                     )
                 )
-                self.stdout.write(f"start_at: {last_suspension.start_at}, end_at: {last_suspension.end_at}")
                 skipped_suspensions_other_reason_counter += 1
-                continue
+            else:
+                self.stdout.write(
+                    (
+                        f"Updating suspension pk={last_suspension.pk} approval={row['approval_number']} "
+                        f"start_at={last_suspension.start_at} "
+                        f"old_end_at={previous_end_at} new_end_at={last_suspension.end_at}"
+                    )
+                )
+                if wet_run:
+                    last_suspension.save(update_fields=["end_at", "updated_at"])
 
-            if wet_run:
-                last_suspension.save(update_fields=["end_at", "updated_at"])
+        self.stdout.write("")
+        self.stdout.write("Results")
+        self.stdout.write("========================================")
         self.stdout.write(f"Updated suspensions: {updated_suspensions_counter}")
-        self.stdout.write(
-            f"Skipped suspensions (one suspension per approval): {skipped_suspensions_no_duplicate_counter}"
-        )
-        self.stdout.write(f"Skipped suspensions (other reasons): {skipped_suspensions_other_reason_counter}")
+        self.stdout.write(f"Skipped suspensions (see reasons above): {skipped_suspensions_other_reason_counter}")
+
+        if updated_suspensions_counter + skipped_suspensions_other_reason_counter != len(df_gouped):
+            self.stdout.write("Some suspensions were not updated or skipped !!")
+        else:
+            self.stdout.write("Everything is good")

--- a/itou/scripts/management/commands/update_suspensions_end_at.py
+++ b/itou/scripts/management/commands/update_suspensions_end_at.py
@@ -1,0 +1,121 @@
+import io
+from datetime import datetime as dt
+
+import pandas
+from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ValidationError
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from itou.approvals.models import Approval, Suspension
+
+
+FIRST_SCRIPT_RUNNING_DATE = timezone.make_aware(dt(2023, 2, 1, 17, 44))
+MONTHS_OF_PROLONGATION = 24
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("--wet-run", action="store_true", dest="wet_run")
+        parser.add_argument(
+            "--file-path",
+            dest="file_path",
+            required=True,
+            action="store",
+            help="Path of the ASP CSV file to deduplicate",
+        )
+
+    def clean_file(self, file_path):
+        with open(file_path, newline="", encoding="utf-8") as input_file:
+            output_file = io.StringIO()
+            for line in input_file:
+                if not line.strip("\n").startswith("\t! skipping "):
+                    output_file.write(line)
+        output_file.seek(0)
+        return output_file
+
+    def handle(self, file_path, wet_run=False, **options):
+        max_threshold = dt.today() + relativedelta(months=Suspension.MAX_DURATION_MONTHS)
+        suspensions = Suspension.objects.filter(end_at__gte=max_threshold)
+        self.stdout.write(f"Problematic suspensions found in database: {suspensions.count()}.")
+
+        csv_file = self.clean_file(file_path)
+        colnames = ["approval_number", "suspension_start_at", "suspension_end_at"]
+        converters = {
+            "approval_number": str,
+            "suspensions_start_at": pandas.to_datetime,
+            "suspensions_end_at": pandas.to_datetime,
+        }
+        df = pandas.read_csv(csv_file, sep=" ", names=colnames, header=None, converters=converters)
+
+        unique_approval_numbers_from_file = set(df["approval_number"].to_list())
+        self.stdout.write(f"Total of unique approvals in input file: {len(unique_approval_numbers_from_file)}")
+
+        # Just for the records as we only have one.
+        # Should be treated manually.
+        excluded_suspensions = suspensions.exclude(approval__number__in=unique_approval_numbers_from_file)
+        for suspension in excluded_suspensions:
+            self.stdout.write(
+                "Suspension not in log file. "
+                f"Pk: {suspension.pk}, start_at: {suspension.start_at}, end_at: {suspension.end_at}"
+            )
+
+        suspensions = suspensions.filter(approval__number__in=unique_approval_numbers_from_file)
+        self.stdout.write(f"Problematic suspensions found in input file: {suspensions.count()}")
+
+        # Count duplicated lines.
+        # Generated dataframe:
+        #               approval_number  size
+        #        35509  9999922919054    4
+        df = df.groupby(by="approval_number", as_index=False).size().sort_values("size")
+
+        updated_suspensions_counter = 0
+        skipped_suspensions_no_duplicate_counter = 0
+        skipped_suspensions_other_reason_counter = 0
+        for _, row in df.iterrows():
+            # Only approvals with several suspensions have caused troubles.
+            if row["size"] == 1:
+                skipped_suspensions_no_duplicate_counter += 1
+                continue
+
+            try:
+                approval = Approval.objects.get(number=row["approval_number"])
+            except Approval.DoesNotExist:
+                self.stdout.write(f"Skipping approval not found: {row['approval_number']}")
+                skipped_suspensions_other_reason_counter += 1
+                continue
+
+            last_suspension = approval.suspension_set.order_by("end_at").last()
+            # Don't update suspensions updated by a user after the first script ran.
+            if last_suspension.updated_at and last_suspension.updated_at > FIRST_SCRIPT_RUNNING_DATE:
+                self.stdout.write(
+                    "Skipping suspension updated after script ran: "
+                    f"{last_suspension.pk}, start_at: {last_suspension.start_at}, end_at: {last_suspension.end_at}, "
+                    f"updated_at: {last_suspension.updated_at.date()}"
+                )
+                skipped_suspensions_other_reason_counter += 1
+                continue
+
+            last_suspension.end_at -= relativedelta(months=MONTHS_OF_PROLONGATION * (row["size"] - 1))
+            try:
+                last_suspension.clean()
+                updated_suspensions_counter += 1
+            except ValidationError as error:
+                self.stdout.write("; ".join(error.messages))
+                self.stdout.write(
+                    (
+                        f">  Skipping because of validation error! Suspension: {last_suspension.pk}, "
+                        f"Approval number: {row['approval_number']}"
+                    )
+                )
+                self.stdout.write(f"start_at: {last_suspension.start_at}, end_at: {last_suspension.end_at}")
+                skipped_suspensions_other_reason_counter += 1
+                continue
+
+            if wet_run:
+                last_suspension.save(update_fields=["end_at", "updated_at"])
+        self.stdout.write(f"Updated suspensions: {updated_suspensions_counter}")
+        self.stdout.write(
+            f"Skipped suspensions (one suspension per approval): {skipped_suspensions_no_duplicate_counter}"
+        )
+        self.stdout.write(f"Skipped suspensions (other reasons): {skipped_suspensions_other_reason_counter}")

--- a/itou/scripts/tests.py
+++ b/itou/scripts/tests.py
@@ -1,12 +1,16 @@
 import datetime
 import io
+import tempfile
 from unittest.mock import patch
 
+from dateutil.relativedelta import relativedelta
 from django.core import management
 from django.test import TransactionTestCase
+from freezegun import freeze_time
 
-from itou.approvals.factories import PoleEmploiApprovalFactory
-from itou.approvals.models import PoleEmploiApproval
+from itou.approvals.factories import PoleEmploiApprovalFactory, SuspensionFactory
+from itou.approvals.models import PoleEmploiApproval, Suspension
+from itou.scripts.management.commands import update_suspensions_end_at as update_suspensions_end_at_mngt_comd
 from itou.utils.test import TestCase
 
 
@@ -152,3 +156,93 @@ class ImportPEApprovalSiretKindTestCase(TransactionTestCase):
         assert pe_approval_1.siae_siret == "123456789"
         assert pe_approval_2.siae_kind == "ETTI"
         assert pe_approval_2.siae_siret == "123456789"
+
+
+class UpdateSuspensionsEndAtTestCase(TransactionTestCase):
+    @freeze_time("2023-02-08")
+    def test_command_output(self):
+        months_of_prolongation = update_suspensions_end_at_mngt_comd.MONTHS_OF_PROLONGATION
+        # One approval per suspension.
+        suspension1 = SuspensionFactory(
+            approval__number="XXXXX0000001",
+            end_at=datetime.datetime.today() + relativedelta(months=Suspension.MAX_DURATION_MONTHS, days=1),
+        )
+        # One approval, 2 suspensions.
+        # The second one should begin when the first one ends.
+        # Only the second one has been updated (but twice).
+        suspension2 = SuspensionFactory(
+            approval__number="XXXXX0000002",
+            start_at=datetime.datetime.today() - relativedelta(months=3),
+            end_at=datetime.datetime.today() - relativedelta(days=1),
+        )
+        suspension3_end_at = datetime.datetime.today() + relativedelta(months=months_of_prolongation * 2)
+        suspension3 = SuspensionFactory(
+            approval=suspension2.approval, start_at=datetime.datetime.today(), end_at=suspension3_end_at
+        )
+
+        # Suspension updated after the first script ran should not be updated.
+        suspension4 = SuspensionFactory(
+            approval__number="XXXXX0000003",
+            start_at=datetime.datetime.today() - relativedelta(days=30),
+            end_at=datetime.datetime.today() - relativedelta(days=1),
+        )
+        suspension5_updated_at = update_suspensions_end_at_mngt_comd.FIRST_SCRIPT_RUNNING_DATE + relativedelta(days=1)
+        suspension5 = SuspensionFactory(
+            approval=suspension4.approval, start_at=datetime.datetime.today(), updated_at=suspension5_updated_at
+        )
+
+        with tempfile.NamedTemporaryFile() as file:
+            suspensions = Suspension.objects.prefetch_related("approval").all()
+            for suspension in suspensions.iterator():
+                log_row = f"{suspension.approval.number} {suspension.start_at} {suspension.end_at}\n"
+                file.write(bytes(log_row, encoding="utf-8"))
+
+                # Approval who was deleted after the first script ran.
+                file.write(b"XXXXX5432764 2022-12-12 2024-12-11\n")
+            file.seek(0)
+
+            stdout = io.StringIO()
+            management.call_command("update_suspensions_end_at", file_path=file.name, wet_run=True, stdout=stdout)
+            output = stdout.getvalue()
+            # Ending after Suspension.MAX_DURATION_MONTHS
+            # suspension1 and suspension3
+            assert "Problematic suspensions found in database: 2." in output
+
+            # XXXXX0000001, XXXXX0000002, XXXXX0000003 and XXXXX5432764 (deleted approval).
+            assert "Total of unique approvals in input file: 4" in output
+
+            # suspension1 and suspension3
+            assert "Problematic suspensions found in input file: 2" in output
+
+            assert "Updated suspensions: 1" in output
+
+            # Edge cases
+            assert (
+                f"Skipping suspension updated after script ran: {suspension5.pk}, "
+                f"start_at: {suspension5.start_at.date()}, end_at: {suspension5.end_at.date()}"
+            ) in output
+            assert "Skipping approval not found: XXXXX5432764" in output
+            assert "Skipped suspensions (one suspension per approval): 1" in output
+            assert (
+                "Skipped suspensions (other reasons): 2" in output
+            )  # Approval not found, suspension updated after script ran.
+
+        suspension1.refresh_from_db()
+        # One suspension linked to one approval. Don't touch it.
+        assert not suspension1.updated_at
+
+        # Many suspensions linked to one approval: the end_at was updated many times.
+        # This is the first suspension. Only the last one should be updated.
+        suspension2.refresh_from_db()
+        assert not suspension2.updated_at
+        suspension3.refresh_from_db()
+        assert suspension3.updated_at
+        assert suspension3.end_at == (suspension3_end_at - relativedelta(months=months_of_prolongation)).date()
+
+        # Many suspensions linked to one approval: the end_at was updated many times.
+        # This is the first suspension. Only the last one should be updated.
+        suspension4.refresh_from_db()
+        assert not suspension4.updated_at
+        # This suspension was updated after the first script ran so we should keep it as it is.
+        suspension5.refresh_from_db()
+        assert suspension5.updated_at == suspension5_updated_at


### PR DESCRIPTION
**Carte Notion : ** (à créer)

[Carte Notion du script précédent.](https://www.notion.so/plateforme-inclusion/2-2-Suspension-36-mois-R-gularisation-sur-le-stock-des-PASS-IAE-suspendus-pour-12-mois-BOOST-18795bec5259430382701d67a3a879e0)

### Pourquoi ?

(à rédiger)

### Comment (optionnel)

- Enregistrement des bonnes dates des suspensions en erreur.
- Gestion des exceptions: 1 PASS ayant été supprimé et 10 suspensions ayant été modifiée par un utilisateur. 

