### PR TITLE
Retrait de l’auxiliaire `format_html`

### DIFF
--- a/itou/conftest.py
+++ b/itou/conftest.py
@@ -91,8 +91,9 @@ def itou_faker_provider(_session_faker):
 
 
 @pytest.fixture(scope="function")
-def unittest_compatibility(request, faker):
+def unittest_compatibility(request, faker, snapshot):
     request.instance.faker = faker
+    request.instance.snapshot = snapshot
 
 
 @pytest.fixture(autouse=True)

--- a/itou/utils/test.py
+++ b/itou/utils/test.py
@@ -7,10 +7,9 @@ from django.test import Client, TestCase as BaseTestCase
 from django.test.utils import TestContextDecorator
 
 
-def format_html(response, **selectors):
+def pprint_html(response, **selectors):
     """
-    Formats an HTML document, ideal for inclusion in the expected outcome of a
-    test.
+    Pretty-print HTML responses (or fragment selected with :arg:`selector`)
 
     Heed the warning from
     https://www.crummy.com/software/BeautifulSoup/bs4/doc/#pretty-printing :
@@ -20,16 +19,11 @@ def format_html(response, **selectors):
       The goal of prettify() is to help you visually understand the structure
       of the documents you work with.
 
-    Prefer `assertHTMLEqual` and `assertContains(…, html=True)`.
-
-    Nonetheless, this tool cuts boilerplate in capturing response output.
+    Use `snapshot`s, `assertHTMLEqual` and `assertContains(…, html=True)` to
+    make assertions.
     """
     parser = BeautifulSoup(response.content, "html5lib")
-    return [elt.prettify() for elt in parser.find_all(**selectors)]
-
-
-def pprint_html(response, **selectors):
-    print("\n\n".join(format_html(response, **selectors)))
+    print("\n\n".join([elt.prettify() for elt in parser.find_all(**selectors)]))
 
 
 def parse_response_to_soup(response, selector=None, no_html_body=False):

--- a/itou/www/apply/tests/__snapshots__/tests_list.ambr
+++ b/itou/www/apply/tests/__snapshots__/tests_list.ambr
@@ -1,0 +1,39 @@
+# serializer version: 1
+# name: ProcessListExportsSiaeTest.test_list_for_siae_exports_view
+  '''
+  <div class="alert alert-info mt-3" id="besoin-dun-chiffre">
+                              <p class="mb-0">
+                                  <i aria-hidden="true" class="ri-information-line mr-1"></i>
+                                  <b>Besoin d'un chiffre ?</b>
+                              </p>
+                              
+                                  <p class="mb-0">
+                                      Accédez aux <a href="/stats/siae/hiring" rel="noopener" target="_blank">données de recrutement de votre structure</a> (non nominatives) compilées, calculées et mises à jour quotidiennement.
+                                  </p>
+                              
+                          </div>
+  '''
+# ---
+# name: ProcessListPrescriberTest.test_list_for_prescriber_pe_exports_view
+  '''
+  <div class="alert alert-info mt-3" id="besoin-dun-chiffre">
+                              <p class="mb-0">
+                                  <i aria-hidden="true" class="ri-information-line mr-1"></i>
+                                  <b>Besoin d'un chiffre ?</b>
+                              </p>
+                              
+                                  <p class="mb-0">
+                                      Accédez aux données de votre agence (non nominatives) compilées, calculées et mises à jour quotidiennement :
+                                  </p>
+                                  <ul>
+                                      <li>
+                                          <a href="/stats/pe/state/main" rel="noopener" target="_blank">Voir les données de l'ensemble de l'état des candidatures orientées</a>
+                                      </li>
+                                      <li>
+                                          <a href="/stats/pe/conversion/main" rel="noopener" target="_blank">Voir les données du taux de transformation des candidatures</a>
+                                      </li>
+                                  </ul>
+                              
+                          </div>
+  '''
+# ---


### PR DESCRIPTION
### Pourquoi ?

Les snapshots (syrupy) permettent de capture plus facilement la représentation HTML des éléments, et de façon plus exacte. Ils sont également plus faciles à mettre à jour.