### PR TITLE
metabase-matomo: Ajout de la synchronisation pour le TB public "suivi pass IAE"

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -56,6 +56,7 @@ PUBLIC_DASHBOARDS = {
     "statistiques-emplois": "tb 43 - Statistiques des emplois",
     "zoom-employeurs": "tb 54 - Typologie des employeurs",
     "zoom-prescripteurs": "tb 52 - Typologie de prescripteurs",
+    "suivi-pass-iae": "tb 217 - Suivi pass IAE",
     # Note: keep those commented for reference. They're not used anymore but if we ever
     # need to regenerate values for the Q1 2022 or before, they're going to be required.
     # "recrutement": "tb 116 - Recrutement",

--- a/itou/metabase/management/test_populate_metabase_matomo.py
+++ b/itou/metabase/management/test_populate_metabase_matomo.py
@@ -64,19 +64,20 @@ def test_matomo_retry(monkeypatch, respx_mock, capsys):
         "\t> fetching date=2022-06-13 dashboard='tb 136 - Prescripteurs habilité",
         "\t> fetching date=2022-06-13 dashboard='tb 140 - ETP conventionnés' pag",
         "\t> fetching date=2022-06-13 dashboard='tb 150 - Fiches de poste en ten",
+        "\t> fetching date=2022-06-13 dashboard='tb 217 - Suivi pass IAE' pageUr",
         "\t> fetching date=2022-06-13 dashboard='tb 32 - Acceptés en auto-prescr",
         "\t> fetching date=2022-06-13 dashboard='tb 43 - Statistiques des emploi",
         "\t> fetching date=2022-06-13 dashboard='tb 52 - Typologie de prescripte",
         "\t> fetching date=2022-06-13 dashboard='tb 54 - Typologie des employeur",
         "\t> fetching date=2022-06-13 dashboard='tb 90 - Analyse des métiers' pa",
-        "> about to fetch count=10 public dashboards from Matomo.",
-    ] + ["For more information check: https://httpstatuses.com/500"] * 30 + [
+        "> about to fetch count=11 public dashboards from Matomo.",
+    ] + ["For more information check: https://httpstatuses.com/500"] * 33 + [
         "attempt=1 failed with outcome=Server error '500 Internal Server Error'"
-    ] * 10 + [
+    ] * 11 + [
         "attempt=2 failed with outcome=Server error '500 Internal Server Error'"
-    ] * 10 + [
+    ] * 11 + [
         "attempt=3 failed with outcome=Server error '500 Internal Server Error'"
-    ] * 10
+    ] * 11
 
 
 @override_settings(MATOMO_BASE_URL="https://mato.mo", MATOMO_AUTH_TOKEN="foobar")
@@ -94,7 +95,7 @@ def test_matomo_populate_public(monkeypatch, respx_mock):
     with connection.cursor() as cursor:
         cursor.execute("SELECT * FROM suivi_visiteurs_tb_publics_v0")
         rows = cursor.fetchall()
-        assert len(rows) == 10
+        assert len(rows) == 11
         assert rows[0] == (
             "25",
             "26",
@@ -346,15 +347,16 @@ def test_matomo_empty_output(monkeypatch, respx_mock, capsys):
     # sort the output because it's random (ThreadPoolExecutor)
     assert sorted(stdout.splitlines()) == [
         "\t! empty matomo values for date=2022-06-13 dashboard=tb 116 - Recrutement",
-        "\t! empty matomo values for date=2022-06-13 dashboard=tb 129 - Analyse des publics",
-        "\t! empty matomo values for date=2022-06-13 dashboard=tb 136 - Prescripteurs habilités",
-        "\t! empty matomo values for date=2022-06-13 dashboard=tb 140 - ETP conventionnés",
-        "\t! empty matomo values for date=2022-06-13 dashboard=tb 150 - Fiches de poste en tension",
-        "\t! empty matomo values for date=2022-06-13 dashboard=tb 32 - Acceptés en auto-prescription",
-        "\t! empty matomo values for date=2022-06-13 dashboard=tb 43 - Statistiques des emplois",
-        "\t! empty matomo values for date=2022-06-13 dashboard=tb 52 - Typologie de prescripteurs",
-        "\t! empty matomo values for date=2022-06-13 dashboard=tb 54 - Typologie des employeurs",
-        "\t! empty matomo values for date=2022-06-13 dashboard=tb 90 - Analyse des métiers",
+        "\t! empty matomo values for date=2022-06-13 dashboard=tb 129 - Analyse des " "publics",
+        "\t! empty matomo values for date=2022-06-13 dashboard=tb 136 - Prescripteurs " "habilités",
+        "\t! empty matomo values for date=2022-06-13 dashboard=tb 140 - ETP " "conventionnés",
+        "\t! empty matomo values for date=2022-06-13 dashboard=tb 150 - Fiches de " "poste en tension",
+        "\t! empty matomo values for date=2022-06-13 dashboard=tb 217 - Suivi pass " "IAE",
+        "\t! empty matomo values for date=2022-06-13 dashboard=tb 32 - Acceptés en " "auto-prescription",
+        "\t! empty matomo values for date=2022-06-13 dashboard=tb 43 - Statistiques " "des emplois",
+        "\t! empty matomo values for date=2022-06-13 dashboard=tb 52 - Typologie de " "prescripteurs",
+        "\t! empty matomo values for date=2022-06-13 dashboard=tb 54 - Typologie des " "employeurs",
+        "\t! empty matomo values for date=2022-06-13 dashboard=tb 90 - Analyse des " "métiers",
         "\t> fetching date=2022-06-13 dashboard='tb 116 - Recrutement' "
         "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etat-suivi-candidatures/",
         "\t> fetching date=2022-06-13 dashboard='tb 129 - Analyse des publics' "
@@ -365,6 +367,8 @@ def test_matomo_empty_output(monkeypatch, respx_mock, capsys):
         "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etp-conventionnes/",
         "\t> fetching date=2022-06-13 dashboard='tb 150 - Fiches de poste en tension' "
         "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/postes-en-tension/",
+        "\t> fetching date=2022-06-13 dashboard='tb 217 - Suivi pass IAE' "
+        "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-pass-iae/",
         "\t> fetching date=2022-06-13 dashboard='tb 32 - Acceptés en "
         "auto-prescription' "
         "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/auto-prescription/",
@@ -376,5 +380,5 @@ def test_matomo_empty_output(monkeypatch, respx_mock, capsys):
         "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-employeurs/",
         "\t> fetching date=2022-06-13 dashboard='tb 90 - Analyse des métiers' "
         "pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/metiers/",
-        "> about to fetch count=10 public dashboards from Matomo.",
+        "> about to fetch count=11 public dashboards from Matomo.",
     ]


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Ajouter-le-tracking-du-TB-suivi-pass-iae-dans-le-suivi-des-visiteurs-18536f30490a4d2ea7d7a69872675960**

### Pourquoi ?
Demande pour le C2.
