### PR TITLE
[Stats] Tentative de résolution d'un souci technique avec le popup Tally sur les vues stats

### DIFF
--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -125,6 +125,17 @@
         </div>
     </section>
 
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+
+    <script nonce="{{ CSP_NONCE }}">
+        document.getElementById("stats-iframe").addEventListener("load", function(){
+            iFrameResize({}, this)
+        });
+    </script>
+
     {% if tally_form_id %}
         <script async src="https://tally.so/widgets/embed.js"></script>
 
@@ -147,13 +158,5 @@
             };
         </script>
     {% endif %}
-{% endblock %}
-
-{% block script %}
-    {{ block.super }}
-    <script nonce="{{ CSP_NONCE }}">
-        document.getElementById("stats-iframe").addEventListener("load", function(){
-            iFrameResize({}, this)
-        });
-    </script>
+ 
 {% endblock %}


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/C0412CTV63D/p1676909525575239**

### Comment

En chargeant le js tally dans le bon ordre en le déplacant dans le `{% block script %}`.
