### PR TITLE
tests: Ajout de `pytest-timeout`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 
 venv: $(VIRTUAL_ENV)
 
-PIP_COMPILE_FLAGS := --upgrade --allow-unsafe --generate-hashes
+PIP_COMPILE_FLAGS := --allow-unsafe --generate-hashes $(PIP_COMPILE_OPTIONS)
 compile-deps: $(VIRTUAL_ENV)
 	pip-compile $(PIP_COMPILE_FLAGS) -o requirements/base.txt requirements/base.in
 	pip-compile $(PIP_COMPILE_FLAGS) -o requirements/dev.txt requirements/dev.in

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,5 @@ addopts =
     --strict-markers
 markers =
     no_django_db: mark tests that should not be marked with django_db.
+timeout = 15
+timeout_method = thread

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -32,4 +32,5 @@ respx  # https://lundberg.github.io/respx/
 pytest  # https://github.com/pytest-dev/pytest
 pytest-django # https://github.com/pytest-dev/pytest-django/
 pytest-mock  # https://github.com/pytest-dev/pytest-mock/
+pytest-timeout  # https://github.com/pytest-dev/pytest-timeout
 pytest-xdist  # https://pypi.org/project/pytest-xdist/

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -911,6 +911,7 @@ pytest==7.2.2 \
     #   -r requirements/dev.in
     #   pytest-django
     #   pytest-mock
+    #   pytest-timeout
     #   pytest-xdist
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
@@ -919,6 +920,10 @@ pytest-django==4.5.2 \
 pytest-mock==3.10.0 \
     --hash=sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b \
     --hash=sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f
+    # via -r requirements/dev.in
+pytest-timeout==2.1.0 \
+    --hash=sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9 \
+    --hash=sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6
     # via -r requirements/dev.in
 pytest-xdist==3.2.1 \
     --hash=sha256:1849bd98d8b242b948e472db7478e090bf3361912a8fed87992ed94085f54727 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1315,3 +1315,15 @@ zipstream==1.1.4 \
     # via
     #   -r requirements/base.txt
     #   xlsx-streaming
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==23.0.1 \
+    --hash=sha256:236bcb61156d76c4b8a05821b988c7b8c35bf0da28a4b614e8d6ab5212c25c6f \
+    --hash=sha256:cd015ea1bfb0fcef59d8a286c1f8bebcb983f6317719d415dc5351efb7cd7024
+    # via pip-tools
+setuptools==67.6.0 \
+    --hash=sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077 \
+    --hash=sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2
+    # via
+    #   nodeenv
+    #   pip-tools


### PR DESCRIPTION
### Pourquoi ?

Afin de détecter automatiquement les tests qui prendraient trop de temps, par défaut nos tests ne devraient pas prendre plus que quelques secondes donc autant avoir un outils qui le fait pour nous :).
Typiquement, les 15 secondes sont là car il faut un certain temps en `--create-db`, je suppose qu'en simplifier le setup de la DB on devrais pouvoir réduire ce temps, même si ça devrais surement être au plugin de ne pas compter ça dedans :shrug:.

J'ai également ajouté la règle `upgrade-deps` dans le Makefile et enlever le `--upgrade` de `compile-deps` car ça me courrais sur le haricot de modifier les fichiers à la mains lors de l'ajout d'une nouvelles dépendance.
Y a encore des trucs pas clair avec les `--allow-unsafe` et `--generate-hashes` car `pip-compile` veux ajouter ça en fin de fichier :
```
# The following packages are considered to be unsafe in a requirements file:
pip==23.0.1 \
    --hash=sha256:236bcb61156d76c4b8a05821b988c7b8c35bf0da28a4b614e8d6ab5212c25c6f \
    --hash=sha256:cd015ea1bfb0fcef59d8a286c1f8bebcb983f6317719d415dc5351efb7cd7024
    # via pip-tools
setuptools==67.6.0 \
    --hash=sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077 \
    --hash=sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2
    # via
    #   nodeenv
    #   pip-tools

```
Donc à voir...