### PR TITLE
Rendre obligatoire la civilité du candidat lors de la création

### DIFF
--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -50,7 +50,8 @@
             {% bootstrap_field form.email form_group_class="form-group mb-1" %}
             <div class="text-right small font-italic mb-0">{% include "signup/includes/no_email_link.html" %}</div>
 
-            {% bootstrap_field form.last_name form_group_class="form-group mt-1" %}
+            {% bootstrap_field form.title form_group_class="form-group mt-1" %}
+            {% bootstrap_field form.last_name %}
             {% bootstrap_field form.first_name %}
             {% bootstrap_field form.password1 %}
             {% bootstrap_field form.password2 %}

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -16,9 +16,6 @@ from itou.utils.password_validation import CnilCompositionPasswordValidator
 from itou.utils.validators import validate_code_safir, validate_nir, validate_siren, validate_siret
 
 
-BLANK_CHOICE = (("", "---------"),)
-
-
 def _get_organization_data_from_api(siret):
     # Fetch name and address from API entreprise.
     establishment, error = api_entreprise.etablissement_get_or_error(siret)

--- a/itou/www/signup/tests/test_job_seeker.py
+++ b/itou/www/signup/tests/test_job_seeker.py
@@ -90,12 +90,15 @@ class JobSeekerSignupTest(TestCase):
         url = reverse("signup:job_seeker")
         response = self.client.get(url)
         assert response.status_code == 200
+        # Since provided NIR starts with a 1, suggest Monsieur title
+        assert response.context["form"]["title"].initial == "M"
 
         address_line_1 = "Test adresse"
         address_line_2 = "Test adresse complémentaire"
         post_code = self.city.post_codes[0]
 
         post_data = {
+            "title": "M",
             "first_name": "John",
             "last_name": "Doe",
             "email": "john.doe+1@siae.com",
@@ -114,6 +117,7 @@ class JobSeekerSignupTest(TestCase):
 
         job_seeker = User.objects.get(email=post_data["email"])
         assert nir == job_seeker.nir
+        assert job_seeker.title == "M"
 
     def test_job_seeker_temporary_nir(self):
         """
@@ -140,12 +144,15 @@ class JobSeekerSignupTest(TestCase):
         url = reverse("signup:job_seeker")
         response = self.client.get(url)
         assert response.status_code == 200
+        # Since no NIR was provided (or it was a temporary number), suggest nothing
+        assert response.context["form"]["title"].initial is None
 
         address_line_1 = "Test adresse"
         address_line_2 = "Test adresse complémentaire"
         post_code = self.city.post_codes[0]
 
         post_data = {
+            "title": "M",
             "first_name": "John",
             "last_name": "Doe",
             "email": "john.doe+2@siae.com",
@@ -164,6 +171,7 @@ class JobSeekerSignupTest(TestCase):
 
         job_seeker = User.objects.get(email=post_data["email"])
         assert job_seeker.nir == ""
+        assert job_seeker.title == "M"
 
     def test_job_seeker_signup(self):
         """Job-seeker signup."""
@@ -182,6 +190,7 @@ class JobSeekerSignupTest(TestCase):
         post_code = self.city.post_codes[0]
 
         post_data = {
+            "title": "M",
             "first_name": "John",
             "last_name": "Doe",
             "email": "john.doe+3@siae.com",
@@ -203,6 +212,7 @@ class JobSeekerSignupTest(TestCase):
         # `username` should be a valid UUID, see `User.generate_unique_username()`.
         assert user.username == uuid.UUID(user.username, version=4).hex
         assert user.kind == UserKind.JOB_SEEKER
+        assert user.title == "M"
 
         # Check `EmailAddress` state.
         assert user.emailaddress_set.count() == 1
@@ -240,6 +250,7 @@ class JobSeekerSignupTest(TestCase):
         response = self.client.post(
             url,
             {
+                "title": "MME",
                 "first_name": "Alice",
                 "last_name": "Evil",
                 "email": "alice@evil.com",

--- a/itou/www/welcoming_tour/tests.py
+++ b/itou/www/welcoming_tour/tests.py
@@ -42,6 +42,7 @@ class WelcomingTourTest(InclusionConnectBaseTestCase):
         # Second signup step: job seeker credentials.
         url = reverse("signup:job_seeker")
         post_data = {
+            "title": job_seeker.title,
             "first_name": job_seeker.first_name,
             "last_name": job_seeker.last_name,
             "email": job_seeker.email,
@@ -49,6 +50,7 @@ class WelcomingTourTest(InclusionConnectBaseTestCase):
             "password2": DEFAULT_PASSWORD,
         }
         response = self.client.post(url, data=post_data)
+        assert response.status_code == 302
         response = self.verify_email(response.wsgi_request, email=job_seeker.email)
 
         # User should be redirected to the welcoming tour as he just signed up
@@ -126,6 +128,7 @@ class WelcomingTourExceptions(TestCase):
         # Second signup step: job seeker credentials.
         url = f"{reverse('signup:job_seeker')}?next={next_to}"
         post_data = {
+            "title": job_seeker.title,
             "first_name": job_seeker.first_name,
             "last_name": job_seeker.last_name,
             "email": job_seeker.email,
@@ -133,6 +136,7 @@ class WelcomingTourExceptions(TestCase):
             "password2": DEFAULT_PASSWORD,
         }
         response = self.client.post(url, data=post_data)
+        assert response.status_code == 302
         response = self.verify_email(job_seeker.email, response.wsgi_request)
 
         # The user should not be redirected to the welcoming path if he wanted to perform


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Rendre-obligatoire-la-civilit-du-candidat-En-tant-que-candidat-je-renseigne-ma-civilit-lorsque-j-7cc3fd16482d47c3ad9e8e01d9c18b78?pvs=4

### Pourquoi ?

Actuellement il manque la civilité du candidat lors de l'inscription en autonomie

### Captures d'écran (optionnel)

![Screenshot 2023-03-01 at 16-34-14 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/222186950-ec450a5a-12ba-4384-b431-0af937834fdf.png)


