### PR TITLE
fix: suppression du gras sur l'adresse d'une SIAE

### DIFF
--- a/itou/templates/siaes/includes/_card_siae.html
+++ b/itou/templates/siaes/includes/_card_siae.html
@@ -20,7 +20,7 @@
                 <small class="text-muted">({{ siae.name|title }})</small>
             {% endif %}
         </h3>
-        <p class="font-weight-bold mb-2 text-muted">{{ siae.address_on_one_line }}</p>
+        <p class="mb-2 text-muted">{{ siae.address_on_one_line }}</p>
         <p class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center mb-0">
             <span class="align-self-start">
                 <span class="badge badge-sm badge-pill badge-primary">à {{ siae.distance|floatformat:"-1"|default:"12" }} km</span>


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=77ca3159cc404d9d97afcd10fe7efdf4&pm=c

### Pourquoi ?

Haromniser l'UI sur la carte des SIAE en enlevant le gras dans l'adresse.


