### PR TITLE
Simplification / Suppression de variables à passer aux templates

### DIFF
--- a/itou/templates/apply/includes/buttons/accept.html
+++ b/itou/templates/apply/includes/buttons/accept.html
@@ -1,13 +1,12 @@
 <div class="my-3">
+    {% url 'apply:accept' job_application_id=job_application.pk as accept_url %}
     {% if show_geiq_eligibility_modal %}
         <button class="btn btn-primary btn-block" data-toggle="modal" data-target="#confirm_no_allowance_modal">
             Je l'embauche
         </button>
         {# Confirmation modal for hiring #}
-        {% include "apply/includes/geiq/no_allowance_modal.html" %}
+        {% include "apply/includes/geiq/no_allowance_modal.html" with next_url=accept_url %}
     {% else %}
-        <a href="{% url 'apply:accept' job_application_id=job_application.pk %}" class="btn btn-primary btn-block">
-            Je l'embauche
-        </a>
+        <a href="{{ accept_url }}" class="btn btn-primary btn-block">Je l'embauche</a>
     {% endif %}
 </div>

--- a/itou/templates/apply/includes/buttons/accept.html
+++ b/itou/templates/apply/includes/buttons/accept.html
@@ -1,6 +1,8 @@
 <div class="my-3">
     {% if show_geiq_eligibility_modal %}
-        <button class="btn btn-primary btn-block" data-toggle="modal" data-target="#confirm_modal">Je l'embauche</button>
+        <button class="btn btn-primary btn-block" data-toggle="modal" data-target="#confirm_no_allowance_modal">
+            Je l'embauche
+        </button>
     {% else %}
         <a href="{% url 'apply:accept' job_application_id=job_application.pk %}" class="btn btn-primary btn-block">
             Je l'embauche

--- a/itou/templates/apply/includes/buttons/accept.html
+++ b/itou/templates/apply/includes/buttons/accept.html
@@ -1,6 +1,6 @@
 <div class="my-3">
     {% url 'apply:accept' job_application_id=job_application.pk as accept_url %}
-    {% if show_geiq_eligibility_modal %}
+    {% if not geiq_eligibility_diagnosis or not geiq_eligibility_diagnosis.is_valid %}
         <button class="btn btn-primary btn-block" data-toggle="modal" data-target="#confirm_no_allowance_modal">
             Je l'embauche
         </button>

--- a/itou/templates/apply/includes/buttons/accept.html
+++ b/itou/templates/apply/includes/buttons/accept.html
@@ -3,6 +3,8 @@
         <button class="btn btn-primary btn-block" data-toggle="modal" data-target="#confirm_no_allowance_modal">
             Je l'embauche
         </button>
+        {# Confirmation modal for hiring #}
+        {% include "apply/includes/geiq/no_allowance_modal.html" %}
     {% else %}
         <a href="{% url 'apply:accept' job_application_id=job_application.pk %}" class="btn btn-primary btn-block">
             Je l'embauche

--- a/itou/templates/apply/includes/geiq/check_geiq_eligibility_form.html
+++ b/itou/templates/apply/includes/geiq/check_geiq_eligibility_form.html
@@ -7,16 +7,16 @@
 
 <div class="my-4 text-right">
     <a href="{{ back_url }}" class="btn btn-link">Annuler</a>
-    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#confirm_modal" {% if not form.proof_of_eligibility.value or form.errors %} disabled{% endif %}>
+    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#confirm_geiq_eligibility_modal" {% if not form.proof_of_eligibility.value or form.errors %} disabled{% endif %}>
         Valider les critères d'éligibilité GEIQ
     </button>
 </div>
 
-<div id="confirm_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+<div id="confirm_geiq_eligibility_modal" class="modal fade" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
-                <h3 class="modal-title" id="confirm_modal">Confirmer votre choix</h3>
+                <h3 class="modal-title">Confirmer votre choix</h3>
             </div>
             <div class="modal-body">
                 {% if allowance_amount != 0 %}

--- a/itou/templates/apply/includes/geiq/continue_without_geiq_diagnosis_form.html
+++ b/itou/templates/apply/includes/geiq/continue_without_geiq_diagnosis_form.html
@@ -9,7 +9,7 @@
 <div class="my-4 text-right">
     <a href="{{ back_url }}" class="btn btn-link">Annuler</a>
     <input type="hidden" id="next_url" value="{{ next_url }}">
-    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#confirm_modal">
+    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#confirm_no_allowance_modal">
         Continuer sans valider les critères GEIQ
     </button>
 </div>

--- a/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
+++ b/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
@@ -112,8 +112,3 @@
         {% endif %}
     {% endif %}
 {% endif %}
-
-{# Confirmation modal for hiring #}
-{% if show_geiq_eligibility_modal %}
-    {% include "apply/includes/geiq/no_allowance_modal.html" %}
-{% endif %}

--- a/itou/templates/apply/includes/geiq/no_allowance_modal.html
+++ b/itou/templates/apply/includes/geiq/no_allowance_modal.html
@@ -1,8 +1,8 @@
-<div id="confirm_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+<div id="confirm_no_allowance_modal" class="modal fade" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
-                <h3 class="modal-title" id="confirm_modal">Confirmer votre choix</h3>
+                <h3 class="modal-title">Confirmer votre choix</h3>
             </div>
             <div class="modal-body">Êtes-vous sûr de vouloir continuer sans bénéficier d’une aide financière de l’État ?</div>
             <div class="modal-footer">

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -52,7 +52,7 @@
                 <hr>
                 <h2>Embauche</h2>
                 {% bootstrap_form_errors form_accept type="non_fields" %}
-                {% if siae_is_geiq %}
+                {% if job_application.to_siae.kind == SiaeKind.GEIQ %}
                     {% bootstrap_field form_accept.contract_type %}
                     <div id="contractTypeDetails" {% if not form_accept.is_bound or form_accept.contract_type.value != hide_value %}class="d-none"{% endif %}>
                         {% bootstrap_field form_accept.contract_type_details %}

--- a/itou/templates/apply/process_details_prescriber.html
+++ b/itou/templates/apply/process_details_prescriber.html
@@ -12,7 +12,7 @@
         <hr>
         <h3 >Informations personnelles</h3>
         {% include "apply/includes/job_seeker_info.html" with job_application=job_application %}
-        {% if siae_is_geiq and geiq_eligibility_diagnosis %}
+        {% if job_application.to_siae.kind == SiaeKind.GEIQ and geiq_eligibility_diagnosis %}
  
             {# GEIQ eligibility details #}
             {% include "apply/includes/geiq/geiq_diagnosis_details.html" with diagnosis=geiq_eligibility_diagnosis %}

--- a/itou/templates/apply/process_details_siae.html
+++ b/itou/templates/apply/process_details_siae.html
@@ -12,7 +12,7 @@
         <hr>
         <h3 >Informations personnelles</h3>
         {% include "apply/includes/job_seeker_info.html" with job_application=job_application %}
-        {% if siae_is_geiq %}
+        {% if job_application.to_siae.kind == SiaeKind.GEIQ %}
             {# GEIQ eligibility details #}
             {% include "apply/includes/geiq/geiq_diagnosis_details.html" with diagnosis=geiq_eligibility_diagnosis %}
         {% else %}

--- a/itou/utils/enums_context_processors.py
+++ b/itou/utils/enums_context_processors.py
@@ -1,5 +1,6 @@
 import itou.approvals.enums as approvals_enums
 import itou.job_applications.enums as job_applications_enums
+import itou.siaes.enums as siaes_enums
 
 
 def expose_enums(*args):
@@ -13,4 +14,5 @@ def expose_enums(*args):
         "JobApplicationOrigin": job_applications_enums.Origin,
         "SenderKind": job_applications_enums.SenderKind,
         "RefusalReason": job_applications_enums.RefusalReason,
+        "SiaeKind": siaes_enums.SiaeKind,
     }

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -111,7 +111,6 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
     if show_geiq_eligibility_modal:
         context |= {
             "show_geiq_eligibility_modal": show_geiq_eligibility_modal,
-            "next_url": reverse("apply:accept", kwargs={"job_application_id": job_application.pk}),
         }
 
     if geiq_eligibility_diagnosis:

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -86,9 +86,9 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
 
     back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("apply:list_for_siae"))
     geiq_eligibility_diagnosis = None
-    siae_is_geiq = job_application.to_siae.kind == SiaeKind.GEIQ
 
-    if siae_is_geiq:
+    show_geiq_eligibility_modal = False
+    if job_application.to_siae.kind == SiaeKind.GEIQ:
         # Get current GEIQ diagnosis or *last expired one*
         geiq_eligibility_diagnosis = (
             job_application.geiq_eligibility_diagnosis
@@ -97,9 +97,7 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
             ).first()
         )
 
-    show_geiq_eligibility_modal = siae_is_geiq and (
-        not geiq_eligibility_diagnosis or not geiq_eligibility_diagnosis.is_valid
-    )
+        show_geiq_eligibility_modal = not geiq_eligibility_diagnosis or not geiq_eligibility_diagnosis.is_valid
 
     context = {
         "can_view_personal_information": True,  # SIAE members have access to personal info
@@ -108,7 +106,6 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
         "job_application": job_application,
         "transition_logs": transition_logs,
         "back_url": back_url,
-        "siae_is_geiq": siae_is_geiq,
     }
 
     if show_geiq_eligibility_modal:
@@ -160,9 +157,8 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
     back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("apply:list_for_prescriber"))
 
     # Latest GEIQ diagnosis for this job seeker created by a *prescriber*
-    siae_is_geiq = job_application.to_siae.kind == SiaeKind.GEIQ
     geiq_eligibility_diagnosis = (
-        siae_is_geiq
+        job_application.to_siae.kind == SiaeKind.GEIQ
         and GEIQEligibilityDiagnosis.objects.valid()
         .filter(author_prescriber_organization__isnull=False)
         .for_job_seeker(job_application.job_seeker)
@@ -175,7 +171,6 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
         "geiq_eligibility_diagnosis": geiq_eligibility_diagnosis,
         "job_application": job_application,
         "transition_logs": transition_logs,
-        "siae_is_geiq": siae_is_geiq,
         "back_url": back_url,
     }
 
@@ -301,7 +296,6 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
         "form_personal_data": form_personal_data,
         "job_application": job_application,
         "can_view_personal_information": True,  # SIAE members have access to personal info
-        "siae_is_geiq": job_application.to_siae.kind == SiaeKind.GEIQ,
         "hide_value": ContractType.OTHER.value,
     }
 

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -87,7 +87,6 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
     back_url = get_safe_url(request, "back_url", fallback_url=reverse_lazy("apply:list_for_siae"))
     geiq_eligibility_diagnosis = None
 
-    show_geiq_eligibility_modal = False
     if job_application.to_siae.kind == SiaeKind.GEIQ:
         # Get current GEIQ diagnosis or *last expired one*
         geiq_eligibility_diagnosis = (
@@ -97,27 +96,15 @@ def details_for_siae(request, job_application_id, template_name="apply/process_d
             ).first()
         )
 
-        show_geiq_eligibility_modal = not geiq_eligibility_diagnosis or not geiq_eligibility_diagnosis.is_valid
-
     context = {
         "can_view_personal_information": True,  # SIAE members have access to personal info
         "eligibility_diagnosis": job_application.get_eligibility_diagnosis(),
         "expired_eligibility_diagnosis": expired_eligibility_diagnosis,
+        "geiq_eligibility_diagnosis": geiq_eligibility_diagnosis,
         "job_application": job_application,
         "transition_logs": transition_logs,
         "back_url": back_url,
     }
-
-    if show_geiq_eligibility_modal:
-        context |= {
-            "show_geiq_eligibility_modal": show_geiq_eligibility_modal,
-        }
-
-    if geiq_eligibility_diagnosis:
-        # show_geiq_eligibility_modal = True
-        context |= {
-            "geiq_eligibility_diagnosis": geiq_eligibility_diagnosis,
-        }
 
     return render(request, template_name, context)
 


### PR DESCRIPTION
A relire commit par commit

### Pourquoi ?

Faciliter la réutilisation des includes sans devoir passer trop de variables

