### PR TITLE
Stats : Ajout d'un lien vers le guide d’analyse PE dans l'espace privé PE

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -31,6 +31,17 @@
                 {% endif %}
                 {% if can_view_stats_pe %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="https://plateforme-inclusion.notion.site/Guide-d-analyse-des-tableaux-de-bord-P-le-emploi-dad8530e64af47bd99787a6d4e81f6b9?mtm_campaign=Notion-Guide-analyse-PE&mtm_kwd=Guide-analyse-PE"
+                           rel="noopener"
+                           target="_blank"
+                           aria-label="Accéder au guide d'analyse Pôle emploi (ouverture dans un nouvel onglet)"
+                           class="btn-link btn-ico">
+                            <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
+                            <span>Voir le guide d’analyse Pôle emploi</span>
+                        </a>
+                        <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
+                    </li>
+                    <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_pe_state_main' %}" class="btn-link btn-ico">
                             <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
                             <span>Voir les données de l’état des candidatures orientées</span>


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Mettre-disposition-le-guide-d-analyse-PE-sur-leur-espace-priv-3c43be960c064e5a989f2cfa3c66da8b**

### Pourquoi ?

Pour que les divers acteurs PE puissent tirer davantage de valeur de leurs stats.

### Captures d'écran

![image](https://user-images.githubusercontent.com/10533583/223480550-0804e362-d461-4e37-8500-619c32417617.png)
