### PR TITLE
Controle a posteriori: application des suspensions d'auto-prescription

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -552,3 +552,10 @@ Usage:
     background-repeat: no-repeat;
     background-position: top -120px left;
 }
+
+/* Workaround while waiting for next version
+--------------------------------------------------------------------------- */
+.disabled {
+    color: #B3B4C3 !important;
+    pointer-events: none;
+}

--- a/itou/templates/apply/includes/buttons/new_diagnosis.html
+++ b/itou/templates/apply/includes/buttons/new_diagnosis.html
@@ -1,5 +1,13 @@
 <p>
-    <a href="{% url 'apply:eligibility' job_application_id=job_application %}" class="btn btn-primary btn-block btn-ico">
-        <span>Valider les critères d'éligibilité</span>
-    </a>
+    {% with suspension=job_application.to_siae.get_active_suspension_text_with_dates %}
+        {% if suspension %}
+            <span data-toggle="tooltip" data-placement="top" title="Vous ne pouvez pas valider les critères d'éligibilité suite aux mesures prises dans le cadre du contrôle a posteriori. {{ suspension }}">
+                <button class="btn btn-primary btn-block btn-ico disabled">Valider les critères d'éligibilité</button>
+            </span>
+        {% else %}
+            <a href="{% url 'apply:eligibility' job_application_id=job_application %}" class="btn btn-primary btn-block btn-ico">
+                <span>Valider les critères d'éligibilité</span>
+            </a>
+        {% endif %}
+    {% endwith %}
 </p>

--- a/itou/templates/dashboard/includes/siae_employees_card.html
+++ b/itou/templates/dashboard/includes/siae_employees_card.html
@@ -11,10 +11,19 @@
                 We will have to discuss this matter further with AVE, but it has been
                 decided that it probably did not make much sense initially.
                 {% endcomment %}
-                <li class="card-text mb-3">
-                    <i class="ri-login-box-line ri-lg mr-1"></i>
-                    <a href="{% url 'apply:start' siae_pk=current_siae.pk %}">Déclarer une embauche</a>
-                </li>
+                {% with suspension=current_siae.get_active_suspension_text_with_dates %}
+                    <li class="card-text mb-3">
+                        {% if suspension %}
+                            <span data-toggle="tooltip" data-placement="top" title="Vous ne pouvez pas déclarer d'embauche suite aux mesures prises dans le cadre du contrôle a posteriori. {{ suspension }}">
+                                <i class="ri-login-box-line disabled"></i>
+                                <a href="" class="disabled">Déclarer une embauche</a>
+                            </span>
+                        {% else %}
+                            <i class="ri-login-box-line ri-lg mr-1"></i>
+                            <a href="{% url 'apply:start' siae_pk=current_siae.pk %} ">Déclarer une embauche</a>
+                        {% endif %}
+                    </li>
+                {% endwith %}
 
                 <li class="card-text mb-3">
                     <i class="ri-contacts-book-line ri-lg mr-1"></i>

--- a/itou/utils/models.py
+++ b/itou/utils/models.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.fields import DateRangeField, ranges
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Func
+from django.db.models import Func, Transform
 
 from itou.utils.types import InclusiveDateRange
 
@@ -42,6 +42,12 @@ class InclusiveRangeEndsWith(ranges.RangeEndsWith):
     def as_sql(self, compiler, connection):
         sql, params = super().as_sql(compiler, connection)
         return f"({sql} - interval '1 day')::date", params
+
+
+@InclusiveDateRangeField.register_lookup
+class Upper(Transform):
+    lookup_name = "upper"
+    function = "UPPER"
 
 
 class AbstractSupportRemark(models.Model):

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -474,6 +474,12 @@ def eligibility(request, job_application_id, template_name="apply/process_eligib
     if not job_application.to_siae.is_subject_to_eligibility_rules:
         raise Http404()
 
+    if suspension_explanation := job_application.to_siae.get_active_suspension_text_with_dates():
+        raise PermissionDenied(
+            "Vous ne pouvez pas valider les critères d'éligibilité suite aux mesures prises dans le cadre "
+            "du contrôle a posteriori. " + suspension_explanation
+        )
+
     form_administrative_criteria = AdministrativeCriteriaForm(
         request.user, siae=job_application.to_siae, data=request.POST or None
     )

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -191,8 +191,14 @@ class StartView(ApplyStepBaseView):
 
     def get(self, request, *args, **kwargs):
         # SIAE members can only submit a job application to their SIAE
-        if request.user.is_siae_staff and not self.siae.has_member(request.user):
-            raise PermissionDenied("Vous ne pouvez postuler pour un candidat que dans votre structure.")
+        if request.user.is_siae_staff:
+            if not self.siae.has_member(request.user):
+                raise PermissionDenied("Vous ne pouvez postuler pour un candidat que dans votre structure.")
+            if suspension_explanation := self.siae.get_active_suspension_text_with_dates():
+                raise PermissionDenied(
+                    "Vous ne pouvez pas déclarer d'embauche suite aux mesures prises dans le cadre du contrôle "
+                    "a posteriori. " + suspension_explanation
+                )
 
         # Refuse all applications except those made by an SIAE member
         if self.siae.block_job_applications and not self.siae.has_member(request.user):


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/4-4-Pack-Sanctions-En-tant-que-SIAE-sanctionn-e-je-ne-peux-plus-r-aliser-d-auto-prescription-penda-52b7f76129b84abdaffd3c593751ffcd

### Pourquoi ?

Pour que les sanctions soient appliquées.

### Captures d'écran (optionnel)
![Screenshot from 2023-02-21 17-23-08](https://user-images.githubusercontent.com/1089744/220401819-adf49bb4-2947-498a-9bf7-af1017c84210.png)



![Screenshot from 2023-02-16 16-32-55](https://user-images.githubusercontent.com/1089744/219416553-2e590b90-6948-4aea-95d2-bd956ed2fbb6.png)
