### PR TITLE
Simplification du calcul d’état des évaluations de SIAE

### DIFF
--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -890,6 +890,7 @@ class EvaluatedSiaeModelTest(TestCase):
     def test_state_on_closed_campaign_criteria_refused_review_not_validated(self):
         evaluated_job_app = EvaluatedJobApplicationFactory(
             evaluated_siae__evaluation_campaign__ended_at=timezone.now(),
+            evaluated_siae__reviewed_at=timezone.now() - relativedelta(days=5),
         )
         EvaluatedAdministrativeCriteriaFactory(
             evaluated_job_application=evaluated_job_app,
@@ -933,6 +934,7 @@ class EvaluatedSiaeModelTest(TestCase):
     def test_state_on_closed_campaign_criteria_accepted(self):
         evaluated_job_app = EvaluatedJobApplicationFactory(
             evaluated_siae__evaluation_campaign__ended_at=timezone.now(),
+            evaluated_siae__reviewed_at=timezone.now() - relativedelta(days=5),
         )
         EvaluatedAdministrativeCriteriaFactory(
             evaluated_job_application=evaluated_job_app,
@@ -941,27 +943,6 @@ class EvaluatedSiaeModelTest(TestCase):
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
         assert evaluated_job_app.evaluated_siae.state == evaluation_enums.EvaluatedSiaeState.ACCEPTED
-
-    def test_review(self):
-        fake_now = timezone.now()
-        evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign__ended_at=fake_now)
-        evaluated_job_application = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
-        EvaluatedAdministrativeCriteriaFactory(
-            evaluated_job_application=evaluated_job_application,
-            submitted_at=fake_now,
-            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
-        )
-
-        evaluated_siae.review()
-        evaluated_siae.refresh_from_db()
-        assert evaluated_siae.reviewed_at is not None
-
-        evaluated_siae.reviewed_at = None
-        evaluated_siae.save(update_fields=["reviewed_at"])
-
-        evaluated_siae.review()
-        evaluated_siae.refresh_from_db()
-        assert evaluated_siae.reviewed_at is not None
 
 
 class EvaluatedJobApplicationModelTest(TestCase):

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -693,13 +693,17 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
             ended_at=timezone.now(),
             name="Contrôle Test",
         )
-        evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign=evaluation_campaign, siae__name="les petits jardins")
+        evaluated_siae = EvaluatedSiaeFactory(
+            evaluation_campaign=evaluation_campaign,
+            siae__name="les petits jardins",
+            reviewed_at=timezone.now() - relativedelta(days=5),
+        )
         evaluated_job_app = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
         EvaluatedAdministrativeCriteriaFactory(
             evaluated_job_application=evaluated_job_app,
             uploaded_at=timezone.now() - relativedelta(days=2),
             submitted_at=timezone.now() - relativedelta(days=1),
-            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED,
+            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2,
         )
 
         self.client.force_login(self.user)


### PR DESCRIPTION
### Comment ?

- Sortir la condition qui rend le contrôle positif lorsque la SIAE est la dernière à avoir soumis un document avant la clôture de la campagne. Cela permet factoriser des traitements répandus dans différentes branches de code.

- Le code explosera si `reviewed_at` n’est pas défini à la clôture de la campagne. Ce champ est défini lors du passage en phase contradictoire, ce qui arrive forcément suivant le planning de la DGEFP.

- Certains tests créaient une situation invalide, où une campagne terminée n’avait `reviewed_at=None`.

- `test_review` ne vérifiait pas un scénario réaliste (faire des revues sur une campagne terminée). Il a été supprimé.