### PR TITLE
Stats : Activation de deux nouveaux TB (Auto-prescription et Suivi CAP) pour les DDETS / DREETS / DGEFP

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -67,8 +67,6 @@
                     </li>
                 {% endif %}
                 {% if can_view_stats_ddets %}
-                    {% comment %}
-                    <!-- TODO @dejafait uncomment as soon as ready -->
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_ddets_auto_prescription' %}" class="btn-link btn-ico">
                             <i class="ri-line-chart-line ri-lg font-weight-normal"></i>
@@ -83,7 +81,6 @@
                         </a>
                         <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
                     </li>
-                    {% endcomment %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_ddets_iae' %}" class="btn-link btn-ico">
                             <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
@@ -98,8 +95,6 @@
                     </li>
                 {% endif %}
                 {% if can_view_stats_dreets %}
-                    {% comment %}
-                    <!-- TODO @dejafait uncomment as soon as ready -->
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_dreets_auto_prescription' %}" class="btn-link btn-ico">
                             <i class="ri-line-chart-line ri-lg font-weight-normal"></i>
@@ -114,7 +109,6 @@
                         </a>
                         <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
                     </li>
-                    {% endcomment %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_dreets_iae' %}" class="btn-link btn-ico">
                             <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
@@ -129,8 +123,6 @@
                     </li>
                 {% endif %}
                 {% if can_view_stats_dgefp %}
-                    {% comment %}
-                    <!-- TODO @dejafait uncomment as soon as ready -->
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_dgefp_auto_prescription' %}">
                             <i class="ri-line-chart-line ri-lg font-weight-normal"></i>
@@ -145,7 +137,6 @@
                         </a>
                         <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
                     </li>
-                    {% endcomment %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_dgefp_iae' %}" class="btn-link btn-ico">
                             <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -64,9 +64,11 @@ METABASE_DASHBOARDS = {
     #
     "stats_ddets_auto_prescription": {
         "dashboard_id": 267,
+        "tally_form_id": "3qLpE2",
     },
     "stats_ddets_follow_siae_evaluation": {
         "dashboard_id": 265,
+        "tally_form_id": "w2XZxV",
     },
     "stats_ddets_iae": {
         "dashboard_id": 117,
@@ -83,9 +85,11 @@ METABASE_DASHBOARDS = {
     #
     "stats_dreets_auto_prescription": {
         "dashboard_id": 267,
+        "tally_form_id": "3qLpE2",
     },
     "stats_dreets_follow_siae_evaluation": {
         "dashboard_id": 265,
+        "tally_form_id": "w2XZxV",
     },
     "stats_dreets_iae": {
         "dashboard_id": 117,
@@ -99,9 +103,11 @@ METABASE_DASHBOARDS = {
     #
     "stats_dgefp_auto_prescription": {
         "dashboard_id": 267,
+        "tally_form_id": "3qLpE2",
     },
     "stats_dgefp_follow_siae_evaluation": {
         "dashboard_id": 265,
+        "tally_form_id": "w2XZxV",
     },
     "stats_dgefp_iae": {
         "dashboard_id": 117,


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Cr-er-le-TB-Focus-Autoprescription-et-contr-le-a-posteriori-dans-le-TB-priv-DDETS-DREETS-et-DGEFP-1770e22dc62b4d50946b26443c53780c**

### Pourquoi ?

Ces nouveaux tableaux de bord était prêts depuis https://github.com/betagouv/itou/pull/2141 mais cachés.

Le grand jour d'ouvrir leur accès est venu !

Voir les screenshots sur https://github.com/betagouv/itou/pull/2141

On ajoute aussi les formulaires Tally correspondants.

### Revue

Pas de revue car trivial.