### PR TITLE
Stats : Tentative de résolution d'une erreur CSP sur l'iframe utilisée par le site Pilotage

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -585,6 +585,9 @@ CSP_FRAME_SRC = [
     "https://communaute.inclusion.beta.gouv.fr",
     "https://inclusion.beta.gouv.fr",
 ]
+CSP_FRAME_ANCESTORS = [
+    "https://pilotage.inclusion.beta.gouv.fr",
+]
 CSP_IMG_SRC = [
     "'self'",
     "data:",  # Because of tarteaucitron.js


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/CT7986ULC/p1678980016000689**

### Pourquoi ?

On a une erreur `Refused to display 'https://emplois.inclusion.beta.gouv.fr/' in a frame because it set 'X-Frame-Options' to 'deny'.` dans certaines situations, par exemple depuis https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/cartographies-iae/

L'erreur n'est pas complètement comprise, notamment elle disparait mystérieusement en mode incognito (sans cookie). Mais cela n'a aucun sens, une erreur CSP devrait être systématique.

![image](https://user-images.githubusercontent.com/10533583/225697480-d8239db2-130a-4bee-83a0-7ce8bb33d722.png)

### Comment ?

En permettant le bon `frame-ancestor`.

Liens utiles :
- https://django-csp.readthedocs.io/en/latest/configuration.html?highlight=frame%20ancestor
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
