### PR TITLE
Fiches salariés : Correction de la disparition du champ de recherche par candidat

### DIFF
--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -17,9 +17,9 @@
             $("#status-filter-form form").submit();
         });
         $("#order-form-group :input").click(function(event) {
-            // Fill the hidden order input of the form
-            $("#id_order").val(event.target.value);
-            $("#status-filter-form form").submit();
+            let input = $("#id_order")
+            input.val(event.target.value); // Fill the hidden order input of the form
+            input.change(); // Fire a change event to notify handlers
         });
         // Show or Hide the search-filter-form sidebar based on responsive breakpoint
         var breakpointMD = getComputedStyle(document.documentElement).getPropertyValue("--breakpoint-md");
@@ -138,6 +138,13 @@
                                         </div>
                                     {% endfor %}
                                 </div>
+                            </fieldset>
+                            {# Job seeker filter #}
+                            <fieldset>
+                                <legend>
+                                    Par candidat
+                                </legend>
+                                {% bootstrap_field filters_form.job_seekers show_label=False %}
                             </fieldset>
                         </div>
                         {# Filled via jQuery #}

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -69,6 +69,25 @@ class ListEmployeeRecordsTest(TestCase):
             response = self.client.get(self.url + f"?status={status.value}")
             self.assertNotContains(response, approval_number_formatted)
 
+    def test_job_seeker_filter(self):
+        approval_number_formatted = format_filters.format_approval_number(self.job_application.approval.number)
+        other_job_application = JobApplicationWithApprovalNotCancellableFactory(to_siae=self.siae)
+        other_approval_number_formatted = format_filters.format_approval_number(other_job_application.approval.number)
+        self.client.force_login(self.user)
+
+        response = self.client.get(self.url)
+        self.assertContains(response, approval_number_formatted)
+        self.assertContains(response, other_approval_number_formatted)
+
+        response = self.client.get(self.url + f"?job_seekers={self.job_seeker.pk}")
+        self.assertContains(response, approval_number_formatted)
+        self.assertNotContains(response, other_approval_number_formatted)
+
+        response = self.client.get(self.url + "?job_seekers=0")
+        self.assertContains(response, "Sélectionnez un choix valide. 0 n’en fait pas partie.")
+        self.assertContains(response, approval_number_formatted)
+        self.assertContains(response, other_approval_number_formatted)
+
     def test_employee_records_with_hiring_end_at(self):
         self.client.force_login(self.user)
         hiring_end_at = self.job_application.hiring_end_at


### PR DESCRIPTION
### Pourquoi ?

Ajouté, sans test :confounded:, dans 24a1b936b (#2146), mais ensuite supprimé dans ce4335f76 (#2274).

### Captures d'écran

![image](https://user-images.githubusercontent.com/20045330/229457627-dcb5072f-974b-40f5-b7b1-6b0e79869351.png)
