### PR TITLE
[Metabase] : retrait d'une condition inutile

### DIFF
--- a/itou/metabase/sql/034_candidats_auto_prescription.sql
+++ b/itou/metabase/sql/034_candidats_auto_prescription.sql
@@ -56,11 +56,6 @@ with autopr_candidates as (
     left join candidats c
     on
         cd.id_candidat = c.id
-    where 
-        état = 'Candidature acceptée'
-        and c.type_auteur_diagnostic = 'Employeur'
-        and cd.origine = 'Employeur'
-        and c.id_auteur_diagnostic_employeur = cd.id_structure
 ),
 all_candidates as (
     select


### PR DESCRIPTION


Retrait de certaines lignes filtrant l'autoprescription directement sur le script sql, alors que cela peut se faire sur metabase (déjà corrigé de ce côté là).



