### PR TITLE
settings: ajout de l'intégraton sentry HueyIntegration

### DIFF
--- a/config/settings/_sentry.py
+++ b/config/settings/_sentry.py
@@ -3,6 +3,7 @@ import logging
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.httpx import HttpxIntegration
+from sentry_sdk.integrations.huey import HueyIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 from sentry_sdk.integrations.redis import RedisIntegration
 
@@ -37,7 +38,7 @@ sentry_logging = LoggingIntegration(
 def sentry_init(dsn, traces_sample_rate):
     sentry_sdk.init(
         dsn=dsn,
-        integrations=[sentry_logging, DjangoIntegration(), HttpxIntegration(), RedisIntegration()],
+        integrations=[sentry_logging, DjangoIntegration(), HttpxIntegration(), HueyIntegration(), RedisIntegration()],
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.


### PR DESCRIPTION
### Pourquoi ?

Tout chaud de la version [1.15 ](https://github.com/getsentry/sentry-python/releases/tag/1.15.0)
