### PR TITLE
Création d'un token d'API: correction du HTML

### DIFF
--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -38,34 +38,32 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </form>
-            {% else %}
-                <div class="col-12">
-                    <div class="form-row align-items-center">
-                        <div class="form-group mb-0 col-8">
-                            Votre token d'API est :
-                            <span id="token">{{ token.key }}</span>
+                    </form>
+                {% else %}
+                    <div class="col-12">
+                        <div class="form-row align-items-center">
+                            <div class="form-group mb-0 col-8">
+                                Votre token d'API est :
+                                <span id="token">{{ token.key }}</span>
+                            </div>
+                            <div class="form-group mb-0 col-4 text-right">
+                                <button class="btn btn-primary" id="copy-token">
+                                    <i class="ri-file-copy-line mr-2 ri-lg"></i>Copier le token
+                                </button>
+                            </div>
                         </div>
-                        <div class="form-group mb-0 col-4 text-right">
-                            <button class="btn btn-primary" id="copy-token">
-                                <i class="ri-file-copy-line mr-2 ri-lg"></i>Copier le token
-                            </button>
-                        </div>
                     </div>
-                </div>
+                {% endif %}
             </div>
-        {% endif %}
+        </div>
     </div>
-</div>
-</div>
 
-<script nonce="{{ CSP_NONCE }}">
-    var copyToken = document.getElementById('copy-token')
-    copyToken.addEventListener("click", function select(event){
-        var token = document.getElementById('token') ;
-        navigator.clipboard.writeText(token.innerText);
-    });
-</script>
+    <script nonce="{{ CSP_NONCE }}">
+        var copyToken = document.getElementById('copy-token')
+        copyToken.addEventListener("click", function select(event){
+            var token = document.getElementById('token') ;
+            navigator.clipboard.writeText(token.innerText);
+        });
+    </script>
 
 {% endblock %}


### PR DESCRIPTION
Suppression d'un `</div>` sauvage.

### Pourquoi ?

Pour avoir un joli document HTML.
