### PR TITLE
deploy_prod: suppression de l'option --no-ff

### DIFF
--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -12,7 +12,7 @@ fi
 # Deployment to Clever Cloud is actually triggered via a hook
 # on a push on this branch
 
-# synchronize master  and master_clever by replaying the local branches on top of remote ones
+# synchronize master and master_clever by replaying the local branches on top of remote ones
 git fetch origin
 git checkout master
 git rebase origin/master master
@@ -20,8 +20,8 @@ git checkout master_clever
 git rebase origin/master_clever master_clever
 
 # merge master into master_clever
-git merge master --no-edit --no-ff
-git push origin master_clever 
+git merge master --no-edit --ff-only
+git push origin master_clever
 
 # When we are done, we want to restore the initial state
 # (in order to avoid writing things directly on master_clever by accident)


### PR DESCRIPTION
### Pourquoi ?

A priori rajouté à l'origine pour faciliter les rollbacks (cf https://github.com/betagouv/itou/pull/747#discussion_r657897032 )

Mais à ma connaissance il y a très peu de rollback.

Je trouve que ce commit de merge n'aide pas pour identifier ce qui tourne en production: avec du fast-forward, on verrait directement sur Clever le dernier commit de master qui tourne en production alors que là il faut regarder les parents du commit de merge.

Et si malgré tout, on souhaite faire un rollback, l'historique des déploiements avec leur commit se trouve sur le canal "tech-notifications-c1".