### PR TITLE
Controle a posteriori: affichage de l'historique des sanctions dans les données d’aide à la décision

### DIFF
--- a/itou/templates/siae_evaluations/includes/evaluation_data.html
+++ b/itou/templates/siae_evaluations/includes/evaluation_data.html
@@ -32,6 +32,27 @@
                             <b class="text-success">Positif</b>
                         {% else %}
                             <b class="text-danger">Négatif</b>
+                            {% if old_evaluated_siae.sanctions %}
+                                <ul class="ml-3">
+                                    {% if old_evaluated_siae.sanctions.training_session %}
+                                        <li>Participation à une session de présentation de l’auto-prescription</li>
+                                    {% endif %}
+                                    {% if old_evaluated_siae.sanctions.suspension_dates and old_evaluated_siae.sanctions.suspension_dates.upper %}
+                                        <li>Retrait temporaire de la capacité d’auto-prescription</li>
+                                    {% elif old_evaluated_siae.sanctions.suspension_dates %}
+                                        <li>Retrait définitif de la capacité d’auto-prescription</li>
+                                    {% endif %}
+                                    {% if old_evaluated_siae.sanctions.subsidy_cut_dates %}
+                                        <li>
+                                            Suppression
+                                            {% if old_evaluated_siae.sanctions.subsidy_cut_percent < 100 %}d’une partie{% endif %}
+                                            de l’aide au poste
+                                        </li>
+                                    {% endif %}
+                                    {% if old_evaluated_siae.sanctions.deactivation_reason %}<li>Déconventionnement de la structure</li>{% endif %}
+                                    {% if old_evaluated_siae.sanctions.no_sanction_reason %}<li>Ne pas sanctionner</li>{% endif %}
+                                </ul>
+                            {% endif %}
                         {% endif %}
                     </li>
                 {% endfor %}

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -211,7 +211,7 @@ def evaluation_campaign_data_context(evaluated_siae):
         # Ignore first evaluation campaigns, they were a test.
         .exclude(evaluation_campaign__evaluated_period_end_at__lt=datetime.date(2022, 1, 1))
         .order_by("-evaluation_campaign__evaluated_period_start_at")
-        .select_related("evaluation_campaign")
+        .select_related("evaluation_campaign", "sanctions")
         .prefetch_related("evaluated_job_applications__evaluated_administrative_criteria")
     )
     return context


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Sanctions-Affichage-des-sanctions-des-campagnes-pr-c-dentes-dans-l-encart-de-donn-es-d-aide-la-d--9ac0d922f0f040e89e90ac4dabbe8173

### Pourquoi ?

Pour aider la prise de décision

### Captures d'écran

![Screenshot 2023-02-09 at 15-27-42 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/217840521-bb54ffa0-ae0d-4310-9ccf-dae3a251f86c.png)


