### PR TITLE
Correction du bouton inclusion connect pour les vieux firefox

### DIFF
--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -72,8 +72,8 @@
                                        data-matomo-action="clic"
                                        data-matomo-option="se-connecter-avec-inclusion-connect">
                                         <picture>
-                                            <source srcset="{% static_theme_images 'logo-inclusion-connect-one-line.svg' %}" height="14" type="image/svg+xml" media="(min-width: 30em)">
-                                            <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" height="37" alt="Se connecter avec Inclusion Connect">
+                                            <source srcset="{% static_theme_images 'logo-inclusion-connect-one-line.svg' %}" height="14" width="286" type="image/svg+xml" media="(min-width: 30em)">
+                                            <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" height="37" width="142" alt="Se connecter avec Inclusion Connect">
                                         </picture>
                                     </a>
                                 </div>

--- a/itou/templates/inclusion_connect/includes/description.html
+++ b/itou/templates/inclusion_connect/includes/description.html
@@ -15,8 +15,8 @@
            data-matomo-action="clic"
            data-matomo-option="se-connecter-avec-inclusion-connect">
             <picture>
-                <source srcset="{% static_theme_images 'logo-inclusion-connect-one-line.svg' %}" height="14" type="image/svg+xml" media="(min-width: 30em)">
-                <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" height="37" alt="Se connecter avec Inclusion Connect">
+                <source srcset="{% static_theme_images 'logo-inclusion-connect-one-line.svg' %}" height="14" width="286" type="image/svg+xml" media="(min-width: 30em)">
+                <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" height="37" width="142" " alt="Se connecter avec Inclusion Connect">
             </picture>
         </a>
         <br>


### PR DESCRIPTION
**Discussion :** https://itou-inclusion.slack.com/archives/C0403V04UAD/p1680096958849269

### Pourquoi ?

Sur les vieux firefox, le support de <picture> et <source> ne semble pas pris en compte et l'image dans picture est déformée. 

### Comment

Hack trouvé, forcer la prise en compte de la taille de l'image.
Le mode "mobile" sur 2 lignes ne fonctionne pas, mais l'image ne déborde plus.

### Captures d'écran (optionnel)
Avant
<img width="645" alt="capture 2023-03-31 à 10 12 54" src="https://user-images.githubusercontent.com/3874024/229064137-3c0f1128-ad6f-4544-80e3-48a769445b5b.png">

Apres
<img width="600" alt="apres" src="https://user-images.githubusercontent.com/3874024/229063876-1aa27a61-e724-4bb2-928e-cf536426ad37.png">



