### PR TITLE
layout/base: Fix tarteaucitron (urgent !)

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -117,7 +117,7 @@
                 "moreInfoLink": true, /* Show more info link */
                 "useExternalCss": true, /* If false, the tarteaucitron.css file will be loaded */
                 "useExternalJs": false, /* If false, the tarteaucitron.js file will be loaded */
-                "readmoreLink": {% url 'legal-privacy' %}, /* Change the default readmore link */
+                "readmoreLink": '{% url 'legal-privacy' %}', /* Change the default readmore link */
                 "mandatory": true, /* Show a message about mandatory cookies */
             });
 


### PR DESCRIPTION
Forgotten chars were responsible for the failing init of tarteaucitron.

Stupid error, but difficult to cover with a test.

En attendant, pas de données envoyées vers Matomo.