### PR TITLE
Retirer le tag "nouveau" de certains fonctionnalités

### DIFF
--- a/itou/templates/dashboard/includes/dora_card.html
+++ b/itou/templates/dashboard/includes/dora_card.html
@@ -4,9 +4,6 @@
             <div class="flex-grow-1">
                 <span class="h4 m-0">DORA</span>
             </div>
-            <div class="ml-2">
-                <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
-            </div>
         </div>
         <div class="card-body">
             <ul class="list-unstyled">

--- a/itou/templates/dashboard/includes/labor_inspector_evaluation_campains_card.html
+++ b/itou/templates/dashboard/includes/labor_inspector_evaluation_campains_card.html
@@ -4,11 +4,6 @@
             <div class="flex-grow-1">
                 <span class="h4 m-0">Contrôle a posteriori</span>
             </div>
-            {% if campaign_in_progress %}
-                <div class="ml-2">
-                    <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
-                </div>
-            {% endif %}
         </div>
         <div class="card-body">
             <ul class="list-unstyled">

--- a/itou/templates/dashboard/includes/prescriber_organisation_card.html
+++ b/itou/templates/dashboard/includes/prescriber_organisation_card.html
@@ -40,7 +40,6 @@
                             <i class="ri-list-unordered ri-lg ri-lg font-weight-normal"></i>
                             <span>Voir la liste des organisations conventionnées</span>
                         </a>
-                        <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
                     </li>
                 {% endif %}
             </ul>

--- a/itou/templates/dashboard/includes/siae_employees_card.html
+++ b/itou/templates/dashboard/includes/siae_employees_card.html
@@ -4,9 +4,6 @@
             <div class="flex-grow-1">
                 <span class="h4 m-0">Salariés</span>
             </div>
-            <div class="ml-2">
-                <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
-            </div>
         </div>
         <div class="card-body">
             <ul class="list-unstyled">

--- a/itou/templates/dashboard/includes/siae_evaluation_campains_card.html
+++ b/itou/templates/dashboard/includes/siae_evaluation_campains_card.html
@@ -4,9 +4,6 @@
             <div class="flex-grow-1">
                 <span class="h4 m-0">Contrôle a posteriori</span>
             </div>
-            <div class="ml-2">
-                <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
-            </div>
         </div>
         <div class="card-body">
             <ul class="list-unstyled">

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -333,9 +333,6 @@ class DashboardViewTest(TestCase):
             <div class="flex-grow-1">
                 <span class="h4 m-0">Contrôle a posteriori</span>
             </div>
-            <div class="ml-2">
-                <span class="badge badge-pill badge-sm badge-important text-white">Nouveau</span>
-            </div>
             """,
             html=True,
             count=1,

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -43,7 +43,6 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
     job_applications_categories = []
     num_rejected_employee_records = 0
     active_campaigns = []
-    campaign_in_progress = False
     evaluated_siae_notifications = EvaluatedSiae.objects.none()
     show_previous_year_financial_annex_info = False
 
@@ -113,7 +112,6 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
     if request.user.is_labor_inspector:
         current_org = get_current_institution_or_404(request)
         active_campaigns = EvaluationCampaign.objects.for_institution(current_org).viewable()
-        campaign_in_progress = any(campaign.ended_at is None for campaign in active_campaigns)
 
     ic_activate_url = None
     if request.user.identity_provider != IdentityProvider.INCLUSION_CONNECT and request.user.kind in [
@@ -145,7 +143,6 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_view_stats_dihal": request.user.can_view_stats_dihal(current_org=current_org),
         "num_rejected_employee_records": num_rejected_employee_records,
         "active_campaigns": active_campaigns,
-        "campaign_in_progress": campaign_in_progress,
         "evaluated_siae_notifications": evaluated_siae_notifications,
         "precriber_kind_pe": PrescriberOrganizationKind.PE,
         "precriber_kind_dept": PrescriberOrganizationKind.DEPT,


### PR DESCRIPTION
https://www.notion.so/plateforme-inclusion/Retirer-le-tag-nouveau-du-bloc-dora-et-bloc-salari-s-54378a3e41e5493da882b11f64ded725?pvs=4

### Pourquoi ?

Les blocs espace salarié, dora et contrôle à posteriori ne sont plus vraiment nouveaux
