### PR TITLE
Stats : Montrer le popup Tally maximum une fois toutes les deux semaines

### DIFF
--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -137,20 +137,64 @@
     </script>
 
     {% if tally_form_id %}
-        <script async src="https://tally.so/widgets/embed.js"></script>
+        {# Do not use `async` here otherwise the Tally popup will randomly fail to load. #}
+        <script src="https://tally.so/widgets/embed.js"></script>
 
-        <script nonce="{{ CSP_NONCE }}">
-            window.TallyConfig = {
-                "formId": "{{ tally_form_id }}",
-                "popup": {
-                    "emoji": {
-                        "text": "👋",
-                        "animation": "wave"
-                    },
-                    "open": {
-                        "trigger": "exit"
-                    }
+        {# `defer` ensures the script runs *after* embed.js above has been loaded. #}
+        <script defer nonce="{{ CSP_NONCE }}">
+
+            // Any given Tally popup will not be shown more than once every `minDaysBetweenDisplays` days.
+            const minDaysBetweenDisplays = 14;
+            const delayBeforeShowingPopupInSeconds = 5;
+            const formId = '{{ tally_form_id }}';
+            const key = 'statsTallyPopupLastShown-' + formId;
+            const todaysDate = new Date();
+
+            function supportsLocalStorage() {
+                try {
+                    return 'localStorage' in window && window['localStorage'] !== null;
+                } catch(e){
+                    return false;
                 }
+            };
+
+            function stopShowingPopupForAWhile() {
+                localStorage.setItem(key, JSON.stringify(todaysDate));
+            }
+
+            function displayTallyPopup() {
+                window.Tally.openPopup(formId, {
+                    emoji: {
+                        text: "👋",
+                        animation: "wave"
+                    },
+                    onClose: () => {
+                        stopShowingPopupForAWhile();
+                    },
+                    onSubmit: () => {
+                        stopShowingPopupForAWhile();
+                    }
+                });
+            };
+
+            function shouldDisplayTallyPopup() {
+                if (!supportsLocalStorage()) {
+                    return true;
+                }
+                infoKey = localStorage.getItem(key);
+                if (infoKey) {
+                    const lastShown = Date.parse(JSON.parse(localStorage.getItem(key)));
+                    const milliSecondsElapsed = todaysDate - lastShown;
+                    const daysElapsed = milliSecondsElapsed / (1000 * 3600 * 24);
+                    if (daysElapsed <= minDaysBetweenDisplays) {
+                        return false;
+                    };
+                };
+                return true;
+            };
+
+            if (shouldDisplayTallyPopup()) {
+                setTimeout(displayTallyPopup, delayBeforeShowingPopupInSeconds * 1000);
             };
         </script>
     {% endif %}


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Param-trer-les-enqu-tes-en-ligne-sur-le-NPS-dc8e6085d64a4b92bbb4a6437c1c3b15**

### Pourquoi ?

Jusqu'ici le popup s'ouvrait à nouveau à chaque fois que la personne revenait sur la page stats. La seule alternative native côté Tally est de ne plus jamais afficher le popup une fois qu'il est rempli. On veut vraiment un juste milieu entre ces deux extrêmes.

Le comportement au final sera : le popup cesse de s'afficher pendant 14 jours à partir du moment où soit 1) l'utilisateur ferme manuellement le popup en cliquant sur la croix en haut à droite, soit 2) l'utilisateur soumet le formulaire. Tant que l'utilisateur n'a fait aucune de ces deux actions on continue d'afficher le popup.

### Comment

On fait ici un code Javascript dédié qui affiche le popup à nouveau toutes les deux semaines.

Fortement inspiré de ce qui a déjà été fait côté Dora : https://github.com/betagouv/dora-front/blob/70155b666ad859bc8b3b212a13ce5c548b21ee8b/src/lib/components/specialized/tally-nps-popup.svelte#L35

### Notes

J'ai peu d'expérience en Javascript donc pas taper ! Mon code est certainement d'un niveau très moyen.