### PR TITLE
Candidature: bouton désactivé & tooltip pour expliquer qu'on ne peut pas modifier les informations personnelles

### DIFF
--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -62,14 +62,16 @@
         </li>
     {% endif %}
 </ul>
-{% if job_application.has_editable_job_seeker %}
-    <p>
-        <a href="{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
-           class="btn btn-outline-primary{% if with_matomo_event %} matomo-event{% endif %}"
-           {% if with_matomo_event %}data-matomo-category="salaries" data-matomo-action="clic" data-matomo-option="modfifier-les-informations-personnelles"{% endif %}>
-            Modifier les informations personnelles
-        </a>
-    </p>
-{% else %}
-    <p>Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations.</p>
-{% endif %}
+<p>
+    <a href="{% if job_application.has_editable_job_seeker %}{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}{% endif %}"
+       class="btn btn-outline-primary{% if with_matomo_event %} matomo-event{% endif %}{% if not job_application.has_editable_job_seeker %} disabled{% endif %}"
+       {% if with_matomo_event %}data-matomo-category="salaries" data-matomo-action="clic" data-matomo-option="modfifier-les-informations-personnelles"{% endif %}>
+        Modifier les informations personnelles
+    </a>
+    {% if not job_application.has_editable_job_seeker %}
+        <i class="ri-information-line ri-xl text-info ml-1"
+           data-toggle="tooltip"
+           data-placement="top"
+           title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+    {% endif %}
+</p>

--- a/itou/www/approvals_views/tests/test_detail.py
+++ b/itou/www/approvals_views/tests/test_detail.py
@@ -115,18 +115,20 @@ class TestApprovalDetailView:
         siae_member = job_application.to_siae.members.first()
         client.force_login(siae_member)
 
-        user_info_allowed = "Modifier les informations personnelles"
+        user_info_edit_url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk}
+        )
         user_info_not_allowed = "Vous ne pouvez pas modifier ses informations"
 
         url = reverse("approvals:detail", kwargs={"pk": approval.pk})
         assert not job_application.has_editable_job_seeker
         response = client.get(url)
-        assertNotContains(response, user_info_allowed)
+        assertNotContains(response, user_info_edit_url)
         assertContains(response, user_info_not_allowed)
 
         job_application.job_seeker.created_by = PrescriberFactory()
         job_application.job_seeker.save()
         assert job_application.has_editable_job_seeker
         response = client.get(url)
-        assertContains(response, user_info_allowed)
+        assertContains(response, user_info_edit_url)
         assertNotContains(response, user_info_not_allowed)


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/En-tant-que-professionnel-je-veux-comprendre-que-je-n-ai-pas-la-possibilit-de-modifier-les-informat-24359ec8005b47a29bb4c5e503c0bddb?pvs=4

### Pourquoi ?

Pour que l'utilisateur comprenne mieux qu'il ne peut pas modifier les informations personnelles.

### Captures d'écran (optionnel)

![Screenshot from 2023-02-17 11-02-09](https://user-images.githubusercontent.com/1089744/219614432-168c2d0e-8595-4dd5-8eb6-3005859f7768.png)


