### PR TITLE
Metabase : Ajout de deux nouveaux TB (Auto-prescription et Suivi CAP) aux DDETS / DREETS / DGEFP => MEP en cachant les TB car pas encore prêts

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -47,7 +47,7 @@
                     </li>
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
-                        <a href="{% url 'stats:stats_ddets_follow_diagnosis_control' %}">Suivre le contrôle à posteriori</a>
+                        <a href="{% url 'stats:stats_ddets_follow_siae_evaluation' %}">Suivre le contrôle à posteriori</a>
                         <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
                     </li>
                     <li class="card-text mb-3">
@@ -67,7 +67,7 @@
                     </li>
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
-                        <a href="{% url 'stats:stats_dreets_follow_diagnosis_control' %}">Suivre le contrôle à posteriori</a>
+                        <a href="{% url 'stats:stats_dreets_follow_siae_evaluation' %}">Suivre le contrôle à posteriori</a>
                         <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
                     </li>
                     <li class="card-text mb-3">
@@ -87,7 +87,7 @@
                     </li>
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
-                        <a href="{% url 'stats:stats_dgefp_follow_diagnosis_control' %}">Suivre le contrôle à posteriori</a>
+                        <a href="{% url 'stats:stats_dgefp_follow_siae_evaluation' %}">Suivre le contrôle à posteriori</a>
                         <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
                     </li>
                     <li class="card-text mb-3">
@@ -96,7 +96,7 @@
                     </li>
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
-                        <a href="{% url 'stats:stats_dgefp_diagnosis_control' %}">Voir les données du contrôle a posteriori (version bêta)</a>
+                        <a href="{% url 'stats:stats_dgefp_siae_evaluation' %}">Voir les données du contrôle a posteriori (version bêta)</a>
                     </li>
                 {% endif %}
                 {% if can_view_stats_dihal %}

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -42,6 +42,16 @@
                 {% if can_view_stats_ddets %}
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
+                        <a href="{% url 'stats:stats_ddets_auto_prescription' %}">Focus auto-prescription</a>
+                        <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
+                    </li>
+                    <li class="card-text mb-3">
+                        <i class="ri-line-chart-line ri-lg mr-1"></i>
+                        <a href="{% url 'stats:stats_ddets_follow_diagnosis_control' %}">Suivre le contrôle à posteriori</a>
+                        <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
+                    </li>
+                    <li class="card-text mb-3">
+                        <i class="ri-line-chart-line ri-lg mr-1"></i>
                         <a href="{% url 'stats:stats_ddets_iae' %}">Voir les données IAE de mon département</a>
                     </li>
                     <li class="card-text mb-3">
@@ -52,6 +62,16 @@
                 {% if can_view_stats_dreets %}
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
+                        <a href="{% url 'stats:stats_dreets_auto_prescription' %}">Focus auto-prescription</a>
+                        <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
+                    </li>
+                    <li class="card-text mb-3">
+                        <i class="ri-line-chart-line ri-lg mr-1"></i>
+                        <a href="{% url 'stats:stats_dreets_follow_diagnosis_control' %}">Suivre le contrôle à posteriori</a>
+                        <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
+                    </li>
+                    <li class="card-text mb-3">
+                        <i class="ri-line-chart-line ri-lg mr-1"></i>
                         <a href="{% url 'stats:stats_dreets_iae' %}">Voir les données IAE de ma région</a>
                     </li>
                     <li class="card-text mb-3">
@@ -60,6 +80,16 @@
                     </li>
                 {% endif %}
                 {% if can_view_stats_dgefp %}
+                    <li class="card-text mb-3">
+                        <i class="ri-line-chart-line ri-lg mr-1"></i>
+                        <a href="{% url 'stats:stats_dgefp_auto_prescription' %}">Focus auto-prescription</a>
+                        <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
+                    </li>
+                    <li class="card-text mb-3">
+                        <i class="ri-line-chart-line ri-lg mr-1"></i>
+                        <a href="{% url 'stats:stats_dgefp_follow_diagnosis_control' %}">Suivre le contrôle à posteriori</a>
+                        <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
+                    </li>
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
                         <a href="{% url 'stats:stats_dgefp_iae' %}">Voir les données IAE France entière</a>

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -40,6 +40,8 @@
                     </li>
                 {% endif %}
                 {% if can_view_stats_ddets %}
+                    {% comment %}
+                    <!-- TODO @dejafait uncomment as soon as ready -->
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
                         <a href="{% url 'stats:stats_ddets_auto_prescription' %}">Focus auto-prescription</a>
@@ -50,6 +52,7 @@
                         <a href="{% url 'stats:stats_ddets_follow_siae_evaluation' %}">Suivre le contrôle à posteriori</a>
                         <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
                     </li>
+                    {% endcomment %}
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
                         <a href="{% url 'stats:stats_ddets_iae' %}">Voir les données IAE de mon département</a>
@@ -60,6 +63,8 @@
                     </li>
                 {% endif %}
                 {% if can_view_stats_dreets %}
+                    {% comment %}
+                    <!-- TODO @dejafait uncomment as soon as ready -->
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
                         <a href="{% url 'stats:stats_dreets_auto_prescription' %}">Focus auto-prescription</a>
@@ -70,6 +75,7 @@
                         <a href="{% url 'stats:stats_dreets_follow_siae_evaluation' %}">Suivre le contrôle à posteriori</a>
                         <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
                     </li>
+                    {% endcomment %}
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
                         <a href="{% url 'stats:stats_dreets_iae' %}">Voir les données IAE de ma région</a>
@@ -80,6 +86,8 @@
                     </li>
                 {% endif %}
                 {% if can_view_stats_dgefp %}
+                    {% comment %}
+                    <!-- TODO @dejafait uncomment as soon as ready -->
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
                         <a href="{% url 'stats:stats_dgefp_auto_prescription' %}">Focus auto-prescription</a>
@@ -90,6 +98,7 @@
                         <a href="{% url 'stats:stats_dgefp_follow_siae_evaluation' %}">Suivre le contrôle à posteriori</a>
                         <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
                     </li>
+                    {% endcomment %}
                     <li class="card-text mb-3">
                         <i class="ri-line-chart-line ri-lg mr-1"></i>
                         <a href="{% url 'stats:stats_dgefp_iae' %}">Voir les données IAE France entière</a>

--- a/itou/templates/siae_evaluations/samples_selection.html
+++ b/itou/templates/siae_evaluations/samples_selection.html
@@ -32,7 +32,7 @@
             </p>
             <p class="font-weight-bold">Données du contrôle a posteriori cette campagne</p>
             <p>
-                <a class="btn btn-outline-primary" href="{% url 'stats:stats_ddets_diagnosis_control' %}{% if back_url %}?back_url={{ back_url }}{% endif %}" aria-label="Voir les données">
+                <a class="btn btn-outline-primary" href="{% url 'stats:stats_ddets_siae_evaluation' %}{% if back_url %}?back_url={{ back_url }}{% endif %}" aria-label="Voir les données">
                     Voir les données
                 </a>
             </p>

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -6,7 +6,7 @@
 {% block content %}
     <h1 class="h1-hero-c1">{{ page_title }}</h1>
 
-    {% if show_diagnosis_control_message %}
+    {% if show_siae_evaluation_message %}
         <p>
             Le tableau ci-dessous comprend 100% des auto-prescriptions faites sur la période de cette campagne, vous y avez accès pour prendre connaissance de ces caractéristiques.
         </p>

--- a/itou/templates/stats/stats_test1.html
+++ b/itou/templates/stats/stats_test1.html
@@ -6,7 +6,7 @@
 {% block content %}
     <h1 class="h1-hero-c1">{{ page_title }}</h1>
 
-    {% if show_diagnosis_control_message %}
+    {% if show_siae_evaluation_message %}
         <p>
             Le tableau ci-dessous comprend 100% des auto-prescriptions faites sur la période de cette campagne, vous y avez accès pour prendre connaissance de ces caractéristiques.
         </p>

--- a/itou/templates/stats/stats_test2.html
+++ b/itou/templates/stats/stats_test2.html
@@ -6,7 +6,7 @@
 {% block content %}
     <h1 class="h1-hero-c1">{{ page_title }}</h1>
 
-    {% if show_diagnosis_control_message %}
+    {% if show_siae_evaluation_message %}
         <p>
             Le tableau ci-dessous comprend 100% des auto-prescriptions faites sur la période de cette campagne, vous y avez accès pour prendre connaissance de ces caractéristiques.
         </p>

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -10,33 +10,40 @@ DEPARTMENT_FILTER_KEY = "d%C3%A9partement"
 REGION_FILTER_KEY = "r%C3%A9gion"
 
 METABASE_DASHBOARDS = {
+    #
     # Public stats.
+    #
     "stats_public": {
         "dashboard_id": 119,
     },
+    #
     # Temporary items to easily test and debug ongoing tally popup issues.
+    #
     "stats_test1": {
         "dashboard_id": 119,
     },
     "stats_test2": {
         "dashboard_id": 119,
     },
+    #
     # Employer stats.
+    #
     "stats_siae_etp": {
         "dashboard_id": 128,
-        # Tally form suspended on 2022/09/30, should be restored soon.
-        # "tally_form_id": "nrjbRv",
     },
     "stats_siae_hiring": {
         "dashboard_id": 185,
         "tally_form_id": "waQPkB",
     },
-    # Prescriber stats.
+    #
+    # Prescriber stats - CD.
+    #
     "stats_cd": {
         "dashboard_id": 118,
-        # Tally form suspended on 2022/09/30, should be restored soon.
-        # "tally_form_id": "wb5Nro",
     },
+    #
+    # Prescriber stats - PE.
+    #
     "stats_pe_delay_main": {
         "dashboard_id": 168,
         "tally_form_id": "3lb9XW",
@@ -62,11 +69,17 @@ METABASE_DASHBOARDS = {
         "dashboard_id": 162,
         "tally_form_id": "wobaYV",
     },
+    #
     # Institution stats - DDETS - department level.
+    #
+    "stats_ddets_auto_prescription": {
+        "dashboard_id": 267,
+    },
+    "stats_ddets_follow_diagnosis_control": {
+        "dashboard_id": 265,
+    },
     "stats_ddets_iae": {
         "dashboard_id": 117,
-        # Tally form suspended on 2022/09/30, should be restored soon.
-        # "tally_form_id": "nPdWLb",
     },
     "stats_ddets_diagnosis_control": {
         "dashboard_id": 144,
@@ -75,17 +88,31 @@ METABASE_DASHBOARDS = {
         "dashboard_id": 160,
         "tally_form_id": "mVLBXv",
     },
+    #
     # Institution stats - DREETS - region level.
+    #
+    "stats_dreets_auto_prescription": {
+        "dashboard_id": 267,
+    },
+    "stats_dreets_follow_diagnosis_control": {
+        "dashboard_id": 265,
+    },
     "stats_dreets_iae": {
         "dashboard_id": 117,
-        # Tally form suspended on 2022/09/30, should be restored soon.
-        # "tally_form_id": "nPdWLb",
     },
     "stats_dreets_hiring": {
         "dashboard_id": 160,
         "tally_form_id": "mVLBXv",
     },
+    #
     # Institution stats - DGEFP - nation level.
+    #
+    "stats_dgefp_auto_prescription": {
+        "dashboard_id": 267,
+    },
+    "stats_dgefp_follow_diagnosis_control": {
+        "dashboard_id": 265,
+    },
     "stats_dgefp_iae": {
         "dashboard_id": 117,
     },
@@ -95,6 +122,9 @@ METABASE_DASHBOARDS = {
     "stats_dgefp_af": {
         "dashboard_id": 142,
     },
+    #
+    # Institution stats - DIHAL - nation level.
+    #
     "stats_dihal_state": {
         "dashboard_id": 235,
     },

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -75,13 +75,13 @@ METABASE_DASHBOARDS = {
     "stats_ddets_auto_prescription": {
         "dashboard_id": 267,
     },
-    "stats_ddets_follow_diagnosis_control": {
+    "stats_ddets_follow_siae_evaluation": {
         "dashboard_id": 265,
     },
     "stats_ddets_iae": {
         "dashboard_id": 117,
     },
-    "stats_ddets_diagnosis_control": {
+    "stats_ddets_siae_evaluation": {
         "dashboard_id": 144,
     },
     "stats_ddets_hiring": {
@@ -94,7 +94,7 @@ METABASE_DASHBOARDS = {
     "stats_dreets_auto_prescription": {
         "dashboard_id": 267,
     },
-    "stats_dreets_follow_diagnosis_control": {
+    "stats_dreets_follow_siae_evaluation": {
         "dashboard_id": 265,
     },
     "stats_dreets_iae": {
@@ -110,13 +110,13 @@ METABASE_DASHBOARDS = {
     "stats_dgefp_auto_prescription": {
         "dashboard_id": 267,
     },
-    "stats_dgefp_follow_diagnosis_control": {
+    "stats_dgefp_follow_siae_evaluation": {
         "dashboard_id": 265,
     },
     "stats_dgefp_iae": {
         "dashboard_id": 117,
     },
-    "stats_dgefp_diagnosis_control": {
+    "stats_dgefp_siae_evaluation": {
         "dashboard_id": 144,
     },
     "stats_dgefp_af": {

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -146,7 +146,7 @@ def get_view_name(request):
     return view_name
 
 
-def metabase_embedded_url(request=None, dashboard_id=None, params={}, with_title=False):
+def metabase_embedded_url(request=None, dashboard_id=None, params=None, with_title=False):
     """
     Creates an embed/signed URL for embedded Metabase dashboards:
     * expiration delay of token set at 10 minutes, kept short on purpose due to the fact that during this short time
@@ -154,6 +154,8 @@ def metabase_embedded_url(request=None, dashboard_id=None, params={}, with_title
     * do not display title of the dashboard in the iframe
     * optional parameters typically for locked filters (e.g. allow viewing data of one departement only)
     """
+    if params is None:
+        params = {}
     if dashboard_id is None:
         view_name = get_view_name(request)
         metabase_dashboard = METABASE_DASHBOARDS.get(view_name)

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -25,13 +25,31 @@ urlpatterns = [
     path("pe/state/raw", views.stats_pe_state_raw, name="stats_pe_state_raw"),
     path("pe/tension", views.stats_pe_tension, name="stats_pe_tension"),
     # Institution stats - DDETS - department level.
+    path("ddets/auto_prescription", views.stats_ddets_auto_prescription, name="stats_ddets_auto_prescription"),
+    path(
+        "ddets/follow_diagnosis_control",
+        views.stats_ddets_follow_diagnosis_control,
+        name="stats_ddets_follow_diagnosis_control",
+    ),
     path("ddets/iae", views.stats_ddets_iae, name="stats_ddets_iae"),
     path("ddets/diagnosis_control", views.stats_ddets_diagnosis_control, name="stats_ddets_diagnosis_control"),
     path("ddets/hiring", views.stats_ddets_hiring, name="stats_ddets_hiring"),
     # Institution stats - DREETS - region level.
+    path("dreets/auto_prescription", views.stats_dreets_auto_prescription, name="stats_dreets_auto_prescription"),
+    path(
+        "dreets/follow_diagnosis_control",
+        views.stats_dreets_follow_diagnosis_control,
+        name="stats_dreets_follow_diagnosis_control",
+    ),
     path("dreets/iae", views.stats_dreets_iae, name="stats_dreets_iae"),
     path("dreets/hiring", views.stats_dreets_hiring, name="stats_dreets_hiring"),
     # Institution stats - DGEFP - nation level.
+    path("dgefp/auto_prescription", views.stats_dgefp_auto_prescription, name="stats_dgefp_auto_prescription"),
+    path(
+        "dgefp/follow_diagnosis_control",
+        views.stats_dgefp_follow_diagnosis_control,
+        name="stats_dgefp_follow_diagnosis_control",
+    ),
     path("dgefp/iae", views.stats_dgefp_iae, name="stats_dgefp_iae"),
     path("dgefp/diagnosis_control", views.stats_dgefp_diagnosis_control, name="stats_dgefp_diagnosis_control"),
     path("dgefp/af", views.stats_dgefp_af, name="stats_dgefp_af"),

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -27,31 +27,31 @@ urlpatterns = [
     # Institution stats - DDETS - department level.
     path("ddets/auto_prescription", views.stats_ddets_auto_prescription, name="stats_ddets_auto_prescription"),
     path(
-        "ddets/follow_diagnosis_control",
-        views.stats_ddets_follow_diagnosis_control,
-        name="stats_ddets_follow_diagnosis_control",
+        "ddets/follow_siae_evaluation",
+        views.stats_ddets_follow_siae_evaluation,
+        name="stats_ddets_follow_siae_evaluation",
     ),
     path("ddets/iae", views.stats_ddets_iae, name="stats_ddets_iae"),
-    path("ddets/diagnosis_control", views.stats_ddets_diagnosis_control, name="stats_ddets_diagnosis_control"),
+    path("ddets/siae_evaluation", views.stats_ddets_siae_evaluation, name="stats_ddets_siae_evaluation"),
     path("ddets/hiring", views.stats_ddets_hiring, name="stats_ddets_hiring"),
     # Institution stats - DREETS - region level.
     path("dreets/auto_prescription", views.stats_dreets_auto_prescription, name="stats_dreets_auto_prescription"),
     path(
-        "dreets/follow_diagnosis_control",
-        views.stats_dreets_follow_diagnosis_control,
-        name="stats_dreets_follow_diagnosis_control",
+        "dreets/follow_siae_evaluation",
+        views.stats_dreets_follow_siae_evaluation,
+        name="stats_dreets_follow_siae_evaluation",
     ),
     path("dreets/iae", views.stats_dreets_iae, name="stats_dreets_iae"),
     path("dreets/hiring", views.stats_dreets_hiring, name="stats_dreets_hiring"),
     # Institution stats - DGEFP - nation level.
     path("dgefp/auto_prescription", views.stats_dgefp_auto_prescription, name="stats_dgefp_auto_prescription"),
     path(
-        "dgefp/follow_diagnosis_control",
-        views.stats_dgefp_follow_diagnosis_control,
-        name="stats_dgefp_follow_diagnosis_control",
+        "dgefp/follow_siae_evaluation",
+        views.stats_dgefp_follow_siae_evaluation,
+        name="stats_dgefp_follow_siae_evaluation",
     ),
     path("dgefp/iae", views.stats_dgefp_iae, name="stats_dgefp_iae"),
-    path("dgefp/diagnosis_control", views.stats_dgefp_diagnosis_control, name="stats_dgefp_diagnosis_control"),
+    path("dgefp/siae_evaluation", views.stats_dgefp_siae_evaluation, name="stats_dgefp_siae_evaluation"),
     path("dgefp/af", views.stats_dgefp_af, name="stats_dgefp_af"),
     # Institution stats - DIHAL - nation level.
     path("dihal/state", views.stats_dihal_state, name="stats_dihal_state"),

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -400,7 +400,9 @@ def stats_dreets_hiring(request):
     )
 
 
-def render_stats_dgefp(request, page_title, add_params=True, extra_context={}):
+def render_stats_dgefp(request, page_title, add_params=True, extra_context=None):
+    if extra_context is None:
+        extra_context = {}
     ensure_stats_dgefp_permission(request)
     context = {
         "page_title": page_title,

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -336,9 +336,9 @@ def stats_ddets_auto_prescription(request):
 
 
 @login_required
-def stats_ddets_follow_diagnosis_control(request):
+def stats_ddets_follow_siae_evaluation(request):
     """
-    This dashboard shows data about the diagnosis control ("Contrôle a posteriori") overall progress.
+    This dashboard shows data about siae evaluation ("Contrôle a posteriori") overall progress.
     """
     return render_stats_ddets(request=request, page_title="Suivre le contrôle à posteriori")
 
@@ -350,13 +350,13 @@ def stats_ddets_iae(request):
 
 
 @login_required
-def stats_ddets_diagnosis_control(request):
+def stats_ddets_siae_evaluation(request):
     """
-    This dashboard shows the diagnosis control ("Contrôle a posteriori") raw data.
+    This dashboard shows siae evaluation ("Contrôle a posteriori") raw data.
     """
     extra_context = {
         "back_url": reverse("siae_evaluations_views:samples_selection"),
-        "show_diagnosis_control_message": True,
+        "show_siae_evaluation_message": True,
     }
     return render_stats_ddets(
         request=request, page_title="Données du contrôle a posteriori", extra_context=extra_context
@@ -395,9 +395,9 @@ def stats_dreets_auto_prescription(request):
 
 
 @login_required
-def stats_dreets_follow_diagnosis_control(request):
+def stats_dreets_follow_siae_evaluation(request):
     """
-    This dashboard shows data about the diagnosis control ("Contrôle a posteriori") overall progress.
+    This dashboard shows data about siae evaluation ("Contrôle a posteriori") overall progress.
     """
     return render_stats_dreets(request=request, page_title="Suivre le contrôle à posteriori")
 
@@ -445,9 +445,9 @@ def stats_dgefp_auto_prescription(request):
 
 
 @login_required
-def stats_dgefp_follow_diagnosis_control(request):
+def stats_dgefp_follow_siae_evaluation(request):
     """
-    This dashboard shows data about the diagnosis control ("Contrôle a posteriori") overall progress.
+    This dashboard shows data about siae evaluation ("Contrôle a posteriori") overall progress.
     """
     return render_stats_dgefp(request=request, page_title="Suivre le contrôle à posteriori")
 
@@ -458,14 +458,14 @@ def stats_dgefp_iae(request):
 
 
 @login_required
-def stats_dgefp_diagnosis_control(request):
+def stats_dgefp_siae_evaluation(request):
     """
-    This dashboard shows diagnosis control ("Contrôle a posteriori") raw data.
+    This dashboard shows siae evaluation ("Contrôle a posteriori") raw data.
     """
     return render_stats_dgefp(
         request=request,
         page_title="Données (version bêta) du contrôle a posteriori",
-        extra_context={"show_diagnosis_control_message": True},
+        extra_context={"show_siae_evaluation_message": True},
     )
 
 

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -315,135 +315,131 @@ def stats_pe_tension(request):
     )
 
 
-@login_required
-def stats_ddets_iae(request):
+def render_stats_ddets(request, page_title, extra_context={}):
     """
     DDETS ("Directions départementales de l’emploi, du travail et des solidarités") stats shown to relevant members.
     They can only view data for their own departement.
-    This dashboard shows data about IAE in general.
     """
     department = get_stats_ddets_department(request)
     params = get_params_for_departement(department)
     context = {
-        "page_title": f"Données de mon département : {DEPARTMENTS[department]}",
+        "page_title": page_title,
         "matomo_custom_url_suffix": format_region_and_department_for_matomo(department),
     }
+    context.update(extra_context)
     return render_stats(request=request, context=context, params=params)
+
+
+@login_required
+def stats_ddets_iae(request):
+    department = get_stats_ddets_department(request)
+    return render_stats_ddets(request=request, page_title=f"Données de mon département : {DEPARTMENTS[department]}")
 
 
 @login_required
 def stats_ddets_diagnosis_control(request):
     """
-    DDETS ("Directions départementales de l’emploi, du travail et des solidarités") stats shown to relevant members.
-    They can only view data for their own departement.
-    This dashboard shows data about diagnosis control ("Contrôle a posteriori").
+    This dashboard shows the diagnosis control ("Contrôle a posteriori") raw data.
     """
-    department = get_stats_ddets_department(request)
-    params = get_params_for_departement(department)
-    context = {
-        "page_title": "Données du contrôle a posteriori",
+    extra_context = {
         "back_url": reverse("siae_evaluations_views:samples_selection"),
         "show_diagnosis_control_message": True,
-        "matomo_custom_url_suffix": format_region_and_department_for_matomo(department),
     }
-    return render_stats(request=request, context=context, params=params)
+    return render_stats_ddets(
+        request=request, page_title="Données du contrôle a posteriori", extra_context=extra_context
+    )
 
 
 @login_required
 def stats_ddets_hiring(request):
     """
-    DDETS ("Directions départementales de l’emploi, du travail et des solidarités") stats shown to relevant members.
-    They can only view data for their own departement.
     This dashboard shows data about hiring ("Facilitation de l'embauche").
     """
     department = get_stats_ddets_department(request)
-    params = get_params_for_departement(department)
+    return render_stats_ddets(
+        request=request,
+        page_title=f"Données facilitation de l'embauche de mon département : {DEPARTMENTS[department]}",
+    )
+
+
+def render_stats_dreets(request, page_title):
+    """
+    DREETS ("Directions régionales de l’économie, de l’emploi, du travail et des solidarités") stats shown to
+    relevant members. They can only view data for their own region and can filter by department.
+    """
+    region = get_stats_dreets_region(request)
+    params = get_params_for_region(region)
     context = {
-        "page_title": f"Données facilitation de l'embauche de mon département : {DEPARTMENTS[department]}",
-        "matomo_custom_url_suffix": format_region_and_department_for_matomo(department),
+        "page_title": page_title,
+        "matomo_custom_url_suffix": format_region_for_matomo(region),
     }
     return render_stats(request=request, context=context, params=params)
 
 
 @login_required
 def stats_dreets_iae(request):
-    """
-    DREETS ("Directions régionales de l’économie, de l’emploi, du travail et des solidarités") stats shown to
-    relevant members. They can only view data for their own region and can filter by department.
-    This dashboard shows data about IAE in general.
-    """
     region = get_stats_dreets_region(request)
-    params = get_params_for_region(region)
-    context = {
-        "page_title": f"Données de ma région : {region}",
-        "matomo_custom_url_suffix": format_region_for_matomo(region),
-    }
-    return render_stats(request=request, context=context, params=params)
+    return render_stats_dreets(
+        request=request,
+        page_title=f"Données de ma région : {region}",
+    )
 
 
 @login_required
 def stats_dreets_hiring(request):
     """
-    DREETS ("Directions régionales de l’économie, de l’emploi, du travail et des solidarités") stats shown to
-    relevant members. They can only view data for their own region and can filter by department.
     This dashboard shows data about hiring ("Facilitation de l'embauche").
     """
     region = get_stats_dreets_region(request)
-    params = get_params_for_region(region)
+    return render_stats_dreets(
+        request=request,
+        page_title=f"Données facilitation de l'embauche de ma région : {region}",
+    )
+
+
+def render_stats_dgefp(request, page_title, add_params=True, extra_context={}):
+    """
+    DGEFP ("délégation générale à l'Emploi et à la Formation professionnelle") stats shown to relevant members.
+    They can view nation wide data and filter by region and/or department.
+    """
+    ensure_stats_dgefp_permission(request)
     context = {
-        "page_title": f"Données facilitation de l'embauche de ma région : {region}",
-        "matomo_custom_url_suffix": format_region_for_matomo(region),
+        "page_title": page_title,
     }
-    return render_stats(request=request, context=context, params=params)
+    context.update(extra_context)
+    if add_params:
+        params = get_params_for_whole_country()
+        return render_stats(request=request, context=context, params=params)
+    return render_stats(request=request, context=context)
 
 
 @login_required
 def stats_dgefp_iae(request):
-    """
-    DGEFP ("délégation générale à l'Emploi et à la Formation professionnelle") stats shown to relevant members.
-    They can view all data and filter by region and/or department.
-    This dashboard shows data about IAE in general.
-    """
-    ensure_stats_dgefp_permission(request)
-    params = get_params_for_whole_country()
-    context = {
-        "page_title": "Données des régions",
-    }
-    return render_stats(request=request, context=context, params=params)
+    return render_stats_dgefp(request=request, page_title="Données des régions")
 
 
 @login_required
 def stats_dgefp_diagnosis_control(request):
     """
-    DGEFP ("délégation générale à l'Emploi et à la Formation professionnelle") stats shown to relevant members.
-    They can view all data and filter by region and/or department.
-    This dashboard shows data about diagnosis control ("Contrôle a posteriori").
+    This dashboard shows diagnosis control ("Contrôle a posteriori") raw data.
     """
-    ensure_stats_dgefp_permission(request)
-    params = get_params_for_whole_country()
-    context = {
-        "page_title": "Données (version bêta) du contrôle a posteriori",
-        "show_diagnosis_control_message": True,
-    }
-    return render_stats(request=request, context=context, params=params)
+    return render_stats_dgefp(
+        request=request,
+        page_title="Données (version bêta) du contrôle a posteriori",
+        extra_context={"show_diagnosis_control_message": True},
+    )
 
 
 @login_required
 def stats_dgefp_af(request):
-    """
-    DGEFP ("délégation générale à l'Emploi et à la Formation professionnelle") stats shown to relevant members.
-    They can view all data and filter by region and/or department.
-    This dashboard shows data about financial annexes ("af").
-    """
-    ensure_stats_dgefp_permission(request)
-    context = {
-        "page_title": "Annexes financières actives",
-    }
-    return render_stats(request=request, context=context)
+    return render_stats_dgefp(request=request, page_title="Annexes financières actives", add_params=False)
 
 
 @login_required
 def stats_dihal_state(request):
+    """
+    DIHAL ("Délégation interministérielle à l'hébergement et à l'accès au logement") stats shown to relevant members.
+    """
     current_org = get_current_institution_or_404(request)
     if not request.user.can_view_stats_dihal(current_org=current_org):
         raise PermissionDenied

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -321,7 +321,7 @@ def render_stats_ddets(request, page_title, extra_context={}):
     department = get_stats_ddets_department(request)
     params = get_params_for_departement(department)
     context = {
-        "page_title": page_title,
+        "page_title": f"{page_title} ({DEPARTMENTS[department]})",
         "matomo_custom_url_suffix": format_region_and_department_for_matomo(department),
     }
     context.update(extra_context)
@@ -340,8 +340,7 @@ def stats_ddets_follow_siae_evaluation(request):
 
 @login_required
 def stats_ddets_iae(request):
-    department = get_stats_ddets_department(request)
-    return render_stats_ddets(request=request, page_title=f"Données de mon département : {DEPARTMENTS[department]}")
+    return render_stats_ddets(request=request, page_title="Données IAE de mon département")
 
 
 @login_required
@@ -357,10 +356,9 @@ def stats_ddets_siae_evaluation(request):
 
 @login_required
 def stats_ddets_hiring(request):
-    department = get_stats_ddets_department(request)
     return render_stats_ddets(
         request=request,
-        page_title=f"Données facilitation de l'embauche de mon département : {DEPARTMENTS[department]}",
+        page_title="Données facilitation de l'embauche de mon département",
     )
 
 
@@ -368,7 +366,7 @@ def render_stats_dreets(request, page_title):
     region = get_stats_dreets_region(request)
     params = get_params_for_region(region)
     context = {
-        "page_title": page_title,
+        "page_title": f"{page_title} ({region})",
         "matomo_custom_url_suffix": format_region_for_matomo(region),
     }
     return render_stats(request=request, context=context, params=params)
@@ -386,19 +384,17 @@ def stats_dreets_follow_siae_evaluation(request):
 
 @login_required
 def stats_dreets_iae(request):
-    region = get_stats_dreets_region(request)
     return render_stats_dreets(
         request=request,
-        page_title=f"Données de ma région : {region}",
+        page_title="Données IAE de ma région",
     )
 
 
 @login_required
 def stats_dreets_hiring(request):
-    region = get_stats_dreets_region(request)
     return render_stats_dreets(
         request=request,
-        page_title=f"Données facilitation de l'embauche de ma région : {region}",
+        page_title="Données facilitation de l'embauche de ma région",
     )
 
 

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -100,7 +100,9 @@ def get_params_for_whole_country():
     }
 
 
-def render_stats(request, context, params={}, template_name="stats/stats.html"):
+def render_stats(request, context, params=None, template_name="stats/stats.html"):
+    if params is None:
+        params = {}
     view_name = get_view_name(request)
     metabase_dashboard = METABASE_DASHBOARDS.get(view_name)
     tally_form_id = None
@@ -400,7 +402,7 @@ def stats_dreets_hiring(request):
     )
 
 
-def render_stats_dgefp(request, page_title, add_params=True, extra_context=None):
+def render_stats_dgefp(request, page_title, extra_params=None, extra_context=None):
     if extra_context is None:
         extra_context = {}
     ensure_stats_dgefp_permission(request)
@@ -408,25 +410,28 @@ def render_stats_dgefp(request, page_title, add_params=True, extra_context=None)
         "page_title": page_title,
     }
     context.update(extra_context)
-    if add_params:
-        params = get_params_for_whole_country()
-        return render_stats(request=request, context=context, params=params)
-    return render_stats(request=request, context=context)
+    return render_stats(request=request, context=context, params=extra_params)
 
 
 @login_required
 def stats_dgefp_auto_prescription(request):
-    return render_stats_dgefp(request=request, page_title="Focus auto-prescription")
+    return render_stats_dgefp(
+        request=request, page_title="Focus auto-prescription", extra_params=get_params_for_whole_country()
+    )
 
 
 @login_required
 def stats_dgefp_follow_siae_evaluation(request):
-    return render_stats_dgefp(request=request, page_title="Suivre le contrôle à posteriori")
+    return render_stats_dgefp(
+        request=request, page_title="Suivre le contrôle à posteriori", extra_params=get_params_for_whole_country()
+    )
 
 
 @login_required
 def stats_dgefp_iae(request):
-    return render_stats_dgefp(request=request, page_title="Données des régions")
+    return render_stats_dgefp(
+        request=request, page_title="Données des régions", extra_params=get_params_for_whole_country()
+    )
 
 
 @login_required
@@ -435,12 +440,13 @@ def stats_dgefp_siae_evaluation(request):
         request=request,
         page_title="Données (version bêta) du contrôle a posteriori",
         extra_context={"show_siae_evaluation_message": True},
+        extra_params=get_params_for_whole_country(),
     )
 
 
 @login_required
 def stats_dgefp_af(request):
-    return render_stats_dgefp(request=request, page_title="Annexes financières actives", add_params=False)
+    return render_stats_dgefp(request=request, page_title="Annexes financières actives")
 
 
 @login_required

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -331,6 +331,19 @@ def render_stats_ddets(request, page_title, extra_context={}):
 
 
 @login_required
+def stats_ddets_auto_prescription(request):
+    return render_stats_ddets(request=request, page_title="Focus auto-prescription")
+
+
+@login_required
+def stats_ddets_follow_diagnosis_control(request):
+    """
+    This dashboard shows data about the diagnosis control ("Contrôle a posteriori") overall progress.
+    """
+    return render_stats_ddets(request=request, page_title="Suivre le contrôle à posteriori")
+
+
+@login_required
 def stats_ddets_iae(request):
     department = get_stats_ddets_department(request)
     return render_stats_ddets(request=request, page_title=f"Données de mon département : {DEPARTMENTS[department]}")
@@ -377,6 +390,19 @@ def render_stats_dreets(request, page_title):
 
 
 @login_required
+def stats_dreets_auto_prescription(request):
+    return render_stats_dreets(request=request, page_title="Focus auto-prescription")
+
+
+@login_required
+def stats_dreets_follow_diagnosis_control(request):
+    """
+    This dashboard shows data about the diagnosis control ("Contrôle a posteriori") overall progress.
+    """
+    return render_stats_dreets(request=request, page_title="Suivre le contrôle à posteriori")
+
+
+@login_required
 def stats_dreets_iae(request):
     region = get_stats_dreets_region(request)
     return render_stats_dreets(
@@ -411,6 +437,19 @@ def render_stats_dgefp(request, page_title, add_params=True, extra_context={}):
         params = get_params_for_whole_country()
         return render_stats(request=request, context=context, params=params)
     return render_stats(request=request, context=context)
+
+
+@login_required
+def stats_dgefp_auto_prescription(request):
+    return render_stats_dgefp(request=request, page_title="Focus auto-prescription")
+
+
+@login_required
+def stats_dgefp_follow_diagnosis_control(request):
+    """
+    This dashboard shows data about the diagnosis control ("Contrôle a posteriori") overall progress.
+    """
+    return render_stats_dgefp(request=request, page_title="Suivre le contrôle à posteriori")
 
 
 @login_required

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -316,10 +316,6 @@ def stats_pe_tension(request):
 
 
 def render_stats_ddets(request, page_title, extra_context={}):
-    """
-    DDETS ("Directions départementales de l’emploi, du travail et des solidarités") stats shown to relevant members.
-    They can only view data for their own departement.
-    """
     department = get_stats_ddets_department(request)
     params = get_params_for_departement(department)
     context = {
@@ -337,9 +333,6 @@ def stats_ddets_auto_prescription(request):
 
 @login_required
 def stats_ddets_follow_siae_evaluation(request):
-    """
-    This dashboard shows data about siae evaluation ("Contrôle a posteriori") overall progress.
-    """
     return render_stats_ddets(request=request, page_title="Suivre le contrôle à posteriori")
 
 
@@ -351,9 +344,6 @@ def stats_ddets_iae(request):
 
 @login_required
 def stats_ddets_siae_evaluation(request):
-    """
-    This dashboard shows siae evaluation ("Contrôle a posteriori") raw data.
-    """
     extra_context = {
         "back_url": reverse("siae_evaluations_views:samples_selection"),
         "show_siae_evaluation_message": True,
@@ -365,9 +355,6 @@ def stats_ddets_siae_evaluation(request):
 
 @login_required
 def stats_ddets_hiring(request):
-    """
-    This dashboard shows data about hiring ("Facilitation de l'embauche").
-    """
     department = get_stats_ddets_department(request)
     return render_stats_ddets(
         request=request,
@@ -376,10 +363,6 @@ def stats_ddets_hiring(request):
 
 
 def render_stats_dreets(request, page_title):
-    """
-    DREETS ("Directions régionales de l’économie, de l’emploi, du travail et des solidarités") stats shown to
-    relevant members. They can only view data for their own region and can filter by department.
-    """
     region = get_stats_dreets_region(request)
     params = get_params_for_region(region)
     context = {
@@ -396,9 +379,6 @@ def stats_dreets_auto_prescription(request):
 
 @login_required
 def stats_dreets_follow_siae_evaluation(request):
-    """
-    This dashboard shows data about siae evaluation ("Contrôle a posteriori") overall progress.
-    """
     return render_stats_dreets(request=request, page_title="Suivre le contrôle à posteriori")
 
 
@@ -413,9 +393,6 @@ def stats_dreets_iae(request):
 
 @login_required
 def stats_dreets_hiring(request):
-    """
-    This dashboard shows data about hiring ("Facilitation de l'embauche").
-    """
     region = get_stats_dreets_region(request)
     return render_stats_dreets(
         request=request,
@@ -424,10 +401,6 @@ def stats_dreets_hiring(request):
 
 
 def render_stats_dgefp(request, page_title, add_params=True, extra_context={}):
-    """
-    DGEFP ("délégation générale à l'Emploi et à la Formation professionnelle") stats shown to relevant members.
-    They can view nation wide data and filter by region and/or department.
-    """
     ensure_stats_dgefp_permission(request)
     context = {
         "page_title": page_title,
@@ -446,9 +419,6 @@ def stats_dgefp_auto_prescription(request):
 
 @login_required
 def stats_dgefp_follow_siae_evaluation(request):
-    """
-    This dashboard shows data about siae evaluation ("Contrôle a posteriori") overall progress.
-    """
     return render_stats_dgefp(request=request, page_title="Suivre le contrôle à posteriori")
 
 
@@ -459,9 +429,6 @@ def stats_dgefp_iae(request):
 
 @login_required
 def stats_dgefp_siae_evaluation(request):
-    """
-    This dashboard shows siae evaluation ("Contrôle a posteriori") raw data.
-    """
     return render_stats_dgefp(
         request=request,
         page_title="Données (version bêta) du contrôle a posteriori",
@@ -476,9 +443,6 @@ def stats_dgefp_af(request):
 
 @login_required
 def stats_dihal_state(request):
-    """
-    DIHAL ("Délégation interministérielle à l'hébergement et à l'accès au logement") stats shown to relevant members.
-    """
     current_org = get_current_institution_or_404(request)
     if not request.user.can_view_stats_dihal(current_org=current_org):
         raise PermissionDenied


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Cr-er-le-TB-Focus-Autoprescription-et-contr-le-a-posteriori-dans-le-TB-priv-DDETS-DREETS-et-DGEFP-1770e22dc62b4d50946b26443c53780c**

### Pourquoi ?

On veut créer plus de valeur pour les DDETS, DREETS et DGEFP.

### Comment ?

- Ca commence à faire beaucoup de vues stats DDETS, DREETS et DGEFP au total donc j'ai factorisé un max de code dans les vues, dans de nouvelles méthodes `render_stats_ddets/dreets/dgefp`. Le refacto est dans un commit séparé.

### Notes

- Pas de test supplémentaire, j'avoue que comme `user.can_view_stats_ddets/dreets/dgefp` est déjà testé je vais pas plus loin avec ces nouveaux TB.

### Screenshots et wording

Ce que voit une DDETS.

![image](https://user-images.githubusercontent.com/10533583/219430028-97d72870-6496-4381-9ef2-6f236e2c2715.png)

Une DREETS.

![image](https://user-images.githubusercontent.com/10533583/219430097-98fd38d4-eafc-49bf-af84-0540372e4261.png)

Et la DGEFP.

![image](https://user-images.githubusercontent.com/10533583/219430305-6b65fbc8-2f60-4313-8cba-91a808f47c84.png)



