### PR TITLE
[Metabase] [CAP] Ajout des tables des critères administratifs

### DIFF
--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -22,6 +22,7 @@ mkdir -p $OUTPUT_PATH
         django-admin populate_metabase_emplois --mode=job_descriptions
         django-admin populate_metabase_emplois --mode=organizations
         django-admin populate_metabase_emplois --mode=job_seekers
+        django-admin populate_metabase_emplois --mode=criteria
         django-admin populate_metabase_emplois --mode=job_applications
         django-admin populate_metabase_emplois --mode=selected_jobs
         django-admin populate_metabase_emplois --mode=approvals
@@ -29,6 +30,7 @@ mkdir -p $OUTPUT_PATH
         django-admin populate_metabase_emplois --mode=evaluation_campaigns
         django-admin populate_metabase_emplois --mode=evaluated_siaes
         django-admin populate_metabase_emplois --mode=evaluated_job_applications
+        django-admin populate_metabase_emplois --mode=evaluated_criteria
         django-admin populate_metabase_emplois --mode=final_tables
         django-admin populate_metabase_emplois --mode=data_inconsistencies
         django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -33,7 +33,7 @@ from itou.approvals.models import Approval, PoleEmploiApproval
 from itou.cities.models import City
 from itou.common_apps.address.departments import DEPARTMENT_TO_REGION, DEPARTMENTS
 from itou.eligibility.enums import AdministrativeCriteriaLevel
-from itou.eligibility.models import EligibilityDiagnosis
+from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.institutions.models import Institution
 from itou.job_applications.enums import Origin, SenderKind
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
@@ -43,6 +43,8 @@ from itou.metabase.db import build_final_tables, populate_table
 from itou.metabase.tables import (
     analytics,
     approvals,
+    criteria,
+    evaluated_criteria,
     evaluated_job_applications,
     evaluated_siaes,
     evaluation_campaigns,
@@ -58,7 +60,12 @@ from itou.metabase.tables import (
 )
 from itou.metabase.tables.utils import get_active_siae_pks
 from itou.prescribers.models import PrescriberOrganization
-from itou.siae_evaluations.models import EvaluatedJobApplication, EvaluatedSiae, EvaluationCampaign
+from itou.siae_evaluations.models import (
+    EvaluatedAdministrativeCriteria,
+    EvaluatedJobApplication,
+    EvaluatedSiae,
+    EvaluationCampaign,
+)
 from itou.siaes.models import Siae, SiaeJobDescription
 from itou.users.enums import UserKind
 from itou.users.models import User
@@ -81,6 +88,7 @@ class Command(BaseCommand):
             "job_descriptions": self.populate_job_descriptions,
             "organizations": self.populate_organizations,
             "job_seekers": self.populate_job_seekers,
+            "criteria": self.populate_criteria,
             "job_applications": self.populate_job_applications,
             "selected_jobs": self.populate_selected_jobs,
             "approvals": self.populate_approvals,
@@ -88,6 +96,7 @@ class Command(BaseCommand):
             "evaluation_campaigns": self.populate_evaluation_campaigns,
             "evaluated_siaes": self.populate_evaluated_siaes,
             "evaluated_job_applications": self.populate_evaluated_job_applications,
+            "evaluated_criteria": self.populate_evaluated_criteria,
             "rome_codes": self.populate_rome_codes,
             "insee_codes": self.populate_insee_codes,
             "insee_codes_vs_post_codes": self.populate_insee_codes_vs_post_codes,
@@ -285,6 +294,10 @@ class Command(BaseCommand):
         job_seekers_table = job_seekers.get_table()
 
         populate_table(job_seekers_table, batch_size=1000, querysets=[queryset])
+
+    def populate_criteria(self):
+        queryset = AdministrativeCriteria.objects.all()
+        populate_table(criteria.TABLE, batch_size=1000, querysets=[queryset])
 
     def populate_job_applications(self):
         queryset = (

--- a/itou/metabase/tables/criteria.py
+++ b/itou/metabase/tables/criteria.py
@@ -1,0 +1,17 @@
+from itou.eligibility.models import AdministrativeCriteria
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+
+
+def get_field(name):
+    return AdministrativeCriteria._meta.get_field(name)
+
+
+TABLE = MetabaseTable(name="critères_iae")
+TABLE.add_columns(
+    [
+        get_column_from_field(get_field("id"), name="id"),
+        get_column_from_field(get_field("name"), name="nom"),
+        get_column_from_field(get_field("level"), name="niveau"),
+        get_column_from_field(get_field("desc"), name="description"),
+    ]
+)

--- a/itou/metabase/tables/evaluated_criteria.py
+++ b/itou/metabase/tables/evaluated_criteria.py
@@ -1,0 +1,19 @@
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria
+
+
+def get_field(name):
+    return EvaluatedAdministrativeCriteria._meta.get_field(name)
+
+
+TABLE = MetabaseTable(name="cap_critères_iae")
+TABLE.add_columns(
+    [
+        get_column_from_field(get_field("id"), name="id"),
+        get_column_from_field(get_field("administrative_criteria_id"), name="id_critère_iae"),
+        get_column_from_field(get_field("evaluated_job_application_id"), name="id_cap_candidature"),
+        get_column_from_field(get_field("uploaded_at"), name="date_dépôt"),
+        get_column_from_field(get_field("submitted_at"), name="date_transmission"),
+        get_column_from_field(get_field("review_state"), name="état"),
+    ]
+)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/Import-des-tables-contr-le-du-contr-le-posteriori-tape-1-DONE-tape-2-WIP-23f28d51d1684fa1ba389eb7d8d399dc**

### Pourquoi ?

Pour permettre à Laurine de produire des TB et KPI du CAP pour le C1.

### Comment ?

Ajout de deux nouvelles tables :
- `cap_critères_iae`
- `critères_iae`

### Quand ?

Objectif MEP d'ici mardi pour le retour de Laurine.