### PR TITLE
Cache l’égibilité IAE de la liste des candidatures

### DIFF
--- a/itou/templates/apply/includes/list_card_body_siae.html
+++ b/itou/templates/apply/includes/list_card_body_siae.html
@@ -17,29 +17,6 @@
                 </span>
             {% endif %}
 
-            {% if siae.is_subject_to_eligibility_rules %}
-                {% with approval=job_application.job_seeker.latest_common_approval %}
-                    {% if approval %}
-                        <span class="badge badge-xs badge-pill{% if approval.state == 'EXPIRED' %} badge-emploi-light{% else %} badge-success-lighter{% endif %} text-primary">
-                            <i class="{% if approval.state == 'EXPIRED' %}ri-close-circle-line{% elif approval.state == 'SUSPENDED' %}ri-pause-circle-line{% else %}ri-checkbox-circle-line{% endif %}"></i>
-                            PASS IAE {{ approval.get_state_display|lower }}
-                        </span>
-                    {% else %}
-                        {% if job_application.eligibility_diagnosis_by_siae_required %}
-                            <span class="badge badge-xs badge-pill badge-accent-02-lighter text-primary">
-                                <i class="ri-error-warning-line"></i>
-                                Éligibilité à l’IAE à valider
-                            </span>
-                        {% else %}
-                            <span class="badge badge-xs badge-pill badge-success-light text-primary">
-                                <i class="ri-check-line"></i>
-                                Éligible à l’IAE
-                            </span>
-                        {% endif %}
-                    {% endif %}
-
-                {% endwith %}
-            {% endif %}
         </div>
     </div>
 

--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -214,14 +214,6 @@ class ProcessListSiaeTest(ProcessListTest):
             #
             # Render template:
             + 1  # context processor: user siae membership
-            # 6 job applications
-            + 6
-            * (
-                1  # select poleemploiapproval (latest_pe_approval)
-                + 1  # select latest eligibility diagnosis (job_application.eligibility_diagnosis_by_siae_required)
-                + 1  # select last valid diagnosis made by prescriber (does not exist)
-                + 1  # select last valid diagnosis made by siae (exists)
-            )
             + 3  # update session
         ):
             response = self.client.get(self.siae_base_url)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Correction-des-requ-tes-1-N-qui-ralentissent-la-prod-f809446c5f87406dab3fc6b11d0bbfa0**

### Pourquoi ?

La DB est très chargée suite à ces commits. Retirons les, le temps d’investiguer une façon d’alléger les calculs.

### Comment (optionnel)

Revert des commits a0164e4caccd959924d7b7808f6890f29ee394fe et
97d9e7b0f9187a61837e90a9d19f855e9918ca90.