### PR TITLE
Metabase : correctifs pour intégrer un filtre par type de structure sur le tb suivi CAP

### DIFF
--- a/itou/metabase/sql/038_suivi_cap_criteres.sql
+++ b/itou/metabase/sql/038_suivi_cap_criteres.sql
@@ -5,6 +5,7 @@ select
     -- REFUSED et REFUSED_2 correspondent au même état (?) - à confirmer par Zo
     case when "cap_criteres"."état" = 'REFUSED_2' then 'REFUSED' else "cap_criteres"."état" end as état,
     "camp"."nom" as "nom_campagne",
+    "structs"."département" as "département",
     "structs"."nom_département" as "nom_département",
     "structs"."région" as "nom_région",
     "structs"."type" as "type_structure"

--- a/itou/metabase/sql/038_suivi_cap_criteres.sql
+++ b/itou/metabase/sql/038_suivi_cap_criteres.sql
@@ -6,7 +6,8 @@ select
     case when "cap_criteres"."état" = 'REFUSED_2' then 'REFUSED' else "cap_criteres"."état" end as état,
     "camp"."nom" as "nom_campagne",
     "structs"."nom_département" as "nom_département",
-    "structs"."région" as "nom_région"
+    "structs"."région" as "nom_région",
+    "structs"."type" as "type_structure"
 from
     "cap_critères_iae" cap_criteres
     left join "critères_iae" criteres on cap_criteres."id_critère_iae" = criteres.id

--- a/itou/metabase/sql/038_suivi_cap_criteres.sql
+++ b/itou/metabase/sql/038_suivi_cap_criteres.sql
@@ -3,7 +3,7 @@ select
     "criteres"."id" as "id_critère",
     "criteres"."niveau" as "niveau_critère",
     -- REFUSED et REFUSED_2 correspondent au même état (?) - à confirmer par Zo
-    case when "cap_criteres"."état" = 'REFUSED_2' then 'REFUSED' else "cap_criteres"."état" end as état,
+    case when "cap_criteres"."état" = 'REFUSED_2' then 'REFUSED' else "cap_criteres"."état" end as "état",
     "camp"."nom" as "nom_campagne",
     "structs"."département" as "département",
     "structs"."nom_département" as "nom_département",
@@ -11,8 +11,8 @@ select
     "structs"."type" as "type_structure"
 from
     "cap_critères_iae" cap_criteres
-    left join "critères_iae" criteres on cap_criteres."id_critère_iae" = criteres.id
-    left join "cap_candidatures" candidatures on cap_criteres.id_cap_candidature = candidatures.id
-    left join "cap_structures" cap_structs on candidatures.id_cap_structure = cap_structs.id
-    left join "structures" structs on cap_structs.id_structure = structs.id
-    left join "cap_campagnes" camp on cap_structs.id_cap_campagne = camp.id;
+    left join "critères_iae" criteres on "cap_criteres"."id_critère_iae" = "criteres"."id"
+    left join "cap_candidatures" candidatures on "cap_criteres"."id_cap_candidature" = "candidatures"."id"
+    left join "cap_structures" cap_structs on "candidatures"."id_cap_structure" = "cap_structs"."id"
+    left join "structures" structs on "cap_structs"."id_structure" = "structs"."id"
+    left join "cap_campagnes" camp on "cap_structs"."id_cap_campagne" = "camp"."id";

--- a/itou/metabase/sql/039_suivi_cap_structures.sql
+++ b/itou/metabase/sql/039_suivi_cap_structures.sql
@@ -1,0 +1,22 @@
+select
+    id_cap_campagne,
+    cap_campagnes.nom as nom_campagne,
+    cap_structures.id_structure id_cap_structure,
+    structures.id id_structure,
+    structures.type,
+    structures.nom_département as nom_département,
+    structures."région" as région,
+    case when cap_structures. "date_contrôle" is not null then
+        1
+    else
+        0
+    end as "controlee",
+    cap_structures.état
+from
+    "public"."structures" structures
+    left join "public"."cap_structures" cap_structures on structures. "id" = cap_structures. "id_structure"
+    left join "cap_campagnes" cap_campagnes on cap_structures.id_cap_campagne = cap_campagnes.id
+where
+    structures. "active" = 1 
+    --and
+    --cap_structures. "date_contrôle" is not null;

--- a/itou/metabase/sql/039_suivi_cap_structures.sql
+++ b/itou/metabase/sql/039_suivi_cap_structures.sql
@@ -6,11 +6,14 @@ select
     structures.type,
     structures.nom_département as nom_département,
     structures."région" as région,
-    structures.active as active,
-    case when cap_structures. "date_contrôle" is not null then
-        1
+    case when structures.active = 1 then
+        'Oui'
     else
-        0
+        'Non' end as active,
+    case when cap_structures. "date_contrôle" is not null then
+        'Oui'
+    else
+        'Non'
     end as "controlee",
     cap_structures.état
 from

--- a/itou/metabase/sql/039_suivi_cap_structures.sql
+++ b/itou/metabase/sql/039_suivi_cap_structures.sql
@@ -4,7 +4,8 @@ select
     cap_structures.id_structure id_cap_structure,
     structures.id id_structure,
     structures.type,
-    structures.nom_département as nom_département,
+    structures."département" as "département",
+    structures."nom_département" as "nom_département",
     structures."région" as région,
     case when structures.active = 1 then
         'Oui'

--- a/itou/metabase/sql/039_suivi_cap_structures.sql
+++ b/itou/metabase/sql/039_suivi_cap_structures.sql
@@ -1,13 +1,13 @@
 select
-    id_cap_campagne,
-    cap_campagnes.nom as nom_campagne,
-    cap_structures.id_structure id_cap_structure,
-    structures.id id_structure,
-    structures.type,
-    structures."département" as "département",
-    structures."nom_département" as "nom_département",
-    structures."région" as région,
-    case when structures.active = 1 then
+    "id_cap_campagne",
+    "cap_campagnes"."nom" as nom_campagne,
+    "cap_structures"."id_structure" id_cap_structure,
+    "structures"."id" id_structure,
+    "structures"."type",
+    "structures"."département" as "département",
+    "structures"."nom_département" as "nom_département",
+    "structures"."région" as "région",
+    case when "structures"."active" = 1 then
         'Oui'
     else
         'Non' end as active,
@@ -16,8 +16,8 @@ select
     else
         'Non'
     end as "controlee",
-    cap_structures.état
+    "cap_structures"."état"
 from
     "public"."structures" structures
-    left join "public"."cap_structures" cap_structures on structures. "id" = cap_structures. "id_structure"
-    left join "cap_campagnes" cap_campagnes on cap_structures.id_cap_campagne = cap_campagnes.id;
+    left join "public"."cap_structures" cap_structures on "structures"."id" = "cap_structures"."id_structure"
+    left join "cap_campagnes" cap_campagnes on "cap_structures"."id_cap_campagne" = "cap_campagnes"."id";

--- a/itou/metabase/sql/039_suivi_cap_structures.sql
+++ b/itou/metabase/sql/039_suivi_cap_structures.sql
@@ -6,6 +6,7 @@ select
     structures.type,
     structures.nom_département as nom_département,
     structures."région" as région,
+    structures.active as active,
     case when cap_structures. "date_contrôle" is not null then
         1
     else
@@ -15,8 +16,4 @@ select
 from
     "public"."structures" structures
     left join "public"."cap_structures" cap_structures on structures. "id" = cap_structures. "id_structure"
-    left join "cap_campagnes" cap_campagnes on cap_structures.id_cap_campagne = cap_campagnes.id
-where
-    structures. "active" = 1 
-    --and
-    --cap_structures. "date_contrôle" is not null;
+    left join "cap_campagnes" cap_campagnes on cap_structures.id_cap_campagne = cap_campagnes.id;

--- a/itou/metabase/sql/039_suivi_cap_structures.sql
+++ b/itou/metabase/sql/039_suivi_cap_structures.sql
@@ -11,7 +11,7 @@ select
         'Oui'
     else
         'Non' end as active,
-    case when cap_structures. "date_contrôle" is not null then
+    case when "cap_structures"."date_contrôle" is not null then
         'Oui'
     else
         'Non'


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Suivi-du-contr-le-posteriori-Prise-en-compte-de-retours-362f52edf1d5453f9540f54753248397?pvs=4


### Pourquoi ?

Intégrer un filtre par type de structure pour le suivi du CAP
