### PR TITLE
Stats : Identification des DTPE (organisations PE qui chapeautent un département voire parfois plusieurs départements)

### DIFF
--- a/itou/prescribers/enums.py
+++ b/itou/prescribers/enums.py
@@ -49,3 +49,117 @@ class PrescriberAuthorizationStatus(models.TextChoices):
     VALIDATED = "VALIDATED", "Habilitation validée"
     REFUSED = "REFUSED", "Validation de l'habilitation refusée"
     NOT_REQUIRED = "NOT_REQUIRED", "Pas d'habilitation nécessaire"
+
+
+# DGPE, as in "Direction Générale Pôle emploi" is a special PE agency which oversees the whole country.
+DGPE_SAFIR_CODE = "00162"
+
+# DRPE, as in "Direction Régionale Pôle emploi", are special PE agencies which oversee their whole region.
+# We keep it simple by hardcoding their (short) list here to avoid the complexity of adding a field or a kind.
+DRPE_SAFIR_CODES = [
+    "13992",  # Provence-Alpes-Côte d'Azur
+    "20010",  # Corse
+    "21069",  # Bourgogne-Franche-Comté
+    "31096",  # Occitanie
+    "33127",  # Nouvelle-Aquitaine
+    "35076",  # Bretagne
+    "44116",  # Pays de la Loire
+    "45054",  # Centre-Val de Loire
+    "59212",  # Hauts-de-France
+    "67085",  # Grand Est
+    "69188",  # Auvergne-Rhône-Alpes
+    "75980",  # Île-de-France
+    "76115",  # Normandie
+    "97110",  # Guadeloupe
+    "97210",  # Martinique
+    "97310",  # Guyane
+    "97410",  # La Réunion
+    "97600",  # Mayotte
+]
+
+# DTPE, as in "Direction Territoriale Pôle emploi", are special PE agencies which generally oversee
+# their whole department and sometimes more than one department.
+# We keep it simple by hardcoding their list here to avoid the complexity of adding a field or a kind.
+# By default (`None`) a DTPE oversees its own department unless a list of several departments is specified below.
+DTPE_SAFIR_CODE_TO_DEPARTMENTS = {
+    # Note that the first two digits of the SAFIR code usually indicate the department.
+    "10038": None,
+    "11030": ["09", "11"],
+    "13010": None,
+    "14056": None,
+    "17041": ["16", "17"],
+    "18029": None,
+    "20423": None,
+    "20431": None,
+    "21265": None,
+    "22045": None,
+    "24036": ["19", "24"],
+    "25019": ["25", "90"],
+    "26085": None,
+    "27002": None,
+    "28004": None,
+    "29110": None,
+    "30600": ["30", "48"],
+    "311": None,
+    "31403": None,
+    "33390": None,
+    "34300": None,
+    "35141": None,
+    "37056": None,
+    "38040": None,
+    "40029": ["40", "47"],
+    "4016": None,
+    "42060": None,
+    "44060": None,
+    "45000": None,
+    "49104": None,
+    "51023": None,
+    "54127": None,
+    "56106": None,
+    "57561": None,
+    "59470": None,
+    "6013": None,
+    "60260": None,
+    "62750": None,
+    "63074": None,
+    "64093": None,
+    "65020": ["65", "32"],
+    "66004": None,
+    "67014": None,
+    "68311": None,
+    "69050": None,
+    "70007": ["39", "70"],
+    "71002": None,
+    "72203": ["72", "53"],
+    "73055": None,
+    "74063": None,
+    "75082": None,
+    "76266": None,
+    "77206": None,
+    "78201": None,
+    "80073": None,
+    "8056": None,
+    "81003": ["81", "12"],
+    "82013": ["82", "46"],
+    "83142": None,
+    "84002": None,
+    "85004": None,
+    "86083": ["79", "86"],
+    "87068": ["23", "87"],
+    "88654": None,
+    "89031": ["58", "89"],
+    "91211": None,
+    "92301": None,
+    "93326": None,
+    "94305": None,
+    "951": None,
+    "952": None,
+    "95204": None,
+    "97201": None,
+    "97312": None,
+    "97460": None,
+    "97549": None,
+    "97600": None,
+    "97715": None,
+    "97716": None,
+}

--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -8,7 +8,13 @@ from django.utils.http import urlencode
 
 from itou.common_apps.address.models import AddressMixin
 from itou.common_apps.organizations.models import MembershipAbstract, OrganizationAbstract, OrganizationQuerySet
-from itou.prescribers.enums import PrescriberAuthorizationStatus, PrescriberOrganizationKind
+from itou.prescribers.enums import (
+    DGPE_SAFIR_CODE,
+    DRPE_SAFIR_CODES,
+    DTPE_SAFIR_CODE_TO_DEPARTMENTS,
+    PrescriberAuthorizationStatus,
+    PrescriberOrganizationKind,
+)
 from itou.utils.emails import get_email_message
 from itou.utils.urls import get_absolute_url, get_tally_form_url
 from itou.utils.validators import validate_code_safir, validate_siret
@@ -87,32 +93,6 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
 
     In case 3, we talk about "prescripteur habilité" in French.
     """
-
-    # DGPE, as in "Direction Générale Pôle emploi" is a special PE agency which oversees the whole country.
-    DGPE_SAFIR_CODE = "00162"
-
-    # DRPE, as in "Direction Régionale Pôle emploi", are special PE agencies which oversee their whole region.
-    # We keep it simple by hardcoding their (short) list here to avoid the complexity of adding a field or a kind.
-    DRPE_SAFIR_CODES = [
-        "13992",
-        "20010",
-        "21069",
-        "31096",
-        "33127",
-        "35076",
-        "44116",
-        "45054",
-        "59212",
-        "67085",
-        "69188",
-        "75980",
-        "76115",
-        "97110",
-        "97210",
-        "97310",
-        "97410",
-        "97600",
-    ]
 
     # Rules:
     # - a SIRET was not mandatory in the past (some entries still have a "blank" siret)
@@ -300,14 +280,25 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
         """
         DGPE, as in "Direction Générale Pôle emploi" is a special PE agency which oversees the whole country.
         """
-        return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi == self.DGPE_SAFIR_CODE
+        return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi == DGPE_SAFIR_CODE
 
     @property
     def is_drpe(self):
         """
         DRPE, as in "Direction Régionale Pôle emploi", are special PE agencies which oversee their whole region.
         """
-        return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi in self.DRPE_SAFIR_CODES
+        return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi in DRPE_SAFIR_CODES
+
+    @property
+    def is_dtpe(self):
+        """
+        DTPE, as in "Direction Territoriale Pôle emploi", are special PE agencies which generally oversee
+        their whole department and sometimes more than one department.
+        """
+        return (
+            self.kind == PrescriberOrganizationKind.PE
+            and self.code_safir_pole_emploi in DTPE_SAFIR_CODE_TO_DEPARTMENTS
+        )
 
 
 class PrescriberMembership(MembershipAbstract):

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -31,7 +31,7 @@
                 {% endif %}
                 {% if can_view_stats_pe %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
-                        <a href="https://plateforme-inclusion.notion.site/Guide-d-analyse-des-tableaux-de-bord-P-le-emploi-dad8530e64af47bd99787a6d4e81f6b9?mtm_campaign=Notion-Guide-analyse-PE&mtm_kwd=Guide-analyse-PE"
+                        <a href="https://plateforme-inclusion.notion.site/Guide-d-analyse-des-tableaux-de-bord-P-le-emploi-dad8530e64af47bd99787a6d4e81f6b9"
                            rel="noopener"
                            target="_blank"
                            aria-label="Accéder au guide d'analyse Pôle emploi (ouverture dans un nouvel onglet)"

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -34,7 +34,11 @@ from itou.common_apps.address.format import format_address
 from itou.common_apps.address.models import AddressMixin
 from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
-from itou.prescribers.enums import PrescriberAuthorizationStatus, PrescriberOrganizationKind
+from itou.prescribers.enums import (
+    DTPE_SAFIR_CODE_TO_DEPARTMENTS,
+    PrescriberAuthorizationStatus,
+    PrescriberOrganizationKind,
+)
 from itou.prescribers.models import PrescriberOrganization
 from itou.siaes.enums import SiaeKind
 from itou.siaes.models import Siae
@@ -753,6 +757,9 @@ class User(AbstractUser, AddressMixin):
             return DEPARTMENTS.keys()
         if current_org.is_drpe:
             return REGIONS[current_org.region]
+        if current_org.is_dtpe:
+            departments = DTPE_SAFIR_CODE_TO_DEPARTMENTS[current_org.code_safir_pole_emploi]
+            return [current_org.department] if departments is None else departments
         return [current_org.department]
 
     def can_view_stats_ddets(self, current_org):

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -679,10 +679,33 @@ class ModelTest(TestCase):
             authorized=True, kind=PrescriberOrganizationKind.PE, department="93"
         )
         user = regular_pe_agency.members.get()
+        assert not regular_pe_agency.is_dtpe
         assert not regular_pe_agency.is_drpe
         assert not regular_pe_agency.is_dgpe
         assert user.can_view_stats_pe(current_org=regular_pe_agency)
         assert user.get_stats_pe_departments(current_org=regular_pe_agency) == ["93"]
+
+    def test_can_view_stats_pe_as_dtpe_with_single_department(self):
+        dtpe_with_single_department = PrescriberOrganizationWithMembershipFactory(
+            authorized=True, kind=PrescriberOrganizationKind.PE, code_safir_pole_emploi="49104", department="49"
+        )
+        user = dtpe_with_single_department.members.get()
+        assert dtpe_with_single_department.is_dtpe
+        assert not dtpe_with_single_department.is_drpe
+        assert not dtpe_with_single_department.is_dgpe
+        assert user.can_view_stats_pe(current_org=dtpe_with_single_department)
+        assert user.get_stats_pe_departments(current_org=dtpe_with_single_department) == ["49"]
+
+    def test_can_view_stats_pe_as_dtpe_with_multiple_departments(self):
+        dtpe_with_multiple_departments = PrescriberOrganizationWithMembershipFactory(
+            authorized=True, kind=PrescriberOrganizationKind.PE, code_safir_pole_emploi="72203", department="72"
+        )
+        user = dtpe_with_multiple_departments.members.get()
+        assert dtpe_with_multiple_departments.is_dtpe
+        assert not dtpe_with_multiple_departments.is_drpe
+        assert not dtpe_with_multiple_departments.is_dgpe
+        assert user.can_view_stats_pe(current_org=dtpe_with_multiple_departments)
+        assert user.get_stats_pe_departments(current_org=dtpe_with_multiple_departments) == ["72", "53"]
 
     def test_can_view_stats_pe_as_drpe(self):
         drpe = PrescriberOrganizationWithMembershipFactory(
@@ -691,6 +714,7 @@ class ModelTest(TestCase):
         user = drpe.members.get()
         assert drpe.is_drpe
         assert not drpe.is_dgpe
+        assert not drpe.is_dtpe
         assert user.can_view_stats_pe(current_org=drpe)
         assert user.get_stats_pe_departments(current_org=drpe) == ["75", "77", "78", "91", "92", "93", "94", "95"]
 
@@ -700,6 +724,7 @@ class ModelTest(TestCase):
         )
         user = dgpe.members.get()
         assert not dgpe.is_drpe
+        assert not dgpe.is_dtpe
         assert dgpe.is_dgpe
         assert user.can_view_stats_pe(current_org=dgpe)
         assert user.get_stats_pe_departments(current_org=dgpe) == DEPARTMENTS.keys()

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -269,9 +269,14 @@ def render_stats_pe(request, page_title):
             "matomo_custom_url_suffix": f"{format_region_for_matomo(current_org.region)}/drpe",
             "region": current_org.region,
         }
+    elif current_org.is_dtpe:
+        context |= {
+            "matomo_custom_url_suffix": f"{format_region_and_department_for_matomo(current_org.department)}/dtpe",
+            "department": current_org.department,
+        }
     else:
         context |= {
-            "matomo_custom_url_suffix": format_region_and_department_for_matomo(current_org.department),
+            "matomo_custom_url_suffix": f"{format_region_and_department_for_matomo(current_org.department)}/agence",
             "department": current_org.department,
         }
     return render_stats(request=request, context=context, params=params)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Identifier-les-DTPE-dans-C1-pour-un-acc-s-aux-donn-es-des-d-partements-rattach-s-cfb152057ab146a8a0e847ab8d446118**

### Pourquoi ?

Jusqu'ici les DTPE étaient indistinguables des agences PE classiques, et donc n'avaient accès qu'aux stats de leur département.

Or certaines DTPE sont techniquement multi-départements, on doit donc les recenser pour leur donner accès à leurs différents départements automatiquement.

### Comment ?

Similairement à la méthode qu'on utilisait déjà pour les DRPE et la DGPE.