### PR TITLE
Ajuster la taille de la colonne badge dans la liste des candidatures

### DIFF
--- a/itou/templates/apply/includes/list_card_body.html
+++ b/itou/templates/apply/includes/list_card_body.html
@@ -1,7 +1,7 @@
 {% load str_filters %}
 <div class="card-body">
     <div class="row">
-        <div class="col-12 col-md-6 col-lg-5 mb-3 mb-lg-0">
+        <div class="col-12 col-md-6 col-lg-4 mb-3 mb-lg-0">
             {% with jobs=job_application.selected_jobs.all %}
                 <p class="font-weight-bold mb-1">Métier{{ jobs|pluralizefr }} recherché{{ jobs|pluralizefr }} :</p>
                 {% if not jobs %}
@@ -51,7 +51,7 @@
                 {% endif %}
             </p>
         </div>
-        <div class="col-12 col-md-12 col-lg-3 pl-lg-0">
+        <div class="col-12 col-md-12 col-lg-4 pl-lg-0">
             <p class="font-weight-bold mb-1">Statut :</p>
             <p class="fs-sm card-text">
                 {% include "apply/includes/state_badge.html" with job_application=job_application %}


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Probl-me-d-Affichage-des-badges-sur-les-cartes-candidatures-boost-d07cc0d793b84d4293e803888c1b5506**

### Captures d'écran

#### Candidat
![image](https://user-images.githubusercontent.com/2758243/231435956-e124165b-fb6c-4e34-be6e-6f7dafcca3ac.png)

#### Prescripteur
![image](https://user-images.githubusercontent.com/2758243/231436110-dbe1c533-b389-4f3c-a333-648d17968787.png)
