### PR TITLE
Modification de commentaires concernant les prescripteurs

### DIFF
--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -70,6 +70,7 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
     Case 1
         A "prescriber" is alone (e.g. "éducateur de rue"). In this case there is only a `User` object
             - User.kind = "prescriber"
+        This kind of prescriber can't be "authorized", because authorization is set on the prescriber organization.
 
     Case 2
         A "prescriber" is a member of an organization (e.g. an association of unemployed people etc.)
@@ -89,9 +90,11 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
 
     In the last 2 cases, there can be n members by organization.
 
-    In case 1 and case 2, we talk about "orienteur" in French.
+    Case 1: refers to an orienter without organisation ("orienteur solo").
 
-    In case 3, we talk about "prescripteur habilité" in French.
+    Case 2: refers to an unauthorized prescriber ("orienteur" or simply "prescripteur").
+
+    Case 3: refers to an authorized prescriber ("prescripteur habilité").
     """
 
     # Rules:

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -408,7 +408,9 @@ class User(AbstractUser, AddressMixin):
 
     @property
     def is_orienter(self):
-        return self.is_prescriber and not self.prescriberorganization_set.exists()
+        # Covers both "orienteur" (unauthorized prescriber)
+        # and "orienteur solo" (unauthorized prescriber without organization)
+        return self.is_prescriber and not self.is_prescriber_with_authorized_org
 
     @property
     def is_siae_staff(self):

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -109,10 +109,6 @@ class ModelTest(TestCase):
         job_seeker = JobSeekerFactory()
         assert job_seeker.is_orienter is False
 
-        # PrescriberFactory does not create a prescriber organization
-        prescriber = PrescriberOrganizationWithMembershipFactory()
-        assert prescriber.members.first().is_orienter is False
-
         siae_staff = SiaeStaffFactory()
         assert siae_staff.is_orienter is False
 
@@ -122,6 +118,10 @@ class ModelTest(TestCase):
         # PrescriberFactory create the simplest form of prescriber: an orienter
         orienter = PrescriberFactory()
         assert orienter.is_orienter is True
+
+        # PrescriberFactory does not create a prescriber organization
+        prescriber = PrescriberOrganizationWithMembershipFactory()
+        assert prescriber.members.first().is_orienter is True
 
     def test_generate_unique_username(self):
         unique_username = User.generate_unique_username()


### PR DESCRIPTION
### Pourquoi ?

Les commentaires sur le modèle des prescripteurs laissaient un doute sur la définition métier d'un orienteur.

Pour rappel, un "orienteur solo" est un prescripteur (de type `User` et `kind=="prescriber"`) sans rattachement à une organisation (`PrescriberOrganization`).
L'habilitation étant rattachée à l'organisation, un "orienteur solo" ne peut être habilité.

D'une manière plus générale, les orienteurs sont des prescripteurs sans habilitation, qu'ils aient une organisation ou pas.


