### PR TITLE
Envoyer le type de prescripteur à Pôle emploi

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -537,7 +537,9 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
                 encrypted_nir,
                 siae.siret,
                 type_siae,
-                job_application_enums.sender_kind_to_pe_origine_candidature(job_application.sender_kind),
+                origine_candidature=job_application_enums.sender_kind_to_pe_origine_candidature(
+                    job_application.sender_kind
+                ),
             )
         except PoleEmploiAPIException:
             logger.info("! notify_pole_emploi approval=%s got a recoverable error in maj_pass_iae", self)
@@ -1307,7 +1309,9 @@ class PoleEmploiApproval(PENotificationMixin, CommonApprovalMixin):
                 encrypted_nir,
                 self.siae_siret,
                 type_siae,
-                "PRES",  # hardcoded, PE approvals are assumed as coming from prescribers
+                origine_candidature=job_application_enums.sender_kind_to_pe_origine_candidature(
+                    job_application_enums.SenderKind.PRESCRIBER
+                ),  # hardcoded, PE approvals are assumed as coming from prescribers
             )
         except PoleEmploiAPIException:
             logger.info("! notify_pole_emploi pe_approval=%s got a recoverable error in maj_pass_iae", self)

--- a/itou/prescribers/enums.py
+++ b/itou/prescribers/enums.py
@@ -43,6 +43,24 @@ class PrescriberOrganizationKind(models.TextChoices):
     SPIP = "SPIP", "SPIP - Service pénitentiaire d'insertion et de probation"
     OTHER = "Autre", "Autre"
 
+    def to_PE_typologie_prescripteur(self):
+        if self in PE_SENSITIVE_PRESCRIBER_KINDS:
+            return PrescriberOrganizationKind.OTHER
+        return self
+
+
+# Sensitive prescriber kinds that we do not want to send via PE API
+PE_SENSITIVE_PRESCRIBER_KINDS = {
+    PrescriberOrganizationKind.ASE,
+    PrescriberOrganizationKind.CAARUD,
+    PrescriberOrganizationKind.CIDFF,
+    PrescriberOrganizationKind.CSAPA,
+    PrescriberOrganizationKind.PENSION,
+    PrescriberOrganizationKind.PJJ,
+    PrescriberOrganizationKind.PREVENTION,
+    PrescriberOrganizationKind.SPIP,
+}
+
 
 class PrescriberAuthorizationStatus(models.TextChoices):
     NOT_SET = "NOT_SET", "Habilitation en attente de validation"

--- a/itou/prescribers/tests.py
+++ b/itou/prescribers/tests.py
@@ -644,3 +644,44 @@ class UpdateRefusedPrescriberOrganizationKindManagementCommandsTest(TestCase):
             ).count()
         )
         assert 1 == PrescriberOrganization.objects.filter(kind=PrescriberOrganizationKind.OTHER).count()
+
+
+@pytest.mark.parametrize("organization_kind", PrescriberOrganizationKind)
+def test_organization_kind_to_PE_typologie_prescripteur(organization_kind):
+    # If you add a new value to PrescriberOrganizationKind:
+    # can this kind be sent to PoleEmploi or should it be considered as "sensitive" ?
+    # Cf PE_SENSITIVE_PRESCRIBER_KINDS variable
+    EXPECTED_TYPOLOGIE = {
+        PrescriberOrganizationKind.AFPA: "AFPA",
+        PrescriberOrganizationKind.ASE: "Autre",
+        PrescriberOrganizationKind.CAARUD: "Autre",
+        PrescriberOrganizationKind.CADA: "CADA",
+        PrescriberOrganizationKind.CAF: "CAF",
+        PrescriberOrganizationKind.CAP_EMPLOI: "CAP_EMPLOI",
+        PrescriberOrganizationKind.CAVA: "CAVA",
+        PrescriberOrganizationKind.CCAS: "CCAS",
+        PrescriberOrganizationKind.CHRS: "CHRS",
+        PrescriberOrganizationKind.CHU: "CHU",
+        PrescriberOrganizationKind.CIDFF: "Autre",
+        PrescriberOrganizationKind.CPH: "CPH",
+        PrescriberOrganizationKind.CSAPA: "Autre",
+        PrescriberOrganizationKind.DEPT: "DEPT",
+        PrescriberOrganizationKind.E2C: "E2C",
+        PrescriberOrganizationKind.EPIDE: "EPIDE",
+        PrescriberOrganizationKind.HUDA: "HUDA",
+        PrescriberOrganizationKind.ML: "ML",
+        PrescriberOrganizationKind.MSA: "MSA",
+        PrescriberOrganizationKind.OACAS: "OACAS",
+        PrescriberOrganizationKind.ODC: "ODC",
+        PrescriberOrganizationKind.OIL: "OIL",
+        PrescriberOrganizationKind.OTHER: "Autre",
+        PrescriberOrganizationKind.PE: "PE",
+        PrescriberOrganizationKind.PENSION: "Autre",
+        PrescriberOrganizationKind.PIJ_BIJ: "PIJ_BIJ",
+        PrescriberOrganizationKind.PJJ: "Autre",
+        PrescriberOrganizationKind.PLIE: "PLIE",
+        PrescriberOrganizationKind.PREVENTION: "Autre",
+        PrescriberOrganizationKind.RS_FJT: "RS_FJT",
+        PrescriberOrganizationKind.SPIP: "Autre",
+    }
+    assert organization_kind.to_PE_typologie_prescripteur() == EXPECTED_TYPOLOGIE[organization_kind]

--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -161,7 +161,9 @@ class PoleEmploiApiClient:
             raise PoleEmploiAPIBadResponse(API_CLIENT_EMPTY_NIR_BAD_RESPONSE)
         return id_national
 
-    def mise_a_jour_pass_iae(self, approval, encrypted_identifier, siae_siret, siae_type, origine_candidature):
+    def mise_a_jour_pass_iae(
+        self, approval, encrypted_identifier, siae_siret, siae_type, origine_candidature, typologie_prescripteur=None
+    ):
         """Example of a JSON response:
         {'codeSortie': 'S000', 'idNational': 'some identifier', 'message': 'Pass IAE prescrit'}
         The only valid result is HTTP 200 + codeSortie = "S000".
@@ -181,6 +183,8 @@ class PoleEmploiApiClient:
             "typeSIAE": siae_type,
             "origineCandidature": origine_candidature,
         }
+        if typologie_prescripteur is not None:
+            params["typologiePrescripteur"] = typologie_prescripteur
         data = self._request(f"{self.base_url}/maj-pass-iae/v1/passIAE/miseAjour", params)
         code_sortie = data.get("codeSortie")
         if code_sortie != API_MAJ_PASS_SUCCESS:


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Envoyer-le-type-de-prescripteur-P-le-emploi-007047d944224dab95a004a48ddd8cab

### Pourquoi ?

Enrichir les infos transmises dans les dossiers PE

### Comment

Attention, comme indiqué dans le ticket et le PPT joint, certains types de prescripteurs sont "sensibles" et on préfère donc envoyer la catégorie "Autre".

