### PR TITLE
Essai/proposition: déplacer les outils de linting dans pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     rev: 5.0.4
     hooks:
     - id: flake8
+      stages: [manual]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,19 @@
 repos:
-  - repo: local
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
     hooks:
-      - id: black
-        name: Black
-        entry: black
-        types: [python]
-        language: system
-      - id: flake8
-        name: Flake8
-        entry: flake8
-        types: [python]
-        language: system
-      - id: isort
-        name: isort
-        entry: isort
-        types: [python]
-        language: system
-      - id: djlint
-        name: djlint
-        entry: djlint --reformat
-        types: [html]
-        language: system
+    - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+    - id: flake8
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+    - id: isort
+  - repo: https://github.com/Riverside-Healthcare/djLint
+    rev: v1.19.13
+    hooks:
+    - id: djlint-django
+      args: ["--reformat"]
+      exclude: duet_date_picker_widget.html

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ cdsitepackages:
 	docker exec -ti -w /usr/local/lib/$(PYTHON_VERSION)/site-packages itou_django /bin/bash
 
 quality: $(VIRTUAL_ENV)
-	pre-commit run --all-files --show-diff-on-failure
+	pre-commit run --all-files --show-diff-on-failure --hook-stage=manual
 
 fix: $(VIRTUAL_ENV)
 	pre-commit run --all-files --show-diff-on-failure

--- a/Makefile
+++ b/Makefile
@@ -51,15 +51,10 @@ cdsitepackages:
 	docker exec -ti -w /usr/local/lib/$(PYTHON_VERSION)/site-packages itou_django /bin/bash
 
 quality: $(VIRTUAL_ENV)
-	black --check config itou
-	isort --check config itou
-	flake8 --count --show-source --statistics config itou
-	djlint --lint --check itou
+	pre-commit run --all-files --show-diff-on-failure
 
 fix: $(VIRTUAL_ENV)
-	black config itou
-	isort config itou
-	djlint --reformat itou
+	pre-commit run --all-files --show-diff-on-failure
 
 pylint: $(VIRTUAL_ENV)
 	pylint config itou

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,3 @@ ignore="H006,H014,H017,H023,H030,H031,T002,T003"
 custom_blocks="buttons,endbuttons"
 max_attribute_length=200
 preserve_blank_lines=true
-extend_exclude = "itou/templates/utils/widgets/duet_date_picker_widget.html"

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -8,14 +8,10 @@ ipdb  # https://github.com/gotcha/ipdb
 
 # Code quality
 # ------------------------------------------------------------------------------
-black  # https://github.com/psf/black
-flake8  # https://github.com/PyCQA/flake8
-isort  # https://github.com/timothycrosley/isort
 pylint  # https://github.com/PyCQA/pylint
 pylint-django  # https://github.com/PyCQA/pylint-django
 pre-commit  # https://github.com/pre-commit/pre-commit
 coverage  # https://github.com/nedbat/coveragepy
-djlint  # https://www.djlint.com
 
 # Django
 # ------------------------------------------------------------------------------

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -73,20 +73,6 @@ beautifulsoup4==4.11.2 \
     #   -r requirements/base.txt
     #   -r requirements/dev.in
     #   django-bootstrap4
-black==22.12.0 \
-    --hash=sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320 \
-    --hash=sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351 \
-    --hash=sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350 \
-    --hash=sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f \
-    --hash=sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf \
-    --hash=sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148 \
-    --hash=sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4 \
-    --hash=sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d \
-    --hash=sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc \
-    --hash=sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d \
-    --hash=sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2 \
-    --hash=sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f
-    # via -r requirements/dev.in
 boto3==1.24.96 \
     --hash=sha256:6b8899542cff82becceb3498a2240bf77c96def0515b0a31f7f6a9d5b92e7a3d \
     --hash=sha256:748c055214c629744c34c7f94bfa888733dfac0b92e1daef9c243e1391ea4f53
@@ -193,14 +179,7 @@ charset-normalizer==2.1.1 \
 click==8.1.3 \
     --hash=sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e \
     --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48
-    # via
-    #   black
-    #   djlint
-    #   pip-tools
-colorama==0.4.6 \
-    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
-    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-    # via djlint
+    # via pip-tools
 coverage==7.2.1 \
     --hash=sha256:0339dc3237c0d31c3b574f19c57985fcbe494280153bbcad33f2cdf469f4ac3e \
     --hash=sha256:09643fb0df8e29f7417adc3f40aaf379d071ee8f0350ab290517c7004f05360b \
@@ -280,9 +259,6 @@ cryptography==39.0.1 \
     #   -r requirements/base.txt
     #   paramiko
     #   pyjwt
-cssbeautifier==1.14.7 \
-    --hash=sha256:be7f1ea7a7b009f0172c2c0d0bebb2d136346e786f7182185ea944affb52135a
-    # via djlint
 decorator==5.1.1 \
     --hash=sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330 \
     --hash=sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186
@@ -394,20 +370,10 @@ djangorestframework==3.14.0 \
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-djlint==1.19.13 \
-    --hash=sha256:172e1185ddd3bcce9bba68f6fe72d6a606c2ef528143447007b0c9e5a8472f60 \
-    --hash=sha256:314aa2d9183d3ec9f79e9cde1988272cf127766a529730e4a6d8245cf4dd4d1f
-    # via -r requirements/dev.in
 drf-spectacular==0.25.1 \
     --hash=sha256:789696f9845ef2397c52f66154aec6d96411baf6aa09a5d40c5f0b0e99f6b3d8 \
     --hash=sha256:d58684e702f5ad436c5bd1735d46df0e123e64de883092d38f1debb9fa4a03c9
     # via -r requirements/base.txt
-editorconfig==0.12.3 \
-    --hash=sha256:57f8ce78afcba15c8b18d46b5170848c88d56fd38f05c2ec60dbbfcb8996e89e \
-    --hash=sha256:6b0851425aa875b08b16789ee0eeadbd4ab59666e9ebe728e526314c4a2e52c1
-    # via
-    #   cssbeautifier
-    #   jsbeautifier
 et-xmlfile==1.1.0 \
     --hash=sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c \
     --hash=sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada
@@ -434,10 +400,6 @@ filelock==3.8.0 \
     --hash=sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc \
     --hash=sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4
     # via virtualenv
-flake8==5.0.4 \
-    --hash=sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db \
-    --hash=sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248
-    # via -r requirements/dev.in
 freezegun==1.2.2 \
     --hash=sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446 \
     --hash=sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f
@@ -448,14 +410,6 @@ h11==0.12.0 \
     # via
     #   -r requirements/base.txt
     #   httpcore
-html-tag-names==0.1.2 \
-    --hash=sha256:04924aca48770f36b5a41c27e4d917062507be05118acb0ba869c97389084297 \
-    --hash=sha256:eeb69ef21078486b615241f0393a72b41352c5219ee648e7c61f5632d26f0420
-    # via djlint
-html-void-elements==0.1.0 \
-    --hash=sha256:784cf39db03cdeb017320d9301009f8f3480f9d7b254d0974272e80e0cb5e0d2 \
-    --hash=sha256:931b88f84cd606fee0b582c28fcd00e41d7149421fb673e1e1abd2f0c4f231f0
-    # via djlint
 html5lib==1.1 \
     --hash=sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d \
     --hash=sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f
@@ -508,9 +462,7 @@ ipython==8.10.0 \
 isort==5.12.0 \
     --hash=sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504 \
     --hash=sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6
-    # via
-    #   -r requirements/dev.in
-    #   pylint
+    # via pylint
 jedi==0.18.1 \
     --hash=sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d \
     --hash=sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab
@@ -522,11 +474,6 @@ jmespath==1.0.1 \
     #   -r requirements/base.txt
     #   boto3
     #   botocore
-jsbeautifier==1.14.7 \
-    --hash=sha256:77993254db1ff6f84eb6e1d75e3b6b72cba2ef20813a585b2d81e8e5e3c713c6
-    # via
-    #   cssbeautifier
-    #   djlint
 jsonschema==4.17.0 \
     --hash=sha256:5bfcf2bca16a087ade17e02b282d34af7ccd749ef76241e7f9bd7c0cb8a9424d \
     --hash=sha256:f660066c3966db7d6daeaea8a75e0b68237a48e51cf49882087757bb59916248
@@ -649,13 +596,7 @@ matplotlib-inline==0.1.6 \
 mccabe==0.7.0 \
     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325 \
     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e
-    # via
-    #   flake8
-    #   pylint
-mypy-extensions==0.4.3 \
-    --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
-    --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
-    # via black
+    # via pylint
 nodeenv==1.7.0 \
     --hash=sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e \
     --hash=sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b
@@ -754,12 +695,6 @@ parso==0.8.3 \
     --hash=sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0 \
     --hash=sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75
     # via jedi
-pathspec==0.10.2 \
-    --hash=sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5 \
-    --hash=sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0
-    # via
-    #   black
-    #   djlint
 pep517==0.13.0 \
     --hash=sha256:4ba4446d80aed5b5eac6509ade100bff3e7943a8489de249654a5ae9b33ee35b \
     --hash=sha256:ae69927c5c172be1add9203726d4b84cf3ebad1edcd5f71fcdc746e66e829f59
@@ -780,7 +715,6 @@ platformdirs==2.5.4 \
     --hash=sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7 \
     --hash=sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10
     # via
-    #   black
     #   pylint
     #   virtualenv
 pluggy==1.0.0 \
@@ -818,20 +752,12 @@ pure-eval==0.2.2 \
     --hash=sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350 \
     --hash=sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3
     # via stack-data
-pycodestyle==2.9.1 \
-    --hash=sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785 \
-    --hash=sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b
-    # via flake8
 pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
     # via
     #   -r requirements/base.txt
     #   cffi
-pyflakes==2.5.0 \
-    --hash=sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2 \
-    --hash=sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3
-    # via flake8
 pygments==2.13.0 \
     --hash=sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1 \
     --hash=sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42
@@ -993,7 +919,6 @@ pyyaml==6.0 \
     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
     # via
     #   -r requirements/base.txt
-    #   djlint
     #   drf-spectacular
     #   pre-commit
     #   tablib
@@ -1001,96 +926,6 @@ redis==4.5.1 \
     --hash=sha256:1eec3741cda408d3a5f84b78d089c8b8d895f21b3b050988351e925faf202864 \
     --hash=sha256:5deb072d26e67d2be1712603bfb7947ec3431fb0eec9c578994052e33035af6d
     # via -r requirements/base.txt
-regex==2022.10.31 \
-    --hash=sha256:052b670fafbe30966bbe5d025e90b2a491f85dfe5b2583a163b5e60a85a321ad \
-    --hash=sha256:0653d012b3bf45f194e5e6a41df9258811ac8fc395579fa82958a8b76286bea4 \
-    --hash=sha256:0a069c8483466806ab94ea9068c34b200b8bfc66b6762f45a831c4baaa9e8cdd \
-    --hash=sha256:0cf0da36a212978be2c2e2e2d04bdff46f850108fccc1851332bcae51c8907cc \
-    --hash=sha256:131d4be09bea7ce2577f9623e415cab287a3c8e0624f778c1d955ec7c281bd4d \
-    --hash=sha256:144486e029793a733e43b2e37df16a16df4ceb62102636ff3db6033994711066 \
-    --hash=sha256:1ddf14031a3882f684b8642cb74eea3af93a2be68893901b2b387c5fd92a03ec \
-    --hash=sha256:1eba476b1b242620c266edf6325b443a2e22b633217a9835a52d8da2b5c051f9 \
-    --hash=sha256:20f61c9944f0be2dc2b75689ba409938c14876c19d02f7585af4460b6a21403e \
-    --hash=sha256:22960019a842777a9fa5134c2364efaed5fbf9610ddc5c904bd3a400973b0eb8 \
-    --hash=sha256:22e7ebc231d28393dfdc19b185d97e14a0f178bedd78e85aad660e93b646604e \
-    --hash=sha256:23cbb932cc53a86ebde0fb72e7e645f9a5eec1a5af7aa9ce333e46286caef783 \
-    --hash=sha256:29c04741b9ae13d1e94cf93fca257730b97ce6ea64cfe1eba11cf9ac4e85afb6 \
-    --hash=sha256:2bde29cc44fa81c0a0c8686992c3080b37c488df167a371500b2a43ce9f026d1 \
-    --hash=sha256:2cdc55ca07b4e70dda898d2ab7150ecf17c990076d3acd7a5f3b25cb23a69f1c \
-    --hash=sha256:370f6e97d02bf2dd20d7468ce4f38e173a124e769762d00beadec3bc2f4b3bc4 \
-    --hash=sha256:395161bbdbd04a8333b9ff9763a05e9ceb4fe210e3c7690f5e68cedd3d65d8e1 \
-    --hash=sha256:44136355e2f5e06bf6b23d337a75386371ba742ffa771440b85bed367c1318d1 \
-    --hash=sha256:44a6c2f6374e0033873e9ed577a54a3602b4f609867794c1a3ebba65e4c93ee7 \
-    --hash=sha256:4919899577ba37f505aaebdf6e7dc812d55e8f097331312db7f1aab18767cce8 \
-    --hash=sha256:4b4b1fe58cd102d75ef0552cf17242705ce0759f9695334a56644ad2d83903fe \
-    --hash=sha256:4bdd56ee719a8f751cf5a593476a441c4e56c9b64dc1f0f30902858c4ef8771d \
-    --hash=sha256:4bf41b8b0a80708f7e0384519795e80dcb44d7199a35d52c15cc674d10b3081b \
-    --hash=sha256:4cac3405d8dda8bc6ed499557625585544dd5cbf32072dcc72b5a176cb1271c8 \
-    --hash=sha256:4fe7fda2fe7c8890d454f2cbc91d6c01baf206fbc96d89a80241a02985118c0c \
-    --hash=sha256:50921c140561d3db2ab9f5b11c5184846cde686bb5a9dc64cae442926e86f3af \
-    --hash=sha256:5217c25229b6a85049416a5c1e6451e9060a1edcf988641e309dbe3ab26d3e49 \
-    --hash=sha256:5352bea8a8f84b89d45ccc503f390a6be77917932b1c98c4cdc3565137acc714 \
-    --hash=sha256:542e3e306d1669b25936b64917285cdffcd4f5c6f0247636fec037187bd93542 \
-    --hash=sha256:543883e3496c8b6d58bd036c99486c3c8387c2fc01f7a342b760c1ea3158a318 \
-    --hash=sha256:586b36ebda81e6c1a9c5a5d0bfdc236399ba6595e1397842fd4a45648c30f35e \
-    --hash=sha256:597f899f4ed42a38df7b0e46714880fb4e19a25c2f66e5c908805466721760f5 \
-    --hash=sha256:5a260758454580f11dd8743fa98319bb046037dfab4f7828008909d0aa5292bc \
-    --hash=sha256:5aefb84a301327ad115e9d346c8e2760009131d9d4b4c6b213648d02e2abe144 \
-    --hash=sha256:5e6a5567078b3eaed93558842346c9d678e116ab0135e22eb72db8325e90b453 \
-    --hash=sha256:5ff525698de226c0ca743bfa71fc6b378cda2ddcf0d22d7c37b1cc925c9650a5 \
-    --hash=sha256:61edbca89aa3f5ef7ecac8c23d975fe7261c12665f1d90a6b1af527bba86ce61 \
-    --hash=sha256:659175b2144d199560d99a8d13b2228b85e6019b6e09e556209dfb8c37b78a11 \
-    --hash=sha256:6a9a19bea8495bb419dc5d38c4519567781cd8d571c72efc6aa959473d10221a \
-    --hash=sha256:6b30bddd61d2a3261f025ad0f9ee2586988c6a00c780a2fb0a92cea2aa702c54 \
-    --hash=sha256:6ffd55b5aedc6f25fd8d9f905c9376ca44fcf768673ffb9d160dd6f409bfda73 \
-    --hash=sha256:702d8fc6f25bbf412ee706bd73019da5e44a8400861dfff7ff31eb5b4a1276dc \
-    --hash=sha256:74bcab50a13960f2a610cdcd066e25f1fd59e23b69637c92ad470784a51b1347 \
-    --hash=sha256:75f591b2055523fc02a4bbe598aa867df9e953255f0b7f7715d2a36a9c30065c \
-    --hash=sha256:763b64853b0a8f4f9cfb41a76a4a85a9bcda7fdda5cb057016e7706fde928e66 \
-    --hash=sha256:76c598ca73ec73a2f568e2a72ba46c3b6c8690ad9a07092b18e48ceb936e9f0c \
-    --hash=sha256:78d680ef3e4d405f36f0d6d1ea54e740366f061645930072d39bca16a10d8c93 \
-    --hash=sha256:7b280948d00bd3973c1998f92e22aa3ecb76682e3a4255f33e1020bd32adf443 \
-    --hash=sha256:7db345956ecce0c99b97b042b4ca7326feeec6b75facd8390af73b18e2650ffc \
-    --hash=sha256:7dbdce0c534bbf52274b94768b3498abdf675a691fec5f751b6057b3030f34c1 \
-    --hash=sha256:7ef6b5942e6bfc5706301a18a62300c60db9af7f6368042227ccb7eeb22d0892 \
-    --hash=sha256:7f5a3ffc731494f1a57bd91c47dc483a1e10048131ffb52d901bfe2beb6102e8 \
-    --hash=sha256:8a45b6514861916c429e6059a55cf7db74670eaed2052a648e3e4d04f070e001 \
-    --hash=sha256:8ad241da7fac963d7573cc67a064c57c58766b62a9a20c452ca1f21050868dfa \
-    --hash=sha256:8b0886885f7323beea6f552c28bff62cbe0983b9fbb94126531693ea6c5ebb90 \
-    --hash=sha256:8ca88da1bd78990b536c4a7765f719803eb4f8f9971cc22d6ca965c10a7f2c4c \
-    --hash=sha256:8e0caeff18b96ea90fc0eb6e3bdb2b10ab5b01a95128dfeccb64a7238decf5f0 \
-    --hash=sha256:957403a978e10fb3ca42572a23e6f7badff39aa1ce2f4ade68ee452dc6807692 \
-    --hash=sha256:9af69f6746120998cd9c355e9c3c6aec7dff70d47247188feb4f829502be8ab4 \
-    --hash=sha256:9c94f7cc91ab16b36ba5ce476f1904c91d6c92441f01cd61a8e2729442d6fcf5 \
-    --hash=sha256:a37d51fa9a00d265cf73f3de3930fa9c41548177ba4f0faf76e61d512c774690 \
-    --hash=sha256:a3a98921da9a1bf8457aeee6a551948a83601689e5ecdd736894ea9bbec77e83 \
-    --hash=sha256:a3c1ebd4ed8e76e886507c9eddb1a891673686c813adf889b864a17fafcf6d66 \
-    --hash=sha256:a5f9505efd574d1e5b4a76ac9dd92a12acb2b309551e9aa874c13c11caefbe4f \
-    --hash=sha256:a8ff454ef0bb061e37df03557afda9d785c905dab15584860f982e88be73015f \
-    --hash=sha256:a9d0b68ac1743964755ae2d89772c7e6fb0118acd4d0b7464eaf3921c6b49dd4 \
-    --hash=sha256:aa62a07ac93b7cb6b7d0389d8ef57ffc321d78f60c037b19dfa78d6b17c928ee \
-    --hash=sha256:ac741bf78b9bb432e2d314439275235f41656e189856b11fb4e774d9f7246d81 \
-    --hash=sha256:ae1e96785696b543394a4e3f15f3f225d44f3c55dafe3f206493031419fedf95 \
-    --hash=sha256:b683e5fd7f74fb66e89a1ed16076dbab3f8e9f34c18b1979ded614fe10cdc4d9 \
-    --hash=sha256:b7a8b43ee64ca8f4befa2bea4083f7c52c92864d8518244bfa6e88c751fa8fff \
-    --hash=sha256:b8e38472739028e5f2c3a4aded0ab7eadc447f0d84f310c7a8bb697ec417229e \
-    --hash=sha256:bfff48c7bd23c6e2aec6454aaf6edc44444b229e94743b34bdcdda2e35126cf5 \
-    --hash=sha256:c14b63c9d7bab795d17392c7c1f9aaabbffd4cf4387725a0ac69109fb3b550c6 \
-    --hash=sha256:c27cc1e4b197092e50ddbf0118c788d9977f3f8f35bfbbd3e76c1846a3443df7 \
-    --hash=sha256:c28d3309ebd6d6b2cf82969b5179bed5fefe6142c70f354ece94324fa11bf6a1 \
-    --hash=sha256:c670f4773f2f6f1957ff8a3962c7dd12e4be54d05839b216cb7fd70b5a1df394 \
-    --hash=sha256:ce6910b56b700bea7be82c54ddf2e0ed792a577dfaa4a76b9af07d550af435c6 \
-    --hash=sha256:d0213671691e341f6849bf33cd9fad21f7b1cb88b89e024f33370733fec58742 \
-    --hash=sha256:d03fe67b2325cb3f09be029fd5da8df9e6974f0cde2c2ac6a79d2634e791dd57 \
-    --hash=sha256:d0e5af9a9effb88535a472e19169e09ce750c3d442fb222254a276d77808620b \
-    --hash=sha256:d243b36fbf3d73c25e48014961e83c19c9cc92530516ce3c43050ea6276a2ab7 \
-    --hash=sha256:d26166acf62f731f50bdd885b04b38828436d74e8e362bfcb8df221d868b5d9b \
-    --hash=sha256:d403d781b0e06d2922435ce3b8d2376579f0c217ae491e273bab8d092727d244 \
-    --hash=sha256:d8716f82502997b3d0895d1c64c3b834181b1eaca28f3f6336a71777e437c2af \
-    --hash=sha256:e4f781ffedd17b0b834c8731b75cce2639d5a8afe961c1e58ee7f1f20b3af185 \
-    --hash=sha256:e613a98ead2005c4ce037c7b061f2409a1a4e45099edb0ef3200ee26ed2a69a8 \
-    --hash=sha256:ef4163770525257876f10e8ece1cf25b71468316f61451ded1a6f44273eedeb5
-    # via djlint
 requests==2.28.2 \
     --hash=sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa \
     --hash=sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf
@@ -1130,9 +965,7 @@ six==1.16.0 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   -r requirements/base.txt
-    #   cssbeautifier
     #   html5lib
-    #   jsbeautifier
     #   python-dateutil
 sniffio==1.3.0 \
     --hash=sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101 \
@@ -1176,9 +1009,7 @@ tomlkit==0.11.6 \
 tqdm==4.64.1 \
     --hash=sha256:5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4 \
     --hash=sha256:6fee160d6ffcd1b1c68c65f14c829c22832bc401726335ce92c52d395944a6a1
-    # via
-    #   -r requirements/base.txt
-    #   djlint
+    # via -r requirements/base.txt
 traitlets==5.5.0 \
     --hash=sha256:1201b2c9f76097195989cdf7f65db9897593b0dfd69e4ac96016661bb6f0d30f \
     --hash=sha256:b122f9ff2f2f6c1709dab289a05555be011c87828e911c0cf4074b85cb780a79


### PR DESCRIPTION
### Pourquoi ?

Avantages:

- Ça permet de revenir sur l'utilisation "classique" de l'outil `pre-commit` (et donc moins de surprises pour les nouveaux)
- Ça marche même sans le venv activé

Inconvénients:

- Les checks se font avec des outils cachés dans les environnements pre-commit et ne sont plus accessibles
- Soit on garde les outils également dans dev.in et on a potentiellement des versions différentes entre venv et pre-commit, soit on les enlève (comme dans ma PR) mais ça peut chagriner certains IDE

Je suis un peu partagé mais je crois avoir une préférence pour le statu quo :grimacing: 



