### PR TITLE
Lecture seule pour l’organisation de PE

### DIFF
--- a/itou/templates/prescribers/edit_organization.html
+++ b/itou/templates/prescribers/edit_organization.html
@@ -10,7 +10,14 @@
     <h2 class="h1 text-muted">{{ organization.display_name }}</h2>
 
     <div class="alert alert-info">
-        <p class="mb-0">Les coordonnées de contact de votre organisation sont visibles par tous les utilisateurs connectés.</p>
+        <p class="mb-0">
+            {% if organization.kind == PrescriberOrganizationKind.PE %}
+                Affichage des informations en lecture seule. Si vous souhaitez modifier ces informations, merci de
+                <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank">contacter notre support technique</a>.
+            {% else %}
+                Les coordonnées de contact de votre organisation sont visibles par tous les utilisateurs connectés.
+            {% endif %}
+        </p>
     </div>
 
     <form method="post" action="" class="js-prevent-multiple-submit">

--- a/itou/utils/enums_context_processors.py
+++ b/itou/utils/enums_context_processors.py
@@ -1,5 +1,6 @@
 import itou.approvals.enums as approvals_enums
 import itou.job_applications.enums as job_applications_enums
+import itou.prescribers.enums as prescribers_enums
 import itou.siaes.enums as siaes_enums
 
 
@@ -15,4 +16,5 @@ def expose_enums(*args):
         "SenderKind": job_applications_enums.SenderKind,
         "RefusalReason": job_applications_enums.RefusalReason,
         "SiaeKind": siaes_enums.SiaeKind,
+        "PrescriberOrganizationKind": prescribers_enums.PrescriberOrganizationKind,
     }

--- a/itou/utils/htmx/test.py
+++ b/itou/utils/htmx/test.py
@@ -1,10 +1,10 @@
 from urllib.parse import urlparse
 
 import pytest
-from bs4 import BeautifulSoup, NavigableString
+from bs4 import NavigableString
 from django.test.client import Client
 
-from itou.utils.test import TestCase
+from itou.utils.test import TestCase, parse_response_to_soup
 
 
 class HtmxClient(Client):
@@ -34,20 +34,6 @@ class HtmxTestCase(TestCase):
     @pytest.fixture(autouse=True)
     def htmx_client(self):
         self.htmx_client = HtmxClient()
-
-
-def parse_response_to_soup(response, selector=None, no_html_body=False):
-    soup = BeautifulSoup(response.content, "html5lib", from_encoding=response.charset or "utf-8")
-    if no_html_body:
-        # If the provided HTML does not contain <html><body> tags
-        # html5lib will always add them around the response:
-        # ignore them
-        soup = soup.body
-    if selector is not None:
-        [soup] = soup.select(selector)
-    for csrf_token_input in soup.find_all("input", attrs={"name": "csrfmiddlewaretoken"}):
-        csrf_token_input["value"] = "NORMALIZED_CSRF_TOKEN"
-    return soup
 
 
 def _handle_swap(page, *, target, new_elements, mode):

--- a/itou/utils/htmx/tests.py
+++ b/itou/utils/htmx/tests.py
@@ -4,7 +4,8 @@ import pytest
 from bs4 import BeautifulSoup
 from django_htmx.middleware import HtmxDetails
 
-from itou.utils.htmx.test import HtmxTestCase, assertSoupEqual, parse_response_to_soup, update_page_with_htmx
+from itou.utils.htmx.test import HtmxTestCase, assertSoupEqual, update_page_with_htmx
+from itou.utils.test import parse_response_to_soup
 
 
 # Unittest style

--- a/itou/utils/test.py
+++ b/itou/utils/test.py
@@ -32,6 +32,20 @@ def pprint_html(response, **selectors):
     print("\n\n".join(format_html(response, **selectors)))
 
 
+def parse_response_to_soup(response, selector=None, no_html_body=False):
+    soup = BeautifulSoup(response.content, "html5lib", from_encoding=response.charset or "utf-8")
+    if no_html_body:
+        # If the provided HTML does not contain <html><body> tags
+        # html5lib will always add them around the response:
+        # ignore them
+        soup = soup.body
+    if selector is not None:
+        [soup] = soup.select(selector)
+    for csrf_token_input in soup.find_all("input", attrs={"name": "csrfmiddlewaretoken"}):
+        csrf_token_input["value"] = "NORMALIZED_CSRF_TOKEN"
+    return soup
+
+
 class NoInlineClient(Client):
     def request(self, **request):
         response = super().request(**request)

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -32,10 +32,10 @@ from itou.siaes.factories import SiaeFactory
 from itou.users.enums import LackOfNIRReason, UserKind
 from itou.users.factories import JobSeekerWithAddressFactory, PrescriberFactory
 from itou.users.models import User
-from itou.utils.htmx.test import assertSoupEqual, parse_response_to_soup, update_page_with_htmx
+from itou.utils.htmx.test import assertSoupEqual, update_page_with_htmx
 from itou.utils.models import InclusiveDateRange
 from itou.utils.templatetags.format_filters import format_nir
-from itou.utils.test import TestCase
+from itou.utils.test import TestCase, parse_response_to_soup
 from itou.utils.widgets import DuetDatePickerWidget
 
 

--- a/itou/www/prescribers_views/forms.py
+++ b/itou/www/prescribers_views/forms.py
@@ -31,6 +31,13 @@ class EditPrescriberOrganizationForm(forms.ModelForm):
             self.fields["siret"].required = False
             self.fields["siret"].widget.attrs["readonly"] = True
 
+        # PE users often mistakenly edit this page, to the point where the
+        # support asked to disable it, and have them reach out in case of
+        # changes.
+        if self.instance.kind == PrescriberOrganizationKind.PE:
+            for field in self.fields.values():
+                field.disabled = True
+
     class Meta:
         model = PrescriberOrganization
         fields = [

--- a/itou/www/prescribers_views/tests/__snapshots__/test_edit.ambr
+++ b/itou/www/prescribers_views/tests/__snapshots__/test_edit.ambr
@@ -1,0 +1,254 @@
+# serializer version: 1
+# name: TestEditOrganization.test_pe_cannot_edit[Fields are disabled]
+  '''
+  <form action="" class="js-prevent-multiple-submit" method="post">
+  
+          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+  
+          <div class="form-group form-group-required"><label for="id_address_line_1">Adresse</label><input class="form-control" disabled="" id="id_address_line_1" maxlength="255" name="address_line_1" placeholder="Adresse" required="" title="" type="text"/></div>
+  <div class="form-group"><label for="id_address_line_2">Complément d'adresse</label><input class="form-control" disabled="" id="id_address_line_2" maxlength="255" name="address_line_2" placeholder="Complément d'adresse" title="Appartement, suite, bloc, bâtiment, boite postale, etc." type="text"/>
+      <small class="form-text text-muted">Appartement, suite, bloc, bâtiment, boite postale, etc.</small>
+  
+  </div>
+  <div class="form-group form-group-required"><label for="id_post_code">Code Postal</label><input class="form-control" disabled="" id="id_post_code" maxlength="5" name="post_code" placeholder="Code Postal" required="" title="" type="text"/></div>
+  <div class="form-group form-group-required"><label for="id_city">Ville</label><input class="form-control" disabled="" id="id_city" maxlength="255" name="city" placeholder="Ville" required="" title="" type="text"/></div>
+  <div class="form-group form-group-required"><label for="id_department">Département</label><select class="form-control" disabled="" id="id_department" name="department" required="" title="">
+    <option value="">---------</option>
+  
+    <option value="01">01 - Ain</option>
+  
+    <option value="02">02 - Aisne</option>
+  
+    <option value="03">03 - Allier</option>
+  
+    <option value="04">04 - Alpes-de-Haute-Provence</option>
+  
+    <option value="05">05 - Hautes-Alpes</option>
+  
+    <option value="06">06 - Alpes-Maritimes</option>
+  
+    <option value="07">07 - Ardèche</option>
+  
+    <option value="08">08 - Ardennes</option>
+  
+    <option value="09">09 - Ariège</option>
+  
+    <option value="10">10 - Aube</option>
+  
+    <option value="11">11 - Aude</option>
+  
+    <option value="12">12 - Aveyron</option>
+  
+    <option value="13">13 - Bouches-du-Rhône</option>
+  
+    <option value="14">14 - Calvados</option>
+  
+    <option value="15">15 - Cantal</option>
+  
+    <option value="16">16 - Charente</option>
+  
+    <option value="17">17 - Charente-Maritime</option>
+  
+    <option value="18">18 - Cher</option>
+  
+    <option value="19">19 - Corrèze</option>
+  
+    <option value="2A">2A - Corse-du-Sud</option>
+  
+    <option value="2B">2B - Haute-Corse</option>
+  
+    <option value="21">21 - Côte-d'Or</option>
+  
+    <option value="22">22 - Côtes-d'Armor</option>
+  
+    <option value="23">23 - Creuse</option>
+  
+    <option value="24">24 - Dordogne</option>
+  
+    <option value="25">25 - Doubs</option>
+  
+    <option value="26">26 - Drôme</option>
+  
+    <option value="27">27 - Eure</option>
+  
+    <option value="28">28 - Eure-et-Loir</option>
+  
+    <option value="29">29 - Finistère</option>
+  
+    <option value="30">30 - Gard</option>
+  
+    <option value="31">31 - Haute-Garonne</option>
+  
+    <option value="32">32 - Gers</option>
+  
+    <option value="33">33 - Gironde</option>
+  
+    <option value="34">34 - Hérault</option>
+  
+    <option value="35">35 - Ille-et-Vilaine</option>
+  
+    <option value="36">36 - Indre</option>
+  
+    <option value="37">37 - Indre-et-Loire</option>
+  
+    <option value="38">38 - Isère</option>
+  
+    <option value="39">39 - Jura</option>
+  
+    <option value="40">40 - Landes</option>
+  
+    <option value="41">41 - Loir-et-Cher</option>
+  
+    <option value="42">42 - Loire</option>
+  
+    <option value="43">43 - Haute-Loire</option>
+  
+    <option value="44">44 - Loire-Atlantique</option>
+  
+    <option value="45">45 - Loiret</option>
+  
+    <option value="46">46 - Lot</option>
+  
+    <option value="47">47 - Lot-et-Garonne</option>
+  
+    <option value="48">48 - Lozère</option>
+  
+    <option value="49">49 - Maine-et-Loire</option>
+  
+    <option value="50">50 - Manche</option>
+  
+    <option value="51">51 - Marne</option>
+  
+    <option value="52">52 - Haute-Marne</option>
+  
+    <option selected="" value="53">53 - Mayenne</option>
+  
+    <option value="54">54 - Meurthe-et-Moselle</option>
+  
+    <option value="55">55 - Meuse</option>
+  
+    <option value="56">56 - Morbihan</option>
+  
+    <option value="57">57 - Moselle</option>
+  
+    <option value="58">58 - Nièvre</option>
+  
+    <option value="59">59 - Nord</option>
+  
+    <option value="60">60 - Oise</option>
+  
+    <option value="61">61 - Orne</option>
+  
+    <option value="62">62 - Pas-de-Calais</option>
+  
+    <option value="63">63 - Puy-de-Dôme</option>
+  
+    <option value="64">64 - Pyrénées-Atlantiques</option>
+  
+    <option value="65">65 - Hautes-Pyrénées</option>
+  
+    <option value="66">66 - Pyrénées-Orientales</option>
+  
+    <option value="67">67 - Bas-Rhin</option>
+  
+    <option value="68">68 - Haut-Rhin</option>
+  
+    <option value="69">69 - Rhône</option>
+  
+    <option value="70">70 - Haute-Saône</option>
+  
+    <option value="71">71 - Saône-et-Loire</option>
+  
+    <option value="72">72 - Sarthe</option>
+  
+    <option value="73">73 - Savoie</option>
+  
+    <option value="74">74 - Haute-Savoie</option>
+  
+    <option value="75">75 - Paris</option>
+  
+    <option value="76">76 - Seine-Maritime</option>
+  
+    <option value="77">77 - Seine-et-Marne</option>
+  
+    <option value="78">78 - Yvelines</option>
+  
+    <option value="79">79 - Deux-Sèvres</option>
+  
+    <option value="80">80 - Somme</option>
+  
+    <option value="81">81 - Tarn</option>
+  
+    <option value="82">82 - Tarn-et-Garonne</option>
+  
+    <option value="83">83 - Var</option>
+  
+    <option value="84">84 - Vaucluse</option>
+  
+    <option value="85">85 - Vendée</option>
+  
+    <option value="86">86 - Vienne</option>
+  
+    <option value="87">87 - Haute-Vienne</option>
+  
+    <option value="88">88 - Vosges</option>
+  
+    <option value="89">89 - Yonne</option>
+  
+    <option value="90">90 - Territoire de Belfort</option>
+  
+    <option value="91">91 - Essonne</option>
+  
+    <option value="92">92 - Hauts-de-Seine</option>
+  
+    <option value="93">93 - Seine-Saint-Denis</option>
+  
+    <option value="94">94 - Val-de-Marne</option>
+  
+    <option value="95">95 - Val-d'Oise</option>
+  
+    <option value="971">971 - Guadeloupe</option>
+  
+    <option value="972">972 - Martinique</option>
+  
+    <option value="973">973 - Guyane</option>
+  
+    <option value="974">974 - La Réunion</option>
+  
+    <option value="975">975 - Saint-Pierre-et-Miquelon</option>
+  
+    <option value="976">976 - Mayotte</option>
+  
+    <option value="977">977 - Saint-Barthélémy</option>
+  
+    <option value="978">978 - Saint-Martin</option>
+  
+    <option value="986">986 - Wallis-et-Futuna</option>
+  
+    <option value="987">987 - Polynésie française</option>
+  
+    <option value="988">988 - Nouvelle-Calédonie</option>
+  
+  </select></div>
+  <div class="form-group"><label for="id_phone">Téléphone</label><input class="form-control" disabled="" id="id_phone" maxlength="20" name="phone" placeholder="Téléphone" title="Par exemple 0610203040" type="text" value="0600000000"/>
+      <small class="form-text text-muted">Par exemple 0610203040</small>
+  
+  </div>
+  <div class="form-group"><label for="id_email">E-mail</label><input class="form-control" disabled="" id="id_email" maxlength="254" name="email" placeholder="E-mail" title="" type="email" value="pe@mailinator.com"/></div>
+  <div class="form-group"><label for="id_website">Site web</label><input class="form-control" disabled="" id="id_website" maxlength="200" name="website" placeholder="Site web" title="Votre site web doit commencer par http:// ou https://" type="url"/>
+      <small class="form-text text-muted">Votre site web doit commencer par http:// ou https://</small>
+  
+  </div>
+  <div class="form-group"><label for="id_description">Description</label><textarea class="form-control" cols="40" disabled="" id="id_description" name="description" placeholder="Description" rows="10" title="Texte de présentation de votre structure."></textarea>
+      <small class="form-text text-muted">Texte de présentation de votre structure.</small>
+  
+  </div>
+  
+          <div class="form-group">
+              <a class="btn btn-outline-primary" href="/dashboard/">Annuler</a>
+              <button class="btn btn-primary" type="submit">Enregistrer</button>
+          </div>
+  
+      </form>
+  '''
+# ---

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -37,3 +37,4 @@ pytest-mock  # https://github.com/pytest-dev/pytest-mock/
 pytest-timeout  # https://github.com/pytest-dev/pytest-timeout
 pytest-xdist  # https://pypi.org/project/pytest-xdist/
 respx  # https://lundberg.github.io/respx/
+syrupy  # https://github.com/tophat/syrupy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -213,6 +213,9 @@ colorama==0.4.6 \
     # via
     #   djlint
     #   sqlfluff
+colored==1.4.4 \
+    --hash=sha256:04ff4d4dd514274fe3b99a21bb52fb96f2688c01e93fba7bef37221e7cb56ce0
+    # via syrupy
 coverage==7.2.3 \
     --hash=sha256:06ddd9c0249a0546997fdda5a30fbcb40f23926df0a874a60a8a185bc3a87d93 \
     --hash=sha256:0743b0035d4b0e32bc1df5de70fba3059662ace5b9a2a86a9f894cfe66569013 \
@@ -993,6 +996,7 @@ pytest==7.3.0 \
     #   pytest-timeout
     #   pytest-xdist
     #   sqlfluff
+    #   syrupy
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -1257,6 +1261,10 @@ stack-data==0.6.1 \
     --hash=sha256:6c9a10eb5f342415fe085db551d673955611afb821551f554d91772415464315 \
     --hash=sha256:960cb054d6a1b2fdd9cbd529e365b3c163e8dabf1272e02cfe36b58403cff5c6
     # via ipython
+syrupy==4.0.1 \
+    --hash=sha256:53d3107cc5e18a5def189c721879cea2cdafdee34b879f602133ca08837d0e4b \
+    --hash=sha256:60e3e94782444e0f978cd3b207de32f6da3199b15a2db32eab02f83cebb63ae8
+    # via -r requirements/dev.in
 tablib[html,ods,xls,xlsx,yaml]==3.2.1 \
     --hash=sha256:870d7e688f738531a14937a055e8bba404fbc388e77d4d500b2c904075d1019c \
     --hash=sha256:a57f2770b8c225febec1cb1e65012a69cf30dd28be810e0ff98d024768c7d0f1


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Emp-cher-les-utilisateurs-de-modifier-les-infos-d-organisation-P-le-emploi-BOOST-4cc28457394a4403adeb30125c648477**

### Pourquoi ?

Les utilisateurs PE modifient régulièrement la description de leur organisation par erreur.

### Comment

Utilisation de [syrupy](https://tophat.github.io/syrupy/) pour les tests, afin de faciliter la comparaison (et la maintenance) de fragments HTML.

### Captures d'écran

![image](https://user-images.githubusercontent.com/2758243/231245759-554f60a8-c151-4e8d-a8b6-35d7fcb32a14.png)
