### PR TITLE
Affichage des critères administratifs sur la carte candidature 

### DIFF
--- a/itou/templates/apply/includes/list_card_body_siae.html
+++ b/itou/templates/apply/includes/list_card_body_siae.html
@@ -18,6 +18,17 @@
             {% endif %}
 
         </div>
+        {% if job_application.preloaded_administrative_criteria %}
+            <div class="col-12 col-lg-7 mb-3 mb-lg-0">
+                <h4 class="h5 mb-2">Critères administratifs IAE</h4>
+                <ul class="mb-2">
+                    {% for criteria in job_application.preloaded_administrative_criteria %}<li>{{ criteria.name }}</li>{% endfor %}
+                </ul>
+                {% if job_application.preloaded_administrative_criteria_extra_nb %}
+                    + {{ job_application.preloaded_administrative_criteria_extra_nb }} autres critères
+                {% endif %}
+            </div>
+        {% endif %}
     </div>
 
 </div>


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/2-4-Refonte-carte-candidature-employeur-En-tant-que-SIAE-je-veux-visualiser-les-crit-res-d-ligi-2fad987c88574e848aec0d44a4ef7d28?pvs=4

### Pourquoi ?

Faciliter les gestions et améliorer le délai de traitement des candidatures


### Captures d'écran

![Screenshot 2023-04-12 at 17-57-58 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/231515389-a16dd311-cc0d-4da6-9b7c-7adbd66e6a45.png)

![Screenshot 2023-04-12 at 17-58-39 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/231515407-ad023c26-039c-44d3-9bd2-2b2613180c55.png)

![Screenshot 2023-04-12 at 18-01-06 Les emplois de l'inclusion](https://user-images.githubusercontent.com/1089744/231515818-2ac9f2fb-acca-4e47-9663-8995933523fd.png)
