### PR TITLE
Etat des candidatures: calcul de la couleur du badge en python

### DIFF
--- a/itou/templates/apply/includes/list_card_body.html
+++ b/itou/templates/apply/includes/list_card_body.html
@@ -1,3 +1,4 @@
+{% load job_applications %}
 {% load str_filters %}
 <div class="card-body">
     <div class="row">
@@ -54,7 +55,7 @@
         <div class="col-12 col-md-12 col-lg-4 pl-lg-0">
             <p class="font-weight-bold mb-1">Statut :</p>
             <p class="fs-sm card-text">
-                {% include "apply/includes/state_badge.html" with job_application=job_application %}
+                {% state_badge job_application %}
                 {% if job_application.has_suspended_approval %}
                     <br>
                     <span class="badge badge-sm badge-pill badge-warning">PASS IAE suspendu</span>

--- a/itou/templates/apply/includes/out_of_band_changes_on_job_application_state_update_siae.html
+++ b/itou/templates/apply/includes/out_of_band_changes_on_job_application_state_update_siae.html
@@ -1,3 +1,4 @@
-{% include "apply/includes/state_badge.html" with job_application=job_application out_of_band_swap=True %}
+{% load job_applications %}
+{% state_badge job_application hx_swap_oob=True %}
 {% include "apply/includes/state_transition_siae.html" with job_application=job_application out_of_band_swap=True %}
 {% include "apply/includes/transition_logs.html" with job_application=job_application transition_logs=transition_logs out_of_band_swap=True %}

--- a/itou/templates/apply/includes/state_badge.html
+++ b/itou/templates/apply/includes/state_badge.html
@@ -1,5 +1,0 @@
-<span id="state_{{ job_application.pk }}"
-      class="badge badge-sm badge-pill text-wrap mb-1 {% if job_application.state.is_new %}badge-info{% elif job_application.state.is_processing %}badge-accent-03 text-primary{% elif job_application.state.is_postponed %}badge-accent-03 text-primary{% elif job_application.state.is_prior_to_hire %}badge-accent-02 text-primary{% elif job_application.state.is_accepted %}badge-success{% elif job_application.state.is_refused %}badge-danger{% elif job_application.state.is_cancelled %}badge-primary{% elif job_application.state.is_obsolete %}badge-primary{% endif %}"
-      {% if out_of_band_swap %} hx-swap-oob="true"{% endif %}>
-    {{ job_application.get_state_display }}
-</span>

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -1,4 +1,5 @@
 {% extends "layout/content_small.html" %}
+{% load job_applications %}
 {% load str_filters %}
 
 {% block title %}
@@ -18,7 +19,7 @@
                     <h1 class="s-title-01__title h1-hero-c1">
                         <strong>Candidature de</strong> <span class="text-muted">{{ job_application.job_seeker.get_full_name|title|mask_unless:can_view_personal_information }}</span>
                     </h1>
-                    <p>{% include "apply/includes/state_badge.html" with job_application=job_application %}</p>
+                    <p>{% state_badge job_application %}</p>
                 </div>
             </div>
         </div>

--- a/itou/templates/approvals/includes/job_description_list.html
+++ b/itou/templates/approvals/includes/job_description_list.html
@@ -1,3 +1,4 @@
+{% load job_applications %}
 <div class="fs-sm d-flex flex-column flex-md-row align-items-center mb-3">
     <span class="text-secondary order-2 order-md-1 mr-auto">
         Émise le {{ job_application.created_at|date:"d F Y" }} par
@@ -30,9 +31,7 @@
 
     </span>
     {# élément à passer au dessus du précédent en vue mobile #}
-    <span class="order-1 order-md-2 ml-auto">
-        {% include "apply/includes/state_badge.html" with job_application=job_application %}
-    </span>
+    <span class="order-1 order-md-2 ml-auto">{% state_badge job_application %}</span>
 </div>
 
 {% with all_jobs=job_application.selected_jobs.all %}

--- a/itou/utils/__snapshots__/tests.ambr
+++ b/itou/utils/__snapshots__/tests.ambr
@@ -1,0 +1,28 @@
+# serializer version: 1
+# name: test_job_application_state_badge_oob_swap
+  '<span id="state_00000000-0000-0000-0000-000000000000" class="badge badge-sm badge-pill text-wrap mb-1 badge-info" hx-swap-oob="true">Nouvelle candidature</span>'
+# ---
+# name: test_job_application_state_badge_processing[accepted]
+  '<span id="state_00000000-0000-0000-0000-000000000000" class="badge badge-sm badge-pill text-wrap mb-1 badge-success">Candidature acceptée</span>'
+# ---
+# name: test_job_application_state_badge_processing[cancelled]
+  '<span id="state_00000000-0000-0000-0000-000000000000" class="badge badge-sm badge-pill text-wrap mb-1 badge-primary">Embauche annulée</span>'
+# ---
+# name: test_job_application_state_badge_processing[new]
+  '<span id="state_00000000-0000-0000-0000-000000000000" class="badge badge-sm badge-pill text-wrap mb-1 badge-info">Nouvelle candidature</span>'
+# ---
+# name: test_job_application_state_badge_processing[obsolete]
+  '<span id="state_00000000-0000-0000-0000-000000000000" class="badge badge-sm badge-pill text-wrap mb-1 badge-primary">Embauché ailleurs</span>'
+# ---
+# name: test_job_application_state_badge_processing[postponed]
+  '<span id="state_00000000-0000-0000-0000-000000000000" class="badge badge-sm badge-pill text-wrap mb-1 badge-accent-03 text-primary">Candidature en liste d\'attente</span>'
+# ---
+# name: test_job_application_state_badge_processing[prior_to_hire]
+  '<span id="state_00000000-0000-0000-0000-000000000000" class="badge badge-sm badge-pill text-wrap mb-1 badge-accent-02 text-primary">Action préalable à l’embauche</span>'
+# ---
+# name: test_job_application_state_badge_processing[processing]
+  '<span id="state_00000000-0000-0000-0000-000000000000" class="badge badge-sm badge-pill text-wrap mb-1 badge-accent-03 text-primary">Candidature à l\'étude</span>'
+# ---
+# name: test_job_application_state_badge_processing[refused]
+  '<span id="state_00000000-0000-0000-0000-000000000000" class="badge badge-sm badge-pill text-wrap mb-1 badge-danger">Candidature déclinée</span>'
+# ---

--- a/itou/utils/templatetags/job_applications.py
+++ b/itou/utils/templatetags/job_applications.py
@@ -1,0 +1,28 @@
+from django import template
+from django.utils.safestring import mark_safe
+
+from itou.job_applications.models import JobApplicationWorkflow
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def state_badge(job_application, *, hx_swap_oob=False):
+    state_classes = {
+        JobApplicationWorkflow.STATE_ACCEPTED: "badge-success",
+        JobApplicationWorkflow.STATE_CANCELLED: "badge-primary",
+        JobApplicationWorkflow.STATE_NEW: "badge-info",
+        JobApplicationWorkflow.STATE_OBSOLETE: "badge-primary",
+        JobApplicationWorkflow.STATE_POSTPONED: "badge-accent-03 text-primary",
+        JobApplicationWorkflow.STATE_PRIOR_TO_HIRE: "badge-accent-02 text-primary",
+        JobApplicationWorkflow.STATE_PROCESSING: "badge-accent-03 text-primary",
+        JobApplicationWorkflow.STATE_REFUSED: "badge-danger",
+    }[job_application.state]
+    attrs = [
+        f'id="state_{ job_application.pk }"',
+        f'class="badge badge-sm badge-pill text-wrap mb-1 { state_classes }"',
+    ]
+    if hx_swap_oob:
+        attrs.append('hx-swap-oob="true"')
+    return mark_safe(f"<span {' '.join(attrs)}>{ job_application.get_state_display() }</span>")

--- a/itou/www/apply/tests/tests_templates.py
+++ b/itou/www/apply/tests/tests_templates.py
@@ -100,41 +100,6 @@ def test_job_application_job_seeker_in_list():
     assert "Le candidat lui-même" in rendered
 
 
-def test_job_application_state_badge_new():
-    tmpl = load_template("apply/includes/state_badge.html")
-    job_application = JobApplicationSentByJobSeekerFactory()
-    rendered = tmpl.render(
-        Context(
-            {
-                "job_application": job_application,
-                "request": get_request(),
-                **expose_enums(),
-            }
-        )
-    )
-
-    assert "badge-info" in rendered
-
-
-def test_job_application_state_badge_processing():
-    tmpl = load_template("apply/includes/state_badge.html")
-    job_application = JobApplicationSentByJobSeekerFactory()
-    job_application.state.is_new = False
-    job_application.state.is_processing = True
-
-    rendered = tmpl.render(
-        Context(
-            {
-                "job_application": job_application,
-                "request": get_request(),
-                **expose_enums(),
-            }
-        )
-    )
-
-    assert "badge-accent-03" in rendered
-
-
 # QPV / ZRR eligibility details
 
 


### PR DESCRIPTION
### Pourquoi ?

Pour faciliter la relecture et la résolution de conflit git.
En bonus: si un nouvel état est ajouté, un joli `KeyError` fera penser à définir la couleur souhaitée
