### PR TITLE
Mise à jour du template de PR pour penser à ajouter le label no-changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 **Carte Notion : **
 
+Pensez à mettre le label "no-changelog" si nécessaire.
+
 ### Pourquoi ?
 
 Indiquer le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements.


### PR DESCRIPTION
### Pourquoi ?

Pour ne pas se faire taper sur les doigts par supportix
