### PR TITLE
Fiches salariés : Récupération des notifications manquées

### DIFF
--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
             help="Just check and report, don't fix anything",
         )
 
-    # Check and fix methods: add as many as needed..
+    # Check and fix methods: add as many as needed.
 
     def _check_3436_error_code(self, dry_run):
         # Report all employee records with ASP error code 3436
@@ -68,7 +68,7 @@ class Command(BaseCommand):
             self.stdout.write(" - done!")
 
     def _check_jobseeker_profiles(self, dry_run):
-        # Check incoherences in user profile leading to validation errors at processing time.
+        # Check incoherence in user profile leading to validation errors at processing time.
         # Employee records in this case are switched back to status NEW for further processing by end-user.
         # Most frequent error cases are:
         # - no HEXA address
@@ -148,7 +148,7 @@ class Command(BaseCommand):
             self.stdout.write(" - done!")
 
     def handle(self, *, dry_run, **options):
-        self.stdout.write("+ Checking employee records coherence before transfering to ASP")
+        self.stdout.write("+ Checking employee records coherence before transferring to ASP")
 
         if dry_run:
             self.stdout.write(" - DRY-RUN mode: not fixing, just reporting")

--- a/itou/employee_record/tests/test_sanitize_employee_records.py
+++ b/itou/employee_record/tests/test_sanitize_employee_records.py
@@ -19,7 +19,7 @@ def test_handle_dry_run_option(mocker, command):
 
     command.handle(dry_run=True)
     assert command.stdout.getvalue().split("\n") == [
-        "+ Checking employee records coherence before transfering to ASP",
+        "+ Checking employee records coherence before transferring to ASP",
         " - DRY-RUN mode: not fixing, just reporting",
         "+ Employee records sanitizing done. Have a great day!",
         "",


### PR DESCRIPTION
### Pourquoi ?

Il est possible que certain PASS IAE soient prolongés ou suspendus après qu'une FS ai été `ARCHIVED` mais avant que le PASS IAE soit inutilisable (voir #2297.)

Le nombre de FS archivées alors que le PASS est toujours utilisable étant de 70K+ il n'était pas vraiment concevable de juste changer le statut à `PROCESSED` (ou `NEW`) de celles-ci car cela aurais voulu dire les réafficher aux employeurs alors que la majorité est surement inutile, ce qui aurais surement engendré plus de support que de traiter les cas en erreur au fil de l'eau sachant que le premier lancement va en corriger 100+.

### Comment

Ajout d'un nouveau check à `sanitize_employee_records` qui vérifiera donc avant chaque envois que les données envoyés vers l'ASP via les FS soient postérieurs aux dernières modifications d'un PASS IAE [1].