### PR TITLE
Metabase : suivi contrôle a posteriori -> distinguer les criteres non transmis de ceux non controlés

### DIFF
--- a/itou/metabase/sql/038_suivi_cap_criteres.sql
+++ b/itou/metabase/sql/038_suivi_cap_criteres.sql
@@ -14,8 +14,6 @@ select
         'Non vérifié'
         when "cap_criteres"."état" = 'PENDING' and "cap_criteres"."date_transmission" is null then
         'Non transmis'
-    else
-        "cap_criteres"."état"
     end as "état",
     "camp"."nom" as "nom_campagne",
     "structs"."département" as "département",

--- a/itou/metabase/sql/038_suivi_cap_criteres.sql
+++ b/itou/metabase/sql/038_suivi_cap_criteres.sql
@@ -3,7 +3,20 @@ select
     "criteres"."id" as "id_critère",
     "criteres"."niveau" as "niveau_critère",
     -- REFUSED et REFUSED_2 correspondent au même état (?) - à confirmer par Zo
-    case when "cap_criteres"."état" = 'REFUSED_2' then 'REFUSED' else "cap_criteres"."état" end as "état",
+    case 
+        when "cap_criteres"."état" = 'ACCEPTED' then
+        'Accepté'
+        when "cap_criteres"."état" = 'REFUSED_2' then
+        'Refusé'
+        when "cap_criteres"."état" = 'REFUSED' then
+        'Refusé'
+        when "cap_criteres"."état" = 'PENDING' and "cap_criteres"."date_transmission" is not null then
+        'Non vérifié'
+        when "cap_criteres"."état" = 'PENDING' and "cap_criteres"."date_transmission" is null then
+        'Non transmis'
+    else
+        "cap_criteres"."état"
+    end as "état",
     "camp"."nom" as "nom_campagne",
     "structs"."département" as "département",
     "structs"."nom_département" as "nom_département",


### PR DESCRIPTION
Les critères à l'état pending peuvent en réalité être de deux types différent : 
- Non transmis : si pas de date de transmission et état pending
- Non contrôlés : si une date de transmission mais toujours état pending 

On souhaite pouvoir distinguer les deux cas sur le suivi des critères. 
