### PR TITLE
Vérifier qu’un utilisateur est authentifié avant get_current_XXX_or_404

### DIFF
--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -39,6 +39,12 @@ fake = faker.Faker(locale="fr_FR")
 
 
 class ApplyTest(TestCase):
+    def test_anonymous_access(self):
+        siae = SiaeFactory(with_jobs=True)
+        url = reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": siae.pk})
+        response = self.client.get(url)
+        assert response.status_code == 403
+
     def test_we_raise_a_permission_denied_on_missing_session(self):
         routes = {
             "apply:check_nir_for_sender",
@@ -2136,6 +2142,22 @@ class UpdateJobSeekerViewTestCase(TestCase):
         assert self.job_seeker.has_jobseeker_profile is True
         assert self.job_seeker.jobseeker_profile.education_level == EducationLevel.BAC_LEVEL
         assert self.job_seeker.last_checked_at != previous_last_checked_at
+
+    def test_anonymous_step_1(self):
+        response = self.client.get(self.step_1_url)
+        assert response.status_code == 403
+
+    def test_anonymous_step_2(self):
+        response = self.client.get(self.step_2_url)
+        assert response.status_code == 403
+
+    def test_anonymous_step_3(self):
+        response = self.client.get(self.step_3_url)
+        assert response.status_code == 403
+
+    def test_anonymous_step_end(self):
+        response = self.client.get(self.step_end_url)
+        assert response.status_code == 403
 
     def test_as_job_seeker(self):
         self._check_nothing_permitted(self.job_seeker)

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -948,7 +948,9 @@ class UpdateJobSeekerBaseView(ApplyStepBaseView):
     def setup(self, request, *args, **kwargs):
         self.job_seeker = get_object_or_404(User, pk=kwargs["job_seeker_pk"])
         self.job_seeker_session = SessionNamespace(request.session, f"job_seeker-{self.job_seeker.pk}")
-        if request.user.is_job_seeker or not request.user.can_view_personal_information(self.job_seeker):
+        if request.user.is_authenticated and (
+            request.user.is_job_seeker or not request.user.can_view_personal_information(self.job_seeker)
+        ):
             # Since the link leading to this process isn't visible to those users, this should never happen
             raise PermissionDenied("Votre utilisateur n'est pas autorisé à vérifier les informations de ce candidat")
         super().setup(request, *args, **kwargs)

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -1169,6 +1169,15 @@ class InstitutionEvaluatedSiaeNotifyViewAccessTestMixin:
     def login(self, evaluated_siae):
         self.client.force_login(self.user)
 
+    def test_anonymous_access(self):
+        evaluated_siae = EvaluatedSiaeFactory(
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.REFUSED_2,
+        )
+        url = reverse(self.urlname, kwargs={"evaluated_siae_pk": evaluated_siae.pk})
+        response = self.client.get(url)
+        self.assertRedirects(response, reverse("account_login") + f"?next={url}")
+
     def test_access_other_institution(self):
         evaluated_siae = EvaluatedSiaeFactory(
             # Evaluation of another institution.

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -222,9 +222,10 @@ class InstitutionEvaluatedSiaeNotifyMixin(LoginRequiredMixin, SingleObjectMixin)
     context_object_name = "evaluated_siae"
     pk_url_kwarg = "evaluated_siae_pk"
 
-    def setup(self, *args, **kwargs):
-        super().setup(*args, **kwargs)
-        self.institution = get_current_institution_or_404(self.request)
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        if request.user.is_authenticated:
+            self.institution = get_current_institution_or_404(self.request)
 
     def get_queryset(self):
         return (


### PR DESCRIPTION
### Pourquoi ?

Éviter des erreurs en cas d’accès anonyme. Voir le commit pour les détails.