### PR TITLE
Metabase : prise en compte de la table V1 pour les visiteurs publics

### DIFF
--- a/itou/metabase/sql/025_suivi_visiteurs_tous_tb.sql
+++ b/itou/metabase/sql/025_suivi_visiteurs_tous_tb.sql
@@ -23,7 +23,7 @@ visiteurs_publics as (
         vp."Tableau de bord" as tableau_de_bord,
         to_number(vp."Unique visitors", '99') as visiteurs_uniques
     from
-        suivi_visiteurs_tb_publics_V0 vp /* Nouvelle table créée par Victor qui reprend toutes les infos des visiteurs des TBs publics */
+        suivi_visiteurs_tb_publics_V1 vp /* Nouvelle table créée par Victor qui reprend toutes les infos des visiteurs des TBs publics */
 )
 select
     semaine,

--- a/itou/metabase/sql/025_suivi_visiteurs_tous_tb.sql
+++ b/itou/metabase/sql/025_suivi_visiteurs_tous_tb.sql
@@ -23,7 +23,7 @@ visiteurs_publics as (
         vp."Tableau de bord" as tableau_de_bord,
         to_number(vp."Unique visitors", '99') as visiteurs_uniques
     from
-        suivi_visiteurs_tb_publics_V1 vp /* Nouvelle table créée par Victor qui reprend toutes les infos des visiteurs des TBs publics */
+        suivi_visiteurs_tb_publics_v1 vp /* Nouvelle table créée par Victor qui reprend toutes les infos des visiteurs des TBs publics */
 )
 select
     semaine,


### PR DESCRIPTION
Prise en compte de la table `_v1` pour le suivi des visiteurs des TBs publics et non `_v0`

