### PR TITLE
Stats : Fix d'une erreur 500 qui se produisait quand un utilisateur authentifié sur le C1 tentait d'accéder à un tableau de bord public sur https://pilotage.inclusion.beta.gouv.fr/

### DIFF
--- a/itou/www/stats/tests/tests_views.py
+++ b/itou/www/stats/tests/tests_views.py
@@ -11,6 +11,7 @@ from itou.common_apps.address.departments import DEPARTMENT_TO_REGION
 from itou.institutions.factories import InstitutionWithMembershipFactory
 from itou.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from itou.siaes.factories import SiaeFactory
+from itou.users.factories import PrescriberFactory
 from itou.utils.apis.metabase import METABASE_DASHBOARDS
 from itou.utils.test import TestCase
 
@@ -31,6 +32,16 @@ class StatsViewTest(TestCase):
         PILOTAGE_DASHBOARDS_WHITELIST=[123], METABASE_SITE_URL="http://metabase.fake", METABASE_SECRET_KEY="foobar"
     )
     def test_stats_pilotage_authorized_dashboard_id(self):
+        url = reverse("stats:stats_pilotage", kwargs={"dashboard_id": 123})
+        response = self.client.get(url)
+        assert response.status_code == 200
+
+    @override_settings(
+        PILOTAGE_DASHBOARDS_WHITELIST=[123], METABASE_SITE_URL="http://metabase.fake", METABASE_SECRET_KEY="foobar"
+    )
+    def test_stats_pilotage_authorized_dashboard_id_while_authenticated(self):
+        user = PrescriberFactory()
+        self.client.force_login(user)
         url = reverse("stats:stats_pilotage", kwargs={"dashboard_id": 123})
         response = self.client.get(url)
         assert response.status_code == 200

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -128,7 +128,7 @@ def render_stats(request, context, params=None, template_name="stats/stats.html"
         # E.g. `/stats/ddets/iae/Provence-Alpes-Cote-d-Azur/04---Alpes-de-Haute-Provence`
         base_context["matomo_custom_url"] += f"/{matomo_custom_url_suffix}"
 
-    if request.user.is_authenticated:
+    if request.user.is_authenticated and metabase_dashboard:
         siae_pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_SIAE_KEY)
         prescriber_org_pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_PRESCRIBER_ORG_KEY)
         institution_pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_INSTITUTION_KEY)


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/CT7986ULC/p1678980016000689**

Erreur sentry : https://itou.sentry.io/issues/4001309519/?project=6164438&referrer=issue-stream

### Pourquoi ?

Bug introduit par le commit suivant (merci sentry !) : https://github.com/betagouv/itou/commit/a673510c897566a644aa207a314feb3d651d2ba7

C'est passé à travers les filets car normalement pour les TB publics on ne pense pas à les tester en étant identifié sur le C1...

### Comment ?

Ajout d'un test en mode TDD.

Les analytics ont vocation à être utilisé pour les TB privés uniquement, ça n'a pas de sens pour les TB publics de Pilotage.