### PR TITLE
Mise à jour de l'adresse email de contact dans les mentions légales

### DIFF
--- a/itou/templates/static/legal/privacy.html
+++ b/itou/templates/static/legal/privacy.html
@@ -166,7 +166,7 @@
         </li>
     </ul>
     <p>
-        Pour exercer ces droits ou pour toute question sur le traitement de vos données dans ce dispositif, contactez-nous à : <a href="mailto:dgefp.protectiondesdonnees@emploi.gouv.fr">dgefp.protectiondesdonnees@emploi.gouv.fr</a>.
+        Pour exercer ces droits ou pour toute question sur le traitement de vos données dans ce dispositif, contactez-nous à : <a href="mailto:dpo@numericite.eu">dpo@numericite.eu</a>.
         <br>
         Vous pouvez exercer vos droits également en adressant un courrier à l’attention du Délégué à la Protection des Données du GIP de l’inclusion par courrier :
     </p>


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/cgu-Mettre-jour-adresse-mail-5a214598ddb34ba8bd530e25ff9ee431?pvs=4

### Pourquoi ?

L'email a changé.

