### PR TITLE
Afficher le nombre de métiers dans SIAE job_description_list

### DIFF
--- a/itou/templates/siaes/job_description_list.html
+++ b/itou/templates/siaes/job_description_list.html
@@ -17,9 +17,9 @@
     <div class="shadow rounded p-4">
         <div class="row">
             <div class="col">
-                <h6>
-                    Le{{ job_pager.paginator.count|pluralize }} métier{{ job_pager.paginator.count|pluralize }} exercé{{ job_pager.paginator.count|pluralize }} dans votre structure
-                </h6>
+                <h3 class="h6">
+                    {{ job_pager.paginator.count }} métier{{ job_pager.paginator.count|pluralize }} exercé{{ job_pager.paginator.count|pluralize }} dans votre structure
+                </h3>
             </div>
             <div class="col text-right">
                 <a class="btn btn-primary btn-sm" href="{% url "siaes_views:edit_job_description" %}?page={{ page|default:1 }}" aria-label="Créer une nouvelle fiche de poste">Créer une nouvelle fiche de poste</a>

--- a/itou/www/siaes_views/tests/tests_job_description_views.py
+++ b/itou/www/siaes_views/tests/tests_job_description_views.py
@@ -77,8 +77,13 @@ class JobDescriptionListViewTest(JobDescriptionAbstractTest):
     def test_job_application_list_response_content(self):
         response = self._login(self.user)
 
-        assert response.status_code == 200
         assert self.siae.job_description_through.count() == 4
+        self.assertContains(
+            response,
+            '<h3 class="h6">4 métiers exercés dans votre structure</h3>',
+            html=True,
+            count=1,
+        )
         assert ITOU_SESSION_JOB_DESCRIPTION_KEY not in self.client.session
         assert ITOU_SESSION_CURRENT_PAGE_KEY in self.client.session
 


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Afficher-le-nombre-de-r-sultats-sur-la-liste-des-metiers-et-recrutements-036885d8b7254386a5a625b23dc52d6f**

### Comment ?

- `assert response.status == 200` est déjà effectué par `assertContains()`
- Le niveau de titre a été ajusté pour correspondre aux autres titres du document

### Capture d’écran

![Screenshot from 2023-03-29 11-20-46](https://user-images.githubusercontent.com/2758243/228488828-643d66fa-5aa6-41dd-9f78-b343fb981a20.png)