### PR TITLE
Envoyer un rapport des EvaluatedSiae acceptées par défaut aux DDETS

### DIFF
--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -29,10 +29,13 @@ class CampaignEmailFactory:
         body = "siae_evaluations/email/to_institution_selected_siae_body.txt"
         return get_email_message(self.recipients, context, subject, body)
 
-    def forced_to_adversarial_stage(self, evaluated_siaes):
-        context = {"evaluated_siaes": evaluated_siaes}
-        subject = "siae_evaluations/email/to_institution_siaes_forced_to_adversarial_stage_subject.txt"
-        body = "siae_evaluations/email/to_institution_siaes_forced_to_adversarial_stage_body.txt"
+    def transition_to_adversarial_stage(self, siaes_forced_to_adversarial_stage, siaes_accepted_by_default):
+        context = {
+            "siaes_forced_to_adversarial_stage": siaes_forced_to_adversarial_stage,
+            "siaes_accepted_by_default": siaes_accepted_by_default,
+        }
+        subject = "siae_evaluations/email/to_institution_siaes_transition_to_adversarial_stage_subject.txt"
+        body = "siae_evaluations/email/to_institution_siaes_transition_to_adversarial_stage_body.txt"
         return get_email_message(self.recipients, context, subject, body)
 
     def close(self):

--- a/itou/templates/siae_evaluations/email/to_institution_siaes_forced_to_adversarial_stage_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_siaes_forced_to_adversarial_stage_subject.txt
@@ -1,4 +1,0 @@
-{% extends "layout/base_email_text_subject.txt" %}
-{% block subject %}
-[Contrôle a posteriori] Liste des SIAE n’ayant pas transmis les justificatifs de leurs auto-prescriptions
-{% endblock %}

--- a/itou/templates/siae_evaluations/email/to_institution_siaes_transition_to_adversarial_stage_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_siaes_transition_to_adversarial_stage_body.txt
@@ -2,15 +2,29 @@
 {% block body %}
 Bonjour,
 
+{% if siaes_forced_to_adversarial_stage %}
 Vous trouverez ci-dessous la liste des SIAE qui n’ont transmis aucun justificatif dans le cadre du contrôle a posteriori :
 
-{% for evaluated_siae in evaluated_siaes %}
+{% for evaluated_siae in siaes_forced_to_adversarial_stage %}
 - {{ evaluated_siae.siae.kind }} {{ evaluated_siae.siae.name }} ID-{{ evaluated_siae.siae_id }}
 {% endfor %}
 
 Ces structures n’ayant pas transmis les justificatifs dans le délai des 6 semaines passent automatiquement en phase contradictoire et disposent à nouveau de 6 semaines pour se manifester.
 
 N’hésitez pas à les contacter afin de comprendre les éventuelles difficultés rencontrées pour transmettre les justificatifs.
+{% endif %}
+{% if siaes_accepted_by_default and siaes_forced_to_adversarial_stage %}
 
+---
+
+{% endif %}
+{% if siaes_accepted_by_default %}
+Les structures suivantes avaient transmis leurs justificatifs mais n’ont pas eu de retour de la DDETS, leur contrôle est considéré positif :
+
+{% for evaluated_siae in siaes_accepted_by_default %}
+- {{ evaluated_siae.siae.kind }} {{ evaluated_siae.siae.name }} ID-{{ evaluated_siae.siae_id }}
+{% endfor %}
+
+{% endif %}
 Cordialement,
 {% endblock %}

--- a/itou/templates/siae_evaluations/email/to_institution_siaes_transition_to_adversarial_stage_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_siaes_transition_to_adversarial_stage_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+[Contrôle a posteriori] Passage en phase contradictoire
+{% endblock %}


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/En-tant-que-SIAE-qui-a-soumis-ses-justificatifs-en-phase-2-mais-qui-n-ont-pas-t-contr-l-s-temps--a0c3feddc60046aeb1807fe8a3fff1d5**

### Pourquoi ?

Informer les DDETS de ce comportement du système, et leur donner plus de détail sur le passage en phase contradictoire.