### PR TITLE
github: add ref_name to concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       DJANGO_SETTINGS_MODULE: config.settings.dev
       PYTHONPATH: .
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+      group: ${{ github.workflow }}-${ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
     services:
       postgres:


### PR DESCRIPTION
to avoid the merge queue getting its build cancelled by the push event (since they have the same pull request but not the same branch)

