### PR TITLE
[Stats] Fix du popup Tally

### DIFF
--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -137,8 +137,12 @@
                         "animation": "wave"
                     },
                     "open": {
-                        "trigger": "exit"
-                    }
+                        "trigger": "time",
+                        "ms": 5000
+                    },
+                    "autoClose": 3000,
+                    "doNotShowAfterSubmit": true,
+                    "showOnce": true
                 }
             };
         </script>


### PR DESCRIPTION
### Pourquoi ?

Avant ce fix, le popup était infermable.

Voir fil slack https://itou-inclusion.slack.com/archives/CT7986ULC/p1676455510844709

### Notes

Je n'ai pas eu le temps de tester en local dev, mais il n'y a rien à perdre vu l'état actuel et l'urgence.