### PR TITLE
Controle a posteriori: toujours afficher le lien vers les justificatifs

### DIFF
--- a/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
@@ -104,17 +104,11 @@
                             </div>
 
                             <div class="card-body">
-                                {% if evaluated_siae.evaluation_is_final %}
-                                    {% if evaluated_job_application.state == "UPLOADED" or evaluated_job_application.state == "SUBMITTED" or evaluated_job_application.state == "ACCEPTED" or evaluated_job_application.state == "REFUSED" or evaluated_job_application.state == "REFUSED_2" %}
-                                        <a href="{% url 'siae_evaluations_views:institution_evaluated_job_application' evaluated_job_application.pk %}" class="btn btn-outline-primary btn-sm float-right">
-                                            Revoir ses justificatifs
-                                        </a>
-                                    {% endif %}
-                                {% elif evaluated_job_application.state == "SUBMITTED" %}
+                                {% if not evaluated_siae.evaluation_is_final and evaluated_job_application.state == "SUBMITTED" %}
                                     <a href="{% url 'siae_evaluations_views:institution_evaluated_job_application' evaluated_job_application.pk %}" class="btn btn-outline-primary btn-sm float-right">
                                         Contrôler cette auto-prescription
                                     </a>
-                                {% elif evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" or evaluated_siae.state == "ADVERSARIAL_STAGE" or evaluated_siae.state == "NOTIFICATION_PENDING" %}
+                                {% elif evaluated_job_application.state != "PENDING" and evaluated_job_application.state != "PROCESSING" %}
                                     <a href="{% url 'siae_evaluations_views:institution_evaluated_job_application' evaluated_job_application.pk %}" class="btn btn-outline-primary btn-sm float-right">
                                         Revoir ses justificatifs
                                     </a>

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -945,6 +945,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         assert response.status_code == 200
         self.assertContains(response, validation_button_disabled, html=True, count=1)
         self.assertContains(response, back_url)
+        self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, "Justificatifs téléversés")
         self.assertContains(response, self.control_text)
 


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/En-tant-que-DDETS-je-souhaite-pouvoir-visualiser-tout-moment-les-justificatifs-et-commentaires-p-eb852e0e303e43d3b16cc34be7f6ed49

### Pourquoi ?

Actuellement, en phase contradictoire, la DDETS n'a plus accès aux justificatifs.

