### PR TITLE
Simplification du gabarit de pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 **Carte Notion : **
 
-Pensez à mettre le label "no-changelog" si nécessaire.
+<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->
 
 ### Pourquoi ?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,11 +6,8 @@
 
 Indiquer le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements.
 
-### Comment (optionnel)
+### Comment <!-- optionnel -->
 
 Attirer l'attention sur les décisions d'architecture ou de conception importantes.
 
-### Captures d'écran (optionnel)
-
-Utile pour les changements liés à l'UI.
-
+### Captures d'écran <!-- optionnel -->


### PR DESCRIPTION
### Pourquoi ?

- Le commentaire évite d’avoir à retirer le texte à propos de `no-changelog`.
- Le retrait de *(optionnel)* évite d’avoir à modifier le titre de la section lorsqu’elle est remplie.
- Le texte explicatif de captures d’écran me semblait superflu.