### PR TITLE
Ignorer les utilitaires de test avec pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = config.settings.dev
-python_files = test*.py
+python_files = tests*.py test_*.py
 addopts =
     --reuse-db
     --strict-markers


### PR DESCRIPTION
### Pourquoi ?

```
.venv/lib/python3.11/site-packages/django/test/utils.py:398
  /home/runner/work/itou/itou/.venv/lib/python3.11/site-packages/django/test/utils.py:398: PytestCollectionWarning: cannot collect test class 'TestContextDecorator' because it has a __init__ constructor (from: itou/utils/test.py)
    class TestContextDecorator:
```