### PR TITLE
RàZ le champ notified_at pour les sanctions SIAE incomplètes

### DIFF
--- a/itou/siae_evaluations/migrations/0003_reset_evaluated_siae_notified_at.py
+++ b/itou/siae_evaluations/migrations/0003_reset_evaluated_siae_notified_at.py
@@ -1,0 +1,24 @@
+from datetime import date
+
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    EvaluatedSiae = apps.get_model("siae_evaluations", "EvaluatedSiae")
+    evaluated_siaes = EvaluatedSiae.objects.filter(
+        notified_at__isnull=False,
+        evaluation_campaign__evaluated_period_start_at=date(2022, 1, 1),
+        sanctions=None,
+    ).order_by("pk")
+    evaluated_siae_pks = "\n".join(f"{e.pk}\t{e.siae_id}" for e in evaluated_siaes)
+    print(f"\nReset notifications for EvaluatedSiae:\n{evaluated_siae_pks}\n")
+    evaluated_siaes.update(notified_at=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siae_evaluations", "0002_sanctions"),
+    ]
+
+    operations = [migrations.RunPython(forwards, elidable=True)]


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Reprise-de-stock-des-SIAE-pour-lesquelles-la-DDETS-a-utilis-la-V1-du-module-des-sanctions-f171c4dba82d4e19b17741156408eb33**

### Pourquoi ?

Certaines DDETS n’ont pas suivi le nouveau processus de sanctions (car il n’était pas disponible avant le 13 février).

Liste des SIAE mises à jour :

| EvaluatedSiae id | SIAE id |
|------------------|---------|
| 810              | 5217    |
| 889              | 7586    |
| 892              | 6339    |
| 893              | 6355    |
| 918              | 7584    |
| 1019             | 5109    |
| 1020             | 5119    |
| 1025             | 9848    |
| 1026             | 3896    |
| 1027             | 5133    |
| 1049             | 4740    |
| 1051             | 2725    |
| 1052             | 10251   |
| 1055             | 6476    |
| 1058             | 7227    |
| 1062             | 6237    |
| 1069             | 9498    |
| 1074             | 9415    |
| 1075             | 2664    |