### PR TITLE
Pip :  Résolution d'un souci uniquement présent sous Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PGDATABASE ?= itou
 ifeq ($(shell uname -s),Linux)
 	REQUIREMENTS_PATH := requirements/dev.txt
 else
-	REQUIREMENTS_PATH := requirements/dev.in
+	REQUIREMENTS_PATH := requirements/dev-mac.txt
 endif
 
 VIRTUAL_ENV ?= .venv

--- a/requirements/dev-mac.txt
+++ b/requirements/dev-mac.txt
@@ -1,0 +1,3 @@
+-r dev.txt
+appnope==0.1.3 \
+  --hash=sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/C0412CTV63D/p1671534012842349**

### Pourquoi ?

Je (dejafait) suis le seul dev C1 sous Mac et depuis quelques mois je me débrouillais avec un souci avec le package `appnope` qui est seulement présent sur Mac. Mais aujourd'hui à mon retour de deux semaines AFK, pas moyen de ressuciter mon local dev... du coup j'ai retenté toutes les solutions dans le fil slack plus haut, et au final voici la PR pour pérenniser la seule qui fonctionne.

### Comment

Ajout d'un `dev-mac.txt` qui permet d'ajouter les packages spécifiques au Mac et stabiliser le build du local dev.