### PR TITLE
Retrait du help_text pour wet_run des commandes de gestion

### DIFF
--- a/itou/employee_record/management/commands/clone_orphan_employee_records.py
+++ b/itou/employee_record/management/commands/clone_orphan_employee_records.py
@@ -14,12 +14,7 @@ class Command(BaseCommand):
             type=int,
             required=True,
         )
-        parser.add_argument(
-            "--wet-run",
-            action="store_true",
-            dest="wet_run",
-            help="Just report, don't do anything",
-        )
+        parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 
     @transaction.atomic()
     def handle(self, for_siae, wet_run=False, **options):

--- a/itou/siaes/management/commands/import_ea_eatt.py
+++ b/itou/siaes/management/commands/import_ea_eatt.py
@@ -172,9 +172,7 @@ class Command(BaseCommand):
     help = "Import the content of the EA+EATT csv file into the database."
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--wet-run", dest="wet_run", action="store_true", help="Do not make any modifications to the database"
-        )
+        parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
     @timeit
     def handle(self, wet_run=False, **options):

--- a/itou/siaes/management/commands/import_geiq.py
+++ b/itou/siaes/management/commands/import_geiq.py
@@ -117,9 +117,7 @@ class Command(BaseCommand):
     help = "Import the content of the GEIQ csv file into the database."
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--wet-run", dest="wet_run", action="store_true", help="Do not make any modifications to the database"
-        )
+        parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
     @timeit
     def handle(self, wet_run=False, **options):


### PR DESCRIPTION
### Pourquoi ?

`--wet-run` écrit les données dans la base (ou appelle les API). La documentation était incorrecte. Comme la plupart des commandes n’ont pas de `help_text` pour cette option, les `help_text` incorrects ont été retirés.