### PR TITLE
Ajout d'une vérification sur le type des candidats d'une candidature

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -23,6 +23,7 @@ from itou.job_applications.enums import Origin, RefusalReason, SenderKind
 from itou.job_applications.tasks import huey_notify_pole_emploi
 from itou.siaes.enums import ContractType, SiaeKind
 from itou.siaes.models import Siae
+from itou.users.enums import UserKind
 from itou.utils.emails import get_email_message, send_email_messages
 from itou.utils.urls import get_absolute_url
 
@@ -633,6 +634,11 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
 
     def clean(self):
         super().clean()
+
+        # We have severals cases of job_applications on job_seekers or siae_staff
+        # We don't know how it happened, so we'll just add a sanity check here
+        if self.job_seeker_id and self.job_seeker.kind != UserKind.JOB_SEEKER:
+            raise ValidationError("Seul un candidat peut candidater")
 
         # `to_siae` is not guaranteed to exist if a `full_clean` is performed in some occasions (f.i. in an admin form)
         # checking existence of `to_siae_id` keeps us safe here

--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -42,7 +42,7 @@ from itou.jobs.factories import create_test_romes_and_appellations
 from itou.jobs.models import Appellation
 from itou.siaes.enums import ContractType, SiaeKind
 from itou.siaes.factories import SiaeWithMembershipAndJobsFactory
-from itou.users.factories import ItouStaffFactory, JobSeekerFactory, SiaeStaffFactory
+from itou.users.factories import ItouStaffFactory, JobSeekerFactory, PrescriberFactory, SiaeStaffFactory
 from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.templatetags import format_filters
@@ -288,6 +288,10 @@ class JobApplicationModelTest(TestCase):
             nb_hours_per_week=30,
             contract_type_details="foo",
         )
+
+    def test_application_on_non_job_seeker(self):
+        with self.assertRaisesRegex(ValidationError, "Seul un candidat peut candidater"):
+            JobApplicationFactory(job_seeker=PrescriberFactory())
 
 
 class JobApplicationQuerySetTest(TestCase):
@@ -1806,6 +1810,13 @@ class JobApplicationAdminFormTest(TestCase):
         job_application.sender_prescriber_organization = None
         form = JobApplicationAdminForm(model_to_dict(job_application))
         assert form.is_valid()
+
+    def test_application_on_non_job_seeker(self):
+        job_application = JobApplicationFactory()
+        job_application.job_seeker = PrescriberFactory()
+        form = JobApplicationAdminForm(model_to_dict(job_application))
+        assert not form.is_valid()
+        assert ["Seul un candidat peut candidater"] == form.errors["__all__"]
 
 
 class JobApplicationsEnumsTest(TestCase):

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -20,6 +20,7 @@ from itou.eligibility.models import AdministrativeCriteria
 from itou.job_applications import enums as job_applications_enums
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.enums import SIAE_WITH_CONVENTION_KINDS, ContractType, SiaeKind
+from itou.users.enums import UserKind
 from itou.users.models import JobSeekerProfile, User
 from itou.utils import constants as global_constants
 from itou.utils.validators import validate_nir, validate_pole_emploi_id
@@ -94,6 +95,12 @@ class CheckJobSeekerNirForm(forms.Form):
                     'target="_blank" aria-label="Ouverture dans un nouvel onglet">nous contacter</a>.'
                 )
                 raise forms.ValidationError(mark_safe(error_message))
+        elif existing_account and existing_account.kind != UserKind.JOB_SEEKER:
+            error_message = (
+                "Vous ne pouvez postuler pour cet utilisateur car ce numéro de sécurité sociale "
+                "est assicé à un prescripteur ou à un employeur."
+            )
+            raise forms.ValidationError(error_message)
         else:
             # For the moment, consider NIR to be unique among users.
             self.job_seeker = existing_account

--- a/itou/www/apply/tests/tests_forms.py
+++ b/itou/www/apply/tests/tests_forms.py
@@ -10,7 +10,7 @@ from itou.job_applications.factories import (
     JobApplicationSentBySiaeFactory,
 )
 from itou.siaes.enums import ContractType, SiaeKind
-from itou.users.factories import JobSeekerFactory
+from itou.users.factories import JobSeekerFactory, PrescriberFactory
 from itou.utils.test import TestCase
 from itou.www.apply import forms as apply_forms
 
@@ -49,6 +49,15 @@ class CheckJobSeekerNirFormTest(TestCase):
         form = apply_forms.CheckJobSeekerNirForm(job_seeker=user, data=form_data)
         assert not form.is_valid()
         assert "Ce numéro de sécurité sociale est déjà utilisé par un autre compte." in form.errors["nir"][0]
+
+        existing_account = PrescriberFactory(nir=JobSeekerFactory.build().nir)
+        form_data = {"nir": existing_account.nir}
+        form = apply_forms.CheckJobSeekerNirForm(data=form_data)
+        assert not form.is_valid()
+        assert (
+            "Vous ne pouvez postuler pour cet utilisateur car ce numéro de sécurité sociale "
+            "est assicé à un prescripteur ou à un employeur."
+        ) == form.errors["nir"][0]
 
 
 class RefusalFormTest(TestCase):


### PR DESCRIPTION
### Pourquoi ?

Éviter que des prescripteurs ou employeurs ne puissent candidater
