### PR TITLE
Stats : Boost Dev C2

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -66,6 +66,13 @@ PUBLIC_DASHBOARDS = {
     # "employeurs": "tb 54 - Typologie des employeurs",
 }
 
+PRIVATE_STATIC_DASHBOARDS = {
+    "stats/dgefp/auto_prescription/": "TB DGEFP AP",
+    "stats/dgefp/follow_siae_evaluation/": "TB DGEFP CAP",
+    "stats/dgefp/iae/": "TB DGEFP IAE",
+    "stats/dihal/state/": "TB DIHAL",
+}
+
 PRIVATE_DEPARTMENT_DASHBOARDS = {
     "stats/cd/{}": "tb 118 - Données IAE CD",
     "stats/ddets/auto_prescription/{}": "tb 267 - Focus auto-prescription DREETS/DDETS",
@@ -254,37 +261,14 @@ class Command(BaseCommand):
         }
         api_call_options = [
             MatomoFetchOptions(
-                "TB DGEFP AP",
+                value,
                 base_options
                 | {
-                    "segment": f"pageUrl=={constants.EMPLOIS_SITE_URL}/stats/dgefp/auto_prescription/",
+                    "segment": f"pageUrl=={constants.EMPLOIS_SITE_URL}/{key}",
                 },
                 base_extra_columns,
-            ),
-            MatomoFetchOptions(
-                "TB DGEFP CAP",
-                base_options
-                | {
-                    "segment": f"pageUrl=={constants.EMPLOIS_SITE_URL}/stats/dgefp/follow_siae_evaluation/",
-                },
-                base_extra_columns,
-            ),
-            MatomoFetchOptions(
-                "TB DGEFP IAE",
-                base_options
-                | {
-                    "segment": f"pageUrl=={constants.EMPLOIS_SITE_URL}/stats/dgefp/iae/",
-                },
-                base_extra_columns,
-            ),
-            MatomoFetchOptions(
-                "TB DIHAL",
-                base_options
-                | {
-                    "segment": f"pageUrl=={constants.EMPLOIS_SITE_URL}/stats/dihal/state/",
-                },
-                base_extra_columns,
-            ),
+            )
+            for key, value in PRIVATE_STATIC_DASHBOARDS.items()
         ]
 
         def _options_from_url_path(url_path):

--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -68,6 +68,8 @@ PUBLIC_DASHBOARDS = {
 
 PRIVATE_DEPARTMENT_DASHBOARDS = {
     "stats/cd/{}": "tb 118 - Données IAE CD",
+    "stats/ddets/auto_prescription/{}": "tb 267 - Focus auto-prescription DREETS/DDETS",
+    "stats/ddets/follow_siae_evaluation/{}": "tb 265 - Suivi CAP DREETS/DDETS",
     "stats/ddets/hiring/{}": "tb 160 - Facilitation de l'embauche DREETS/DDETS",
     "stats/ddets/iae/{}": "tb 117 - Données IAE DREETS/DDETS",
     "stats/pe/conversion/main/{}": "tb 169 - Taux de transformation PE",
@@ -78,6 +80,8 @@ PRIVATE_DEPARTMENT_DASHBOARDS = {
 }
 
 PRIVATE_REGION_DASHBOARDS = {
+    "stats/dreets/auto_prescription/{}": "tb 267 - Focus auto-prescription DREETS/DDETS",
+    "stats/dreets/follow_siae_evaluation/{}": "tb 265 - Suivi CAP DREETS/DDETS",
     "stats/dreets/hiring/{}": "tb 160 - Facilitation de l'embauche DREETS/DDETS",
     "stats/dreets/iae/{}": "tb 117 - Données IAE DREETS/DDETS",
     "stats/pe/conversion/main/{}/drpe": "tb 169 - Taux de transformation PE",
@@ -250,13 +254,37 @@ class Command(BaseCommand):
         }
         api_call_options = [
             MatomoFetchOptions(
-                "TB DGEFP",
+                "TB DGEFP AP",
+                base_options
+                | {
+                    "segment": f"pageUrl=={constants.EMPLOIS_SITE_URL}/stats/dgefp/auto_prescription/",
+                },
+                base_extra_columns,
+            ),
+            MatomoFetchOptions(
+                "TB DGEFP CAP",
+                base_options
+                | {
+                    "segment": f"pageUrl=={constants.EMPLOIS_SITE_URL}/stats/dgefp/follow_siae_evaluation/",
+                },
+                base_extra_columns,
+            ),
+            MatomoFetchOptions(
+                "TB DGEFP IAE",
                 base_options
                 | {
                     "segment": f"pageUrl=={constants.EMPLOIS_SITE_URL}/stats/dgefp/iae/",
                 },
                 base_extra_columns,
-            )
+            ),
+            MatomoFetchOptions(
+                "TB DIHAL",
+                base_options
+                | {
+                    "segment": f"pageUrl=={constants.EMPLOIS_SITE_URL}/stats/dihal/state/",
+                },
+                base_extra_columns,
+            ),
         ]
 
         def _options_from_url_path(url_path):

--- a/itou/metabase/management/test_populate_metabase_matomo.py
+++ b/itou/metabase/management/test_populate_metabase_matomo.py
@@ -205,7 +205,7 @@ def test_matomo_populate_private(monkeypatch, respx_mock):
     with connection.cursor() as cursor:
         cursor.execute("SELECT * FROM suivi_visiteurs_tb_prives_v1")
         rows = cursor.fetchall()
-        assert len(rows) == 23
+        assert len(rows) == 32
         assert rows[0] == (
             "25",
             "26",
@@ -291,19 +291,24 @@ def test_matomo_populate_private(monkeypatch, respx_mock):
             "9.3",
             "11 min 2s",
             "2022-06-13",
-            "TB DGEFP",
+            "TB DGEFP AP",
             None,
             None,
             None,
         )
         assert [line[-5:] for line in rows] == [
-            ("2022-06-13", "TB DGEFP", None, None, None),
+            ("2022-06-13", "TB DGEFP AP", None, None, None),
+            ("2022-06-13", "TB DGEFP CAP", None, None, None),
+            ("2022-06-13", "TB DGEFP IAE", None, None, None),
+            ("2022-06-13", "TB DIHAL", None, None, None),
             ("2022-06-13", "tb 117 - Données IAE DREETS/DDETS", None, None, "Bretagne"),
             ("2022-06-13", "tb 149 - Candidatures orientées PE", None, None, "Bretagne"),
             ("2022-06-13", "tb 160 - Facilitation de l'embauche DREETS/DDETS", None, None, "Bretagne"),
             ("2022-06-13", "tb 162 - Fiches de poste en tension PE", None, None, "Bretagne"),
             ("2022-06-13", "tb 168 - Délai d'entrée en IAE", None, None, "Bretagne"),
             ("2022-06-13", "tb 169 - Taux de transformation PE", None, None, "Bretagne"),
+            ("2022-06-13", "tb 265 - Suivi CAP DREETS/DDETS", None, None, "Bretagne"),
+            ("2022-06-13", "tb 267 - Focus auto-prescription DREETS/DDETS", None, None, "Bretagne"),
             ("2022-06-13", "tb 117 - Données IAE DREETS/DDETS", "31 - Haute-Garonne", "31", "Occitanie"),
             ("2022-06-13", "tb 118 - Données IAE CD", "31 - Haute-Garonne", "31", "Occitanie"),
             ("2022-06-13", "tb 149 - Candidatures orientées PE", "31 - Haute-Garonne", "31", "Occitanie"),
@@ -318,6 +323,8 @@ def test_matomo_populate_private(monkeypatch, respx_mock):
             ("2022-06-13", "tb 165 - Recrutement SIAE", "31 - Haute-Garonne", "31", "Occitanie"),
             ("2022-06-13", "tb 168 - Délai d'entrée en IAE", "31 - Haute-Garonne", "31", "Occitanie"),
             ("2022-06-13", "tb 169 - Taux de transformation PE", "31 - Haute-Garonne", "31", "Occitanie"),
+            ("2022-06-13", "tb 265 - Suivi CAP DREETS/DDETS", "31 - Haute-Garonne", "31", "Occitanie"),
+            ("2022-06-13", "tb 267 - Focus auto-prescription DREETS/DDETS", "31 - Haute-Garonne", "31", "Occitanie"),
             ("2022-06-13", "tb 117 - Données IAE DREETS/DDETS", "75 - Paris", "75", "Île-de-France"),
             ("2022-06-13", "tb 118 - Données IAE CD", "75 - Paris", "75", "Île-de-France"),
             ("2022-06-13", "tb 149 - Candidatures orientées PE", "75 - Paris", "75", "Île-de-France"),
@@ -326,6 +333,8 @@ def test_matomo_populate_private(monkeypatch, respx_mock):
             ("2022-06-13", "tb 165 - Recrutement SIAE", "75 - Paris", "75", "Île-de-France"),
             ("2022-06-13", "tb 168 - Délai d'entrée en IAE", "75 - Paris", "75", "Île-de-France"),
             ("2022-06-13", "tb 169 - Taux de transformation PE", "75 - Paris", "75", "Île-de-France"),
+            ("2022-06-13", "tb 265 - Suivi CAP DREETS/DDETS", "75 - Paris", "75", "Île-de-France"),
+            ("2022-06-13", "tb 267 - Focus auto-prescription DREETS/DDETS", "75 - Paris", "75", "Île-de-France"),
         ]
 
 

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -69,14 +69,14 @@
                 {% if can_view_stats_ddets %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_ddets_auto_prescription' %}" class="btn-link btn-ico">
-                            <i class="ri-line-chart-line ri-lg font-weight-normal"></i>
+                            <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
                             <span>Focus auto-prescription</span>
                         </a>
                         <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
                     </li>
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_ddets_follow_siae_evaluation' %}" class="btn-link btn-ico">
-                            <i class="ri-line-chart-line ri-lg font-weight-normal"></i>
+                            <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
                             <span>Suivre le contrôle à posteriori</span>
                         </a>
                         <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
@@ -97,15 +97,15 @@
                 {% if can_view_stats_dreets %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_dreets_auto_prescription' %}" class="btn-link btn-ico">
-                            <i class="ri-line-chart-line ri-lg font-weight-normal"></i>
+                            <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
                             <span>Focus auto-prescription</span>
                         </a>
                         <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
                     </li>
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_dreets_follow_siae_evaluation' %}" class="btn-link btn-ico">
-                            <i class="ri-line-chart-line ri-lg font-weight-normal"></i>
-                            <soan>Suivre le contrôle à posteriori</soan>
+                            <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
+                            <span>Suivre le contrôle à posteriori</span>
                         </a>
                         <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
                     </li>
@@ -124,15 +124,15 @@
                 {% endif %}
                 {% if can_view_stats_dgefp %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
-                        <a href="{% url 'stats:stats_dgefp_auto_prescription' %}">
-                            <i class="ri-line-chart-line ri-lg font-weight-normal"></i>
+                        <a href="{% url 'stats:stats_dgefp_auto_prescription' %}" class="btn-link btn-ico">
+                            <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
                             <span>Focus auto-prescription</span>
                         </a>
                         <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
                     </li>
                     <li class="d-flex justify-content-between align-items-center mb-3">
-                        <a href="{% url 'stats:stats_dgefp_follow_siae_evaluation' %}">
-                            <i class="ri-line-chart-line ri-lg font-weight-normal"></i>
+                        <a href="{% url 'stats:stats_dgefp_follow_siae_evaluation' %}" class="btn-link btn-ico">
+                            <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
                             <span>Suivre le contrôle à posteriori</span>
                         </a>
                         <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -154,8 +154,9 @@
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_dihal_state' %}" class="btn-link btn-ico">
                             <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
-                            <span>Voir les données des prescriptions</span>
+                            <span>Suivre les prescriptions des AHI</span>
                         </a>
+                        <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
                     </li>
                 {% endif %}
                 <li class="d-flex justify-content-between align-items-center mb-3">

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -239,7 +239,7 @@ class DashboardViewTest(TestCase):
         membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DIHAL)
         self.client.force_login(membershipfactory.user)
         response = self.client.get(reverse("dashboard:index"))
-        self.assertContains(response, "Voir les données des prescriptions")
+        self.assertContains(response, "Suivre les prescriptions des AHI")
         self.assertContains(response, reverse("stats:stats_dihal_state"))
 
     def test_dashboard_siae_evaluations_institution_access(self):

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -474,6 +474,6 @@ def stats_dihal_state(request):
     if not request.user.can_view_stats_dihal(current_org=current_org):
         raise PermissionDenied
     context = {
-        "page_title": "Suivi des prescriptions",
+        "page_title": "Suivi des prescriptions des AHI",
     }
     return render_stats(request=request, context=context, params={})


### PR DESCRIPTION
### Note importante pour la MEP (par vperron en l'absence de dejafait)

- bien penser à faire un `update suivi_visiteurs_tb_prives_v1 set "Tableau de bord"='TB DGEFP IAE' where "Tableau de bord"='TB DGEFP'` juste après la MEP pour rendre le changement de nom de TB dans Matomo rétroactif. @vperron 
- penser à prévenir Y&L du changement en question

### Quoi ?

#### Tracking de plusieurs TB supplémentaires dans Matomo

#### harmonisation des liens stats dans le TB C1 (sans cela certains liens avaient un look différent)

Avant (le bug était seulement côté DGEFP)

![image](https://user-images.githubusercontent.com/10533583/230421843-85ce74a7-4d65-464f-a6b2-db3af6120fd7.png)

Après

![image](https://user-images.githubusercontent.com/10533583/230421895-f5e27193-81a5-4e56-a8a7-f852e1ed007c.png)

#### Renommage de la page stats DIHAL et ajout d'un badge "Nouveau"

Avant

![image](https://user-images.githubusercontent.com/10533583/230424584-50ccb581-fb56-40df-80ac-eaac7c77246c.png)

Après

![image](https://user-images.githubusercontent.com/10533583/230424629-9de04a8f-6f79-4f4e-87d2-4c259ea90887.png)
