### PR TITLE
Metabase : CAP : ne prendre en compte que les structures actives 

### DIFF
--- a/itou/metabase/sql/037_suivi_cap.sql
+++ b/itou/metabase/sql/037_suivi_cap.sql
@@ -1,4 +1,3 @@
-create table suivi_cap as
 with nb_structures_par_dept as (
     select
         "département",

--- a/itou/metabase/sql/037_suivi_cap.sql
+++ b/itou/metabase/sql/037_suivi_cap.sql
@@ -1,3 +1,4 @@
+create table suivi_cap as
 with nb_structures_par_dept as (
     select
         "département",
@@ -66,6 +67,7 @@ from
     left join structures struct on cap_struct_cnt.id_structure = struct.id
     left join cap_campagnes cap_camp on cap_camp.id = cap_struct_cnt.id_cap_campagne
     left join nb_structures_par_dept nb_tot_dep on nb_tot_dep. "nom_département" = struct. "nom_département"
+where struct.active = 1
 group by
     cap_camp.nom,
     struct. "région",


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Suivi-du-contr-le-posteriori-derniers-retours-avant-d-ploiement-854a9d94fd62412d90d7377b2b840baa?pvs=4

### Pourquoi ?

Correction d'incohérences liées aux structures inactives mais contrôlées.

