### PR TITLE
`move_siae_data` : Gestion du cas où le salarié à déjà été rembauché

### DIFF
--- a/itou/employee_record/exceptions.py
+++ b/itou/employee_record/exceptions.py
@@ -8,3 +8,7 @@ class InvalidStatusError(Exception):
 
 class CloningError(Exception):
     """This employee record can't be cloned."""
+
+
+class DuplicateCloningError(CloningError):
+    """This employee record can't be cloned because it's a duplicate"""

--- a/itou/employee_record/management/commands/clone_orphan_employee_records.py
+++ b/itou/employee_record/management/commands/clone_orphan_employee_records.py
@@ -49,8 +49,7 @@ class Command(BaseCommand):
                 continue
 
             try:
-                with transaction.atomic():
-                    employee_record_clone = employee_record.clone()
+                employee_record_clone = employee_record.clone()
             except Exception as e:
                 self.stdout.write(f"  Error when cloning {employee_record.pk=}: {e}")
             else:

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -3,7 +3,7 @@ import json
 
 import django.db.utils
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models.manager import Manager
 from django.db.models.query import F, Q, QuerySet
 from django.utils import timezone
@@ -453,7 +453,8 @@ class EmployeeRecord(ASPExchangeInformation):
         )
 
         try:
-            er_copy.save()
+            with transaction.atomic():
+                er_copy.save()
         except django.db.utils.IntegrityError as ex:
             raise DuplicateCloningError(
                 f"The clone is a duplicate of ({er_copy.asp_id=}, {er_copy.approval_number=})"

--- a/itou/employee_record/tests/tests_models.py
+++ b/itou/employee_record/tests/tests_models.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from itou.approvals.factories import ApprovalFactory
 from itou.employee_record import constants
 from itou.employee_record.enums import Status
-from itou.employee_record.exceptions import CloningError, InvalidStatusError
+from itou.employee_record.exceptions import CloningError, DuplicateCloningError, InvalidStatusError
 from itou.employee_record.factories import (
     BareEmployeeRecordFactory,
     BareEmployeeRecordUpdateNotificationFactory,
@@ -255,7 +255,7 @@ def test_clone_for_disabled_employee_record():
 
 def test_clone_when_a_duplicate_exists():
     employee_record = EmployeeRecordFactory()
-    with pytest.raises(CloningError, match=r"Duplicate asp_id / approval_number pair"):
+    with pytest.raises(DuplicateCloningError, match=r"The clone is a duplicate of"):
         employee_record.clone()
 
 

--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -228,8 +228,7 @@ class Command(BaseCommand):
             )
             for employee_record in employee_records_to_clone:
                 try:
-                    with transaction.atomic():
-                        employee_record.clone()
+                    employee_record.clone()
                 except DuplicateCloningError as e:
                     self.stdout.write(f"| + Failed to clone {employee_record}: {e}")
 


### PR DESCRIPTION
**Notion :** https://www.notion.so/plateforme-inclusion/Support-C1-Move-SIAE-data-partiel-Mode-2-b429a83ada564a03bd768d8c328301c7

### Pourquoi ?

Pour diverse raisons (plus ou moins légitimes) un salarié de la structure _source_ peux déjà exister dans la structure _destinataire_, on peux donc l'ignorer.