### PR TITLE
Autoriser la création d'antenne pour les GEIQ

### DIFF
--- a/itou/templates/siaes/create_siae.html
+++ b/itou/templates/siaes/create_siae.html
@@ -16,7 +16,7 @@
                     ayant déjà un ou plusieurs membres, <b>demandez à l’un de ces membres de vous inviter depuis son tableau de bord</b>
                 </li>
                 <li>
-                    connue dans l'extranet IAE 2.0 de l'ASP mais n’ayant pas encore de membre : <a href="{% url 'signup:siae_select' %}">utilisez ce formulaire</a>
+                    connue des services des emplois de l'inclusion mais n’ayant pas encore de membre : <a href="{% url 'signup:siae_select' %}">utilisez ce formulaire</a>
                 </li>
             </ul>
             <p class="mb-0">Dans les autres cas, complétez le formulaire ci-dessous.</p>

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -614,7 +614,10 @@ class ModelTest(TestCase):
             with self.subTest(kind=kind):
                 siae = SiaeFactory(kind=kind, with_membership=True, membership__is_admin=True)
                 user = siae.members.get()
-                assert user.can_create_siae_antenna(siae) == siae.should_have_convention
+                if kind == SiaeKind.GEIQ:
+                    assert user.can_create_siae_antenna(siae)
+                else:
+                    assert user.can_create_siae_antenna(siae) == siae.should_have_convention
 
     def test_can_view_stats_siae_hiring(self):
         # An employer can only view hiring stats of their own SIAE.


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/R-activer-l-option-Cr-er-Rejoindre-une-structure-pour-les-GEIQ-0f189147861045ff817717783256ad65

### Pourquoi ?

Demande de la FFGEIQ (acceptée par la DGEFP)


