### PR TITLE
Notifier les SIAE dont le contrôle vient d’être forcé positif

### DIFF
--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -94,6 +94,15 @@ class SIAEEmailFactory:
         body = "siae_evaluations/email/to_siae_reviewed_body.txt"
         return get_email_message(self.recipients, context, subject, body)
 
+    def force_accepted(self):
+        context = {
+            "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
+            "siae": self.evaluated_siae.siae,
+        }
+        subject = "siae_evaluations/email/to_siae_force_accepted_subject.txt"
+        body = "siae_evaluations/email/to_siae_force_accepted_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
     def notify_before_adversarial_stage(self):
         job_app_list_url = reverse(
             "siae_evaluations_views:siae_job_applications_list",

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -257,7 +257,7 @@ class EvaluationCampaign(models.Model):
                 evaluated_siae.reviewed_at = now
                 evaluated_siae.final_reviewed_at = now
                 accept_by_default.append(evaluated_siae)
-                # TODO: Notify SIAE of their accepted evaluation with an email.
+                emails.append(SIAEEmailFactory(evaluated_siae).force_accepted())
         if siaes_to_notify:
             siaes_to_notify.sort(key=lambda evaluated_siae: evaluated_siae.siae.name)
             summary_email = CampaignEmailFactory(self).forced_to_adversarial_stage(siaes_to_notify)

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -473,7 +473,7 @@ class EvaluationCampaignManagerTest(TestCase):
         assert evaluated_siae_refused.reviewed_at == refused_ts
         assert evaluated_siae_refused.final_reviewed_at is None
 
-        [siae_no_response_email, siae_no_docs_email, institution_email] = sorted(
+        [siae_no_response_email, siae_no_docs_email, siae_force_accepted, institution_email] = sorted(
             mail.outbox, key=lambda mail: mail.subject
         )
         assert (
@@ -522,6 +522,25 @@ class EvaluationCampaignManagerTest(TestCase):
             "“Justifier mes auto-prescriptions”.\n"
             f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_no_docs.pk}/\n\n"
             "En cas de besoin, vous pouvez consulter ce mode d’emploi.\n\n"
+            "Cordialement,\n\n"
+            "---\n"
+            "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
+            "merci de ne pas en tenir compte [DEV]\n"
+            "Les emplois de l'inclusion\n"
+            "http://127.0.0.1:8000"
+        )
+
+        assert (
+            siae_force_accepted.subject == f"Résultat du contrôle - EI Prim’vert ID-{evaluated_siae_submitted.siae_id}"
+        )
+        assert siae_force_accepted.body == (
+            "Bonjour,\n\n"
+            "La campagne de contrôle a posteriori sur les embauches réalisées en auto-prescription entre "
+            "le 02 Octobre 2022 et le 02 Décembre 2022 entre en phase contradictoire.\n\n"
+            "La DDETS 1 n’a pas étudié la conformité des justificatifs que vous avez transmis dans le délai "
+            "imparti. Par conséquent, vos auto-prescriptions sont considérées comme conformes.\n\n"
+            "Cette campagne de contrôle est terminée pour votre SIAE EI Prim’vert "
+            f"ID-{evaluated_siae_submitted.siae_id}.\n\n"
             "Cordialement,\n\n"
             "---\n"
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "

--- a/itou/templates/siae_evaluations/email/to_siae_force_accepted_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_force_accepted_body.txt
@@ -1,0 +1,12 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+La campagne de contrôle a posteriori sur les embauches réalisées en auto-prescription entre le {{ evaluation_campaign.evaluated_period_start_at|date:"d E Y" }} et le {{ evaluation_campaign.evaluated_period_end_at|date:"d E Y" }} entre en phase contradictoire.
+
+La {{ evaluation_campaign.institution.name }} n’a pas étudié la conformité des justificatifs que vous avez transmis dans le délai imparti. Par conséquent, vos auto-prescriptions sont considérées comme conformes.
+
+Cette campagne de contrôle est terminée pour votre SIAE {{ siae.kind }} {{ siae.name }} ID-{{siae.id}}.
+
+Cordialement,
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/to_siae_force_accepted_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_force_accepted_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+Résultat du contrôle - {{ siae.kind }} {{ siae.name }} ID-{{siae.id}}
+{% endblock %}


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/En-tant-que-SIAE-qui-a-soumis-ses-justificatifs-en-phase-2-mais-qui-n-ont-pas-t-contr-l-s-temps--a0c3feddc60046aeb1807fe8a3fff1d5**

### Pourquoi ?

Les informer.