### PR TITLE
Mettre à jour les champs dénormalisés sur les transitions `NEW` et `READY` plutôt que `SENT`

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -61,17 +61,19 @@ class JobApplicationInline(admin.StackedInline):
                 debug += ", ORPHAN"
             return format_html(f"<a href='{url}'><b>{employee_record.get_status_display()} ({debug})</b></a>")
 
-        if obj.candidate_has_employee_record:
-            return "Une fiche salarié existe déjà pour ce candidat"
-
         if not obj.to_siae.can_use_employee_record:
             return "La SIAE n'utilise pas les fiches salariés"
 
         if not obj.create_employee_record:
             return "Création désactivée"
 
+        already_exists = obj.candidate_has_employee_record
+
         if JobApplication.objects.eligible_as_employee_record(siae=obj.to_siae).filter(pk=obj.pk).exists():
-            return "En attente de création"
+            return "En attente de création" + (" (doublon)" if already_exists else "")
+
+        if already_exists:  # Put this check after the eligibility to show that one is proposed but is also a duplicate
+            return "Une fiche salarié existe déjà pour ce candidat"
 
         return "-"
 


### PR DESCRIPTION
**Carte Notion :** Remontée support

### Pourquoi ?

Si la SIAE change de SIRET ou de convention alors les FS déjà créées restent sur les anciennes données, ces données étant périmées l'ASP les refusent et la FS n'est pas intégrée.

Je fait également `approval_number` pour gérer le cas (plus rare) où l'on crée un nouveau PASS IAE pour une personne suite à une erreur lors de l'embauche, l'idée étant de dire "Désactive/Réactive, si ça ne marche pas il y a quelque chose à corriger" plutôt que d'avoir des cas particuliers.

Le faire pour `asp_id` est normalement inutile car la FS est orpheline et donc plus affichée à la SIAE, mais au moins c'est exhaustif et si il y a un trou quelque part ça permet de rester dans la logique "Désactive/Réactive".

Le reste des infos est dans le commit.