### PR TITLE
Détecter automatiquement les blocs "title" variables (+ correction)

### DIFF
--- a/itou/conftest.py
+++ b/itou/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 # Workaround being able to use freezegun with pandas.
 # https://github.com/spulec/freezegun/issues/98
 import pandas  # noqa F401
@@ -95,6 +97,10 @@ def unittest_compatibility(request, faker):
 
 @pytest.fixture(autouse=True)
 def django_ensure_matomo_titles(monkeypatch) -> None:
+    is_running_on_ci = os.getenv("CI", False)
+    if not is_running_on_ci:
+        return
+
     from django.template import base, defaulttags, loader, loader_tags
 
     original_render = loader.render_to_string

--- a/itou/www/search/tests.py
+++ b/itou/www/search/tests.py
@@ -1,5 +1,6 @@
 from django.contrib.gis.geos import Point
 from django.template.defaultfilters import capfirst
+from django.test import override_settings
 from django.urls import reverse
 
 from itou.cities.factories import create_city_guerande, create_city_saint_andre, create_city_vannes
@@ -23,6 +24,7 @@ class SearchSiaeTest(TestCase):
         response = self.client.get(self.url, {"city": "foo-44"})
         self.assertContains(response, "Aucun résultat avec les filtres actuels.")
 
+    @override_settings(MATOMO_BASE_URL="https://matomo.example.com")
     def test_district(self):
         city_slug = "paris-75"
         paris_city = City.objects.create(
@@ -53,6 +55,8 @@ class SearchSiaeTest(TestCase):
             response = self.client.get(self.url, {"city": city_slug})
 
         self.assertContains(response, "Employeurs solidaires à 25 km du centre de Paris (75)")
+        # look for the matomo_custom_title
+        self.assertContains(response, "Recherche d&#x27;employeurs solidaires")
         self.assertContains(response, "(2 résultats)")
         self.assertContains(response, "Arrondissements de Paris")
 

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -19,7 +19,6 @@ INSEE_CODES_WITH_DISTRICTS = {"13055", "75056", "69123"}
 
 
 class EmployerSearchBaseView(FormView):
-
     template_name = "search/siaes_search_results.html"
     form_class = SiaeSearchForm
     initial = {"distance": SiaeSearchForm.DISTANCE_DEFAULT}
@@ -28,11 +27,6 @@ class EmployerSearchBaseView(FormView):
         kwargs = super().get_form_kwargs()
         kwargs["data"] = self.request.GET or None
         return kwargs
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["matomo_custom_title"] = "Recherche d'employeurs solidaires"
-        return context
 
     def get(self, request, *args, **kwargs):
         # rewire the GET onto the POST since in this particular view, the form data is passed by GET
@@ -120,13 +114,14 @@ class EmployerSearchBaseView(FormView):
             "results_page": self.get_results_page(siaes, job_descriptions),
             "siaes_count": siaes.count(),
             "job_descriptions_count": job_descriptions.count(),
+            "matomo_custom_title": "Recherche d'employeurs solidaires",
         }
-
         return render(self.request, self.template_name, context)
 
     def form_invalid(self, form):
         context = {
             "form": form,
+            "matomo_custom_title": "Recherche d'employeurs solidaires",
         }
         return render(self.request, self.template_name, context)
 
@@ -192,7 +187,6 @@ class EmployerSearchView(EmployerSearchBaseView):
 
 
 class JobDescriptionSearchView(EmployerSearchBaseView):
-
     form_class = JobDescriptionSearchForm
 
     def add_form_choices(self, form, _siaes, job_descriptions):
@@ -241,7 +235,6 @@ def search_prescribers_results(request, template_name="search/prescribers_search
     prescriber_orgs_page = None
 
     if form.is_valid():
-
         city = form.cleaned_data["city"]
         distance = form.cleaned_data["distance"]
 


### PR DESCRIPTION
Cela permet de détecter dès les tests qu'une vue devrait surcharger le contexte `matomo_custom_url`.

Ca fonctionne mais ça fait peut-être beaucoup de magie noire non documentée et lente pour une petite chose.

 ```
 FAILED itou/www/search/tests.py::SearchSiaeTest::test_distance - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::SearchSiaeTest::test_district - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::JobDescriptionSearchViewTest::test_district - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::JobDescriptionSearchViewTest::test_domains - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::SearchSiaeTest::test_is_popular - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::SearchSiaeTest::test_kind - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::SearchSiaeTest::test_not_existing - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::SearchSiaeTest::test_opcs_displays_card_differently - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::JobDescriptionSearchViewTest::test_is_popular - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::SearchSiaeTest::test_order_by - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::JobDescriptionSearchViewTest::test_kind - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::JobDescriptionSearchViewTest::test_no_department - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::JobDescriptionSearchViewTest::test_not_existing - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::JobDescriptionSearchViewTest::test_contract_type - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::JobDescriptionSearchViewTest::test_order_by - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::JobDescriptionSearchViewTest::test_pec_display - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
FAILED itou/www/search/tests.py::JobDescriptionSearchViewTest::test_distance - AssertionError: template=search/siaes_search_results.html uses a variable title; please provide a `matomo_custom_title` in the context !
```