### PR TITLE
Corrections : badge d'éligibilité GEIQ et redirection des orienteurs

### DIFF
--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -27,7 +27,7 @@
                                 <span class="badge badge-base badge-pill badge-warning"><i class="ri-error-warning-line"></i>Éligibilité IAE à valider</span>
                             {% endif %}
                         {% elif is_subject_to_geiq_eligibility_rules %}
-                            {% if geiq_eligibility_diagnosis %}
+                            {% if geiq_eligibility_diagnosis.eligibility_confirmed %}
                                 <span class="badge badge-base badge-pill badge-success-light"><i class="ri-check-fill"></i>Éligibilité GEIQ confirmée</span>
                             {% else %}
                                 <span class="badge badge-base badge-pill badge-warning-light text-warning"><i class="ri-information-line"></i>Éligibilité GEIQ non confirmée</span>

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -407,6 +407,10 @@ class User(AbstractUser, AddressMixin):
         return self.kind == UserKind.PRESCRIBER
 
     @property
+    def is_orienter(self):
+        return self.is_prescriber and not self.prescriberorganization_set.exists()
+
+    @property
     def is_siae_staff(self):
         return self.kind == UserKind.SIAE_STAFF
 

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -2433,8 +2433,8 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.geiq = SiaeFactory(with_membership=True, with_jobs=True, kind=SiaeKind.GEIQ)
-        cls.prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True)
-        cls.orienter = PrescriberOrganizationWithMembershipFactory(authorized=False)
+        cls.prescriber_org = PrescriberOrganizationWithMembershipFactory(authorized=True)
+        cls.orienter = PrescriberFactory()
         cls.job_seeker_with_geiq_diagnosis = GEIQEligibilityDiagnosisFactory(with_prescriber=True).job_seeker
         cls.siae = SiaeFactory(with_membership=True, kind=SiaeKind.EI)
 
@@ -2454,7 +2454,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         # - if user structure is not a GEIQ : should not be possible, form asserts it and crashes
 
         # Redirect orienter
-        self.client.force_login(self.orienter.members.first())
+        self.client.force_login(self.orienter)
         self._setup_session()
         response = self.client.get(reverse("apply:application_geiq_eligibility", kwargs={"siae_pk": self.geiq.pk}))
 
@@ -2491,7 +2491,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
             self.client.get(reverse("apply:application_geiq_eligibility", kwargs={"siae_pk": self.siae.pk}))
 
     def test_access_as_authorized_prescriber(self):
-        self.client.force_login(self.prescriber.members.first())
+        self.client.force_login(self.prescriber_org.members.first())
         self._setup_session()
 
         response = self.client.get(reverse("apply:application_geiq_eligibility", kwargs={"siae_pk": self.geiq.pk}))
@@ -2500,7 +2500,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         self.assertTemplateUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
 
     def test_geiq_eligibility_badge(self):
-        self.client.force_login(self.prescriber.members.first())
+        self.client.force_login(self.prescriber_org.members.first())
 
         # Badge OK if job seeker has a valid eligibility diagnosis
         self._setup_session(self.job_seeker_with_geiq_diagnosis)
@@ -2537,7 +2537,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         self.assertTemplateUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
 
     def test_geiq_diagnosis_form_validation(self):
-        self.client.force_login(self.prescriber.members.first())
+        self.client.force_login(self.prescriber_org.members.first())
         self._setup_session(self.job_seeker_with_geiq_diagnosis)
 
         response = self.client.post(

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -847,7 +847,8 @@ class ApplicationGEIQEligibilityView(ApplicationBaseView):
         # - authorized prescribers
         # - GEIQ
         # otherwise, skip to next step: application resume
-        if not request.user.is_job_seeker:
+        # Note: don't forget to redirect orienters
+        if not any([request.user.is_job_seeker, request.user.is_orienter]):
             if prescriber_org_pk := request.session.get("current_prescriber_organization"):
                 # Only for authorized prescribers (not orienters)
                 try:


### PR DESCRIPTION
### Pourquoi ?

Correction de deux anomalies repérées en production :
- affichage du badge d'éligibilité GEIQ incorrect pour les diagnostics valides mais sans montant d'allocation
- les orienteurs pouvaient avoir accès à la saisie de critères GEIQ
