### PR TITLE
Nettoyage journalier des sessions expirées

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -10,6 +10,7 @@
 
   "1 0 * * * $ROOT/clevercloud/run_management_command.sh update_prescriber_organization_with_api_entreprise --verbosity 2",
   "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
+  "0 3 * * * $ROOT/clevercloud/run_management_command.sh clearsessions",
   "0 12 * * * $ROOT/clevercloud/run_management_command.sh evaluation_campaign_notify",
   "30 20 * * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --daily",
 

--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,19 +1,25 @@
 [
   "*/5 * * * * $ROOT/clevercloud/status-probes.sh",
+  "*/5 * * * * $ROOT/clevercloud/run_management_command.sh scan_s3_files",
+
+  "0 * * * * $ROOT/clevercloud/send_approvals_to_pe.sh",
+  "5 * * * * $ROOT/clevercloud/run_management_command.sh sync_pec_offers --wet-run",
+  "5 * * * * $ROOT/clevercloud/run_management_command.sh update_siaes_job_app_score",
+
+  "0 */6 * * * $ROOT/clevercloud/run_management_command.sh sync_s3_files",
+
   "1 0 * * * $ROOT/clevercloud/run_management_command.sh update_prescriber_organization_with_api_entreprise --verbosity 2",
+  "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
+  "0 12 * * * $ROOT/clevercloud/run_management_command.sh evaluation_campaign_notify",
+  "30 20 * * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --daily",
+
   "25 8-18/2 * * 1-5 $ROOT/clevercloud/download_employee_records.sh",
   "55 8-18/2 * * 1-5 $ROOT/clevercloud/upload_employee_records.sh",
   "5 23 * * 1-5 $ROOT/clevercloud/archive_employee_records.sh",
-  "0 * * * * $ROOT/clevercloud/send_approvals_to_pe.sh",
-  "0 12 * * * $ROOT/clevercloud/run_management_command.sh evaluation_campaign_notify",
-  "0 */6 * * * $ROOT/clevercloud/run_management_command.sh sync_s3_files",
-  "*/5 * * * * $ROOT/clevercloud/run_management_command.sh scan_s3_files",
-  "5 * * * * $ROOT/clevercloud/run_management_command.sh update_siaes_job_app_score",
-  "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
-  "0 0 15 * * $ROOT/clevercloud/run_management_command.sh sync_romes_and_appellations --wet-run",
+
   "0 6 * * 1 $ROOT/clevercloud/crons/populate_metabase_matomo.sh",
-  "30 20 * * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --daily",
+
+  "0 0 1 * * $ROOT/clevercloud/run_management_command.sh sync_cities --wet-run",
   "0 0 2 * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --monthly",
-  "5 * * * * $ROOT/clevercloud/run_management_command.sh sync_pec_offers --wet-run",
-  "0 0 1 * * $ROOT/clevercloud/run_management_command.sh sync_cities --wet-run"
+  "0 0 15 * * $ROOT/clevercloud/run_management_command.sh sync_romes_and_appellations --wet-run"
 ]


### PR DESCRIPTION
### Pourquoi ?

Avant :
```sql
SELECT count("session_key") AS total_session, count("session_key") FILTER ( WHERE expire_date < NOW() ) AS expired_session FROM django_session;
 total_session | expired_session 
---------------+-----------------
       3471368 |         3383043

SELECT pg_size_pretty(pg_total_relation_size('django_session')) AS django_session_size, pg_size_pretty(pg_database_size('itou')) AS database_size;
 django_session_size | database_size 
---------------------+---------------
 1925 MB             | 6938 MB
```

Après un `VACUUM FULL django_session;` :
```sql
SELECT count("session_key") AS total_session, count("session_key") FILTER ( WHERE expire_date < NOW() ) AS expired_session FROM django_session;
 total_session | expired_session 
---------------+-----------------
         86869 |             131

SELECT pg_size_pretty(pg_total_relation_size('django_session')) AS django_session_size, pg_size_pretty(pg_database_size('itou')) AS database_size;
 django_session_size | database_size 
---------------------+---------------
 62 MB               | 5075 MB

```
