### PR TITLE
Candidature: réusinage lien avec matomo-event

### DIFF
--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -64,19 +64,11 @@
 </ul>
 {% if job_application.has_editable_job_seeker %}
     <p>
-        {% if with_matomo_event %}
-            <a href="{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
-               class="btn btn-outline-primary matomo-event"
-               data-matomo-category="salaries"
-               data-matomo-action="clic"
-               data-matomo-option="modfifier-les-informations-personnelles">
-                Modifier les informations personnelles
-            </a>
-        {% else %}
-            <a href="{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-outline-primary">
-                Modifier les informations personnelles
-            </a>
-        {% endif %}
+        <a href="{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}"
+           class="btn btn-outline-primary{% if with_matomo_event %} matomo-event{% endif %}"
+           {% if with_matomo_event %}data-matomo-category="salaries" data-matomo-action="clic" data-matomo-option="modfifier-les-informations-personnelles"{% endif %}>
+            Modifier les informations personnelles
+        </a>
     </p>
 {% else %}
     <p>Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations.</p>


### PR DESCRIPTION
### Pourquoi ?

Simplifier le code et ne pas répéter plusieurs fois le même lien, texte, etc

On garde la typo modfifier-les-informations-personnelles pour ne pas fausser les stats matomo