### PR TITLE
deploy_prod: resynchronisation de la branche master_clever

### DIFF
--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -17,7 +17,8 @@ git fetch origin
 git checkout master
 git rebase origin/master master
 git checkout master_clever
-git rebase origin/master_clever master_clever
+# Since we changed the deployment process, a hard reset is needed to resync local master_clever with origin
+git reset --hard origin/master_clever
 
 # merge master into master_clever
 git merge master --no-edit --ff-only


### PR DESCRIPTION
Suite à c75e20ed8646c21e942b2b08009ffa4f708a8d53, `origin/master_clever` a subi un push force pour se réaligner sur `origin/master`. La plupart des devs ont donc un `master_clever` qui ne pourra pas se rebase sur `origin/master_clever`.


