### PR TITLE
BOOST: Amélioration de l'alerte d'annulation de candidature

### DIFF
--- a/itou/templates/apply/process_cancel.html
+++ b/itou/templates/apply/process_cancel.html
@@ -12,7 +12,11 @@
             </div>
             <div class="col">
                 <p class="mb-0">
-                    En validant, <b>vous renoncez aux aides au poste</b> liées à cette candidature pour tous les jours travaillés de ce salarié. Si ce salarié a travaillé dans votre structure, il est préférable de suspendre son PASS IAE ci-dessus.
+                    {% if job_application.to_siae.is_subject_to_eligibility_rules %}
+                        En validant, <b>vous renoncez aux aides au poste</b> liées à cette candidature pour tous les jours travaillés de ce salarié. Si ce salarié a travaillé dans votre structure, il est préférable de suspendre son PASS IAE ci-dessus.
+                    {% else %}
+                        En annulant cette embauche, vous confirmez que le salarié n’avait pas encore commencé à travailler dans votre structure.
+                    {% endif %}
                 </p>
             </div>
         </div>

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -371,7 +371,7 @@ def cancel(request, job_application_id, template_name="apply/process_cancel.html
     """
     Trigger the `cancel` transition.
     """
-    queryset = JobApplication.objects.siae_member_required(request.user)
+    queryset = JobApplication.objects.siae_member_required(request.user).select_related("to_siae")
     job_application = get_object_or_404(queryset, id=job_application_id)
     check_waiting_period(job_application)
     next_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.pk})


### PR DESCRIPTION
https://www.notion.so/plateforme-inclusion/Adapter-le-texte-de-confirmation-d-annulation-d-embauche-pour-les-structures-GEIQ-EA-et-OPCS-boost-e5176bea4d1345c783a188e32c7ea661?pvs=4

### Pourquoi ?

Certaines structures ne sont pas concernées par les PASS IAE, il ne faut pas leur en parler.
