### PR TITLE
Pytest : Augmentation du timeout pour éviter le crash des tests en local

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,5 @@ addopts =
     --strict-markers
 markers =
     no_django_db: mark tests that should not be marked with django_db.
-timeout = 15
+timeout = 30
 timeout_method = thread


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/C0412CTV63D/p1680598007807029**

### Pourquoi ?

Parfois l'ensemble des workers d'un `make test` se mettent à crasher sur un timeout de db. Le problème est arrivé au moins à moi-même (@dejafait) et à @tonial .

La présente augmentation du timeout semble résoudre le problème systématiquement au moins dans mon cas.