### PR TITLE
Suppression des href sur les boutons HTML

### DIFF
--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -17,7 +17,7 @@
             <button id="js-approvals-filters-button"
                     type="button"
                     class="btn btn-outline-primary w-100 d-block d-md-none"
-                    href="#js-approvals-filters-form"
+                    data-target="#js-approvals-filters-form"
                     data-toggle="collapse"
                     aria-expanded="false"
                     aria-controls="collapseFilter">

--- a/itou/templates/approvals/printable_approval.html
+++ b/itou/templates/approvals/printable_approval.html
@@ -85,7 +85,7 @@
 
         <div class="row justify-content-center no-print">
             <div class="mt-5 mb-2">
-                <button id="printButton" class="btn btn-primary btn-primary-lg btn-ico" href="#">
+                <button id="printButton" class="btn btn-primary btn-primary-lg btn-ico" type="button">
                     <i class="ri-printer-line ri-xl"></i>
                     <span>Imprimer ce PASS IAE</span>
                 </button>


### PR DESCRIPTION
### Pourquoi ?

Les éléments button n'ont pas de raison d'avoir des href.

Pour le toggle: cf https://getbootstrap.com/docs/4.6/components/collapse/#example
