### PR TITLE
CAP: Retrait de l’option pour ne pas participer

### DIFF
--- a/itou/static/js/siae_evaluations_sample_selection.js
+++ b/itou/static/js/siae_evaluations_sample_selection.js
@@ -1,8 +1,6 @@
 "use strict";
 
 (function() {
-  let showConfirm = true;
-
   function initSlider() {
     const slider = document.getElementById("chosenPercentRange");
     const output = document.getElementById("showChosenPercentValue");
@@ -14,13 +12,9 @@
   }
 
   function initConfirmModal() {
-    document.getElementById("id_opt_out").addEventListener("change", function (e) {
-      showConfirm = !e.target.checked;
-    });
-
     document.getElementById("ratio-form").addEventListener("submit", function (e) {
       const text = "Le ratio sélectionné ne sera plus modifiable pour cette campagne de contrôle. Confirmez-vous son enregistrement ?";
-      if (showConfirm && !window.confirm(text)) {
+      if (!window.confirm(text)) {
         e.preventDefault();
       } else {
         // Clicking cancel in the window.confirm should not lock the submit

--- a/itou/templates/siae_evaluations/samples_selection.html
+++ b/itou/templates/siae_evaluations/samples_selection.html
@@ -81,13 +81,6 @@
                         <p>{{ min }}% {{ form.chosen_percent }} {{ max }}%</p>
                     </div>
 
-                    <h3>Désactiver le contrôle pour cette campagne</h3>
-                    {{ form.opt_out.errors }}
-                    <label for="{{ form.opt_out.id_for_label }}">
-                        {{ form.opt_out }}
-                        {{ form.opt_out.label }}
-                    </label>
-
                     {% buttons %}
                         <button type="submit" class="btn btn-primary float-right">Valider</button>
                     {% endbuttons %}

--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -3,7 +3,6 @@ from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
-from django.forms import widgets
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 
@@ -19,19 +18,6 @@ from itou.utils.widgets import DuetDatePickerWidget
 
 
 class SetChosenPercentForm(forms.ModelForm):
-    opt_out = forms.BooleanField(
-        label="Je choisis de ne pas débuter le contrôle",
-        required=False,
-        widget=widgets.CheckboxInput(
-            attrs={
-                "aria-expanded": "true",
-                "aria-controls": "ratio-select",
-                "data-target": "#ratio-select",
-                "data-toggle": "collapse",
-            }
-        ),
-    )
-
     class Meta:
         model = EvaluationCampaign
         fields = ["chosen_percent"]
@@ -47,11 +33,6 @@ class SetChosenPercentForm(forms.ModelForm):
                 }
             )
         }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Use default when not specified. Can be omitted when opt_out is True.
-        self.fields["chosen_percent"].required = False
 
 
 class SubmitEvaluatedAdministrativeCriteriaProofForm(forms.ModelForm):

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -168,21 +168,6 @@ class SamplesSelectionViewTest(TestCase):
         assert updated_evaluation_campaign.percent_set_at is not None
         assert updated_evaluation_campaign.chosen_percent == post_data["chosen_percent"]
 
-    def test_post_form_opt_out(self):
-        EvaluationCampaignFactory(institution=self.institution, name="Campagne 2022")
-
-        self.client.force_login(self.user)
-        response = self.client.post(self.url, data={"opt_out": "on"})
-
-        assert list(messages.get_messages(response.wsgi_request)) == [
-            Message(
-                messages.SUCCESS,
-                "DDETS Ille et Vilaine ne participera pas à la campagne de contrôle a posteriori Campagne 2022.",
-            )
-        ]
-        self.assertRedirects(response, reverse("dashboard:index"))
-        assert not EvaluationCampaign.objects.exists()
-
 
 class InstitutionEvaluatedSiaeListViewTest(TestCase):
     def setUp(self):

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -8,7 +8,7 @@ from django.db.models import Min, Q
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_list_or_404, get_object_or_404, render
 from django.urls import reverse
-from django.utils import text, timezone
+from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.views import generic
 from django.views.decorators.http import require_POST
@@ -52,14 +52,6 @@ def samples_selection(request, template_name="siae_evaluations/samples_selection
     form = SetChosenPercentForm(instance=evaluation_campaign, data=request.POST or None)
 
     if request.method == "POST" and form.is_valid():
-        if form.cleaned_data["opt_out"]:
-            msg = (
-                f"{text.capfirst(institution)} ne participera pas à la campagne de contrôle a posteriori "
-                f"{evaluation_campaign.name}."
-            )
-            evaluation_campaign.delete()
-            messages.success(request, msg)
-            return HttpResponseRedirect(dashboard_url)
         form.instance.percent_set_at = timezone.now()
         form.save()
         messages.success(


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Retirer-la-case-cocher-qui-permet-une-DDETS-de-ne-pas-r-aliser-la-campagne-de-contr-le-e8bc69f63c5644da86f58cce7a9418bb**

### Captures d'écran

![image](https://user-images.githubusercontent.com/2758243/231471948-24631188-b068-483a-8254-560cd9d6cca1.png)