### PR TITLE
metabase : CAP : creation d'une table avec le détail des critères d'eligibilité par campagne

### DIFF
--- a/itou/metabase/sql/038_suivi_cap_criteres.sql
+++ b/itou/metabase/sql/038_suivi_cap_criteres.sql
@@ -1,0 +1,16 @@
+select
+    "criteres"."nom" as "nom_critère",
+    "criteres"."id" as "id_critère",
+    "criteres"."niveau" as "niveau_critère",
+    -- REFUSED et REFUSED_2 correspondent au même état (?) - à confirmer par Zo
+    case when "cap_criteres"."état" = 'REFUSED_2' then 'REFUSED' else "cap_criteres"."état" end as état,
+    "camp"."nom" as "nom_campagne",
+    "structs"."nom_département" as "nom_département",
+    "structs"."région" as "nom_région"
+from
+    "cap_critères_iae" cap_criteres
+    left join "critères_iae" criteres on cap_criteres."id_critère_iae" = criteres.id
+    left join "cap_candidatures" candidatures on cap_criteres.id_cap_candidature = candidatures.id
+    left join "cap_structures" cap_structs on candidatures.id_cap_structure = cap_structs.id
+    left join "structures" structs on cap_structs.id_structure = structs.id
+    left join "cap_campagnes" camp on cap_structs.id_cap_campagne = camp.id;


### PR DESCRIPTION
**Carte Notion : ** : https://www.notion.so/plateforme-inclusion/Suivi-du-contr-le-posteriori-Prise-en-compte-de-retours-362f52edf1d5453f9540f54753248397?pvs=4


### Pourquoi ?

Permettre d'afficher les statistiques détaillées des critères d'éligibilité dans le cadre du suivi du contrôle a posteriori.
