### PR TITLE
Simplifier la recherche des fiches salarié : Ajout du filtre par nom du candidat

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -107,6 +107,11 @@
     z-index: 4051 !important;
 }
 
+.select2-selection__choice__remove {
+    float: right;
+    margin-left: 2px;
+}
+
 .c-aside-filters .select2.select2-container.select2-container--default {
     width: 100% !important;
 }

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -6,16 +6,20 @@
 
 {% block title %}Fiches salarié ASP - {{ current_siae.display_name }} {{ block.super }}{% endblock %}
 
+{% block extra_head %}{{ filters_form.media.css }}{% endblock %}
+
 {% block script %}
     {{ block.super }}
+    <!-- Needed to use Select2MultipleWidget. -->
+    {{ filters_form.media.js }}
     <script nonce="{{ CSP_NONCE }}">
-        $("#status-filter-form-group :input").change(function() {
+        $("#status-filter-form :input").change(function () {
             $("#status-filter-form").submit();
         });
         $("#order-form-group :input").click(function(event) {
-            // Fill the hidden order input of the form
-            $("#id_order").val(event.target.value);
-            $("#status-filter-form").submit();
+            let input = $("#id_order")
+            input.val(event.target.value); // Fill the hidden order input of the form
+            input.change(); // Fire a change event to notify handlers
         });
     </script>
 {% endblock %}
@@ -29,18 +33,19 @@
     <div class="mt-3">
         <div class="row">
 
-            <div class="col-sm-3">
-                <div class="card-deck">
-                    <div class="card">
+            <div class="col-12 col-md-4 mt-2">
+                <form method="get" class="form" id="status-filter-form">
+                    <div class="card c-card h-100 w-100 c-card--emploi">
                         <div class="card-header">
-                            <b>Filtrer les fiches</b>
+                            <h3>Filtrer les fiches</h3>
                         </div>
                         <div class="card-body">
-                            <form method="get" class="form" id="status-filter-form">
-                                <p class="text-muted">
-                                    <b>Par statut</b>
-                                </p>
-                                <div class="container form-group m-0" id="status-filter-form-group">
+                            {# Status filter #}
+                            <div class="pt-3 w-100 border-bottom">
+                                <span class="h5 mb-1">Par statut</span>
+                            </div>
+                            <div class="p-1">
+                                <div class="container form-group m-0">
                                     {% for status, badge in form.status|zip:badges %}
                                         <div class="row">
                                             <div class="col-10 p-0">{{ status }}</div>
@@ -52,15 +57,19 @@
                                         </div>
                                     {% endfor %}
                                 </div>
-                                {# Filled via jQuery #}
-                                {{ form.order.as_hidden }}
-                            </form>
+                            </div>
+                            {# Job seeker filter #}
+                            <div class="pt-3 w-100 border-bottom">
+                                <span class="h5 mb-1">Par candidat</span>
+                            </div>
+                            <div class="p-1">{% bootstrap_field filters_form.job_seekers %}</div>
+                            {# Filled via jQuery #}
+                            {{ form.order.as_hidden }}
                         </div>
                     </div>
-                </div>
+                </form>
             </div>
-
-            <div class="col-sm-9">
+            <div class="col-12 col-md-8 mt-2">
                 <div class="container rounded bg-gray-400 p-3 mb-3">
                     <div class="row">
                         <div class="col-sm-10">
@@ -179,9 +188,9 @@
                 </div>
 
                 {% if not navigation_pages %}
-                    <div class="text-muted text-center">
+                    <div class="text-muted text-center mt-5">
                         <i class="ri-forbid-line mr-1"></i>
-                        <span>Aucune fiche salarié avec le statut selectionné ...</span>
+                        <span>Aucune fiche salarié avec le statut sélectionné ...</span>
                     </div>
                 {% endif %}
 

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.core.validators import MinLengthValidator, RegexValidator
 from django.urls import reverse_lazy
 from django.utils import timezone
+from django_select2.forms import Select2MultipleWidget
 
 from itou.asp.exceptions import CommuneUnknownInPeriodError, UnknownCommuneError
 from itou.asp.models import Commune, RSAAllocation
@@ -46,6 +47,23 @@ class SelectEmployeeRecordStatusForm(forms.Form):
         initial=EmployeeRecordOrder.HIRING_START_AT_DESC,
         required=False,
     )
+
+
+class EmployeeRecordFilterForm(forms.Form):
+
+    job_seekers = forms.MultipleChoiceField(
+        required=False,
+        label="Nom du candidat",
+        widget=Select2MultipleWidget,
+    )
+
+    def __init__(self, job_seekers, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["job_seekers"].choices = sorted(
+            [(user.id, user.get_full_name().title()) for user in job_seekers if user.get_full_name()],
+            key=lambda u: u[1],
+        )
 
 
 class NewEmployeeRecordStep1Form(forms.ModelForm):

--- a/itou/www/employee_record_views/tests/test_reactivate.py
+++ b/itou/www/employee_record_views/tests/test_reactivate.py
@@ -5,6 +5,7 @@ from itou.employee_record.enums import Status
 from itou.employee_record.factories import EmployeeRecordWithProfileFactory
 from itou.job_applications.factories import JobApplicationWithCompleteJobSeekerProfileFactory
 from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
+from itou.utils.templatetags import format_filters
 from itou.utils.test import TestCase
 
 
@@ -36,10 +37,10 @@ class ReactivateEmployeeRecordsTest(TestCase):
         self.employee_record.refresh_from_db()
         assert self.employee_record.status == Status.NEW
 
-        job_seeker_name = self.employee_record.job_seeker.get_full_name().title()
+        approval_number_formatted = format_filters.format_approval_number(self.employee_record.approval_number)
 
         response = self.client.get(f"{self.next_url}?status=NEW")
-        self.assertContains(response, job_seeker_name)
+        self.assertContains(response, approval_number_formatted)
 
         response = self.client.get(f"{self.next_url}?status=DISABLED")
-        self.assertNotContains(response, job_seeker_name)
+        self.assertNotContains(response, approval_number_formatted)


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/2-2-Simplifier-la-recherche-des-fiches-salari-En-tant-que-SIAE-je-veux-filtrer-les-fiches-salari-2d839498402946ac805d3d3f9ec26263

### Pourquoi ?

Faciliter la recherche d’une fiche salarié.
A noter que les badges (à droite des statuts) ne sont pas impactés par le filtre, l'idée est que l'on indique toujours le nombre total.

### Captures d'écran

![image](https://user-images.githubusercontent.com/20045330/219329527-de513e54-3f9e-4127-962c-e788c8a99f34.png)

