### PR TITLE
Affichage du nombre de résultats dans la liste des fiches salarié 

### DIFF
--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -151,7 +151,9 @@
             <div class="c-box p-3 p-md-4">
                 <div class="d-flex align-items-center">
                     <div class="flex-grow-1">
-                        <span class="h4 m-0">Résultat</span>
+                        {% with cnt=navigation_pages.paginator.count %}
+                            <span class="h4 m-0">{{ cnt|default:"Aucun" }} résultat{{ cnt|pluralize }}</span>
+                        {% endwith %}
                     </div>
                     <div>
                         <span class="btn-link fs-sm">Trier par :</span>

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -353,3 +353,15 @@ class ListEmployeeRecordsTest(TestCase):
             recordZ.job_application,
             recordA.job_application,
         )
+
+    def test_display_result_count(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url + "?status=NEW")
+        self.assertContains(response, "1 résultat")
+
+        JobApplicationWithApprovalNotCancellableFactory(to_siae=self.siae)
+        response = self.client.get(self.url + "?status=NEW")
+        self.assertContains(response, "2 résultats")
+
+        response = self.client.get(self.url + "?status=READY")
+        self.assertContains(response, "Aucun résultat")


### PR DESCRIPTION
**Carte Notion :**
https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=79adca370b9c41f5ba8ea58062d05549&pm=c

### Pourquoi ?

Le total du nombre de fiches salarié est aussi affiché au dessus de la liste de résultats (pas seulement dans les badges).

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/147232/229464432-644ecbe3-3589-44bd-b2ae-3da773b1b065.png)

![image](https://user-images.githubusercontent.com/147232/229464583-eec02d45-d30b-4935-9e5f-244f892e398e.png)

![image](https://user-images.githubusercontent.com/147232/229464782-e4df5046-c7a2-4dfa-b4f0-acd1d0a41cea.png)
