### PR TITLE
Correction de l'embauche pour les candidats avec un diagnostic déjà existant non relié à la candidature

### DIFF
--- a/itou/approvals/admin_forms.py
+++ b/itou/approvals/admin_forms.py
@@ -54,7 +54,7 @@ class ApprovalAdminForm(ApprovalFormMixin, forms.ModelForm):
         eligibility_diagnosis = self.cleaned_data["eligibility_diagnosis"]
         if eligibility_diagnosis and eligibility_diagnosis.job_seeker != self.cleaned_data["user"]:
             # Could we filter available eligibility diagnosis ?
-            raise forms.ValidationError("Le diagnostique doit appartenir au même utilisateur que le PASS")
+            raise forms.ValidationError("Le diagnostic doit appartenir au même utilisateur que le PASS")
         return eligibility_diagnosis
 
 

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -744,7 +744,7 @@ class AutomaticApprovalAdminViewsTest(TestCase):
         self.assertFormError(
             response.context["adminform"],
             "eligibility_diagnosis",
-            ["Le diagnostique doit appartenir au même utilisateur que le PASS"],
+            ["Le diagnostic doit appartenir au même utilisateur que le PASS"],
         )
         assert not Approval.objects.exists()
 

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -251,13 +251,9 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
         "can_view_personal_information": True,  # SIAE members have access to personal info
     }
 
-    if (
-        not job_application.hiring_without_approval
-        and job_application.to_siae.is_subject_to_eligibility_rules
-        and job_application.eligibility_diagnosis is None
-    ):
-        messages.error(request, "Cette candidature requiert un diagnostic d'éligibilité pour être acceptée")
-        return HttpResponseClientRedirect(next_url)
+    if not job_application.hiring_without_approval and job_application.eligibility_diagnosis_by_siae_required:
+        messages.error(request, "Cette candidature requiert un diagnostic d'éligibilité pour être acceptée.")
+        return HttpResponseRedirect(next_url)
 
     if request.method == "POST" and all([form.is_valid() for form in forms]):
         if request.htmx and not request.POST.get("confirmed"):

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -256,7 +256,7 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
         and job_application.to_siae.is_subject_to_eligibility_rules
         and job_application.eligibility_diagnosis is None
     ):
-        messages.error(request, "Cette candidature requiert un diagnostique d'éligibilité pour être acceptée")
+        messages.error(request, "Cette candidature requiert un diagnostic d'éligibilité pour être acceptée")
         return HttpResponseClientRedirect(next_url)
 
     if request.method == "POST" and all([form.is_valid() for form in forms]):


### PR DESCRIPTION
### Pourquoi ?

Si un candidat a déjà un diasgnostic d'éligibilité, pas besoin de demander à créer un diagnostic pour accepter la candidature

