### PR TITLE
Permettre de changer les informations personnelles d'utilisateurs sous PE Connect

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -12,6 +12,7 @@ from itou.prescribers.models import PrescriberMembership
 from itou.siaes.models import SiaeMembership
 from itou.users import models
 from itou.users.admin_forms import ItouUserCreationForm, UserAdminForm
+from itou.users.enums import IdentityProvider
 from itou.utils.admin import PkSupportRemarkInline
 
 
@@ -268,7 +269,9 @@ class ItouUserAdmin(UserAdmin):
         if not request.user.is_superuser:
             rof += ("is_staff", "is_superuser", "groups", "user_permissions")
         if obj and obj.has_sso_provider:
-            rof += ("first_name", "last_name", "email", "username")
+            rof += ("username",)
+            if obj.identity_provider != IdentityProvider.PE_CONNECT:
+                rof += ("first_name", "last_name", "email")
         return rof
 
 

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -8,6 +8,7 @@ from itou.job_applications.notifications import (
     NewQualifiedJobAppEmployersNotification,
     NewSpontaneousJobAppEmployersNotification,
 )
+from itou.users.enums import IdentityProvider
 from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.apis.exceptions import AddressLookupError
@@ -17,8 +18,8 @@ from itou.utils.widgets import DuetDatePickerWidget, MultipleSwitchCheckboxWidge
 class SSOReadonlyMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.instance.has_sso_provider:
-            # When a user has logged in with a SSO,
+        if self.instance.has_sso_provider and self.instance.identity_provider != IdentityProvider.PE_CONNECT:
+            # When a user has logged in with a SSO other than PEAMU
             # it should see the field but most should be disabled
             # (that’s a requirement on FranceConnect’s side).
             disabled_fields = ["first_name", "last_name", "email", "birthdate"]
@@ -52,8 +53,8 @@ class EditJobSeekerInfoForm(JobSeekerNIRUpdateMixin, MandatoryAddressFormMixin, 
         )
 
         # Noboby can edit its own email.
-        if self.instance.has_sso_provider:
-            # If the job seeker uses SSO, point them to the modification process
+        if self.instance.identity_provider == IdentityProvider.FRANCE_CONNECT:
+            # If the job seeker uses France Connect, point them to the modification process
             self.fields["email"].help_text = (
                 "Si vous souhaitez modifier votre adresse e-mail merci de "
                 f"<a href='{global_constants.ITOU_ASSISTANCE_URL}/#support' target='_blank'>"


### PR DESCRIPTION
### Pourquoi ?

Vu qu'on ne compte pas conserver PEAMU sur le long terme, et que modifier la connexion pour mettre à jour ces informations est complexe, autant juste donner la main au support et à l'utilisateur pour modifier les nom/prénom/email
