### PR TITLE
feat: ajout d'un tooltip d'explication pour le refus `prevent_objectives`

### DIFF
--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -20,7 +20,18 @@
                 <ul class="list-unstyled">
                     {% for radio in form.refusal_reason %}
                         <li>
-                            <label for="{{ radio.id_for_label }}">{{ radio.tag }} {{ radio.choice_label }}</label>
+                            <label for="{{ radio.id_for_label }}">
+                                {{ radio.tag }}
+                                {% if radio.data.value == RefusalReason.PREVENT_OBJECTIVES %}
+                                    {{ radio.choice_label }}&nbsp;<i class="ri-question-fill ri-xl text-button ml-1"
+   data-toggle="tooltip"
+   data-placement="top"
+   data-trigger="click focus"
+   title="L'embauche empêche l'atteinte des engagements contractuels avec les parties prenantes à la convention de financement mise en place par l'État."></i>
+                                {% else %}
+                                    {{ radio.choice_label }}
+                                {% endif %}
+                            </label>
                         </li>
                     {% endfor %}
                 </ul>

--- a/itou/utils/enums_context_processors.py
+++ b/itou/utils/enums_context_processors.py
@@ -1,5 +1,5 @@
 import itou.approvals.enums as approvals_enums
-import itou.job_applications.enums as job_aplication_enums
+import itou.job_applications.enums as job_applications_enums
 
 
 def expose_enums(*args):
@@ -10,6 +10,7 @@ def expose_enums(*args):
 
     return {
         "ApprovalOrigin": approvals_enums.Origin,
-        "JobApplicationOrigin": job_aplication_enums.Origin,
-        "SenderKind": job_aplication_enums.SenderKind,
+        "JobApplicationOrigin": job_applications_enums.Origin,
+        "SenderKind": job_applications_enums.SenderKind,
+        "RefusalReason": job_applications_enums.RefusalReason,
     }


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=e45fd06a4cb9432295c2199510c2e8e8&pm=c

### Pourquoi ?

Expliquer le motif  de refus “ L’embauche empêche la réalisation des objectifs du dialogue de gestion”
