### PR TITLE
Pré-remplir l'email sur inclusion connect pour un utilisateur voulant activer un compte qui l'est déjà

### DIFF
--- a/itou/templates/account/activate_inclusion_connect_account.html
+++ b/itou/templates/account/activate_inclusion_connect_account.html
@@ -36,7 +36,7 @@
                                                 <br>
                                                 {{ existing_ic_account }}
                                             </p>
-                                            <a href="{{ inclusion_connect_url }}"
+                                            <a href="{{ existing_ic_account_url }}"
                                                class="btn btn-link matomo-event"
                                                data-matomo-category="inscription {{ account_type_display_name }}"
                                                data-matomo-action="clic"

--- a/itou/www/login/tests.py
+++ b/itou/www/login/tests.py
@@ -223,6 +223,7 @@ def test_prescriber_account_activation_view_already_exists(client):
     response = client.post(url, data={"email": user.email}, follow=True)
     assertRedirects(response, f"{url}?{urlencode({'existing_ic_account': user.email})}")
     assertContains(response, "Vous avez déjà un compte Inclusion Connect associé à l'adresse")
+    assertContains(response, f"user_email={quote(user.email)}")
 
 
 def test_siae_staff_account_activation_view(client):
@@ -239,3 +240,4 @@ def test_siae_staff_account_activation_view_already_exists(client):
     response = client.post(url, data={"email": user.email}, follow=True)
     assertRedirects(response, f"{url}?{urlencode({'existing_ic_account': user.email})}")
     assertContains(response, "Vous avez déjà un compte Inclusion Connect associé à l'adresse")
+    assertContains(response, f"user_email={quote(user.email)}")

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -111,10 +111,15 @@ class AccountMigrationBaseView(FormView):
         params = self._get_inclusion_connect_base_params()
         existing_ic_account = self.request.GET.get("existing_ic_account")
         inclusion_connect_url = f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
+        existing_ic_account_url = None
+        if existing_ic_account:
+            params["user_email"] = existing_ic_account
+            existing_ic_account_url = f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}"
         extra_context = {
             "activate_account_url": reverse(self.url_name),
             "inclusion_connect_url": inclusion_connect_url,
             "existing_ic_account": existing_ic_account,
+            "existing_ic_account_url": existing_ic_account_url,
         }
         return context | extra_context
 


### PR DESCRIPTION
Carte Notion : https://www.notion.so/plateforme-inclusion/Bugfix-Activation-compte-Inclusion-Connect-0d0825c2103b4216a5bdfacde1e976fd

### Pourquoi ?

Faire gagner du temps à l’utilisateur.
