### PR TITLE
Candidatures : L'annulation n'est plus possible si une fiche salarié existe

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -580,17 +580,6 @@ class EmployeeRecord(ASPExchangeInformation):
         return self._batch_line_number
 
     @property
-    def is_blocking_job_application_cancellation(self):
-        """
-        Linked job application can't be cancelled if the employee record
-        is sent or already processed.
-        """
-        return self.status in [
-            Status.SENT,
-            Status.PROCESSED,
-        ]
-
-    @property
     def is_orphan(self):
         """Orphan employee records have different stored and actual `asp_id` fields."""
         return self.job_application.to_siae.convention.asp_id != self.asp_id

--- a/itou/employee_record/tests/tests_models.py
+++ b/itou/employee_record/tests/tests_models.py
@@ -627,35 +627,6 @@ class EmployeeRecordJobApplicationConstraintsTest(TestCase):
         self.employee_record = EmployeeRecord.from_job_application(self.job_application)
         self.employee_record.update_as_ready()
 
-    @mock.patch(
-        "itou.common_apps.address.format.get_geocoding_data",
-        side_effect=mock_get_geocoding_data,
-    )
-    def test_job_application_is_cancellable(self, _mock):
-        # A job application can be cancelled only if there is no
-        # linked employee records with ACCEPTED or SENT status
-
-        # status is READY
-        assert self.job_application.can_be_cancelled
-
-        # status is SENT
-        self.employee_record.update_as_sent(self.faker.asp_batch_filename(), 1, None)
-        assert not self.job_application.can_be_cancelled
-
-        # status is REJECTED
-        self.employee_record.update_as_rejected("12", "JSON Invalide", None)
-        assert self.job_application.can_be_cancelled
-
-        # status is PROCESSED
-        self.employee_record.update_as_ready()
-        self.employee_record.update_as_sent(self.faker.asp_batch_filename(), 1, None)
-        process_code, process_message = (
-            EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE,
-            "La ligne de la fiche salarié a été enregistrée avec succès.",
-        )
-        self.employee_record.update_as_processed(process_code, process_message, "{}")
-        assert not self.job_application.can_be_cancelled
-
 
 class TestEmployeeRecordQueryset:
     @pytest.mark.parametrize("status", list(Status))

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -703,15 +703,10 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     def can_be_cancelled(self):
         if self.origin == Origin.AI_STOCK:
             return False
-        if self.hiring_start_at:
-            # A job application can be canceled provided that
-            # there is no employee record linked with a status:
-            # - SENT
-            # - ACCEPTED
-            # (likely to be accepted or already accepted by ASP)
-            employee_record = self.employee_record.first()
-            blocked = employee_record and employee_record.is_blocking_job_application_cancellation
-            return not blocked
+        if not self.employee_record.exists():
+            # A job application can be canceled provided that there is no employee record linked to it,
+            # as it is possible that some information were already sent to the ASP.
+            return True
         return False
 
     @property

--- a/itou/templates/apply/includes/state_transition_siae.html
+++ b/itou/templates/apply/includes/state_transition_siae.html
@@ -73,7 +73,6 @@
             <p>
                 {{ job_application.job_seeker.get_full_name|title }} restera éligible à l'IAE et pourra de nouveau vous envoyer une candidature dans le futur.
             </p>
-            <p>Si une fiche salarié a été saisie pour cette embauche, elle sera annulée.</p>
         {% endif %}
         <p>
             <a href="{% url 'apply:cancel' job_application_id=job_application.id %}" class="btn btn-danger btn-block text-decoration-none">Annuler l'embauche</a>


### PR DESCRIPTION
### Pourquoi ?

L'ASP nous a remonté un cas de doublon de PASS IAE pour la même personne, la SIAE a désactivé la FS ce qui lui à permis d'annuler la candidature ce qui a ensuite eu pour effet de supprimer le PASS IAE puisque cette candidature était la seule acceptée.
L'annulation à été possible car actuellement une fiche salarié existante ne bloque que si celle-ci est dans l'état `SENT` ou `PROCESSED`, mais les autres états (en particulier `DISABLED` et `ARCHIVED`) ne veulent pas forcément dire que celle-ci n'a jamais été envoyée (et acceptée) par l'ASP.

### Comment

La piste de bloquer dès la présence d'une FS à été prise afin d'être (quasiment) sûr que ce cas ne se reproduira pas, ou en tout cas pas involontairement, et pour simplifier la logique métier de _Si FS dans tel ou tel état alors annulation possible_ à _Si FS, annulation impossible_ d'autant plus que nous n'avons actuellement pas de moyen fiable de savoir si les données d'un PASS ont déjà été envoyé ou pas.