### PR TITLE
Retrait d’un garde invalide dans User.save()

### DIFF
--- a/itou/users/migrations/0013_user_has_kind.py
+++ b/itou/users/migrations/0013_user_has_kind.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0012_user_lack_of_nir_reason_and_more"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="user",
+            constraint=models.CheckConstraint(
+                check=models.Q(
+                    ("kind", "itou_staff"),
+                    ("kind", "job_seeker"),
+                    ("kind", "prescriber"),
+                    ("kind", "siae_staff"),
+                    ("kind", "labor_inspector"),
+                    _connector="OR",
+                ),
+                name="has_kind",
+                violation_error_message="Le type d’utilisateur est incorrect.",
+            ),
+        ),
+    ]

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -327,6 +327,17 @@ class User(AbstractUser, AddressMixin):
                     "Un utilisateur ayant un NIR ne peut avoir un motif justifiant l'absence de son NIR."
                 ),
             ),
+            models.CheckConstraint(
+                name="has_kind",
+                violation_error_message="Le type d’utilisateur est incorrect.",
+                check=(
+                    models.Q(kind=UserKind.ITOU_STAFF)
+                    | models.Q(kind=UserKind.JOB_SEEKER)
+                    | models.Q(kind=UserKind.PRESCRIBER)
+                    | models.Q(kind=UserKind.SIAE_STAFF)
+                    | models.Q(kind=UserKind.LABOR_INSPECTOR)
+                ),
+            ),
         ]
 
     def __str__(self):
@@ -362,11 +373,9 @@ class User(AbstractUser, AddressMixin):
         elif self.kind in UserKind:
             # Any other user kind isn't staff
             self.is_staff = False
-        else:  # self.kind == "" : handle django admin_client pytest fixture
-            if self.is_staff:
-                self.kind = UserKind.ITOU_STAFF
-            else:
-                ValidationError("User is missing kind")
+        elif self.is_staff:
+            # self.kind == "" : handle django admin_client pytest fixture
+            self.kind = UserKind.ITOU_STAFF
 
         super().save(*args, **kwargs)
 

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -1268,3 +1268,13 @@ def test_staff_user():
     with transaction.atomic():
         with pytest.raises(IntegrityError):
             User.objects.update(is_staff=False)
+
+
+def test_user_invalid_kind():
+    # Avoid crashing the database connection because of the IntegrityError
+    with transaction.atomic():
+        with pytest.raises(
+            IntegrityError,
+            match='new row for relation "users_user" violates check constraint "has_kind"',
+        ):
+            UserFactory(kind="")


### PR DESCRIPTION
### Pourquoi ?

L’exception doit être `raise` pour être utile, la construire seulement ne nous sert pas.
Aussi, le champ est validé par une `CheckContraint`.