### PR TITLE
Fiches salariés : Plus d'erreur lors d'un `--preflight`, un peu de nettoyage, et tests plus complets

### DIFF
--- a/itou/employee_record/common_management.py
+++ b/itou/employee_record/common_management.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from rest_framework.renderers import JSONRenderer
 
 from itou.employee_record import constants
+from itou.employee_record.enums import NotificationStatus
 from itou.employee_record.exceptions import SerializationError
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch, EmployeeRecordUpdateNotification, Status
 from itou.employee_record.serializers import EmployeeRecordSerializer, EmployeeRecordUpdateNotificationSerializer
@@ -101,7 +102,7 @@ class EmployeeRecordTransferCommand(BaseCommand):
         assert object_class in [EmployeeRecord, EmployeeRecordUpdateNotification]
 
         new_objects = (
-            EmployeeRecordUpdateNotification.objects.new()
+            EmployeeRecordUpdateNotification.objects.filter(status=NotificationStatus.NEW)
             if object_class == EmployeeRecordUpdateNotification
             else EmployeeRecord.objects.filter(status=Status.READY)
         )

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -276,7 +276,7 @@ class Command(EmployeeRecordTransferCommand):
         for batch in chunks(ready_employee_records, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS):
             self._upload_batch_file(sftp, batch, dry_run)
 
-    def handle(self, *, upload, download, preflight, dry_run, asp_test, **_):
+    def handle(self, *, upload, download, preflight, dry_run, asp_test, **options):
         if preflight:
             self.stdout.write("Preflight activated, checking for possible serialization errors...")
             self.preflight(EmployeeRecord)
@@ -290,18 +290,17 @@ class Command(EmployeeRecordTransferCommand):
                 self.stdout.write("Using *TEST* JSON serializers (SIRET number mapping)")
 
             with self.get_sftp_connection() as sftp:
-                user = settings.ASP_FS_SFTP_USER
-                self.stdout.write(f"Connected to {user}@{settings.ASP_FS_SFTP_HOST}")
-                self.stdout.write(f"Current dir: {sftp.pwd}")
+                self.stdout.write(f'Connected to "{settings.ASP_FS_SFTP_HOST}" as "{settings.ASP_FS_SFTP_USER}"')
+                self.stdout.write(f'Current remote dir is "{sftp.pwd}"')
 
-                # Send files
+                # Send files to ASP
                 if upload:
                     self.upload(sftp, dry_run)
 
-                # Fetch results from ASP
+                # Fetch result files from ASP
                 if download:
                     self.download(sftp, dry_run)
 
-            self.stdout.write("Employee records processing done")
+            self.stdout.write("Employee records processing done!")
         else:
-            self.stdout.write("No valid options (upload, download, archive or preflight) were given")
+            self.stdout.write("No valid options (upload, download or preflight) were given")

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -7,7 +7,7 @@ from rest_framework.renderers import JSONRenderer
 from sentry_sdk.crons import monitor
 
 from itou.employee_record import constants
-from itou.employee_record.enums import MovementType, Status
+from itou.employee_record.enums import MovementType, NotificationStatus, Status
 from itou.employee_record.exceptions import SerializationError
 from itou.employee_record.mocks.fake_serializers import TestEmployeeRecordUpdateNotificationBatchSerializer
 from itou.employee_record.models import EmployeeRecordBatch, EmployeeRecordUpdateNotification
@@ -213,7 +213,7 @@ class Command(EmployeeRecordTransferCommand):
 
     @monitor(monitor_slug="transfer-employee-records-updates-upload")
     def upload(self, conn: pysftp.Connection, dry_run: bool):
-        new_notifications = EmployeeRecordUpdateNotification.objects.new()
+        new_notifications = EmployeeRecordUpdateNotification.objects.filter(status=NotificationStatus.NEW)
 
         if len(new_notifications) > 0:
             self.stdout.write(f"Starting UPLOAD of {len(new_notifications)} notification(s)")

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -715,18 +715,6 @@ class EmployeeRecordBatch:
 
 
 class EmployeeRecordUpdateNotificationQuerySet(QuerySet):
-    def new(self):
-        return self.filter(status=NotificationStatus.NEW)
-
-    def sent(self):
-        return self.filter(status=NotificationStatus.SENT)
-
-    def processed(self):
-        return self.filter(status=NotificationStatus.PROCESSED)
-
-    def rejected(self):
-        return self.filter(status=NotificationStatus.REJECTED)
-
     def find_by_batch(self, filename, line_number):
         return self.filter(asp_batch_file=filename, asp_batch_line_number=line_number)
 

--- a/itou/employee_record/tests/__snapshots__/tests_management_commands.ambr
+++ b/itou/employee_record/tests/__snapshots__/tests_management_commands.ambr
@@ -1,18 +1,29 @@
 # serializer version: 1
-# name: EmployeeRecordManagementCommandTest.test_smoke_download
+# name: EmployeeRecordManagementCommandTest.test_asp_test
   '''
-  Connected to django_tests@foobar.com
-  Current dir: PWD
+  Using *TEST* JSON serializers (SIRET number mapping)
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
   Starting DOWNLOAD of employee records
   No feedback files found
-  Employee records processing done
+  Employee records processing done!
+  
+  '''
+# ---
+# name: EmployeeRecordManagementCommandTest.test_smoke_download
+  '''
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
+  Starting DOWNLOAD of employee records
+  No feedback files found
+  Employee records processing done!
   
   '''
 # ---
 # name: EmployeeRecordManagementCommandTest.test_smoke_download_and_upload
   '''
-  Connected to django_tests@foobar.com
-  Current dir: PWD
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
   Starting UPLOAD of employee records
   Successfully uploaded: RIAE_FS_20210927000000.json
   Starting DOWNLOAD of employee records
@@ -20,40 +31,46 @@
   Record: line_number=1, processing_code=None, processing_label=None
   Parsed 1/1 files
   Deleting 'RIAE_FS_20210927000000_FichierRetour.json' from SFTP server
-  Employee records processing done
+  Employee records processing done!
   
   '''
 # ---
 # name: EmployeeRecordManagementCommandTest.test_smoke_upload
   '''
-  Connected to django_tests@foobar.com
-  Current dir: PWD
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
   Starting UPLOAD of employee records
   Successfully uploaded: RIAE_FS_20210927000000.json
-  Employee records processing done
+  Employee records processing done!
   
   '''
 # ---
 # name: EmployeeRecordManagementCommandTest.test_upload_and_download_success[download]
   '''
-  Connected to django_tests@foobar.com
-  Current dir: PWD
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
   Starting DOWNLOAD of employee records
   Fetching file: result_file='RIAE_FS_20210927000000_FichierRetour.json'
   Record: line_number=1, processing_code='0000', processing_label='La ligne de la fiche salarié a été enregistrée avec succès.'
   Parsed 1/1 files
   Deleting 'RIAE_FS_20210927000000_FichierRetour.json' from SFTP server
-  Employee records processing done
+  Employee records processing done!
   
   '''
 # ---
 # name: EmployeeRecordManagementCommandTest.test_upload_and_download_success[upload]
   '''
-  Connected to django_tests@foobar.com
-  Current dir: PWD
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
   Starting UPLOAD of employee records
   Successfully uploaded: RIAE_FS_20210927000000.json
-  Employee records processing done
+  Employee records processing done!
+  
+  '''
+# ---
+# name: EmployeeRecordManagementCommandTest.test_wrong_environment
+  '''
+  Your environment is missing ASP_FS_SFTP_HOST to run this command.
   
   '''
 # ---

--- a/itou/employee_record/tests/__snapshots__/tests_management_commands.ambr
+++ b/itou/employee_record/tests/__snapshots__/tests_management_commands.ambr
@@ -1,0 +1,59 @@
+# serializer version: 1
+# name: EmployeeRecordManagementCommandTest.test_smoke_download
+  '''
+  Connected to django_tests@foobar.com
+  Current dir: PWD
+  Starting DOWNLOAD of employee records
+  No feedback files found
+  Employee records processing done
+  
+  '''
+# ---
+# name: EmployeeRecordManagementCommandTest.test_smoke_download_and_upload
+  '''
+  Connected to django_tests@foobar.com
+  Current dir: PWD
+  Starting UPLOAD of employee records
+  Successfully uploaded: RIAE_FS_20210927000000.json
+  Starting DOWNLOAD of employee records
+  Fetching file: result_file='RIAE_FS_20210927000000_FichierRetour.json'
+  Record: line_number=1, processing_code=None, processing_label=None
+  Parsed 1/1 files
+  Deleting 'RIAE_FS_20210927000000_FichierRetour.json' from SFTP server
+  Employee records processing done
+  
+  '''
+# ---
+# name: EmployeeRecordManagementCommandTest.test_smoke_upload
+  '''
+  Connected to django_tests@foobar.com
+  Current dir: PWD
+  Starting UPLOAD of employee records
+  Successfully uploaded: RIAE_FS_20210927000000.json
+  Employee records processing done
+  
+  '''
+# ---
+# name: EmployeeRecordManagementCommandTest.test_upload_and_download_success[download]
+  '''
+  Connected to django_tests@foobar.com
+  Current dir: PWD
+  Starting DOWNLOAD of employee records
+  Fetching file: result_file='RIAE_FS_20210927000000_FichierRetour.json'
+  Record: line_number=1, processing_code='0000', processing_label='La ligne de la fiche salarié a été enregistrée avec succès.'
+  Parsed 1/1 files
+  Deleting 'RIAE_FS_20210927000000_FichierRetour.json' from SFTP server
+  Employee records processing done
+  
+  '''
+# ---
+# name: EmployeeRecordManagementCommandTest.test_upload_and_download_success[upload]
+  '''
+  Connected to django_tests@foobar.com
+  Current dir: PWD
+  Starting UPLOAD of employee records
+  Successfully uploaded: RIAE_FS_20210927000000.json
+  Employee records processing done
+  
+  '''
+# ---

--- a/itou/employee_record/tests/__snapshots__/tests_update_management_command.ambr
+++ b/itou/employee_record/tests/__snapshots__/tests_update_management_command.ambr
@@ -50,6 +50,19 @@
   
   '''
 # ---
+# name: TransferUpdatesManagementCommandTest.test_preflight_with_error
+  '''
+  DRY-RUN mode
+  Preflight activated, checking for possible serialization errors...
+  Found 2 object(s) to check, split in chunks of 700 objects.
+  Checking file #1 (chunk of 2 objects)
+  ERROR: serialization of EmployeeRecordUpdateNotification object (42) failed!
+  > Got AttributeError when attempting to get a value for field `codeinseecom` on serializer `_AddressSerializer`.
+  > The serializer field might be named incorrectly and not match any attribute or key on the `User` instance.
+  > Original exception text was: 'NoneType' object has no attribute 'code'.
+  
+  '''
+# ---
 # name: TransferUpdatesManagementCommandTest.test_preflight_without_error
   '''
   DRY-RUN mode

--- a/itou/employee_record/tests/__snapshots__/tests_update_management_command.ambr
+++ b/itou/employee_record/tests/__snapshots__/tests_update_management_command.ambr
@@ -1,0 +1,86 @@
+# serializer version: 1
+# name: TransferUpdatesManagementCommandTest.test_asp_test
+  '''
+  Using *TEST* JSON serializers (SIRET number mapping)
+  Connected to: django_tests@foobar.com
+  Current remote dir is: PWD
+  Employee record notifications processing done!
+  
+  '''
+# ---
+# name: TransferUpdatesManagementCommandTest.test_download[download]
+  '''
+  Connected to: django_tests@foobar.com
+  Current remote dir is: PWD
+  Starting DOWNLOAD of employee record notifications
+  Fetching file: RIAE_FS_20210927000000_FichierRetour.json
+  Parsed 1/1 files
+  Deleting 'RIAE_FS_20210927000000_FichierRetour.json' from SFTP server
+  Employee record notifications processing done!
+  
+  '''
+# ---
+# name: TransferUpdatesManagementCommandTest.test_download[upload]
+  '''
+  Connected to: django_tests@foobar.com
+  Current remote dir is: PWD
+  Starting UPLOAD of 1 notification(s)
+  Successfully uploaded: RIAE_FS_20210927000000.json
+  Employee record notifications processing done!
+  
+  '''
+# ---
+# name: TransferUpdatesManagementCommandTest.test_dry_run_empty_download
+  '''
+  DRY-RUN mode
+  Connected to: django_tests@foobar.com
+  Current remote dir is: PWD
+  Starting DOWNLOAD of employee record notifications
+  No new feedback file found
+  Employee record notifications processing done!
+  
+  '''
+# ---
+# name: TransferUpdatesManagementCommandTest.test_dry_run_upload
+  '''
+  DRY-RUN mode
+  Connected to: django_tests@foobar.com
+  Current remote dir is: PWD
+  Starting UPLOAD of 1 notification(s)
+  
+  '''
+# ---
+# name: TransferUpdatesManagementCommandTest.test_preflight_without_error
+  '''
+  DRY-RUN mode
+  Preflight activated, checking for possible serialization errors...
+  Found 1 object(s) to check, split in chunks of 700 objects.
+  Checking file #1 (chunk of 1 objects)
+  All serializations ok, you may skip preflight...
+  
+  '''
+# ---
+# name: TransferUpdatesManagementCommandTest.test_preflight_without_object
+  '''
+  DRY-RUN mode
+  Preflight activated, checking for possible serialization errors...
+  No object to check. Exiting preflight.
+  
+  '''
+# ---
+# name: TransferUpdatesManagementCommandTest.test_upload
+  '''
+  Connected to: django_tests@foobar.com
+  Current remote dir is: PWD
+  Starting UPLOAD of 1 notification(s)
+  Successfully uploaded: RIAE_FS_20210927000000.json
+  Employee record notifications processing done!
+  
+  '''
+# ---
+# name: TransferUpdatesManagementCommandTest.test_wrong_environment
+  '''
+  Your environment is missing ASP_FS_SFTP_HOST to run this command.
+  
+  '''
+# ---

--- a/itou/employee_record/tests/__snapshots__/tests_update_management_command.ambr
+++ b/itou/employee_record/tests/__snapshots__/tests_update_management_command.ambr
@@ -2,16 +2,18 @@
 # name: TransferUpdatesManagementCommandTest.test_asp_test
   '''
   Using *TEST* JSON serializers (SIRET number mapping)
-  Connected to: django_tests@foobar.com
-  Current remote dir is: PWD
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
+  Starting DOWNLOAD of employee record notifications
+  No new feedback file found
   Employee record notifications processing done!
   
   '''
 # ---
 # name: TransferUpdatesManagementCommandTest.test_download[download]
   '''
-  Connected to: django_tests@foobar.com
-  Current remote dir is: PWD
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
   Starting DOWNLOAD of employee record notifications
   Fetching file: RIAE_FS_20210927000000_FichierRetour.json
   Parsed 1/1 files
@@ -22,8 +24,8 @@
 # ---
 # name: TransferUpdatesManagementCommandTest.test_download[upload]
   '''
-  Connected to: django_tests@foobar.com
-  Current remote dir is: PWD
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
   Starting UPLOAD of 1 notification(s)
   Successfully uploaded: RIAE_FS_20210927000000.json
   Employee record notifications processing done!
@@ -32,27 +34,16 @@
 # ---
 # name: TransferUpdatesManagementCommandTest.test_dry_run_empty_download
   '''
-  DRY-RUN mode
-  Connected to: django_tests@foobar.com
-  Current remote dir is: PWD
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
   Starting DOWNLOAD of employee record notifications
   No new feedback file found
   Employee record notifications processing done!
   
   '''
 # ---
-# name: TransferUpdatesManagementCommandTest.test_dry_run_upload
-  '''
-  DRY-RUN mode
-  Connected to: django_tests@foobar.com
-  Current remote dir is: PWD
-  Starting UPLOAD of 1 notification(s)
-  
-  '''
-# ---
 # name: TransferUpdatesManagementCommandTest.test_preflight_with_error
   '''
-  DRY-RUN mode
   Preflight activated, checking for possible serialization errors...
   Found 2 object(s) to check, split in chunks of 700 objects.
   Checking file #1 (chunk of 2 objects)
@@ -65,7 +56,6 @@
 # ---
 # name: TransferUpdatesManagementCommandTest.test_preflight_without_error
   '''
-  DRY-RUN mode
   Preflight activated, checking for possible serialization errors...
   Found 1 object(s) to check, split in chunks of 700 objects.
   Checking file #1 (chunk of 1 objects)
@@ -75,7 +65,6 @@
 # ---
 # name: TransferUpdatesManagementCommandTest.test_preflight_without_object
   '''
-  DRY-RUN mode
   Preflight activated, checking for possible serialization errors...
   No object to check. Exiting preflight.
   
@@ -83,8 +72,8 @@
 # ---
 # name: TransferUpdatesManagementCommandTest.test_upload
   '''
-  Connected to: django_tests@foobar.com
-  Current remote dir is: PWD
+  Connected to "foobar.com" as "django_tests"
+  Current remote dir is "PWD"
   Starting UPLOAD of 1 notification(s)
   Successfully uploaded: RIAE_FS_20210927000000.json
   Employee record notifications processing done!

--- a/itou/employee_record/tests/common.py
+++ b/itou/employee_record/tests/common.py
@@ -1,10 +1,12 @@
 from io import StringIO
 
+import pytest
 from django.core import management
 
 from itou.utils.test import TestCase
 
 
+@pytest.mark.usefixtures("unittest_compatibility")
 class ManagementCommandTestCase(TestCase):
 
     # Override as needed

--- a/itou/employee_record/tests/tests_management_commands.py
+++ b/itou/employee_record/tests/tests_management_commands.py
@@ -143,6 +143,16 @@ class EmployeeRecordManagementCommandTest(ManagementCommandTestCase):
             == "La ligne de la fiche salarié a été enregistrée avec succès."
         )
 
+    @mock.patch("pysftp.Connection", SFTPGoodConnectionMock)
+    def test_asp_test(self):
+        out, _ = self.call_command(test=True, download=True)
+        assert out == self.snapshot
+
+    @override_settings(ASP_FS_SFTP_HOST="")
+    def test_wrong_environment(self):
+        out, _ = self.call_command(download=True)
+        assert out == self.snapshot
+
     @mock.patch("pysftp.Connection", SFTPAllDupsConnectionMock)
     @mock.patch(
         "itou.common_apps.address.format.get_geocoding_data",

--- a/itou/employee_record/tests/tests_management_commands.py
+++ b/itou/employee_record/tests/tests_management_commands.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import freezegun
 import pytest
 from django.test.utils import override_settings
 
@@ -33,77 +34,79 @@ class EmployeeRecordManagementCommandTest(ManagementCommandTestCase):
 
     MANAGEMENT_COMMAND_NAME = "transfer_employee_records"
 
+    @classmethod
     @mock.patch(
         "itou.common_apps.address.format.get_geocoding_data",
         side_effect=mock_get_geocoding_data,
     )
-    def setUp(self, _mock):
-        job_application = JobApplicationWithCompleteJobSeekerProfileFactory()
-        employee_record = EmployeeRecord.from_job_application(job_application)
-        employee_record.update_as_ready()
-        self.employee_record = employee_record
-        self.job_application = job_application
+    def setUpTestData(cls, _mock):
+        cls.job_application = JobApplicationWithCompleteJobSeekerProfileFactory()
+        cls.employee_record = EmployeeRecord.from_job_application(cls.job_application)
+        cls.employee_record.update_as_ready()
 
     @mock.patch("pysftp.Connection", SFTPConnectionMock)
     def test_smoke_download(self):
-        self.call_command(download=True)
+        out, _ = self.call_command(download=True)
+        assert out == self.snapshot
 
     @mock.patch("pysftp.Connection", SFTPConnectionMock)
     def test_smoke_upload(self):
-        self.call_command(upload=True)
+        with freezegun.freeze_time("2021-09-27"):
+            out, _ = self.call_command(upload=True)
+        assert out == self.snapshot
 
     @mock.patch("pysftp.Connection", SFTPConnectionMock)
     def test_smoke_download_and_upload(self):
-        self.call_command()
+        with freezegun.freeze_time("2021-09-27"):
+            out, _ = self.call_command(upload=True, download=True)
+        assert out == self.snapshot
 
     @mock.patch("pysftp.Connection", SFTPGoodConnectionMock)
     @mock.patch(
         "itou.common_apps.address.format.get_geocoding_data",
         side_effect=mock_get_geocoding_data,
     )
-    def test_dryrun_upload(self, _mock):
-        employee_record = self.employee_record
+    def test_dry_run_upload_and_download(self, _mock):
+        self.call_command(upload=True, download=True, dry_run=True)
 
-        # Upload with dry run
-        self.call_command(upload=True, dry_run=True)
-
-        # Then download "for real", should work but leave
-        # employee record untouched
-        self.call_command(upload=False, download=True)
-
-        assert employee_record.status == Status.READY
-
-    @mock.patch("pysftp.Connection", SFTPGoodConnectionMock)
-    @mock.patch(
-        "itou.common_apps.address.format.get_geocoding_data",
-        side_effect=mock_get_geocoding_data,
-    )
-    def test_dryrun_download(self, _mock):
-        employee_record = self.employee_record
-
-        # Upload "for real"
-        self.call_command(upload=True)
-
-        # Then download dry run, should work but leave
-        # employee record untouched
-        self.call_command(upload=False, download=True, dry_run=True)
-
-        assert employee_record.status == Status.READY
+        self.employee_record.refresh_from_db()
+        assert self.employee_record.status == Status.READY
 
     @mock.patch("pysftp.Connection", SFTPBadConnectionMock)
     def test_upload_failure(self):
-        employee_record = self.employee_record
         with pytest.raises(Exception):
             self.call_command(upload=True)
 
-        assert employee_record.status == Status.READY
+        self.employee_record.refresh_from_db()
+        assert self.employee_record.status == Status.READY
 
     @mock.patch("pysftp.Connection", SFTPBadConnectionMock)
     def test_download_failure(self):
-        employee_record = self.employee_record
         with pytest.raises(Exception):
             self.call_command(download=True)
 
+        self.employee_record.refresh_from_db()
+        assert self.employee_record.status == Status.READY
+
+    @mock.patch("pysftp.Connection", SFTPEvilConnectionMock)
+    @mock.patch(
+        "itou.common_apps.address.format.get_geocoding_data",
+        side_effect=mock_get_geocoding_data,
+    )
+    def test_random_connection_failure(self, _mock):
+        employee_record = self.employee_record
+
+        # Random upload failure
+        with pytest.raises(Exception):
+            self.call_command(upload=True)
+        # Employee record must be in the same status
+        employee_record.refresh_from_db()
+        assert employee_record.status == Status.READY
+
+        with pytest.raises(Exception):
+            self.call_command(download=True)
+        # Employee record must be in the same status
+        employee_record.refresh_from_db()
         assert employee_record.status == Status.READY
 
     @mock.patch("pysftp.Connection", SFTPGoodConnectionMock)
@@ -120,62 +123,25 @@ class EmployeeRecordManagementCommandTest(ManagementCommandTestCase):
         """
         employee_record = self.employee_record
 
-        self.call_command(upload=True, download=False)
-        employee_record.refresh_from_db()
+        with freezegun.freeze_time("2021-09-27"):
+            out, _ = self.call_command(upload=True)
+        assert out == self.snapshot(name="upload")
 
+        employee_record.refresh_from_db()
         assert employee_record.status == Status.SENT
         assert employee_record.batch_line_number == 1
         assert employee_record.asp_batch_file is not None
 
-        self.call_command(upload=False, download=True)
-        employee_record.refresh_from_db()
+        out, _ = self.call_command(download=True)
+        assert out == self.snapshot(name="download")
 
+        employee_record.refresh_from_db()
         assert employee_record.status == Status.PROCESSED
         assert employee_record.asp_processing_code == EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE
-
-    @mock.patch("pysftp.Connection", SFTPGoodConnectionMock)
-    @mock.patch(
-        "itou.common_apps.address.format.get_geocoding_data",
-        side_effect=mock_get_geocoding_data,
-    )
-    def test_employee_record_proof(self, _mock):
-        """
-        Check that "proof" of validated employee record is OK
-        """
-        employee_record = self.employee_record
-
-        self.call_command(upload=True, download=True)
-        employee_record.refresh_from_db()
-
-        assert Status.PROCESSED == employee_record.status
-        assert employee_record.archived_json is not None
-
-        assert EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE == employee_record.archived_json.get("codeTraitement")
-        assert employee_record.archived_json.get("libelleTraitement") is not None
-
-    @mock.patch("pysftp.Connection", SFTPEvilConnectionMock)
-    @mock.patch(
-        "itou.common_apps.address.format.get_geocoding_data",
-        side_effect=mock_get_geocoding_data,
-    )
-    def test_random_connection_failure(self, _mock):
-        employee_record = self.employee_record
-
-        # Random upload failure
-        for _ in range(10):
-            with pytest.raises(Exception):
-                self.call_command(upload=True, download=False)
-
-        # Employee record must be in the same status
-        employee_record.refresh_from_db()
-        assert employee_record.status == Status.READY
-
-        for _ in range(10):
-            with pytest.raises(Exception):
-                self.call_command(upload=False, download=True)
-
-        employee_record.refresh_from_db()
-        assert employee_record.status == Status.READY
+        assert (
+            employee_record.archived_json.get("libelleTraitement")
+            == "La ligne de la fiche salarié a été enregistrée avec succès."
+        )
 
     @mock.patch("pysftp.Connection", SFTPAllDupsConnectionMock)
     @mock.patch(

--- a/itou/employee_record/tests/tests_serializers.py
+++ b/itou/employee_record/tests/tests_serializers.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
-from itou.employee_record.enums import Status
+from itou.employee_record.enums import NotificationStatus, Status
 from itou.employee_record.factories import EmployeeRecordWithProfileFactory
 from itou.employee_record.models import EmployeeRecordBatch, EmployeeRecordUpdateNotification
 from itou.employee_record.serializers import (
@@ -115,7 +115,7 @@ class EmployeeRecordUpdateNotificationSerializerTest(TestCase):
                 asp_batch_line_number=idx,
             ).save()
 
-        new_notifications = EmployeeRecordUpdateNotification.objects.new()
+        new_notifications = EmployeeRecordUpdateNotification.objects.filter(status=NotificationStatus.NEW)
 
         batch = EmployeeRecordBatch(new_notifications)
         data = EmployeeRecordUpdateNotificationBatchSerializer(batch).data

--- a/itou/employee_record/tests/tests_update_management_command.py
+++ b/itou/employee_record/tests/tests_update_management_command.py
@@ -1,11 +1,9 @@
 from unittest import mock
 
 import freezegun
-import pytest
 from django.test import override_settings
 
 import itou.employee_record.enums as er_enums
-from itou.employee_record.exceptions import SerializationError
 from itou.employee_record.factories import EmployeeRecordUpdateNotificationFactory
 from itou.employee_record.mocks.transfer_employee_records import SFTPGoodConnectionMock
 from itou.employee_record.models import EmployeeRecordUpdateNotification
@@ -107,12 +105,12 @@ class TransferUpdatesManagementCommandTest(ManagementCommandTestCase):
         # but with an incorrect JSON structure.
 
         # Create a notification with a bad structure : no HEXA address
-        bad_notification = EmployeeRecordUpdateNotificationFactory()
+        bad_notification = EmployeeRecordUpdateNotificationFactory(pk=42)
         # Beware of 1:1 objects auto-update when not at top level
         # (i.e. don't do: bad_notification.employee_record.job_seeker.jobseeker_profile.hexa_commune = None).
         profile = bad_notification.employee_record.job_seeker.jobseeker_profile
         profile.hexa_commune = None
         profile.save()
 
-        with pytest.raises(SerializationError):
-            self.call_command(preflight=True)
+        out, _ = self.call_command(preflight=True)
+        assert out == self.snapshot

--- a/itou/employee_record/tests/tests_update_management_command.py
+++ b/itou/employee_record/tests/tests_update_management_command.py
@@ -108,7 +108,7 @@ class TransferUpdatesManagementCommandTest(ManagementCommandTestCase):
         EmployeeRecordUpdateNotification.objects.all().delete()
         out, _ = self.call_command(preflight=True)
 
-        assert not EmployeeRecordUpdateNotification.objects.new()
+        assert not EmployeeRecordUpdateNotification.objects.filter(status=er_enums.NotificationStatus.NEW)
         assert "Preflight activated, checking for possible serialization errors..." in out
         assert "No object to check. Exiting preflight." in out
 

--- a/itou/employee_record/tests/tests_update_management_command.py
+++ b/itou/employee_record/tests/tests_update_management_command.py
@@ -22,11 +22,7 @@ class TransferUpdatesManagementCommandTest(ManagementCommandTestCase):
 
     @mock.patch("pysftp.Connection", SFTPGoodConnectionMock)
     def test_dry_run_upload(self):
-        out, _ = self.call_command(upload=True)
-        # FIXME(rsebille): Refactor test and factory to make it possible to use a full snapshot.
-        # With upload=True and wet_run=False we print the JSON representation of the notification,
-        # using the first 4 lines is sufficient enough to check that we are indeed in dry run mode.
-        assert "".join(out.splitlines(keepends=True)[:4]) == self.snapshot
+        self.call_command(upload=True)
 
         self.notification.refresh_from_db()
         assert er_enums.NotificationStatus.NEW == self.notification.status
@@ -72,12 +68,12 @@ class TransferUpdatesManagementCommandTest(ManagementCommandTestCase):
 
     @mock.patch("pysftp.Connection", SFTPGoodConnectionMock)
     def test_asp_test(self):
-        out, _ = self.call_command(test=True, wet_run=True)
+        out, _ = self.call_command(test=True, download=True, wet_run=True)
         assert out == self.snapshot
 
     @override_settings(ASP_FS_SFTP_HOST="")
     def test_wrong_environment(self):
-        out, _ = self.call_command(wet_run=True)
+        out, _ = self.call_command(download=True, wet_run=True)
         assert out == self.snapshot
 
     # Next part is about testing --preflight option,


### PR DESCRIPTION
### Pourquoi ?

Le but premier était de ne plus générer d'erreur dans sentry lors de l'utilisation de `--preflight`, et ça a dérapé :grin:.