### PR TITLE
Remplacement de l'attibut title sur balises de liens

### DIFF
--- a/itou/templates/403.html
+++ b/itou/templates/403.html
@@ -9,8 +9,8 @@
             <h1 class="h1-hero-c1">Vous ne pouvez pas continuer</h1>
 
             {% if exception %}
-                <div class="lead alert alert-warning" role="status">
-                    <p class="mb-0">{{ exception }}</p>
+                <div class="alert alert-warning" role="status">
+                    <p class="lead mb-0">{{ exception }}</p>
                 </div>
             {% else %}
                 <h2 class="h1">Accès refusé</h2>

--- a/itou/templates/account/email_confirm.html
+++ b/itou/templates/account/email_confirm.html
@@ -13,7 +13,7 @@
     {% if confirmation %}
 
         <p>
-            Confirmez que <a href="mailto:{{ confirmation.email_address.email }}" title="{{ confirmation.email_address.email }} est bien votre adresse e-mail">{{ confirmation.email_address.email }}</a> est bien votre adresse e-mail en cliquant sur le bouton ci-dessous.
+            Confirmez que <a href="mailto:{{ confirmation.email_address.email }}" aria-label="{{ confirmation.email_address.email }} est bien votre adresse e-mail">{{ confirmation.email_address.email }}</a> est bien votre adresse e-mail en cliquant sur le bouton ci-dessous.
         </p>
 
         <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">

--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -9,7 +9,7 @@
                 <div class="col-12 p-3">
                     <h1 class="h1-hero-c1">API Les emplois de l’inclusion</h1>
                     <p class="lead">
-                        L'API des <a href="{% url 'home:hp' %}" title="Vers l'API des emplois de l'inclusion">emplois de l'inclusion</a> met à disposition des données de la plateforme.
+                        L'API des <a href="{% url 'home:hp' %}" aria-label="Vers l'API des emplois de l'inclusion">emplois de l'inclusion</a> met à disposition des données de la plateforme.
                     </p>
                     <p>Cette API est encore en construction et est appelée à évoluer.</p>
                     <p class="text-muted">Version: 1</p>
@@ -20,7 +20,7 @@
                     L’accès à certaines ressources peut nécessiter une authentification avec des droits particuliers.
                     <br />
                     Si vous désirez obtenir ces droits sur votre compte, merci de
-                    <a class="text-decoration-underline font-weight-bold text-white" href="mailto:{{ API_EMAIL_CONTACT }}" title="Nous contacter par e-mail">nous contacter</a>
+                    <a class="text-decoration-underline font-weight-bold text-white" href="mailto:{{ API_EMAIL_CONTACT }}" aria-label="Nous contacter par e-mail">nous contacter</a>
                     <i class="ri-external-link-line"></i>.
                 </div>
             </div>

--- a/itou/templates/apply/list_for_job_seeker.html
+++ b/itou/templates/apply/list_for_job_seeker.html
@@ -68,7 +68,7 @@
                         {% include "apply/includes/list_card_body.html" with job_application=job_application %}
 
                         <div class="card-footer">
-                            <a href="#" data-toggle="collapse" data-target="#answer{{ forloop.counter0 }}" aria-expanded="false" aria-controls="answer{{ forloop.counter0 }}" title="Plus d'informations sur cette candidature">Plus d'informations</a>
+                            <a href="#" data-toggle="collapse" data-target="#answer{{ forloop.counter0 }}" aria-expanded="false" aria-controls="answer{{ forloop.counter0 }}" aria-label="Plus d'informations sur cette candidature">Plus d'informations</a>
                             <div id="answer{{ forloop.counter0 }}" class="collapse mt-3">
                                 <p>
                                     <b>Message de candidature :</b>

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -61,7 +61,7 @@
                                    data-matomo-category="candidatures"
                                    data-matomo-action="exports"
                                    data-matomo-option="export-siae"
-                                   title="Télécharger cet export SIAE"
+                                   aria-label="Télécharger cet export SIAE"
                                    href="{% url 'apply:list_for_siae_exports_download' %}">
                                     Télécharger
                                 </a>
@@ -71,7 +71,7 @@
                                    data-matomo-category="candidatures"
                                    data-matomo-action="exports"
                                    data-matomo-option="export-prescripteur"
-                                   title="Télécharger cet export prescripteur"
+                                   aria-label="Télécharger cet export prescripteur"
                                    href="{% url 'apply:list_for_prescriber_exports_download' %}">
                                     Télécharger
                                 </a>
@@ -89,7 +89,7 @@
                                        data-matomo-category="candidatures"
                                        data-matomo-action="exports"
                                        data-matomo-option="export-siae"
-                                       title="Télécharger cet export SIAE"
+                                       aria-label="Télécharger cet export SIAE"
                                        href="{% url 'apply:list_for_siae_exports_download' month_identifier=month.month|date:"Y-m" %}">
                                         Télécharger
                                     </a>
@@ -99,7 +99,7 @@
                                        data-matomo-category="candidatures"
                                        data-matomo-action="exports"
                                        data-matomo-option="export-prescripteur"
-                                       title="Télécharger cet export prescripteur"
+                                       aria-label="Télécharger cet export prescripteur"
                                        href="{% url 'apply:list_for_prescriber_exports_download' month_identifier=month.month|date:"Y-m" %}">
                                         Télécharger
                                     </a>

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -104,7 +104,7 @@
                                        href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/diagnostic-socio-professionnel/"
                                        target="_blank"
                                        rel="noreferrer noopener"
-                                       title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.
+                                       aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.
                                     <br />
                                     Précisez également dans le message, vos motivations, vos compétences, ainsi que vos disponibilités.
                                 {% else %}
@@ -116,7 +116,7 @@
                                        href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/diagnostic-socio-professionnel/"
                                        target="_blank"
                                        rel="noreferrer noopener"
-                                       title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.
+                                       aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.
                                     <br />
                                     Précisez également dans le message, ses motivations, ses compétences, ainsi que ses disponibilités.
                                 {% endif %}

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -50,7 +50,7 @@
                                         <br>
                                     {% endif %}
                                     <a href="https://www.ameli.fr/assure/droits-demarches/principes/numero-securite-sociale"
-                                       title="ameli.fr, article concernant le numéro de sécurité sociale (ouverture dans un nouvel onglet)"
+                                       aria-label="ameli.fr, article concernant le numéro de sécurité sociale (ouverture dans un nouvel onglet)"
                                        rel="noopener"
                                        target="_blank">ameli.fr</a><i class="ri-external-link-line ml-1"></i>, le site de l'assurance maladie, vous explique comment l'obtenir.
                                 </p>
@@ -64,7 +64,7 @@
 
                     <div class="row mt-3 mt-lg-5 justify-content-end">
                         <div class="col-6 col-lg-auto">
-                            <a class="btn btn-link" title="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
+                            <a class="btn btn-link" aria-label="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
                         </div>
                         <div class="col-6 col-lg-auto">
                             <button type="submit" name="preview" value="1" class="btn btn-primary">Suivant</button>

--- a/itou/templates/apply/submit_step_pending_authorization.html
+++ b/itou/templates/apply/submit_step_pending_authorization.html
@@ -27,7 +27,7 @@
                 </div>
                 <div class="row mt-3 mt-lg-5 justify-content-end">
                     <div class="col-6 col-lg-auto">
-                        <a class="btn btn-link" title="Revenir à la recherche" href="{% url 'home:hp' %}">Revenir à la recherche</a>
+                        <a class="btn btn-link" aria-label="Revenir à la recherche" href="{% url 'home:hp' %}">Revenir à la recherche</a>
                     </div>
                     <div class="col-6 col-lg-auto">
                         <a href="{% url 'apply:check_nir_for_sender' siae_pk=siae.pk %}" class="btn btn-primary">Suivant</a>

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -37,7 +37,7 @@
                 </p>
 
                 <p>
-                    <a href="{% url 'search:prescribers_home' %}" rel="noopener" target="_blank" title="Rechercher des prescripteurs (ouverture dans une nouvelle fenêtre)">Rechercher des prescripteurs</a> <i class="ri-external-link-line ml-1"></i>
+                    <a href="{% url 'search:prescribers_home' %}" rel="noopener" target="_blank" aria-label="Rechercher des prescripteurs (ouverture dans une nouvelle fenêtre)">Rechercher des prescripteurs</a> <i class="ri-external-link-line ml-1"></i>
                 </p>
             </div>
 

--- a/itou/templates/approvals/pe_approval_search.html
+++ b/itou/templates/approvals/pe_approval_search.html
@@ -20,7 +20,7 @@
             </p>
         </div>
         <p>
-            S'il s'agit bien d'un numéro d'agrément Pôle emploi, vous pouvez <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" title="Contacter le support (ouverture dans un nouvel onglet)">contacter le support</a><i class="ri-external-link-line ml-1"></i>.
+            S'il s'agit bien d'un numéro d'agrément Pôle emploi, vous pouvez <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" aria-label="Contacter le support (ouverture dans un nouvel onglet)">contacter le support</a><i class="ri-external-link-line ml-1"></i>.
         </p>
 
     {% endif %}

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -46,10 +46,10 @@
             </p>
         </div>
         <p>
-            S'il s'agit d'un nouveau contrat, vous pouvez solliciter <a href="{% url 'search:prescribers_home' %}" title="Solliciter un prescripteur habilité">un prescripteur habilité</a> pour qu'il puisse vous orienter le candidat.
+            S'il s'agit d'un nouveau contrat, vous pouvez solliciter <a href="{% url 'search:prescribers_home' %}" aria-label="Solliciter un prescripteur habilité">un prescripteur habilité</a> pour qu'il puisse vous orienter le candidat.
         </p>
         <p>
-            Si le salarié travaille actuellement dans votre structure, <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" title="Contactez-nous (ouverture dans un nouvel onglet)">contactez-nous</a><i class="ri-external-link-line ml-1"></i>.
+            Si le salarié travaille actuellement dans votre structure, <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" aria-label="Contactez-nous (ouverture dans un nouvel onglet)">contactez-nous</a><i class="ri-external-link-line ml-1"></i>.
         </p>
         <a class="btn btn-primary" href="{{ back_url }}">Nouvelle recherche</a>
     {% endif %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -29,7 +29,7 @@
                         Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
                     {% endwith %}
                 {% endif %}
-                ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
+                ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" aria-label="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
             </p>
         </div>
     {% endif %}
@@ -60,7 +60,7 @@
                         Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
                     {% endwith %}
                 {% endif %}
-                ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
+                ou <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" aria-label="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
             </p>
         </div>
     {% endif %}
@@ -101,7 +101,7 @@
                     <a href="{% tally_form_url "wgDzz1" idprescriber=current_prescriber_organization.pk iduser=user.pk source=ITOU_ENVIRONMENT %}"
                        rel="noopener"
                        target="_blank"
-                       title="Cliquez ici pour l'envoyer (ouverture dans un nouvel onglet)">
+                       aria-label="Cliquez ici pour l'envoyer (ouverture dans un nouvel onglet)">
                         cliquez ici pour l'envoyer
                         <i class="ri-external-link-line ri-lg"></i>
                     </a>
@@ -134,7 +134,7 @@
                                     <p class="mb-0">
                                         <a class="btn btn-primary btn-ico"
                                            href="https://dora.fabrique.social.gouv.fr/?utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
-                                           title="Consulter les services (ouverture dans un nouvel onglet)"
+                                           aria-label="Consulter les services (ouverture dans un nouvel onglet)"
                                            rel="noopener"
                                            target="_blank">
                                             <span>Consulter les services</span>
@@ -142,7 +142,7 @@
                                         </a>
                                         <a class="btn btn-link btn-ico"
                                            href="https://dora.fabrique.social.gouv.fr/contribuer?utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
-                                           title="Suggérer les services de vos partenaires (ouverture dans un nouvel onglet)"
+                                           aria-label="Suggérer les services de vos partenaires (ouverture dans un nouvel onglet)"
                                            rel="noopener"
                                            target="_blank">
                                             <span>Suggérer les services de vos partenaires</span>
@@ -157,7 +157,7 @@
                                     <p class="mb-0">
                                         <a class="btn btn-primary btn-ico"
                                            href="https://dora.fabrique.social.gouv.fr/auth/rattachement?siret={{ current_org.siret }}&utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
-                                           title="Référencer un service (ouverture dans un nouvel onglet)"
+                                           aria-label="Référencer un service (ouverture dans un nouvel onglet)"
                                            rel="noopener"
                                            target="_blank">
                                             <span>Référencer un service</span>
@@ -165,7 +165,7 @@
                                         </a>
                                         <a class="btn btn-link btn-ico"
                                            href="https://dora.fabrique.social.gouv.fr/?utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
-                                           title="Découvrir DORA (ouverture dans un nouvel onglet)"
+                                           aria-label="Découvrir DORA (ouverture dans un nouvel onglet)"
                                            rel="noopener"
                                            target="_blank">
                                             <span>Découvrir DORA</span>

--- a/itou/templates/dashboard/includes/dora_card.html
+++ b/itou/templates/dashboard/includes/dora_card.html
@@ -7,21 +7,21 @@
             <ul class="list-unstyled">
                 <li class="card-text mb-3">
                     <i class="ri-global-line ri-lg mr-1"></i>
-                    <a href="https://dora.fabrique.social.gouv.fr/?{{ tracker }}" rel="noopener" target="_blank" title="Consulter les services d'insertion de votre territoire (ouverture dans un nouvel onglet)">
+                    <a href="https://dora.fabrique.social.gouv.fr/?{{ tracker }}" rel="noopener" target="_blank" aria-label="Consulter les services d'insertion de votre territoire (ouverture dans un nouvel onglet)">
                         Consulter les services d'insertion de votre territoire
                     </a>
                     <i class="ri-external-link-line ri-lg mr-1"></i>
                 </li>
                 <li class="card-text mb-3">
                     <i class="ri-file-add-line ri-lg mr-1"></i>
-                    <a href="https://dora.fabrique.social.gouv.fr/auth/rattachement?siret={{ siret }}&{{ tracker }}" rel="noopener" target="_blank" title="Référencer vos services (ouverture dans un nouvel onglet)">
+                    <a href="https://dora.fabrique.social.gouv.fr/auth/rattachement?siret={{ siret }}&{{ tracker }}" rel="noopener" target="_blank" aria-label="Référencer vos services (ouverture dans un nouvel onglet)">
                         Référencer vos services
                     </a>
                     <i class="ri-external-link-line ri-lg mr-1"></i>
                 </li>
                 <li class="card-text mb-3">
                     <i class="ri-file-transfer-line ri-lg mr-1"></i>
-                    <a href="https://dora.fabrique.social.gouv.fr/contribuer?{{ tracker }}" rel="noopener" target="_blank" title="Suggérer un service partenaire (ouverture dans un nouvel onglet)">
+                    <a href="https://dora.fabrique.social.gouv.fr/contribuer?{{ tracker }}" rel="noopener" target="_blank" aria-label="Suggérer un service partenaire (ouverture dans un nouvel onglet)">
                         Suggérer un service partenaire
                     </a>
                     <i class="ri-external-link-line ri-lg mr-1"></i>

--- a/itou/templates/dashboard/includes/prescriber_job_applications_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_applications_card.html
@@ -18,7 +18,7 @@
                 {% if current_prescriber_organization and current_prescriber_organization.kind == precriber_kind_pe %}
                     <li class="card-text mb-3">
                         <i class="ri-pause-circle-line ri-lg"></i>
-                        <a href="https://tally.so/r/w2Ex0M" title="Suspendre un PASS IAE (ouverture dans un nouvel onglet)" target="_blank">Suspendre un PASS IAE</a><i class="ri-external-link-line ml-1"></i>
+                        <a href="https://tally.so/r/w2Ex0M" aria-label="Suspendre un PASS IAE (ouverture dans un nouvel onglet)" target="_blank">Suspendre un PASS IAE</a><i class="ri-external-link-line ml-1"></i>
                     </li>
                 {% endif %}
             </ul>

--- a/itou/templates/dashboard/includes/prescriber_organisation_card.html
+++ b/itou/templates/dashboard/includes/prescriber_organisation_card.html
@@ -37,7 +37,7 @@
                     <li class="card-text mb-3">
                         <i class="ri-award-line ri-lg"></i>
                         <span>
-                            {{ current_prescriber_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/diagnostic-socio-professionnel/" target="_blank" title="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
+                            {{ current_prescriber_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/diagnostic-socio-professionnel/" target="_blank" aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
                         </span>
                     </li>
                 {% endif %}

--- a/itou/templates/dashboard/includes/siae_card.html
+++ b/itou/templates/dashboard/includes/siae_card.html
@@ -19,7 +19,7 @@
                 {% endif %}
                 <li class="card-text mb-3">
                     <i class="ri-briefcase-line ri-lg mr-1"></i>
-                    <a class="title-with-badge" href="{% url 'siaes_views:job_description_list' %}" title="Gérer les métiers et recrutements">
+                    <a class="title-with-badge" href="{% url 'siaes_views:job_description_list' %}" aria-label="Gérer les métiers et recrutements">
                         Gérer les métiers et recrutements
                     </a>
                 </li>

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -76,7 +76,7 @@
                     </li>
                 {% endif %}
                 <li class="card-text mb-3">
-                    <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)">
+                    <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)">
                         Accéder aux tableaux de bord publics
                     </a>
                     <i class="ri-external-link-line ri-lg mr-1"></i>

--- a/itou/templates/eligibility/includes/criteria_input.html
+++ b/itou/templates/eligibility/includes/criteria_input.html
@@ -31,7 +31,7 @@
                     {% endif %}
                     {% if criteria.written_proof_url %}
                         <p class="small mb-0 form-text text-muted">
-                            <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" title="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
+                            <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" aria-label="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
                                 {{ criteria.written_proof_url }}
                             </a>
                         </p>

--- a/itou/templates/home/home.html
+++ b/itou/templates/home/home.html
@@ -42,7 +42,7 @@
                             <h3 class="h4 card-title font-weight-light">Découvrez l'espace de documentation pour tout comprendre</h3>
                         </div>
                         <div class="card-footer">
-                            <a class="btn btn-primary stretched-link" href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/" target="_blank" title="En savoir plus (ouverture dans un nouvel onglet)">
+                            <a class="btn btn-primary stretched-link" href="{{ ITOU_COMMUNITY_URL }}/aide/emplois/" target="_blank" aria-label="En savoir plus (ouverture dans un nouvel onglet)">
                                 En savoir plus
                             </a>
                         </div>

--- a/itou/templates/includes/members.html
+++ b/itou/templates/includes/members.html
@@ -18,9 +18,7 @@
                     <td>
                         {{ member.user.get_full_name }}
                         {% if member.user in active_admin_members %}
-                            <small>
-                                <span class="badge badge-pill badge-info" data-toggle="tooltip" title="Administrateur de la structure">admin</span>
-                            </small>
+                            <span class="badge badge-xs badge-pill badge-info" data-toggle="tooltip" title="Administrateur de la structure">admin</span>
                         {% endif %}
                     </td>
                     <td>

--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -27,13 +27,13 @@
                         <a href="{% url 'releases:list' %}">Journal des modifications</a>
                     </li>
                     <li>
-                        <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/1829-2/" rel="noopener" target="_blank" title="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">
+                        <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/1829-2/" rel="noopener" target="_blank" aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">
                             Qui peut bénéficier des contrats d'IAE ?
                         </a>
                         <i class="ri-external-link-line ml-1 font-weight-bold"></i>
                     </li>
                     <li>
-                        <a href="https://stats.uptimerobot.com/JYJ6XHq6xY" rel="noopener" target="_blank" title="Disponibilité (ouverture dans un nouvel onglet)">
+                        <a href="https://stats.uptimerobot.com/JYJ6XHq6xY" rel="noopener" target="_blank" aria-label="Disponibilité (ouverture dans un nouvel onglet)">
                             Disponibilité
                         </a>
                         <i class="ri-external-link-line ml-1 font-weight-bold"></i>
@@ -50,7 +50,7 @@
                 <div class="s-footer-help__col col-12 col-lg">
                     <ul>
                         <li>
-                            <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" title="Besoin d'aide ? (ouverture dans un nouvel onglet)">Besoin d'aide ?</a><i class="ri-external-link-line ml-1 font-weight-bold"></i>
+                            <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" aria-label="Besoin d'aide ? (ouverture dans un nouvel onglet)">Besoin d'aide ?</a><i class="ri-external-link-line ml-1 font-weight-bold"></i>
                         </li>
                     </ul>
                 </div>
@@ -60,27 +60,27 @@
                             <span>Nous suivre</span>
                         </li>
                         <li>
-                            <a href="https://twitter.com/inclusion_gouv" rel="noopener" target="_blank" title="Rejoignez-nous sur Twitter (ouverture dans un nouvel onglet)">
+                            <a href="https://twitter.com/inclusion_gouv" rel="noopener" target="_blank" aria-label="Rejoignez-nous sur Twitter (ouverture dans un nouvel onglet)">
                                 <img src="{% static_theme_images 'picto-twitter.svg' %}" height="25" alt="Rejoignez-nous sur Twitter">
                             </a>
                         </li>
                         <li>
-                            <a href="https://www.linkedin.com/company/inclusion-gouv/" rel="noopener" target="_blank" title="Rejoignez-nous sur Linkedin (ouverture dans un nouvel onglet)">
+                            <a href="https://www.linkedin.com/company/inclusion-gouv/" rel="noopener" target="_blank" aria-label="Rejoignez-nous sur Linkedin (ouverture dans un nouvel onglet)">
                                 <img src="{% static_theme_images 'picto-linkedin.svg' %}" height="25" alt="Rejoignez-nous sur Linkedin">
                             </a>
                         </li>
                         <li>
-                            <a href="https://www.facebook.com/inclusion.gouv/" rel="noopener" target="_blank" title="Rejoignez-nous sur Facebook (ouverture dans un nouvel onglet)">
+                            <a href="https://www.facebook.com/inclusion.gouv/" rel="noopener" target="_blank" aria-label="Rejoignez-nous sur Facebook (ouverture dans un nouvel onglet)">
                                 <img src="{% static_theme_images 'picto-facebook.svg' %}" height="25" alt="Rejoignez-nous sur Facebook">
                             </a>
                         </li>
                         <li>
-                            <a href="https://www.instagram.com/inclusion_gouv/" rel="noopener" target="_blank" title="Rejoignez-nous sur Instagram (ouverture dans un nouvel onglet)">
+                            <a href="https://www.instagram.com/inclusion_gouv/" rel="noopener" target="_blank" aria-label="Rejoignez-nous sur Instagram (ouverture dans un nouvel onglet)">
                                 <img src="{% static_theme_images 'picto-instagram.svg' %}" height="25" alt="Rejoignez-nous sur Instagram">
                             </a>
                         </li>
                         <li>
-                            <a href="https://www.youtube.com/channel/UC06_yIYfzAiDOMTemH9q3OQ" rel="noopener" target="_blank" title="Rejoignez-nous sur Youtube (ouverture dans un nouvel onglet)">
+                            <a href="https://www.youtube.com/channel/UC06_yIYfzAiDOMTemH9q3OQ" rel="noopener" target="_blank" aria-label="Rejoignez-nous sur Youtube (ouverture dans un nouvel onglet)">
                                 <img src="{% static_theme_images 'picto-youtube.svg' %}" height="25" alt="Rejoignez-nous sur Youtube">
                             </a>
                         </li>

--- a/itou/templates/layout/_nav_preheader_items.html
+++ b/itou/templates/layout/_nav_preheader_items.html
@@ -1,30 +1,30 @@
 <ul>
     <li>
-        <a href="https://inclusion.beta.gouv.fr" class="is-plateforme" rel="noopener" target="_blank" title="La Plateforme de l'inclusion (lien externe)">
+        <a href="https://inclusion.beta.gouv.fr" class="is-plateforme" rel="noopener" target="_blank" aria-label="La Plateforme de l'inclusion (lien externe)">
             <span>La plateforme</span>
             <i class="ri-arrow-right-up-line ri-lg"></i>
         </a>
     </li>
     <li>
-        <a href="https://emplois.inclusion.beta.gouv.fr" class="is-emploi" rel="noopener" target="_blank" title="Les emplois de l'inclusion (lien externe)">
+        <a href="https://emplois.inclusion.beta.gouv.fr" class="is-emploi" rel="noopener" target="_blank" aria-label="Les emplois de l'inclusion (lien externe)">
             <span>Les emplois</span>
             <i class="ri-arrow-right-up-line ri-lg"></i>
         </a>
     </li>
     <li>
-        <a href="https://communaute-experimentation.inclusion.beta.gouv.fr" class="is-communaute" rel="noopener" target="_blank" title="La communauté de l'inclusion (lien externe)">
+        <a href="https://communaute-experimentation.inclusion.beta.gouv.fr" class="is-communaute" rel="noopener" target="_blank" aria-label="La communauté de l'inclusion (lien externe)">
             <span>La communauté</span>
             <i class="ri-arrow-right-up-line ri-lg"></i>
         </a>
     </li>
     <li>
-        <a href="https://lemarche.inclusion.beta.gouv.fr" class="is-marche" rel="noopener" target="_blank" title="Le marché de l'inclusion (lien externe)">
+        <a href="https://lemarche.inclusion.beta.gouv.fr" class="is-marche" rel="noopener" target="_blank" aria-label="Le marché de l'inclusion (lien externe)">
             <span>Le marché</span>
             <i class="ri-arrow-right-up-line ri-lg"></i>
         </a>
     </li>
     <li>
-        <a href="https://pilotage.inclusion.beta.gouv.fr" class="is-pilotage" rel="noopener" target="_blank" title="Le pilotage de l'inclusion (lien externe)">
+        <a href="https://pilotage.inclusion.beta.gouv.fr" class="is-pilotage" rel="noopener" target="_blank" aria-label="Le pilotage de l'inclusion (lien externe)">
             <span>Le pilotage</span>
             <i class="ri-arrow-right-up-line ri-lg"></i>
         </a>

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -221,7 +221,7 @@
         {% else %}
             {# Sticky FAQ link is not displayed on HP and on small devices #}
             <div class="rounded-pill bg-white shadow fixed-sm-bottom d-none d-sm-inline-block m-4 py-2 px-3 text-center text-md-right">
-                <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" class="text-decoration-none" title="Besoin d'aide ? (ouverture dans un nouvel onglet)">
+                <a href="{{ ITOU_ASSISTANCE_URL }}" rel="noopener" target="_blank" class="text-decoration-none" aria-label="Besoin d'aide ? (ouverture dans un nouvel onglet)">
                     Besoin d'aide ?
                 </a>
                 <i class="ri-external-link-line ml-1"></i>

--- a/itou/templates/prescribers/card.html
+++ b/itou/templates/prescribers/card.html
@@ -43,7 +43,7 @@
     {% if prescriber_org.website %}
         <p>
             <i class="ri-external-link-line mr-1"></i>
-            <a href="{{ prescriber_org.website }}" rel="noopener" target="_blank" title="{{ prescriber_org.website }} (ouverture dans un nouvel onglet)">{{ prescriber_org.website }}</a>
+            <a href="{{ prescriber_org.website }}" rel="noopener" target="_blank" aria-label="{{ prescriber_org.website }} (ouverture dans un nouvel onglet)">{{ prescriber_org.website }}</a>
         </p>
     {% endif %}
 

--- a/itou/templates/search/includes/prescribers_search_form.html
+++ b/itou/templates/search/includes/prescribers_search_form.html
@@ -21,6 +21,6 @@
         </div>
     </div>
     <div class="col-12 col-md-3 col-lg-2 mb-2 pl-md-3">
-        <button type="submit" class="btn btn-primary form-control js-search-button" title="Rechercher">Rechercher</button>
+        <button type="submit" class="btn btn-primary form-control js-search-button" aria-label="Rechercher">Rechercher</button>
     </div>
 </div>

--- a/itou/templates/search/includes/siaes_search_form.html
+++ b/itou/templates/search/includes/siaes_search_form.html
@@ -21,6 +21,6 @@
         </div>
     </div>
     <div class="col-12 col-md-3 col-lg-2 mb-2 pl-md-3">
-        <button type="submit" class="btn btn-primary btn-block js-search-button" title="Rechercher">Rechercher</button>
+        <button type="submit" class="btn btn-primary btn-block js-search-button" aria-label="Rechercher">Rechercher</button>
     </div>
 </div>

--- a/itou/templates/siae_evaluations/includes/criterion_infos.html
+++ b/itou/templates/siae_evaluations/includes/criterion_infos.html
@@ -30,7 +30,7 @@
         {% endif %}
         {% if criteria.written_proof_url %}
             <p class="small mb-0 form-text text-muted">
-                <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" title="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
+                <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" aria-label="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
                     {{ criteria.written_proof_url }}
                 </a>
             </p>

--- a/itou/templates/siae_evaluations/includes/criterion_validation.html
+++ b/itou/templates/siae_evaluations/includes/criterion_validation.html
@@ -2,7 +2,7 @@
     <div class="card-body">
         <div class="row align-items-center">
             <div class="col-lg-8 col-md-8 col-12">
-                <a href="{{ evaluated_administrative_criteria.proof_url }}" rel="noopener" target="_blank" title="Vérifier ce justificatif (ouverture dans un nouvel onglet)">
+                <a href="{{ evaluated_administrative_criteria.proof_url }}" rel="noopener" target="_blank" aria-label="Vérifier ce justificatif (ouverture dans un nouvel onglet)">
                     <i class="ri-file-copy-2-line ri-lg mr-1"></i>
                     {% if evaluated_siae.state == "SUBMITTED" or evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}
                         Vérifier ce justificatif
@@ -17,20 +17,22 @@
                     <div class="col-lg-2 col-md-2 col-9">
                         <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_administrative_criteria' evaluated_administrative_criteria.pk 'accept' %}">
                             {% csrf_token %}
-                            <button class="btn btn-success btn-sm float-right" title="Accepter ce justificatif">Accepter</button>
+                            <button class="btn btn-success btn-sm float-right" aria-label="Accepter ce justificatif">Accepter</button>
                         </form>
                     </div>
                     <div class="col-lg-2 col-md-2 col-3">
                         <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_administrative_criteria' evaluated_administrative_criteria.pk 'refuse' %}">
                             {% csrf_token %}
-                            <button class="btn btn-danger btn-sm float-right" title="Refuser ce justificatif">Refuser</button>
+                            <button class="btn btn-danger btn-sm float-right" aria-label="Refuser ce justificatif">Refuser</button>
                         </form>
                     </div>
                 {% else %}
                     <div class="col-lg-4 col-md-4 col-12">
                         <form method="post" action="{% url 'siae_evaluations_views:institution_evaluated_administrative_criteria' evaluated_administrative_criteria.pk 'reinit' %}">
                             {% csrf_token %}
-                            <button class="btn btn-outline-primary btn-sm float-right" title="Modifier l'état de ce justificatif">Modifier</button>
+                            <button class="btn btn-outline-primary btn-sm float-right" aria-label="Modifier l'état de ce justificatif">
+                                Modifier
+                            </button>
                         </form>
                     </div>
                 {% endif %}

--- a/itou/templates/siae_evaluations/institution_evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_job_application.html
@@ -18,7 +18,7 @@
                             {% for evaluated_administrative_criteria in evaluated_job_application.evaluated_administrative_criteria.all %}
                                 {% include "siae_evaluations/includes/criterion_infos.html" with criteria=evaluated_administrative_criteria.administrative_criteria review_state=evaluated_administrative_criteria.review_state %}
                                 {% if evaluated_siae.evaluation_is_final %}
-                                    <a href="{{ evaluated_administrative_criteria.proof_url }}" rel="noopener" target="_blank" title="Revoir ce justificatif (ouverture dans un nouvel onglet)">
+                                    <a href="{{ evaluated_administrative_criteria.proof_url }}" rel="noopener" target="_blank" aria-label="Revoir ce justificatif (ouverture dans un nouvel onglet)">
                                         Revoir ce justificatif
                                     </a>
                                 {% else %}

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
@@ -68,7 +68,7 @@
                     </h3>
                     <p>
                         Numéro de téléphone à utiliser au besoin :
-                        <a title="Contact téléphonique" href="tel:{{ evaluated_siae.siae.phone }}">
+                        <a aria-label="Contact téléphonique" href="tel:{{ evaluated_siae.siae.phone }}">
                             {{ evaluated_siae.siae.phone|format_phone }}
                         </a>
                     </p>

--- a/itou/templates/siae_evaluations/samples_selection.html
+++ b/itou/templates/siae_evaluations/samples_selection.html
@@ -32,7 +32,7 @@
             </p>
             <p class="font-weight-bold">Données du contrôle a posteriori cette campagne</p>
             <p>
-                <a class="btn btn-outline-primary" href="{% url 'stats:stats_ddets_diagnosis_control' %}{% if back_url %}?back_url={{ back_url }}{% endif %}" title="Voir les données">
+                <a class="btn btn-outline-primary" href="{% url 'stats:stats_ddets_diagnosis_control' %}{% if back_url %}?back_url={{ back_url }}{% endif %}" aria-label="Voir les données">
                     Voir les données
                 </a>
             </p>

--- a/itou/templates/siae_evaluations/sanctions_helper.html
+++ b/itou/templates/siae_evaluations/sanctions_helper.html
@@ -15,7 +15,7 @@
 
             <a target="_blank"
                href="https://www.legifrance.gouv.fr/download/pdf/circ?id=45319"
-               title="Voir l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription"
+               aria-label="Voir l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription"
                class="d-block mt-3 mb-4">https://www.legifrance.gouv.fr/download/pdf/circ?id=45319</a>
         </p>
 

--- a/itou/templates/siaes/card.html
+++ b/itou/templates/siaes/card.html
@@ -49,7 +49,7 @@
                     {% if not siae.block_job_applications %}
                         <a class="btn btn-primary btn-block btn-ico"
                            href="{% url 'apply:start' siae_pk=siae.pk %}{% if back_url %}?back_url={{ back_url }}{% endif %}"
-                           title="Proposer une candidature auprès de l'employeur solidaire {{ siae.display_name }}">
+                           aria-label="Proposer une candidature auprès de l'employeur solidaire {{ siae.display_name }}">
                             <i class="ri-draft-line"></i>
                             <span>Proposer une candidature</span>
                         </a>
@@ -76,21 +76,21 @@
                             {% if siae.email %}
                                 <li class="my-3">
                                     <i class="ri-mail-line ri-xl mr-2"></i>
-                                    <a title="Contact par mail" href="mailto:{{ siae.email }}" class="font-weight-bold">{{ siae.email }}</a>
+                                    <a aria-label="Contact par mail" href="mailto:{{ siae.email }}" class="font-weight-bold">{{ siae.email }}</a>
                                 </li>
                             {% endif %}
 
                             {% if siae.phone %}
                                 <li class="my-3">
                                     <i class="ri-phone-line ri-xl mr-2"></i>
-                                    <a title="Contact téléphonique" href="tel:{{ siae.phone|cut:" " }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
+                                    <a aria-label="Contact téléphonique" href="tel:{{ siae.phone|cut:" " }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
                                 </li>
                             {% endif %}
 
                             {% if siae.website %}
                                 <li class="my-3">
                                     <i class="ri-global-line ri-xl mr-2"></i>
-                                    <a title="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="font-weight-bold">{{ siae.website }}</a>
+                                    <a aria-label="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="font-weight-bold">{{ siae.website }}</a>
                                 </li>
                             {% endif %}
                         </ul>
@@ -150,7 +150,7 @@
                             <div class="d-flex justify-content-end mt-3">
                                 <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
                                    href="{% url 'apply:start' siae_pk=siae.pk %}{% if back_url %}?back_url={{ back_url }}{% endif %}"
-                                   title="Proposer une candidature auprès de l'employeur solidaire {{ siae.display_name }}">
+                                   aria-label="Proposer une candidature auprès de l'employeur solidaire {{ siae.display_name }}">
                                     <i class="ri-draft-line"></i>
                                     <span>Proposer une candidature</span>
                                 </a>

--- a/itou/templates/siaes/edit_job_description.html
+++ b/itou/templates/siaes/edit_job_description.html
@@ -55,7 +55,7 @@
 
             {% buttons %}
                 <div align="right" class="pt-3">
-                    <a class="btn btn-outline-primary" href="{% url "siaes_views:job_description_list" %}" title="Retour à la liste des métiers">Retour</a>
+                    <a class="btn btn-outline-primary" href="{% url "siaes_views:job_description_list" %}" aria-label="Retour à la liste des métiers">Retour</a>
                     <button type="submit" class="btn btn-primary" aria-label="Passer à l'étape suivante">Suivant</button>
                 </div>
             {% endbuttons %}

--- a/itou/templates/siaes/edit_job_description_details.html
+++ b/itou/templates/siaes/edit_job_description_details.html
@@ -39,7 +39,7 @@
                             <b>Conseil</b>
                         </p>
                         <p>
-                            Vous pouvez vous référer à la description sur la fiche métier présente dans le <a href="https://candidat.pole-emploi.fr/marche-du-travail/fichemetierrome?codeRome={{ rome }}" title="Référentiel des codes ROME" rel="noopener" target="_blank"><b>Répertoire Opérationnel des Métiers et des Emplois (ROME)</b></a>.
+                            Vous pouvez vous référer à la description sur la fiche métier présente dans le <a href="https://candidat.pole-emploi.fr/marche-du-travail/fichemetierrome?codeRome={{ rome }}" aria-label="Référentiel des codes ROME" rel="noopener" target="_blank"><b>Répertoire Opérationnel des Métiers et des Emplois (ROME)</b></a>.
                         </p>
                     </div>
                 </div>
@@ -75,7 +75,7 @@
 
             {% buttons %}
                 <div align="right" class="pt-3">
-                    <a class="btn btn-outline-primary" href="{% url "siaes_views:edit_job_description" %}" title="Retour à la page précédente">Retour</a>
+                    <a class="btn btn-outline-primary" href="{% url "siaes_views:edit_job_description" %}" aria-label="Retour à la page précédente">Retour</a>
                     <button type="submit" class="btn btn-primary" aria-label="Passer à l'étape suivante">Suivant</button>
                 </div>
             {% endbuttons %}

--- a/itou/templates/siaes/edit_job_description_preview.html
+++ b/itou/templates/siaes/edit_job_description_preview.html
@@ -41,7 +41,7 @@
             {% csrf_token %}
             {% buttons %}
                 <div align="right">
-                    <a class="btn btn-outline-primary" title="Retour à la page précédente" href="{% url "siaes_views:edit_job_description_details" %}">Retour</a>
+                    <a class="btn btn-outline-primary" aria-label="Retour à la page précédente" href="{% url "siaes_views:edit_job_description_details" %}">Retour</a>
                     <button type="submit" class="btn btn-primary" aria-label="Publier la fiche de poste">Publier la fiche de poste</button>
                 </div>
             {% endbuttons %}

--- a/itou/templates/siaes/edit_siae.html
+++ b/itou/templates/siaes/edit_siae.html
@@ -66,7 +66,7 @@
 
             <div class="row mt-3 mt-lg-5 justify-content-end">
                 <div class="col-6 col-lg-auto">
-                    <a class="btn btn-link" title="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
+                    <a class="btn btn-link" aria-label="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
                 </div>
                 <div class="col-6 col-lg-auto">
                     <button type="submit" aria-label="Vers l'étape suivante du formulaire" class="btn float-right btn-primary">

--- a/itou/templates/siaes/edit_siae_description.html
+++ b/itou/templates/siaes/edit_siae_description.html
@@ -73,7 +73,7 @@
 
             <div class="row mt-3 mt-lg-5 justify-content-end">
                 <div class="col-6 col-lg-auto">
-                    <a class="btn btn-link" title="Retourner à l'édition des coordonnées" href="{{ prev_url }}">Retour</a>
+                    <a class="btn btn-link" aria-label="Retourner à l'édition des coordonnées" href="{{ prev_url }}">Retour</a>
                 </div>
                 <div class="col-6 col-lg-auto">
                     <button type="submit"  aria-label="Vers l'étape suivante du formulaire"  class="btn float-right btn-primary">

--- a/itou/templates/siaes/edit_siae_preview.html
+++ b/itou/templates/siaes/edit_siae_preview.html
@@ -69,21 +69,21 @@
                 {% if siae.email %}
                     <p>
                         <i class="ri-mail-line ri-xl mr-2"></i>
-                        <a title="Contact par mail" href="mailto:{{ siae.email }}" class="font-weight-bold">{{ siae.email }}</a>
+                        <a aria-label="Contact par mail" href="mailto:{{ siae.email }}" class="font-weight-bold">{{ siae.email }}</a>
                     </p>
                 {% endif %}
 
                 {% if siae.phone %}
                     <p>
                         <i class="ri-phone-line ri-xl mr-2"></i>
-                        <a title="Contact téléphonique" href="tel:{{ siae.phone|cut:' ' }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
+                        <a aria-label="Contact téléphonique" href="tel:{{ siae.phone|cut:' ' }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
                     </p>
                 {% endif %}
 
                 {% if siae.website %}
                     <p>
                         <i class="ri-global-line ri-xl mr-2"></i>
-                        <a title="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="font-weight-bold">{{ siae.website }}</a>
+                        <a aria-label="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="font-weight-bold">{{ siae.website }}</a>
                     </p>
                 {% endif %}
             {% endif %}
@@ -105,7 +105,7 @@
 
             <div class="row mt-3 mt-lg-5 justify-content-end">
                 <div class="col-6 col-lg-auto">
-                    <a class="btn btn-link" title="Retourner à l'édition de la description" href="{{ prev_url }}">Retour</a>
+                    <a class="btn btn-link" aria-label="Retourner à l'édition de la description" href="{{ prev_url }}">Retour</a>
                 </div>
                 <div class="col-6 col-lg-auto">
                     <button type="submit" aria-label="Publier le formulaire" class="btn btn-primary float-right">Publier</button>

--- a/itou/templates/siaes/includes/_card_jobdescription.html
+++ b/itou/templates/siaes/includes/_card_jobdescription.html
@@ -20,7 +20,7 @@
                            data-matomo-action="clic"
                            data-matomo-option="clic-structure-fichedeposte"
                            target="_blank"
-                           title="Ouvrir la page de la structure dans un nouvel onglet">
+                           aria-label="Ouvrir la page de la structure dans un nouvel onglet">
                             <b>{{ job_description.siae.kind }}</b>&nbsp;- {{ job_description.siae.display_name }}
                             <i class="ri-external-link-line ri-lg"></i>
                         </a>
@@ -50,7 +50,7 @@
                        href="{{ job_description.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}"
                        data-matomo-category="candidature"
                        data-matomo-action="clic"
-                       {% if job_description.is_external %} rel="noopener" target="_blank" data-matomo-option="clic-card-fichedeposte-externe" title="Visiter l'offre sur le site d'origine" {% else %} data-matomo-option="clic-card-fichedeposte" title="Aller vers la description de ce poste"  {% endif %}>
+                       {% if job_description.is_external %} rel="noopener" target="_blank" data-matomo-option="clic-card-fichedeposte-externe" aria-label="Visiter l'offre sur le site d'origine" {% else %} data-matomo-option="clic-card-fichedeposte" aria-label="Aller vers la description de ce poste"  {% endif %}>
                         <span class="h3">{{ job_description.display_name | capfirst }}</span>
                         {% if job_description.is_external %}&nbsp;<i class="ri-external-link-line ri-lg text-secondary"></i>{% endif %}
                     </a>

--- a/itou/templates/siaes/includes/_card_siae.html
+++ b/itou/templates/siaes/includes/_card_siae.html
@@ -57,7 +57,7 @@
                     <span>Cette structure vous intéresse ?</span>
                     <a class="btn btn-sm btn-primary"
                        href="{% url 'apply:start' siae_pk=siae.pk %}{% if back_url %}?back_url={{ back_url }}{% endif %}"
-                       title="Proposer votre candidature auprès de l'employeur solidaire {{ siae.display_name }}">
+                       aria-label="Proposer votre candidature auprès de l'employeur solidaire {{ siae.display_name }}">
                         Proposer votre candidature
                     </a>
                 </div>

--- a/itou/templates/siaes/includes/_siae_details.html
+++ b/itou/templates/siaes/includes/_siae_details.html
@@ -5,20 +5,20 @@
 {% if siae.email %}
     <p>
         <i class="ri-mail-line ri-xl mr-2"></i>
-        <a title="Contact par mail" href="mailto:{{ siae.email }}" class="font-weight-bold">{{ siae.email }}</a>
+        <a aria-label="Contact par mail" href="mailto:{{ siae.email }}" class="font-weight-bold">{{ siae.email }}</a>
     </p>
 {% endif %}
 
 {% if siae.phone %}
     <p>
         <i class="ri-phone-line ri-xl mr-2"></i>
-        <a title="Contact téléphonique" href="tel:{{ siae.phone }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
+        <a aria-label="Contact téléphonique" href="tel:{{ siae.phone }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
     </p>
 {% endif %}
 
 {% if siae.website %}
     <p>
         <i class="ri-global-line ri-xl mr-2"></i>
-        <a title="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="font-weight-bold">{{ siae.website }}</a>
+        <a aria-label="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="font-weight-bold">{{ siae.website }}</a>
     </p>
 {% endif %}

--- a/itou/templates/siaes/job_description_card.html
+++ b/itou/templates/siaes/job_description_card.html
@@ -22,7 +22,7 @@
                         </a>
                     </div>
                     <div class="col-auto">
-                        <a href="{% url "siaes_views:job_description_list" %}" class="btn btn-sm btn-primary" title="Retour vers la liste des postes">
+                        <a href="{% url "siaes_views:job_description_list" %}" class="btn btn-sm btn-primary" aria-label="Retour vers la liste des postes">
                             Fermer
                         </a>
                     </div>
@@ -30,7 +30,7 @@
             {% else %}
                 <div class="row mb-4">
                     <div class="col">
-                        <a href="#job_description_link" class="btn btn-sm btn-outline-primary" data-toggle="collapse" title="Partager cette fiche métier">Partager cette fiche métier</a>
+                        <a href="#job_description_link" class="btn btn-sm btn-outline-primary" data-toggle="collapse" aria-label="Partager cette fiche métier">Partager cette fiche métier</a>
                         <div class="collapse pt-2" id="job_description_link">
                             <p class="small mb-1">Cliquez sur le lien ci-dessous pour le copier:</p>
                             <input type="text" class="form-control form-control-sm" value="{{ request.scheme }}://{{ request.get_host }}{{ job.get_absolute_url }}">
@@ -43,7 +43,7 @@
                                data-matomo-category="candidature"
                                data-matomo-action="clic"
                                data-matomo-option="clic-metiers"
-                               title="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                               aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                                 Postuler
                             </a>
                         </div>

--- a/itou/templates/siaes/job_description_list.html
+++ b/itou/templates/siaes/job_description_list.html
@@ -22,7 +22,7 @@
                 </h6>
             </div>
             <div class="col text-right">
-                <a class="btn btn-primary btn-sm" href="{% url "siaes_views:edit_job_description" %}?page={{ page|default:1 }}" title="Créer une nouvelle fiche de poste">Créer une nouvelle fiche de poste</a>
+                <a class="btn btn-primary btn-sm" href="{% url "siaes_views:edit_job_description" %}?page={{ page|default:1 }}" aria-label="Créer une nouvelle fiche de poste">Créer une nouvelle fiche de poste</a>
             </div>
         </div>
 
@@ -72,7 +72,7 @@
                         <tr>
                             <th>{{ job_description.appellation.rome.code }}</th>
                             <th>
-                                <a href="{% url "siaes_views:job_description_card" job_description_id=job_description.id %}" title="Lien vers fiche de poste : '{{ job_description.display_name }}'">
+                                <a href="{% url "siaes_views:job_description_card" job_description_id=job_description.id %}" aria-label="Lien vers fiche de poste : '{{ job_description.display_name }}'">
                                     {{ job_description.display_name }}
                                 </a>
                             </th>
@@ -144,7 +144,7 @@
                                 </div>
                             </td>
                             <td>
-                                <a href="{% url "siaes_views:job_description_card" job_description_id=job_description.id %}" class="text-decoration-none" title="Lien vers fiche de poste : '{{ job_description.display_name }}'">
+                                <a href="{% url "siaes_views:job_description_card" job_description_id=job_description.id %}" class="text-decoration-none" aria-label="Lien vers fiche de poste : '{{ job_description.display_name }}'">
                                     <i class="ri-arrow-right-s-line ri-xl"></i>
 
                                 </a>
@@ -193,7 +193,7 @@
                 <div id="js-modal-preview-body" class="modal-body">
                 </div>
                 <div class="modal-footer">
-                    <a class="btn btn-sm btn-primary" href="#" data-dismiss="modal" title="Fermer la fenêtre">Fermer la fenêtre</a>
+                    <a class="btn btn-sm btn-primary" href="#" data-dismiss="modal" aria-label="Fermer la fenêtre">Fermer la fenêtre</a>
                 </div>
             </div>
         </div>

--- a/itou/templates/siaes/select_financial_annex.html
+++ b/itou/templates/siaes/select_financial_annex.html
@@ -22,6 +22,6 @@
 
     </form>
 
-    Si votre annexe financière correspond à un SIREN différent de {{ current_siae.siren }} ou à un type de structure différent de {{ current_siae.kind }}, ou bien si elle n'apparait pas dans la liste ci-dessus, contactez nous via la rubrique votre structure sur <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
+    Si votre annexe financière correspond à un SIREN différent de {{ current_siae.siren }} ou à un type de structure différent de {{ current_siae.kind }}, ou bien si elle n'apparait pas dans la liste ci-dessus, contactez nous via la rubrique votre structure sur <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" aria-label="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
 
 {% endblock %}

--- a/itou/templates/siaes/show_financial_annexes.html
+++ b/itou/templates/siaes/show_financial_annexes.html
@@ -22,7 +22,7 @@
             <p class="mb-0">
                 {# Inactive siaes of ASP source cannot be fixed by user. #}
                 Votre structure est inactive car elle n'est associée à aucune annexe financière valide. Contactez nous via la rubrique votre structure sur
-                <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
+                <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" aria-label="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
             </p>
         </div>
     {% elif current_siae_is_user_created %}

--- a/itou/templates/signup/facilitator_search.html
+++ b/itou/templates/signup/facilitator_search.html
@@ -25,7 +25,7 @@
 
         <div class="row mt-3 mt-lg-5 justify-content-end">
             <div class="col-6 col-lg-auto">
-                <a class="btn btn-link" title="Retourner à l'édition des coordonnées" href="{{ prev_url }}">Retour</a>
+                <a class="btn btn-link" aria-label="Retourner à l'édition des coordonnées" href="{{ prev_url }}">Retour</a>
             </div>
             <div class="col-6 col-lg-auto">
                 <button type="submit"  aria-label="Rechercher une entreprise par SIRET"  class="btn float-right btn-primary">

--- a/itou/templates/signup/includes/france_connect_button.html
+++ b/itou/templates/signup/includes/france_connect_button.html
@@ -8,7 +8,7 @@
 </p>
 <div class="text-center">
     <a href="{% url 'france_connect:authorize' %}"
-       title="S'identifier avec FranceConnect"
+       aria-label="S'identifier avec FranceConnect"
        class="matomo-event"
        data-matomo-category="inscription-candidat"
        data-matomo-action="clic"

--- a/itou/templates/signup/includes/peamu_button.html
+++ b/itou/templates/signup/includes/peamu_button.html
@@ -4,7 +4,7 @@
     {% csrf_token %}
     <input type="image"
            src="{% static 'img/peamu_btn.svg' %}"
-           title="Se connecter avec votre compte Pôle emploi"
+           aria-label="Se connecter avec votre compte Pôle emploi"
            class="matomo-event"
            data-matomo-category="inscription-candidat"
            data-matomo-action="clic"

--- a/itou/templates/signup/includes/submit_rgpd.html
+++ b/itou/templates/signup/includes/submit_rgpd.html
@@ -9,11 +9,11 @@
     <p class="mb-0">
         <small>
             Pour plus d'information sur le traitement de vos données personnelles ou pour exercer vos droits, consultez
-            <a href="{% url 'legal-privacy' %}" rel="noopener" target="_blank" title="Consultez la section Protection des données (ouverture dans une nouvel onglet)">
+            <a href="{% url 'legal-privacy' %}" rel="noopener" target="_blank" aria-label="Consultez la section Protection des données (ouverture dans une nouvel onglet)">
                 la section Protection des données
             </a><i class="ri-external-link-line ml-1"></i>.
             En cliquant sur le bouton "Inscription", vous acceptez
-            <a href="{% url 'legal-terms' %}" rel="noopener" target="_blank" title="Acceptez les conditions générales d'utilisation (ouverture dans une nouvel onglet)">
+            <a href="{% url 'legal-terms' %}" rel="noopener" target="_blank" aria-label="Acceptez les conditions générales d'utilisation (ouverture dans une nouvel onglet)">
                 les conditions générales d'utilisation
             </a><i class="ri-external-link-line ml-1"></i>.
         </small>

--- a/itou/templates/signup/job_seeker_nir.html
+++ b/itou/templates/signup/job_seeker_nir.html
@@ -38,7 +38,7 @@
             Vous n'avez pas de numéro de sécurité sociale ?
             <br>
             <a href="https://www.ameli.fr/assure/droits-demarches/principes/numero-securite-sociale"
-               title="Article concernant le numéro de sécurité sociale (ouverture dans un nouvel onglet)"
+               aria-label="Article concernant le numéro de sécurité sociale (ouverture dans un nouvel onglet)"
                rel="noopener"
                target="_blank">ameli.fr</a><i class="ri-external-link-line ml-1"></i>, le site de l'assurance maladie, vous explique comment l'obtenir.
         </p>

--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -16,7 +16,7 @@
             Les organisations habilitées permettent à leurs collaborateurs de valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique. Cette habilitation est officialisée par arrêté préfectoral.
         </p>
         <p class="mb-0">
-            <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/prescripteur-habilite/" rel="noopener" target="_blank" title="En savoir plus sur les différents prescripteurs (ouverture dans un nouvel onglet)">En savoir plus sur les différents prescripteurs</a><i class="ri-external-link-line ml-1"></i>
+            <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/prescripteur-habilite/" rel="noopener" target="_blank" aria-label="En savoir plus sur les différents prescripteurs (ouverture dans un nouvel onglet)">En savoir plus sur les différents prescripteurs</a><i class="ri-external-link-line ml-1"></i>
         </p>
     </div>
 

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -44,17 +44,17 @@
                 <i>Si ce n’est pas le cas</i>, demandez à votre DDETS d’enregistrer au plus vite l’annexe financière dans l’ASP.
             </p>
             <p>
-                En cas de nécessité d’inscription rapide, demandez à votre DDETS de nous contacter via <a href="https://communaute.inclusion.beta.gouv.fr/aide/emplois/#support" target="_blank" rel="noopener" title="lien de contact pour votre DDETS (ouverture dans un nouvel onglet)">ce formulaire</a>.
+                En cas de nécessité d’inscription rapide, demandez à votre DDETS de nous contacter via <a href="https://communaute.inclusion.beta.gouv.fr/aide/emplois/#support" target="_blank" rel="noopener" aria-label="lien de contact pour votre DDETS (ouverture dans un nouvel onglet)">ce formulaire</a>.
             </p>
 
             <p>
                 <strong>Si vous tentez d'inscrire une Entreprise Adaptée ou un GEIQ</strong> :
-                Utilisez <a href="{% tally_form_url "wA799W" %}" target="_blank" rel="noopener" title="lien pour une Entreprise Adaptée ou un GEIQ (ouverture dans un nouvel onglet)">ce formulaire</a>.
+                Utilisez <a href="{% tally_form_url "wA799W" %}" target="_blank" rel="noopener" aria-label="lien pour une Entreprise Adaptée ou un GEIQ (ouverture dans un nouvel onglet)">ce formulaire</a>.
             </p>
 
             <p class="mb-0">
                 <strong>Si votre organisation est porteuse de la clause sociale</strong> :
-                Utilisez <a href="{% url "signup:facilitator_search" %}" rel="noopener" title="lien pour une organisation porteuse de la clause sociale">ce formulaire</a>.
+                Utilisez <a href="{% url "signup:facilitator_search" %}" rel="noopener" aria-label="lien pour une organisation porteuse de la clause sociale">ce formulaire</a>.
             </p>
         </div>
     {% endif %}
@@ -158,7 +158,7 @@
     {% if siaes_without_members or siaes_with_members %}
         <div class="mt-5">
             <p>
-                En cas de problème contactez-nous : <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" title="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
+                En cas de problème contactez-nous : <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" aria-label="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
             </p>
         </div>
     {% endif %}

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -16,7 +16,7 @@
         <div class="mb-4">
             <i class="ri-external-link-line ri-lg mr-1"></i>.
             Cette page a pour objectif de présenter l'impact des emplois de l'inclusion. Pour retrouver les indicateurs qui étaient présentés ici, merci de vous rendre sur le
-            <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" title="Vous rendre sur le pilotage de l'inclusion (ouverture dans un nouvel onglet)">
+            <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" aria-label="Vous rendre sur le pilotage de l'inclusion (ouverture dans un nouvel onglet)">
                 pilotage de l'inclusion
             </a>
         </div>

--- a/itou/templates/status/index.html
+++ b/itou/templates/status/index.html
@@ -32,19 +32,19 @@
                             {% endif %}
                         </td>
                         <td>
-                            <span title="{{ status.last_success_at|date:"c"|default:"" }}">
+                            <span aria-label="{{ status.last_success_at|date:"c"|default:"" }}">
                                 {{ status.last_success_at|timesince|default:"N/A" }}
                             </span>
                             {% if status.last_success_info %}
-                                <i class="ri-information-line fs-lg" title="{{ status.last_success_info }}"></i>
+                                <i class="ri-information-line fs-lg" aria-label="{{ status.last_success_info }}"></i>
                             {% endif %}
                         </td>
                         <td>
-                            <span title="{{ status.last_failure_at|date:"c"|default:"" }}">
+                            <span aria-label="{{ status.last_failure_at|date:"c"|default:"" }}">
                                 {{ status.last_failure_at|timesince|default:"N/A" }}
                             </span>
                             {% if status.last_failure_info %}
-                                <i class="ri-error-warning-line fs-lg" title="{{ status.last_failure_info }}"></i>
+                                <i class="ri-error-warning-line fs-lg" aria-label="{{ status.last_failure_info }}"></i>
                             {% endif %}
                         </td>
                     </tr>

--- a/itou/templates/storage/s3_upload_form.html
+++ b/itou/templates/storage/s3_upload_form.html
@@ -24,7 +24,7 @@
        matomo-category="ajout-fichier-candidature"
        matomo-action="clic"
        matomo-option="clic-sur-lien-aide-pdf"
-       title="Découvrez comment le convertir (ouverture dans un nouvel onglet)">
+       aria-label="Découvrez comment le convertir (ouverture dans un nouvel onglet)">
         Découvrez comment le convertir.
     </a>
 </p>

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -2646,7 +2646,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
 
 class InstitutionEvaluatedJobApplicationViewTest(TestCase):
     btn_modifier_html = """
-        <button class="btn btn-outline-primary btn-sm float-right" title="Modifier l'état de ce justificatif">
+        <button class="btn btn-outline-primary btn-sm float-right" aria-label="Modifier l'état de ce justificatif">
             Modifier
         </button>
     """
@@ -2743,7 +2743,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
             <a href="https://server.com/rocky-balboa.pdf"
                rel="noopener"
                target="_blank"
-               title="Revoir ce justificatif (ouverture dans un nouvel onglet)"
+               aria-label="Revoir ce justificatif (ouverture dans un nouvel onglet)"
             >
                 Revoir ce justificatif
             </a>
@@ -2880,7 +2880,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
             <a href="https://server.com/rocky-balboa.pdf"
                rel="noopener"
                target="_blank"
-               title="Revoir ce justificatif (ouverture dans un nouvel onglet)"
+               aria-label="Revoir ce justificatif (ouverture dans un nouvel onglet)"
             >
                 Revoir ce justificatif
             </a>

--- a/itou/www/siaes_views/tests/tests_views.py
+++ b/itou/www/siaes_views/tests/tests_views.py
@@ -150,7 +150,7 @@ class CardViewTest(TestCase):
              <div class="d-flex justify-content-end mt-3">
               <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
                  href="/apply/{siae.pk}/start"
-                 title="Proposer une candidature aupr&egrave;s de l'employeur solidaire Les petits jardins">
+                 aria-label="Proposer une candidature aupr&egrave;s de l'employeur solidaire Les petits jardins">
                <i class="ri-draft-line">
                </i>
                <span>
@@ -250,7 +250,7 @@ class CardViewTest(TestCase):
              <div class="d-flex justify-content-end mt-3">
               <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
                  href="/apply/{siae.pk}/start"
-                 title="Proposer une candidature aupr&egrave;s de l'employeur solidaire Les petits jardins">
+                 aria-label="Proposer une candidature aupr&egrave;s de l'employeur solidaire Les petits jardins">
                <i class="ri-draft-line">
                </i>
                <span>
@@ -404,7 +404,7 @@ class CardViewTest(TestCase):
              <div class="d-flex justify-content-end mt-3">
               <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
                  href="/apply/{siae.pk}/start"
-                 title="Proposer une candidature aupr&egrave;s de l'employeur solidaire Les petits jardins">
+                 aria-label="Proposer une candidature aupr&egrave;s de l'employeur solidaire Les petits jardins">
                <i class="ri-draft-line">
                </i>
                <span>


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/A11Y-Am-lioration-des-title-et-aria-label-7e6d702c19e749b6bd4e18ff09937376

### Pourquoi ?

Amélioration de l'accessibilité. Remplacement de l'attibut `title` par `aria-label` sur balises de liens `<a>` .

De manière générale, il est maintenant recommandé d'utiliser `aria-label` plutot que `title` partout sauf sur les `<iframes>` (et les tooltip, popover pour bs). Donc a mettre quand nécessaire sur les `<button>`, `<input>` (sans label), `<a>`



