### PR TITLE
Correction de l'export des candidature pour les orienteurs sans organisation

### DIFF
--- a/itou/www/apply/tests/tests_list.py
+++ b/itou/www/apply/tests/tests_list.py
@@ -585,6 +585,13 @@ class ProcessListPrescriberTest(ProcessListTest):
         assert 200 == response.status_code
         assert format_html(response, id="besoin-dun-chiffre") == []  # no link to pilotage
 
+    def test_list_for_prescriber_exports_view_without_organization(self):
+        prescriber = PrescriberFactory()
+        self.client.force_login(prescriber)
+        response = self.client.get(self.prescriber_exports_url)
+        assert 200 == response.status_code
+        assert format_html(response, id="besoin-dun-chiffre") == []  # no link to pilotage
+
     def test_list_for_prescriber_exports_download_view(self):
         """
         Connect as Thibault to see a list of available job applications exports

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -84,9 +84,13 @@ def list_for_prescriber_exports(request, template_name="apply/list_of_available_
     List of applications for a prescriber, sorted by month, displaying the count of applications per month
     with the possibiliy to download those applications as a CSV file.
     """
-    current_org = get_current_org_or_404(request)
-    job_applications = get_all_available_job_applications_as_prescriber(request)
+    if not request.user.is_prescriber_with_org:
+        can_view_stats_pe = None
+    else:
+        current_org = get_current_org_or_404(request)
+        can_view_stats_pe = request.user.can_view_stats_pe(current_org=current_org)
 
+    job_applications = get_all_available_job_applications_as_prescriber(request)
     total_job_applications = job_applications.count()
     job_applications_by_month = job_applications.with_monthly_counts()
 
@@ -94,7 +98,7 @@ def list_for_prescriber_exports(request, template_name="apply/list_of_available_
         "job_applications_by_month": job_applications_by_month,
         "total_job_applications": total_job_applications,
         "export_for": "prescriber",
-        "can_view_stats_pe": request.user.can_view_stats_pe(current_org=current_org),
+        "can_view_stats_pe": can_view_stats_pe,
     }
     return render(request, template_name, context)
 


### PR DESCRIPTION
https://www.notion.so/plateforme-inclusion/Export-des-candidatures-impossible-pour-un-orienteur-sans-organisation-36b52f80750f4981b5d0d6a0f57b9731?pvs=4

### Pourquoi ?

Il fallait une organisation pour accéder à ce lien avant.
