### PR TITLE
Ne plus considérer les super-utilisateurs comme des membres des organisations

### DIFF
--- a/itou/common_apps/organizations/models.py
+++ b/itou/common_apps/organizations/models.py
@@ -14,8 +14,6 @@ class OrganizationQuerySet(models.QuerySet):
     """
 
     def member_required(self, user):
-        if user.is_superuser:
-            return self
         return self.filter(members=user, members__is_active=True)
 
     def prefetch_active_memberships(self):

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -94,8 +94,6 @@ class JobApplicationWorkflow(xwf_models.Workflow):
 
 class JobApplicationQuerySet(models.QuerySet):
     def siae_member_required(self, user):
-        if user.is_superuser:
-            return self
         return self.filter(to_siae__members=user, to_siae__members__is_active=True)
 
     def pending(self):


### PR DESCRIPTION
### Pourquoi ?

Cela complexifie le code qui doit alors gérer différents types d'utilisateur.

Si un super-utilisateur veut avoir accès il peut soit rajouter un des comptes de support (assistanceemployeur@inclusion.beta.gouv.fr, etc) à l'organisation, soit utiliser la fonctionnalité de hijack.

