### PR TITLE
Correction de 1+N pour la ville du poste dans la liste des candidatures

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -242,6 +242,7 @@ class JobApplicationQuerySet(models.QuerySet):
             "to_siae__convention",
         ).prefetch_related(
             "selected_jobs__appellation",
+            "selected_jobs__location",
             Prefetch("job_seeker__approvals", queryset=Approval.objects.order_by("-start_at")),
         )
 

--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -25,7 +25,8 @@ from itou.utils.widgets import DuetDatePickerWidget
 
 
 class ProcessListTest(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """
         Create three organizations with two members each:
         - pole_emploi: job seekers agency.
@@ -83,21 +84,21 @@ class ProcessListTest(TestCase):
             eligibility_diagnosis=None,
         )
 
-        self.prescriber_base_url = reverse("apply:list_for_prescriber")
-        self.job_seeker_base_url = reverse("apply:list_for_job_seeker")
-        self.siae_base_url = reverse("apply:list_for_siae")
-        self.prescriber_exports_url = reverse("apply:list_for_prescriber_exports")
-        self.siae_exports_url = reverse("apply:list_for_siae_exports")
+        cls.prescriber_base_url = reverse("apply:list_for_prescriber")
+        cls.job_seeker_base_url = reverse("apply:list_for_job_seeker")
+        cls.siae_base_url = reverse("apply:list_for_siae")
+        cls.prescriber_exports_url = reverse("apply:list_for_prescriber_exports")
+        cls.siae_exports_url = reverse("apply:list_for_siae_exports")
 
         # Variables available for unit tests
-        self.pole_emploi = pole_emploi
-        self.hit_pit = hit_pit
-        self.l_envol = l_envol
-        self.thibault_pe = thibault_pe
-        self.laurie_pe = laurie_pe
-        self.eddie_hit_pit = eddie_hit_pit
-        self.audrey_envol = audrey_envol
-        self.maggie = maggie
+        cls.pole_emploi = pole_emploi
+        cls.hit_pit = hit_pit
+        cls.l_envol = l_envol
+        cls.thibault_pe = thibault_pe
+        cls.laurie_pe = laurie_pe
+        cls.eddie_hit_pit = eddie_hit_pit
+        cls.audrey_envol = audrey_envol
+        cls.maggie = maggie
 
 
 ####################################################


### PR DESCRIPTION
### Pourquoi ?

Lenteur importante de la base de données de prod, suite à l’ajout d’une requête de type 1+N pour les villes.

https://itou.sentry.io/issues/4060571138/?project=6164438&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&referrer=issue-stream&sort=inbox&stream_index=1