### PR TITLE
Correction de balises matomo dans le parcours d'activation de compte Inclusion Connect

### DIFF
--- a/itou/templates/account/activate_inclusion_connect_account.html
+++ b/itou/templates/account/activate_inclusion_connect_account.html
@@ -38,7 +38,7 @@
                                             </p>
                                             <a href="{{ existing_ic_account_url }}"
                                                class="btn btn-link matomo-event"
-                                               data-matomo-category="connexion {{ account_type_display_name }}"
+                                               data-matomo-category="connexion {{ matomo_account_type }}"
                                                data-matomo-action="clic"
                                                data-matomo-option="se-connecter-avec-inclusion-connect">Se connecter</a>
                                         </strong>
@@ -55,7 +55,7 @@
                             </fieldset>
                             <button type="submit"
                                     class="btn btn-block btn-primary matomo-event"
-                                    data-matomo-category="activation {{ account_type_display_name }}"
+                                    data-matomo-category="activation {{ matomo_account_type }}"
                                     data-matomo-action="clic"
                                     data-matomo-option="activer-son-compte-inclusion-connect">
                                 Valider
@@ -66,7 +66,7 @@
                             <h2 class="h5">Vous avez déjà un compte Inclusion Connect ?</h2>
                             <a href="{{ inclusion_connect_url }}"
                                class="btn btn-link matomo-event"
-                               data-matomo-category="connexion {{ account_type_display_name }}"
+                               data-matomo-category="connexion {{ matomo_account_type }}"
                                data-matomo-action="clic"
                                data-matomo-option="se-connecter-avec-inclusion-connect">Se connecter</a>
                         </div>

--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -67,7 +67,7 @@
                                 <div class="text-center">
                                     <a href="{{ inclusion_connect_url }}"
                                        class="btn-inclusion-connect matomo-event"
-                                       data-matomo-category="connexion {{ account_type_display_name }}"
+                                       data-matomo-category="connexion {{ matomo_account_type }}"
                                        data-matomo-action="clic"
                                        data-matomo-option="se-connecter-avec-inclusion-connect">
                                         <img src="{% static 'img/inclusion_connect/logo-inclusion-connect-one-line.svg' %}" alt="Se connecter avec Inclusion Connect" height="14">

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -208,7 +208,7 @@
                                         <div class="col-12 col-md-auto mt-2">
                                             <a href="{{ ic_activate_url }}"
                                                class="btn btn-primary btn-block matomo-event"
-                                               data-matomo-category="activation {{ account_type_display_name }}"
+                                               data-matomo-category="activation {{ matomo_custom_variables.account_type }}"
                                                data-matomo-action="clic"
                                                data-matomo-option="activer-son-compte-inclusion-connect-bandeau">Activer Inclusion Connect</a>
                                         </div>

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -142,9 +142,10 @@ def get_context_institution(user, institution_pk):
 
 
 def user_to_account_type(user):
+    account_type = user.kind
     if user.is_job_seeker:
         return {
-            "account_type": "job_seeker",
+            "account_type": account_type,
             "account_sub_type": (
                 "job_seeker_with_peconnect"
                 if user.identity_provider == IdentityProvider.PE_CONNECT
@@ -153,22 +154,22 @@ def user_to_account_type(user):
         }
     elif user.is_siae_staff:
         return {
-            "account_type": "employer",
+            "account_type": account_type,
             "account_sub_type": "employer_not_admin",
         }
     elif user.is_prescriber:
         return {
-            "account_type": "prescriber",
+            "account_type": account_type,
             "account_sub_type": "prescriber_without_org",
         }
     elif user.is_labor_inspector:
         return {
-            "account_type": "labor_inspector",
+            "account_type": account_type,
             "account_sub_type": "inspector_not_admin",
         }
 
     # especially usual in tests.
     return {
-        "account_type": "unknown",
+        "account_type": account_type,
         "account_sub_type": "unknown",
     }

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -104,7 +104,7 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                 "matomo_custom_variables": {
                     "account_id": user.pk,
                     "is_authenticated": "yes",
-                    "account_type": "employer",
+                    "account_type": "siae_staff",
                     "account_sub_type": "employer_admin",
                     "account_current_siae_id": siae.pk,
                     "account_siae_ids": str(siae.pk),
@@ -136,7 +136,7 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                 "matomo_custom_variables": {
                     "account_id": user.pk,
                     "is_authenticated": "yes",
-                    "account_type": "employer",
+                    "account_type": "siae_staff",
                     "account_sub_type": "employer_not_admin",
                     "account_current_siae_id": siae2.pk,
                     "account_siae_ids": f"{siae1.pk};{siae2.pk}",

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -46,6 +46,7 @@ class PrescriberLoginView(ItouLoginView):
         context = super().get_context_data(**kwargs)
         extra_context = {
             "account_type_display_name": "prescripteur",
+            "matomo_account_type": UserKind.PRESCRIBER,
             "login_url": reverse("login:prescriber"),
             "signup_url": reverse("signup:prescriber_check_already_exists"),
             "signup_allowed": True,
@@ -62,6 +63,7 @@ class SiaeStaffLoginView(ItouLoginView):
         context = super().get_context_data(**kwargs)
         extra_context = {
             "account_type_display_name": "employeur solidaire",
+            "matomo_account_type": UserKind.SIAE_STAFF,
             "login_url": reverse("login:siae_staff"),
             "signup_url": reverse("signup:siae_select"),
             "signup_allowed": True,
@@ -120,6 +122,7 @@ class AccountMigrationBaseView(FormView):
             "inclusion_connect_url": inclusion_connect_url,
             "existing_ic_account": existing_ic_account,
             "existing_ic_account_url": existing_ic_account_url,
+            "matomo_account_type": self.user_kind,
         }
         return context | extra_context
 


### PR DESCRIPTION
** Carte notion : **  En créer une ? ou rattacher à la carte précédente ?

TODO:
- [ ] brancher sur le matomo de preprod.

### Pourquoi ?

Sinon, le tracking est incomplet

### Comment ?
Commentaire du commit (en anglais) : We could rely on UserKind labels, using user.get_kind_display() when available, but tht means :
- changing "employeur" to "employeur solidaire" in SIAE_STAFF label
- any change in labels would change data in matomo (which does not seems a good idea)

Je serai d'avis de ne pas utiliser le label de UserKind pour éviter des erreurs bêtes dans le futur.
