### PR TITLE
Faire correspondre les `handle()` des commandes avec leurs arguments

### DIFF
--- a/itou/approvals/management/commands/send_approvals_to_pe.py
+++ b/itou/approvals/management/commands/send_approvals_to_pe.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
         parser.add_argument("--delay", action="store", dest="delay", default=0, type=int, choices=range(0, 5))
 
-    def handle(self, wet_run=False, delay=0, **options):
+    def handle(self, *, wet_run, delay, **options):
         today = timezone.localdate()
         queryset = (
             approvals_models.Approval.objects.filter(

--- a/itou/approvals/management/commands/update_nir_from_pe_data.py
+++ b/itou/approvals/management/commands/update_nir_from_pe_data.py
@@ -173,7 +173,7 @@ class Command(BaseCommand):
             "--dry-run", dest="dry_run", action="store_true", help="Only print possible errors and stats"
         )
 
-    def handle(self, file_path, dry_run=False, **options):
+    def handle(self, file_path, *, dry_run, **options):
         self.dry_run = dry_run
         self.stdout.write("Exporting approvals / PASS IAE")
         # The fastest way I’ve found to parse this file is to use a CsvDictReader with a CSV file

--- a/itou/asp/management/commands/gen_asp_ref_fixtures.py
+++ b/itou/asp/management/commands/gen_asp_ref_fixtures.py
@@ -246,7 +246,7 @@ class Command(DeprecatedLoggerMixin, BaseCommand):
 
         self.write_fixture_file(export_path, records)
 
-    def handle(self, dry_run=False, **options):
+    def handle(self, *, dry_run, **options):
         self.dry_run = dry_run
         self.set_logger(options.get("verbosity"))
 

--- a/itou/cities/management/commands/sync_cities.py
+++ b/itou/cities/management/commands/sync_cities.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
-    def handle(self, wet_run, **options):
+    def handle(self, *, wet_run, **options):
         cities_from_api = fetch_cities() + fetch_cities(districts_only=True)
 
         cities_added_by_api = []

--- a/itou/employee_record/management/commands/archive_employee_records.py
+++ b/itou/employee_record/management/commands/archive_employee_records.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
         parser.add_argument("--wet-run", action="store_true")
 
     @transaction.atomic()
-    def handle(self, wet_run=False, **options):
+    def handle(self, *, wet_run, **options):
         self.stdout.write("Start archiving employee records")
 
         archivable = (

--- a/itou/employee_record/management/commands/clone_orphan_employee_records.py
+++ b/itou/employee_record/management/commands/clone_orphan_employee_records.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
         parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 
     @transaction.atomic()
-    def handle(self, for_siae, wet_run=False, **options):
+    def handle(self, for_siae, *, wet_run=False, **options):
         siae = siaes_models.Siae.objects.filter(pk=for_siae).select_related("convention").first()
         if not siae:
             self.stderr.write(f"No SIAE found for pk={for_siae!r}.")

--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -147,7 +147,7 @@ class Command(BaseCommand):
 
             self.stdout.write(" - done!")
 
-    def handle(self, dry_run=False, **options):
+    def handle(self, *, dry_run, **options):
         self.stdout.write("+ Checking employee records coherence before transfering to ASP")
 
         if dry_run:

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -276,15 +276,7 @@ class Command(EmployeeRecordTransferCommand):
         for batch in chunks(ready_employee_records, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS):
             self._upload_batch_file(sftp, batch, dry_run)
 
-    def handle(
-        self,
-        upload=False,
-        download=False,
-        preflight=False,
-        dry_run=False,
-        asp_test=False,
-        **_,
-    ):
+    def handle(self, *, upload, download, preflight, dry_run, asp_test, **_):
         if preflight:
             self.stdout.write("Preflight activated, checking for possible serialization errors...")
             self.preflight(EmployeeRecord)

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -223,7 +223,7 @@ class Command(EmployeeRecordTransferCommand):
         for batch in chunks(new_notifications, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS):
             self._upload_batch_file(conn, batch, dry_run)
 
-    def handle(self, upload=False, download=False, preflight=False, wet_run=False, asp_test=False, **options):
+    def handle(self, *, upload, download, preflight, wet_run, asp_test, **options):
         if not settings.ASP_FS_SFTP_HOST:
             self.stdout.write("Your environment is missing ASP_FS_SFTP_HOST to run this command.")
             return

--- a/itou/employee_record/tests/test_archive_employee_records.py
+++ b/itou/employee_record/tests/test_archive_employee_records.py
@@ -18,7 +18,7 @@ def test_management_command_default_run(command):
     employee_record = factories.EmployeeRecordFactory(archivable=True)
     assert list(EmployeeRecord.objects.archivable()) == [employee_record]
 
-    command.handle()
+    command.handle(wet_run=False)
     employee_record.refresh_from_db()
 
     assert employee_record.status != Status.ARCHIVED

--- a/itou/jobs/management/commands/sync_romes_and_appellations.py
+++ b/itou/jobs/management/commands/sync_romes_and_appellations.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
-    def handle(self, wet_run=False, **options):
+    def handle(self, *, wet_run, **options):
         now = timezone.now()
         pe_client = pole_emploi_api_client()
 

--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -209,7 +209,7 @@ class Command(BaseCommand):
         parser.add_argument("--mode", action="store", dest="mode", type=str, choices=self.MODE_TO_OPERATION.keys())
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
-    def handle(self, mode, wet_run, **options):
+    def handle(self, mode, *, wet_run, **options):
         today = datetime.date.today()
         max_date = datetime.date.today() - datetime.timedelta(days=today.weekday() + 1)
         # NOTE(vperron): if you need to initiate this table, just run the following line with

--- a/itou/prescribers/management/commands/import_pole_emploi_agencies.py
+++ b/itou/prescribers/management/commands/import_pole_emploi_agencies.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         if verbosity > 1:
             self.logger.setLevel(logging.DEBUG)
 
-    def handle(self, dry_run=False, path_to_file=None, **options):
+    def handle(self, path_to_file, *, dry_run, **options):
 
         self.set_logger(options.get("verbosity"))
 

--- a/itou/prescribers/management/commands/import_prescribers.py
+++ b/itou/prescribers/management/commands/import_prescribers.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
         if verbosity > 1:
             self.logger.setLevel(logging.DEBUG)
 
-    def handle(self, dry_run=False, **options):
+    def handle(self, *, dry_run, **options):
 
         self.set_logger(options.get("verbosity"))
 

--- a/itou/prescribers/management/commands/merge_organizations.py
+++ b/itou/prescribers/management/commands/merge_organizations.py
@@ -108,5 +108,5 @@ class Command(BaseCommand):
         )
         parser.add_argument("--dry-run", action=argparse.BooleanOptionalAction, default=False)
 
-    def handle(self, from_id, to_id, dry_run, **options):
+    def handle(self, from_id, to_id, *, dry_run, **options):
         organization_merge_into(from_id, to_id, dry_run)

--- a/itou/prescribers/management/commands/update_prescriber_organizations_with_api_entreprise.py
+++ b/itou/prescribers/management/commands/update_prescriber_organizations_with_api_entreprise.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         if verbosity > 1:
             self.logger.setLevel(logging.DEBUG)
 
-    def handle(self, days, n_organizations, verbosity, **options):
+    def handle(self, *, days, n_organizations, verbosity, **options):
         self.set_logger(verbosity)
 
         prescriber_orgs = PrescriberOrganization.objects.filter(

--- a/itou/scripts/management/commands/deduplicate_asp_approvals.py
+++ b/itou/scripts/management/commands/deduplicate_asp_approvals.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             help="Path of the ASP CSV file to deduplicate",
         )
 
-    def handle(self, file_path, debug, **options):
+    def handle(self, file_path, *, debug, **options):
         def debug_log(s):
             if debug:
                 self.stdout.write(f"[DEBUG_LOG] {s}")

--- a/itou/scripts/management/commands/export_asp_approval_data.py
+++ b/itou/scripts/management/commands/export_asp_approval_data.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         )
         parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 
-    def handle(self, file_path, wet_run=False, **options):
+    def handle(self, file_path, *, wet_run, **options):
         nb_unknown_approval_errors = 0
         nb_unknown_user_errors = 0
         nb_unknown_errors = 0

--- a/itou/scripts/management/commands/geolocate_jobseeker_addresses.py
+++ b/itou/scripts/management/commands/geolocate_jobseeker_addresses.py
@@ -290,6 +290,7 @@ class Command(BaseCommand):
     def handle(
         self,
         action,
+        *,
         filename: str,
         wet_run: bool,
         **options,

--- a/itou/scripts/management/commands/import_pe_approvals.py
+++ b/itou/scripts/management/commands/import_pe_approvals.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
         )
         parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 
-    def handle(self, file_path, wet_run=False, **options):
+    def handle(self, file_path, *, wet_run, **options):
         now = timezone.localdate()
 
         count_before = PoleEmploiApproval.objects.count()

--- a/itou/scripts/management/commands/import_pe_approvals_siret_kind.py
+++ b/itou/scripts/management/commands/import_pe_approvals_siret_kind.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         )
         parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 
-    def handle(self, file_path, wet_run=False, **options):
+    def handle(self, file_path, *, wet_run, **options):
         df = pd.read_excel(file_path)
         self.stdout.write(f"Ready to import up to length={len(df)} approvals from file={file_path}")
         df.apply(lambda row: update_approval(row, wet_run, self.stdout), axis=1)

--- a/itou/scripts/management/commands/merge_pe_approvals.py
+++ b/itou/scripts/management/commands/merge_pe_approvals.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
             print(f"Running:\n{query}")
             self.cursor.execute(query)
 
-    def handle(self, dry_run=False, reset=False, **options):
+    def handle(self, *, dry_run, reset, **options):
         self.dry_run = dry_run
         self.stdout.write("Merging approvals / PASS IAE")
         self.cursor = connection.cursor()

--- a/itou/scripts/management/commands/send_pe_approvals_to_pe.py
+++ b/itou/scripts/management/commands/send_pe_approvals_to_pe.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
         parser.add_argument("--delay", action="store", dest="delay", default=0, type=int, choices=range(0, 5))
 
-    def handle(self, wet_run=False, delay=0, **options):
+    def handle(self, *, wet_run, delay, **options):
         now = timezone.now()
 
         # change all the PoleEmploiApproval state to "error" if we can't get information on it.

--- a/itou/scripts/management/commands/update_nir_from_pass.py
+++ b/itou/scripts/management/commands/update_nir_from_pass.py
@@ -207,7 +207,7 @@ class Command(DeprecatedLoggerMixin, BaseCommand):
         )
         return df
 
-    def handle(self, file_path, dry_run=False, **options):
+    def handle(self, file_path, *, dry_run, **options):
         self.dry_run = dry_run
         self.set_logger(options.get("verbosity"))
         sample_size = options.get("sample_size")

--- a/itou/scripts/management/commands/update_pe_approvals_from_asp_data.py
+++ b/itou/scripts/management/commands/update_pe_approvals_from_asp_data.py
@@ -152,7 +152,7 @@ class Command(BaseCommand):
             "--dry-run", dest="dry_run", action="store_true", help="Only print possible errors and stats"
         )
 
-    def handle(self, file_path, dry_run=False, **options):
+    def handle(self, file_path, *, dry_run, **options):
         self.dry_run = dry_run
         self.stdout.write("Importing NIR from ASP data.")
         # The fastest way I’ve found to parse this file is to use a CsvDictReader with a CSV file

--- a/itou/siaes/management/commands/import_ea_eatt.py
+++ b/itou/siaes/management/commands/import_ea_eatt.py
@@ -175,7 +175,7 @@ class Command(BaseCommand):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
     @timeit
-    def handle(self, wet_run=False, **options):
+    def handle(self, *, wet_run, **options):
         ea_eatt_df, info_stats = get_ea_eatt_df()
         info_stats |= sync_structures(
             df=ea_eatt_df,

--- a/itou/siaes/management/commands/import_geiq.py
+++ b/itou/siaes/management/commands/import_geiq.py
@@ -120,7 +120,7 @@ class Command(BaseCommand):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
     @timeit
-    def handle(self, wet_run=False, **options):
+    def handle(self, *, wet_run, **options):
         geiq_df, info_stats = get_geiq_df()
         info_stats |= sync_structures(
             df=geiq_df,

--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
         )
         parser.add_argument("--wet-run", action=argparse.BooleanOptionalAction, default=False)
 
-    def handle(self, from_id, to_id, wet_run=False, only_job_applications=False, **options):
+    def handle(self, from_id, to_id, *, wet_run, only_job_applications, **options):
         if from_id == to_id:
             self.stderr.write("Unable to use the same siae as source and destination (ID %s)\n" % from_id)
             return

--- a/itou/siaes/management/commands/sync_pec_offers.py
+++ b/itou/siaes/management/commands/sync_pec_offers.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
         parser.add_argument("--delay", action="store", dest="delay", default=1, type=int, choices=range(0, 5))
 
-    def handle(self, wet_run, delay, **options):
+    def handle(self, *, wet_run, delay, **options):
         pe_client = pole_emploi_api_client()
         pe_siae = Siae.unfiltered_objects.get(siret=POLE_EMPLOI_SIRET)
 

--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -169,7 +169,7 @@ class Command(XlsxExportMixin, DeprecatedLoggerMixin, BaseCommand):
             # We are only logging for now.
             self.NIR_DUPLICATES_LOGS.append(log_info)
 
-    def handle(self, wet_run=False, no_xlsx=False, **options):
+    def handle(self, *, wet_run, no_xlsx, **options):
 
         self.set_logger(options.get("verbosity"))
 

--- a/itou/users/management/commands/extract_c2_users.py
+++ b/itou/users/management/commands/extract_c2_users.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
             "Région": org.region,
         }
 
-    def handle(self, no_csv=False, **options):
+    def handle(self, *, no_csv, **options):
 
         self.no_csv = no_csv
 


### PR DESCRIPTION
Pensez à mettre le label "no-changelog" si nécessaire.

### Pourquoi ?

Éviter de dupliquer la valeur par défaut des arguments, qui risque d’entraîner une différence entre l’appel via `call_command` et l’appel via la *CLI*.

### Comment (optionnel)

Les arguments positionnels, requis sont passés de manière positionnelle. Les arguments optionnels sont passés en tant que *keyword only arguments*.