### PR TITLE
Correction du formulaire de délivrance manuelle de PASS IAE

### DIFF
--- a/itou/approvals/admin_forms.py
+++ b/itou/approvals/admin_forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.forms import widgets
 
 from itou.approvals.models import Approval
 
@@ -67,6 +68,7 @@ class ManuallyAddApprovalFromJobApplicationForm(ApprovalFormMixin, forms.ModelFo
         self.fields["start_at"].required = True
         self.fields["end_at"].required = True
         self.fields["created_by"].required = True
+        self.fields["eligibility_diagnosis"].required = True
 
         # Optional fields.
         # The `number` field can be filled in manually by an admin when a Pôle emploi
@@ -76,5 +78,10 @@ class ManuallyAddApprovalFromJobApplicationForm(ApprovalFormMixin, forms.ModelFo
 
     class Meta:
         model = Approval
-        fields = ["user", "start_at", "end_at", "number", "created_by", "origin"]
-        widgets = {"user": forms.HiddenInput(), "created_by": forms.HiddenInput(), "origin": forms.HiddenInput()}
+        fields = ["user", "start_at", "end_at", "number", "created_by", "origin", "eligibility_diagnosis"]
+        widgets = {
+            "user": widgets.HiddenInput(),
+            "created_by": widgets.HiddenInput(),
+            "origin": widgets.HiddenInput(),
+            "eligibility_diagnosis": widgets.HiddenInput(),
+        }

--- a/itou/approvals/factories.py
+++ b/itou/approvals/factories.py
@@ -7,6 +7,7 @@ from dateutil.relativedelta import relativedelta
 from faker import Faker
 
 from itou.approvals.models import Approval, PoleEmploiApproval, Prolongation, Suspension
+from itou.eligibility.factories import EligibilityDiagnosisFactory
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.enums import SiaeKind
@@ -25,6 +26,7 @@ class ApprovalFactory(factory.django.DjangoModelFactory):
     number = factory.fuzzy.FuzzyText(length=7, chars=string.digits, prefix=Approval.ASP_ITOU_PREFIX)
     start_at = factory.LazyFunction(datetime.date.today)
     end_at = factory.LazyAttribute(lambda obj: Approval.get_default_end_date(obj.start_at))
+    eligibility_diagnosis = factory.SubFactory(EligibilityDiagnosisFactory, job_seeker=factory.SelfAttribute("..user"))
 
     @factory.post_generation
     def with_jobapplication(self, create, extracted, **kwargs):

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -827,6 +827,7 @@ class CustomApprovalAdminViewsTest(TestCase):
             "created_by": user.pk,
             "origin": Origin.ADMIN,
             "number": f"{Approval.ASP_ITOU_PREFIX}1234567",
+            "eligibility_diagnosis": job_application.eligibility_diagnosis,
         }
         response = self.client.post(url, data=post_data)
         assert response.status_code == 200
@@ -839,6 +840,7 @@ class CustomApprovalAdminViewsTest(TestCase):
             "user": job_application.job_seeker.pk,
             "created_by": user.pk,
             "origin": Origin.ADMIN,
+            "eligibility_diagnosis": job_application.eligibility_diagnosis,
         }
         response = self.client.post(url, data=post_data)
         assert response.status_code == 302

--- a/itou/eligibility/tests/tests_iae.py
+++ b/itou/eligibility/tests/tests_iae.py
@@ -70,7 +70,7 @@ class EligibilityDiagnosisManagerTest(TestCase):
         assert has_considered_valid
 
         # Has a valid PASS IAE but NO diagnosis.
-        approval = ApprovalFactory()
+        approval = ApprovalFactory(eligibility_diagnosis=None)
         job_seeker = approval.user
         assert 0 == job_seeker.eligibility_diagnoses.count()
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(job_seeker=job_seeker)
@@ -119,7 +119,7 @@ class EligibilityDiagnosisManagerTest(TestCase):
 
         # Has expired Itou diagnosis but has an ongoing PASS IAE.
         expired_diagnosis = ExpiredEligibilityDiagnosisFactory()
-        ApprovalFactory(user=expired_diagnosis.job_seeker)
+        ApprovalFactory(user=expired_diagnosis.job_seeker, eligibility_diagnosis=expired_diagnosis)
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
             job_seeker=expired_diagnosis.job_seeker
         )

--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -32,7 +32,11 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
         job_seeker_with_address = factory.Trait(job_seeker=factory.SubFactory(JobSeekerWithMockedAddressFactory))
         with_approval = factory.Trait(
             state=models.JobApplicationWorkflow.STATE_ACCEPTED,
-            approval=factory.SubFactory(ApprovalFactory, user=factory.SelfAttribute("..job_seeker")),
+            approval=factory.SubFactory(
+                ApprovalFactory,
+                user=factory.SelfAttribute("..job_seeker"),
+                eligibility_diagnosis=factory.SelfAttribute("..eligibility_diagnosis"),
+            ),
         )
         sent_by_authorized_prescriber_organisation = factory.Trait(
             sender_prescriber_organization=factory.SubFactory(

--- a/itou/metabase/management/test_populate_metabase_emplois.py
+++ b/itou/metabase/management/test_populate_metabase_emplois.py
@@ -166,7 +166,6 @@ def test_populate_job_seekers():
         job_seeker=user_3,
         created_at=datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc),
         with_approval=True,
-        approval=ApprovalFactory(user=user_3),
         eligibility_diagnosis__author_kind="siae_staff",
         eligibility_diagnosis__author_prescriber_organization=None,
         eligibility_diagnosis__author_siae=SiaeFactory(),

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -976,7 +976,13 @@ def user_with_approval_in_waiting_period():
     user = JobSeekerFactory()
     end_at = timezone.localdate() - relativedelta(days=30)
     start_at = end_at - relativedelta(years=2)
-    ApprovalFactory(user=user, start_at=start_at, end_at=end_at)
+    # Force the approval to have no eligibility diagnosis
+    ApprovalFactory(
+        user=user,
+        start_at=start_at,
+        end_at=end_at,
+        eligibility_diagnosis=None,
+    )
     return user
 
 

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -1233,7 +1233,7 @@ class ApplyAsPrescriberTest(S3AccessingTestCase):
         # Create an approval in waiting period.
         end_at = datetime.date.today() - relativedelta(days=30)
         start_at = end_at - relativedelta(years=2)
-        ApprovalFactory(user=job_seeker, start_at=start_at, end_at=end_at)
+        ApprovalFactory(user=job_seeker, start_at=start_at, end_at=end_at, eligibility_diagnosis=None)
 
         user = PrescriberFactory()
         self.client.force_login(user)
@@ -1683,7 +1683,7 @@ class ApplyAsSiaeTest(S3AccessingTestCase):
         # Create an approval in waiting period.
         end_at = datetime.date.today() - relativedelta(days=30)
         start_at = end_at - relativedelta(years=2)
-        ApprovalFactory(user=job_seeker, start_at=start_at, end_at=end_at)
+        ApprovalFactory(user=job_seeker, start_at=start_at, end_at=end_at, eligibility_diagnosis=None)
 
         user = siae.members.first()
         self.client.force_login(user)

--- a/itou/www/approvals_views/tests/test_display.py
+++ b/itou/www/approvals_views/tests/test_display.py
@@ -56,8 +56,8 @@ class TestDisplayApproval(TestCase):
         self.assertContains(response, "Imprimer ce PASS IAE")
         self.assertContains(response, "Astuce pour conserver cette attestation en format PDF")
 
-    def test_no_display_approval_no_job_applications(self, *args, **kwargs):
-        approval = ApprovalFactory()
+    def test_dont_display_approval_with_no_eligibility_diagnosis_and_no_job_applications(self, *args, **kwargs):
+        approval = ApprovalFactory(eligibility_diagnosis=None)
         siae_member = SiaeMembershipFactory().user
         self.client.force_login(siae_member)
 
@@ -88,7 +88,8 @@ class TestDisplayApproval(TestCase):
         self.assertContains(response, "Imprimer ce PASS IAE")
         self.assertContains(response, "Astuce pour conserver cette attestation en format PDF")
 
-    def test_display_approval_missing_diagnosis_ai_approval(self, *args, **kwargs):
+    def test_display_approval_missing_diagnosis_ai_job_application(self, *args, **kwargs):
+        # TODO(alaurent) remove once last approvals were manually fixed
         # On November 30th, 2021, AI were delivered approvals without a diagnosis.
         job_application = JobApplicationFactory(
             with_approval=True,
@@ -110,7 +111,8 @@ class TestDisplayApproval(TestCase):
         self.assertContains(response, "Imprimer ce PASS IAE")
         self.assertContains(response, "Astuce pour conserver cette attestation en format PDF")
 
-    def test_display_approval_missing_diagnosis_ai_job_application(self, *args, **kwargs):
+    def test_display_approval_missing_diagnosis_ai_approval(self, *args, **kwargs):
+        # TODO(alaurent) remove once last approvals were manually fixed
         # On November 30th, 2021, AI were delivered approvals without a diagnosis.
         job_application = JobApplicationFactory(
             with_approval=True,


### PR DESCRIPTION
https://www.notion.so/plateforme-inclusion/Associer-les-diagnostiques-aux-PASS-IAE-116db83de976432e93b94474631c7401?pvs=4

### Pourquoi ?

Il restait un trou dans la raquette.

### Comment (optionnel)

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.

