### PR TITLE
Spécifier le type d’utilisateur à la création dans l’admin

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -11,7 +11,7 @@ from itou.institutions.models import InstitutionMembership
 from itou.prescribers.models import PrescriberMembership
 from itou.siaes.models import SiaeMembership
 from itou.users import models
-from itou.users.admin_forms import UserAdminForm
+from itou.users.admin_forms import ItouUserCreationForm, UserAdminForm
 from itou.utils.admin import PkSupportRemarkInline
 
 
@@ -127,6 +127,7 @@ class CreatedByProxyFilter(admin.SimpleListFilter):
 @admin.register(models.User)
 class ItouUserAdmin(UserAdmin):
 
+    add_form = ItouUserCreationForm
     form = UserAdminForm
     inlines = [
         SiaeMembershipInline,
@@ -203,6 +204,16 @@ class ItouUserAdmin(UserAdmin):
     # Add last_checked_at in "Important dates" section, alongside last_login & date_joined
     assert "last_login" in fieldsets[-2][1]["fields"]
     fieldsets[-2][1]["fields"] += ("last_checked_at",)
+
+    add_fieldsets = UserAdmin.add_fieldsets + (
+        (
+            "Type d’utilisateur",
+            {
+                "classes": ["wide"],
+                "fields": ["kind"],
+            },
+        ),
+    )
 
     def has_verified_email(self, obj):
         """

--- a/itou/users/admin_forms.py
+++ b/itou/users/admin_forms.py
@@ -1,10 +1,16 @@
 from django.contrib.admin import widgets
-from django.contrib.auth.forms import UserChangeForm
+from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 from django.core.exceptions import ValidationError
 
 from itou.users.enums import UserKind
 from itou.users.models import User
 from itou.utils.apis.exceptions import AddressLookupError
+
+
+class ItouUserCreationForm(UserCreationForm):
+    class Meta(UserCreationForm.Meta):
+        model = User
+        fields = UserCreationForm.Meta.fields + ("kind",)
 
 
 class UserAdminForm(UserChangeForm):

--- a/itou/users/tests/test_admin_views.py
+++ b/itou/users/tests/test_admin_views.py
@@ -7,6 +7,31 @@ from itou.users.factories import ItouStaffFactory, JobSeekerFactory
 from itou.users.models import IdentityProvider, User
 
 
+def test_add_user(client):
+    admin_user = ItouStaffFactory(is_superuser=True)
+    client.force_login(admin_user)
+    response = client.post(
+        reverse("admin:users_user_add"),
+        {
+            "username": "foo",
+            "password1": "hunter2",
+            "password2": "hunter2",
+            "kind": UserKind.JOB_SEEKER,
+            "siaemembership_set-INITIAL_FORMS": "0",
+            "siaemembership_set-TOTAL_FORMS": "0",
+            "prescribermembership_set-INITIAL_FORMS": "0",
+            "prescribermembership_set-TOTAL_FORMS": "0",
+            "institutionmembership_set-INITIAL_FORMS": "0",
+            "institutionmembership_set-TOTAL_FORMS": "0",
+            "utils-pksupportremark-content_type-object_id-INITIAL_FORMS": "0",
+            "utils-pksupportremark-content_type-object_id-TOTAL_FORMS": "0",
+        },
+    )
+    user = User.objects.get(username="foo")
+    assertRedirects(response, reverse("admin:users_user_change", kwargs={"object_id": user.pk}))
+    assert user.kind == UserKind.JOB_SEEKER
+
+
 def test_no_email_sent(client):
     user = JobSeekerFactory(identity_provider=IdentityProvider.INCLUSION_CONNECT)
 


### PR DESCRIPTION
### Pourquoi ?

Le type d’utilisateur est central a itou et doit être spécifié. Une `CheckConstraint` a été ajoutée avec 58c68c9899f358c9de8163a3362d1ae4c24735da pour vérifier ce point. La création d’utilisateurs via l’admin Django ne respectait pas cette contrainte.