### PR TITLE
fix: comparaison des emails inclusion connect en casse insensible

### DIFF
--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -251,7 +251,7 @@ def inclusion_connect_callback(request):  # pylint: disable=too-many-return-stat
     ic_user_data = USER_DATA_CLASSES[user_kind].from_user_info(user_data)
     ic_session_email = ic_session.get("user_email")
 
-    if ic_session_email and ic_session_email != ic_user_data.email:
+    if ic_session_email.lower() and ic_session_email.lower() != ic_user_data.email.lower():
         if ic_session["channel"] == InclusionConnectChannel.INVITATION:
             error = (
                 "L’adresse e-mail que vous avez utilisée pour vous connecter avec Inclusion Connect "

--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -251,7 +251,7 @@ def inclusion_connect_callback(request):  # pylint: disable=too-many-return-stat
     ic_user_data = USER_DATA_CLASSES[user_kind].from_user_info(user_data)
     ic_session_email = ic_session.get("user_email")
 
-    if ic_session_email.lower() and ic_session_email.lower() != ic_user_data.email.lower():
+    if ic_session_email and ic_session_email.lower() != ic_user_data.email.lower():
         if ic_session["channel"] == InclusionConnectChannel.INVITATION:
             error = (
                 "L’adresse e-mail que vous avez utilisée pour vous connecter avec Inclusion Connect "

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -107,6 +107,7 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
             self,
             KIND_SIAE_STAFF,
             assert_redirects=False,
+            # Using the same email with a different case should not fail
             user_email=invitation.email.upper(),
             channel="invitation",
             previous_url=previous_url,

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -101,7 +101,7 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
         url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
         self.assertContains(response, url + '"')
 
-        total_users_before = User.objects.count()
+        assert User.objects.filter(email=invitation.email).first() is None
 
         response = mock_oauth_dance(
             self,
@@ -117,9 +117,6 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
         # Check user is redirected to the welcoming tour
         last_url, _ = response.redirect_chain[-1]
         assert last_url == reverse("welcoming_tour:index")
-
-        total_users_after = User.objects.count()
-        assert (total_users_before + 1) == total_users_after
 
         user = User.objects.get(email=invitation.email)
         self.assert_accepted_invitation(response, invitation, user)

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -84,7 +84,7 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
 
     @respx.mock
     def test_accept_invitation_signup_bad_email_case(self):
-        invitation = SentSiaeStaffInvitationFactory(email=OIDC_USERINFO["email"])
+        invitation = SentSiaeStaffInvitationFactory(email=OIDC_USERINFO["email"].upper())
         response = self.client.get(invitation.acceptance_link, follow=True)
         self.assertContains(response, "logo-inclusion-connect-one-line.svg")
 
@@ -108,7 +108,7 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
             KIND_SIAE_STAFF,
             assert_redirects=False,
             # Using the same email with a different case should not fail
-            user_email=invitation.email.upper(),
+            user_email=invitation.email.lower(),
             channel="invitation",
             previous_url=previous_url,
             next_url=next_url,

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -2,7 +2,6 @@ from urllib.parse import urlencode
 
 import respx
 from django.conf import settings
-from django.contrib.messages import get_messages
 from django.core import mail
 from django.shortcuts import reverse
 from django.utils.html import escape
@@ -73,7 +72,7 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
         )
         response = self.client.get(response.url, follow=True)
         # Check user is redirected to the welcoming tour
-        last_url, _status_code = response.redirect_chain[-1]
+        last_url, _ = response.redirect_chain[-1]
         assert last_url == reverse("welcoming_tour:index")
 
         total_users_after = User.objects.count()
@@ -82,18 +81,9 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
         user = User.objects.get(email=invitation.email)
         self.assert_accepted_invitation(response, invitation, user)
 
-    def test_accept_invitation_logged_in_user(self):
-        # A logged in user should log out before accepting an invitation.
-        logged_in_user = SiaeStaffFactory()
-        self.client.force_login(logged_in_user)
-        # Invitation for another user
-        invitation = SentSiaeStaffInvitationFactory(email="loutre@example.com")
-        response = self.client.get(invitation.acceptance_link, follow=True)
-        self.assertRedirects(response, reverse("account_logout"))
-
     @respx.mock
-    def test_accept_invitation_signup_wrong_email(self):
-        invitation = SentSiaeStaffInvitationFactory()
+    def test_accept_invitation_signup_bad_email_case(self):
+        invitation = SentSiaeStaffInvitationFactory(email=OIDC_USERINFO["email"])
         response = self.client.get(invitation.acceptance_link, follow=True)
         self.assertContains(response, "logo-inclusion-connect-one-line.svg")
 
@@ -110,25 +100,36 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
         url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
         self.assertContains(response, url + '"')
 
-        url = reverse("dashboard:index")
+        total_users_before = User.objects.count()
+
         response = mock_oauth_dance(
             self,
             KIND_SIAE_STAFF,
             assert_redirects=False,
-            # the login hint is different from OIDC_USERINFO["email"] which is used to create the IC account
-            user_email=invitation.email,
+            user_email=invitation.email.upper(),
             channel="invitation",
             previous_url=previous_url,
             next_url=next_url,
         )
-        # Follow the redirection.
         response = self.client.get(response.url, follow=True)
-        # Signup should have failed : as the email used in IC isn't the one from the invitation
-        messages = list(get_messages(response.wsgi_request))
-        assert len(messages) == 1
-        assert "ne correspond pas à l’adresse e-mail de l’invitation" in messages[0].message
-        assert response.wsgi_request.get_full_path() == previous_url
-        assert not User.objects.filter(email=invitation.email).exists()
+        # Check user is redirected to the welcoming tour
+        last_url, _ = response.redirect_chain[-1]
+        assert last_url == reverse("welcoming_tour:index")
+
+        total_users_after = User.objects.count()
+        assert (total_users_before + 1) == total_users_after
+
+        user = User.objects.get(email=invitation.email)
+        self.assert_accepted_invitation(response, invitation, user)
+
+    def test_accept_invitation_logged_in_user(self):
+        # A logged in user should log out before accepting an invitation.
+        logged_in_user = SiaeStaffFactory()
+        self.client.force_login(logged_in_user)
+        # Invitation for another user
+        invitation = SentSiaeStaffInvitationFactory(email="loutre@example.com")
+        response = self.client.get(invitation.acceptance_link, follow=True)
+        self.assertRedirects(response, reverse("account_logout"))
 
     def test_expired_invitation(self):
         invitation = ExpiredSiaeStaffInvitationFactory()


### PR DESCRIPTION
### Carte Notion

https://www.notion.so/plateforme-inclusion/BUG-une-diff-rence-de-casse-au-niveau-de-l-e-mail-impacte-les-invitations-2d2ed331e8b04529a738a7ba40f47797?pvs=4

### Pourquoi ?

Une différence de casse au niveau de l’e-mail impacte les invitations

