### PR TITLE
Déconnecter automatiquement les utilisateurs le lundi matin très très tôt

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -18,6 +18,7 @@
   "55 8-18/2 * * 1-5 $ROOT/clevercloud/upload_employee_records.sh",
   "5 23 * * 1-5 $ROOT/clevercloud/archive_employee_records.sh",
 
+  "0 0 * * 1 $ROOT/clevercloud/run_management_command.sh shorten_active_sessions",
   "0 6 * * 1 $ROOT/clevercloud/crons/populate_metabase_matomo.sh",
 
   "0 0 1 * * $ROOT/clevercloud/run_management_command.sh sync_cities --wet-run",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -234,7 +234,15 @@ SESSION_COOKIE_HTTPONLY = True
 
 SESSION_COOKIE_SECURE = True
 
+# Force browser to end session when closing.
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+
+# Since some browser restore session when restarting, the previous setting may not
+# work as we want. This is why we ask Django to expire sessions in DB after 1 week
+# of inactivity.
+# -> https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_the_lifetime_of_a_cookie
+# In addition, the command shorten_active_sessions is run every week to force user to connect at least once per week
+SESSION_COOKIE_AGE = 60 * 60 * 24 * 7
 
 SESSION_SERIALIZER = "itou.utils.session.JSONSerializer"
 

--- a/itou/users/management/commands/shorten_active_sessions.py
+++ b/itou/users/management/commands/shorten_active_sessions.py
@@ -1,0 +1,21 @@
+from importlib import import_module
+
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+
+class Command(BaseCommand):
+    """Shorten all active sessions to let them alive for only one more hour.
+
+    Any currently active user will be able to continue wotking on our website,
+    but all offline users will have to login again.
+    """
+
+    def handle(self, **options):
+        engine = import_module(settings.SESSION_ENGINE)
+        new_expire = timezone.now() + relativedelta(hours=1)
+        active_sessions_qs = engine.SessionStore.get_model_class().objects.filter(expire_date__gte=new_expire)
+        self.stdout.write(f"Found {len(active_sessions_qs)} active sessions to shorten")
+        active_sessions_qs.update(expire_date=new_expire)


### PR DESCRIPTION
https://www.notion.so/plateforme-inclusion/V-rifier-s-il-existe-une-d-connexion-automatique-des-utilisateurs-8c402b9de67d426ab639287ad68f6b98?pvs=4


### Pourquoi ?

On veut forcer les utilisateurs à se re-connecter régulièrement (notamment pour encourager la migration à Inclusion Connect des employeurs / prescripteurs)

### Comment ?

On a le setting `SESSION_EXPIRE_AT_BROWSER_CLOSE = True` qui devrait forcer le navigateur à supprimer le cookie de session à la fermeture.
Cependant certains navigateurs restaurent les sessions (https://developer.mozilla.org/fr/docs/Web/HTTP/Cookies#d%C3%A9finir_la_dur%C3%A9e_de_vie_dun_cookie) donc la session ne se termine jamais.

Comme à chaque changement de SIAE/organisation, ou à chaque parcours de candidature réalisé par un prescripteur ou un employeur on va modifier la session, cela va remettre l'expiration de la session en DB à 15 jours plus tard, et ces personnes actives n'ont jamais besoin de se connecter à nouveau.

À part pour les utilisateurs qui ont modifié leur session il y a moins d'une heure, on va déconnecter tous les utilisateurs pour les forcer à se re-connecter à leur premier accès à la plateforme le lundi matin