### PR TITLE
matomo: Correction d'un bug qui annule certaines écritures + autres correctifs

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -5,7 +5,6 @@ import io
 import threading
 import urllib
 from dataclasses import dataclass
-from time import sleep
 
 import httpx
 import tenacity
@@ -170,18 +169,13 @@ def get_matomo_dashboard(at: datetime.datetime, options: MatomoFetchOptions):
         if not column_names:
             column_names = list(row.keys())
         results.append(list(row.values()))
-    # The private dashboards are so many that we need to sleep before 2 calls, as Matomo
-    # severely limits the client request rate to the point of the timeout (10 minutes for a single call)
-    # Introducing a delay of 1 second between the calls drops the complete fetch from impossible (timeout
-    # after 2 hours) to less than 5 minutes.
-    sleep(1)
     return column_names, results
 
 
 def multiget_matomo_dashboards(at: datetime.datetime, dashboard_options: list[MatomoFetchOptions]):
     all_rows = []
     column_names = None
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
         futures = [
             executor.submit(
                 get_matomo_dashboard,

--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -101,8 +101,8 @@ MATOMO_OPTIONS = {
 
 MATOMO_TIMEOUT = 60  # in seconds. Matomo can be slow.
 
-METABASE_PUBLIC_DASHBOARDS_TABLE_NAME = "suivi_visiteurs_tb_publics_v0"
-METABASE_PRIVATE_DASHBOARDS_TABLE_NAME = "suivi_visiteurs_tb_prives_v0"
+METABASE_PUBLIC_DASHBOARDS_TABLE_NAME = "suivi_visiteurs_tb_publics_v1"
+METABASE_PRIVATE_DASHBOARDS_TABLE_NAME = "suivi_visiteurs_tb_prives_v1"
 
 
 def matomo_api_call(options):

--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -192,7 +192,7 @@ def multiget_matomo_dashboards(at: datetime.datetime, dashboard_options: list[Ma
         ]
         for future in concurrent.futures.as_completed(futures, timeout=60 * 60 * 3):  # 3h max for all dashboards
             cols, rows = future.result()
-            if rows is None:
+            if not cols or not rows:
                 continue
             # redefine column_names every time, they should always be the same
             column_names = cols

--- a/itou/metabase/management/test_populate_metabase_matomo.py
+++ b/itou/metabase/management/test_populate_metabase_matomo.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 import tenacity
 from django.core import management
@@ -48,8 +46,7 @@ MATOMO_ONLINE_CONTENT = (
 @pytest.mark.respx(base_url="https://mato.mo")
 @pytest.mark.usefixtures("metabase")
 @freeze_time("2022-06-21")
-def test_matomo_retry(monkeypatch, respx_mock, capsys):
-    monkeypatch.setattr(time, "sleep", lambda x: None)
+def test_matomo_retry(respx_mock, capsys):
     respx_mock.get("/index.php").respond(
         500,
         content=f"{MATOMO_HEADERS}\n{MATOMO_ONLINE_CONTENT}".encode("utf-16"),
@@ -87,8 +84,7 @@ def test_matomo_retry(monkeypatch, respx_mock, capsys):
 @pytest.mark.respx(base_url="https://mato.mo")
 @pytest.mark.usefixtures("metabase")
 @freeze_time("2022-06-21")
-def test_matomo_populate_public(monkeypatch, respx_mock):
-    monkeypatch.setattr(time, "sleep", lambda x: None)
+def test_matomo_populate_public(respx_mock):
     respx_mock.get("/index.php").respond(
         200,
         content=f"{MATOMO_HEADERS}\n{MATOMO_ONLINE_CONTENT}".encode("utf-16"),
@@ -199,7 +195,6 @@ def test_matomo_populate_private(monkeypatch, respx_mock):
 
     # rewrite the REGIONS import or the test, even with mocked HTTP calls, is several minutes
     monkeypatch.setattr(populate_metabase_matomo, "REGIONS", {"Bretagne": ["75", "31"]})
-    monkeypatch.setattr(time, "sleep", lambda x: None)
     respx_mock.get("/index.php").respond(
         200,
         content=f"{MATOMO_HEADERS}\n{MATOMO_ONLINE_CONTENT}".encode("utf-16"),
@@ -337,8 +332,7 @@ def test_matomo_populate_private(monkeypatch, respx_mock):
 @pytest.mark.respx(base_url="https://mato.mo")
 @pytest.mark.usefixtures("metabase")
 @freeze_time("2022-06-21")
-def test_matomo_empty_output(monkeypatch, respx_mock, capsys):
-    monkeypatch.setattr(time, "sleep", lambda x: None)
+def test_matomo_empty_output(respx_mock, capsys):
     MATOMO_ONLINE_EMPTY_CONTENT = "0," * 56 + "0"
     respx_mock.get("/index.php").respond(
         200,

--- a/itou/metabase/management/test_populate_metabase_matomo.py
+++ b/itou/metabase/management/test_populate_metabase_matomo.py
@@ -91,7 +91,7 @@ def test_matomo_populate_public(respx_mock):
     )
     management.call_command("populate_metabase_matomo", wet_run=True, mode="public")
     with connection.cursor() as cursor:
-        cursor.execute("SELECT * FROM suivi_visiteurs_tb_publics_v0")
+        cursor.execute("SELECT * FROM suivi_visiteurs_tb_publics_v1")
         rows = cursor.fetchall()
         assert len(rows) == 13
         assert rows[0] == (
@@ -201,7 +201,7 @@ def test_matomo_populate_private(monkeypatch, respx_mock):
     )
     management.call_command("populate_metabase_matomo", wet_run=True, mode="private")
     with connection.cursor() as cursor:
-        cursor.execute("SELECT * FROM suivi_visiteurs_tb_prives_v0")
+        cursor.execute("SELECT * FROM suivi_visiteurs_tb_prives_v1")
         rows = cursor.fetchall()
         assert len(rows) == 23
         assert rows[0] == (

--- a/itou/metabase/sql/025_suivi_visiteurs_tous_tb.sql
+++ b/itou/metabase/sql/025_suivi_visiteurs_tous_tb.sql
@@ -15,7 +15,7 @@ visiteurs_prives_0 as (
         svtp0."Tableau de bord" as tableau_de_bord,
         to_number(svtp0."Unique visitors", '99') as visiteurs_uniques
     from
-        suivi_visiteurs_tb_prives_v0 svtp0 /* Nouvelle table créée par Victor qui démarre le 19/12/22 */
+        suivi_visiteurs_tb_prives_v1 svtp0 /* Nouvelle table créée par Victor qui démarre le 01/01/22 */
 ),
 visiteurs_publics as (
     select

--- a/itou/metabase/sql/030_taux_penetration_tb_prives.sql
+++ b/itou/metabase/sql/030_taux_penetration_tb_prives.sql
@@ -53,11 +53,11 @@ visiteurs_prives_0 as (
         svtp0."Département" as departement,
         svtp0."Nom Département" as nom_departement
     from
-        suivi_visiteurs_tb_prives_v0 svtp0 /* Nouvelle table créée par Victor qui démarre le 19/12/22 */
+        suivi_visiteurs_tb_prives_v1 svtp0 /* Nouvelle table créée par Victor qui démarre le 01/01/22 */
 ),
 /* Tables finales utilisées pour l'union all */
-visiteur_utilisateurs as ( 
-    select 
+visiteur_utilisateurs as (
+    select
         semaine,
         tableau_de_bord,
         visiteurs_uniques,
@@ -65,7 +65,7 @@ visiteur_utilisateurs as (
         vup.nombre_utilisateurs,
         vu.departement,
         vu.nom_departement
-    from 
+    from
         visiteurs_prives vu
     left join visiteurs_utilisateurs_privés vup
         on
@@ -73,7 +73,7 @@ visiteur_utilisateurs as (
         and vu.departement = vup.departement
 ),
 visiteur_utilisateurs_0 as (
-    select 
+    select
         semaine,
         tableau_de_bord,
         visiteurs_uniques,
@@ -81,7 +81,7 @@ visiteur_utilisateurs_0 as (
         vup.nombre_utilisateurs,
         vu.departement,
         vu.nom_departement
-    from 
+    from
         visiteurs_prives_0 vu
     left join visiteurs_utilisateurs_privés vup
         on


### PR DESCRIPTION
Sometimes the order of execution makes it possible that we don't write any of the results to metabase.

Explanation: we run 20 dashboard fetches in parallel.

Let's imagine that the 19 first to return get us valid values, but unfortunately the 20th and latest is empty.

We would not detect correctly its emptiness and would make `columns` be [], which would in turn make the subsequent check before updating Metabase fail.

Not only because of this but because the Matomo table structure did change, we need to re-run this from the beginning of 2022.

This is tricky to test though cause the order of the ThreadPoolExecutor is by nature non deterministic so it is difficult to design mocks so that the first URLs are filled and "the last one consulted" is empty.
