### PR TITLE
Metabase : ajout du genre sur la table candidatures par secteur

### DIFF
--- a/itou/metabase/sql/032_metier_candidatures.sql
+++ b/itou/metabase/sql/032_metier_candidatures.sql
@@ -5,9 +5,6 @@ select
     crdp."code_rome" as code_rome
 from
     candidatures_echelle_locale cel
-inner join fiches_de_poste_par_candidature fdpc on
-    fdpc.id_candidature = cel.id
-inner join fiches_de_poste fdp on
-    fdpc.id_fiche_de_poste = fdp.id
-inner join code_rome_domaine_professionnel crdp on
-    fdp.code_rome = crdp.code_rome
+    inner join fiches_de_poste_par_candidature fdpc on fdpc.id_candidature = cel.id
+    inner join fiches_de_poste fdp on fdpc.id_fiche_de_poste = fdp.id
+    inner join code_rome_domaine_professionnel crdp on fdp.code_rome = crdp.code_rome

--- a/itou/metabase/sql/032_metier_candidatures.sql
+++ b/itou/metabase/sql/032_metier_candidatures.sql
@@ -6,7 +6,7 @@ select
     crdp."code_rome" as code_rome
 from
     candidatures_echelle_locale cel
-    left join candidats cand on candidats.id = cel.id_candidat
+    left join candidats cand on cand.id = cel.id_candidat
     inner join fiches_de_poste_par_candidature fdpc on fdpc.id_candidature = cel.id
     inner join fiches_de_poste fdp on fdpc.id_fiche_de_poste = fdp.id
     inner join code_rome_domaine_professionnel crdp on fdp.code_rome = crdp.code_rome

--- a/itou/metabase/sql/032_metier_candidatures.sql
+++ b/itou/metabase/sql/032_metier_candidatures.sql
@@ -1,10 +1,12 @@
 select
     cel.*,
+    cand.sexe_selon_nir,
     crdp."grand_domaine" as metier,
     fdp."nom_rome" as nom_rome,
     crdp."code_rome" as code_rome
 from
     candidatures_echelle_locale cel
+    left join candidats cand on candidats.id = cel.id_candidat
     inner join fiches_de_poste_par_candidature fdpc on fdpc.id_candidature = cel.id
     inner join fiches_de_poste fdp on fdpc.id_fiche_de_poste = fdp.id
     inner join code_rome_domaine_professionnel crdp on fdp.code_rome = crdp.code_rome

--- a/itou/metabase/sql/032_metier_candidatures.sql
+++ b/itou/metabase/sql/032_metier_candidatures.sql
@@ -1,8 +1,8 @@
 select
     cel.*,
-    grand_domaine as metier,
-    crdp.code_rome,
-    nom_rome
+    crdp."grand_domaine" as metier,
+    fdp."nom_rome" as nom_rome,
+    crdp."code_rome" as code_rome
 from
     candidatures_echelle_locale cel
 inner join fiches_de_poste_par_candidature fdpc on


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Ajouter-dans-TB-genre-la-sectorisation-17df3cf3af5f44a4b8a318d93b03a210?pvs=4

### Pourquoi ?

Créer des indicateur sur la répartition des candidatures h/f en fonction du secteur d activité

### Comment (optionnel)

nécessaire de passer par cette table car une candidature peut être associée à plusieurs fiches de poste



