### PR TITLE
Retrait des assertions dupliquées response.status_code == 200

### DIFF
--- a/itou/allauth_adapters/peamu/tests.py
+++ b/itou/allauth_adapters/peamu/tests.py
@@ -174,7 +174,6 @@ class PEAMUTests(OAuth2TestsMixin, TestCase):
 
         url = reverse("signup:job_seeker")
         response = self.client.get(url)
-        assert response.status_code == 200
         pe_url = reverse("peamu_login")
         self.assertContains(response, pe_url)
 
@@ -193,7 +192,6 @@ class PEAMUTests(OAuth2TestsMixin, TestCase):
         # Temporary NIR is not stored with user information.
         url = reverse("signup:job_seeker")
         response = self.client.get(url)
-        assert response.status_code == 200
         pe_url = reverse("peamu_login")
         self.assertContains(response, pe_url)
 

--- a/itou/openid_connect/inclusion_connect/tests.py
+++ b/itou/openid_connect/inclusion_connect/tests.py
@@ -617,7 +617,6 @@ class InclusionConnectLoginTest(InclusionConnectBaseTestCase):
         # This is already tested in itou.www.login.tests but only at form level.
         post_data = {"login": user.email, "password": DEFAULT_PASSWORD}
         response = self.client.post(reverse("login:prescriber"), data=post_data)
-        assert response.status_code == 200
         error_message = "Votre compte est relié à Inclusion Connect."
         self.assertContains(response, error_message)
         assert not auth.get_user(self.client).is_authenticated

--- a/itou/settings_viewer/tests.py
+++ b/itou/settings_viewer/tests.py
@@ -9,10 +9,8 @@ def test_as_superuser(client):
     admin_user = ItouStaffFactory(is_superuser=True)
     client.force_login(admin_user)
     response = client.get(reverse("admin:index"))
-    assert response.status_code == 200
     assertContains(response, "Affichage des settings")
     response = client.get(reverse("admin:settings_viewer_setting_changelist"))
-    assert response.status_code == 200
     assertContains(response, "ALLOWED_HOSTS")
     assertContains(response, "DATABASES")
     assertContains(response, "SECRET_KEY")
@@ -23,7 +21,6 @@ def test_as_staff(client):
     admin_user = ItouStaffFactory(is_superuser=False)
     client.force_login(admin_user)
     response = client.get(reverse("admin:index"))
-    assert response.status_code == 200
     assertNotContains(response, "Affichage des settings")
     response = client.get(reverse("admin:settings_viewer_setting_changelist"))
     assert response.status_code == 302

--- a/itou/www/apply/tests/test_edit.py
+++ b/itou/www/apply/tests/test_edit.py
@@ -82,7 +82,6 @@ class EditContractTest(TestCase):
 
         # test how hiring_end_date is displayed
         response = self.client.get(next_url)
-        assert response.status_code == 200
         self.assertContains(response, f"Fin : {future_end_date.strftime('%d')}")
 
     def test_future_contract_date_without_hiring_end_at(self):
@@ -129,7 +128,6 @@ class EditContractTest(TestCase):
 
         # test how hiring_end_date is displayed
         response = self.client.get(next_url)
-        assert response.status_code == 200
         self.assertContains(response, "Fin : Non renseigné")
 
     def test_past_contract_date(self):

--- a/itou/www/apply/tests/tests_geiq.py
+++ b/itou/www/apply/tests/tests_geiq.py
@@ -70,7 +70,6 @@ class JobApplicationGEIQEligibilityDetailsTest(TestCase):
             )
         )
 
-        assert response.status_code == 200
         self.assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
         self.assertContains(
             response,
@@ -99,7 +98,6 @@ class JobApplicationGEIQEligibilityDetailsTest(TestCase):
             )
         )
 
-        assert response.status_code == 200
         self.assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
         self.assertContains(response, "Le diagnostic du candidat a expiré")
         self.assertContains(

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -55,7 +55,6 @@ class ProcessViewsTest(TestCase):
         """
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url_accept)
-        assert response.status_code == 200
         self.assertContains(response, "Confirmation de l’embauche")
         # Make sure modal is hidden.
         assert response.headers.get("HX-Trigger") is None
@@ -189,7 +188,6 @@ class ProcessViewsTest(TestCase):
 
         url = reverse("apply:details_for_prescriber", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
-        assert response.status_code == 200
         # Job seeker nir is displayed
         self.assertContains(response, format_nir(job_application.job_seeker.nir))
         # Approval is displayed
@@ -357,7 +355,6 @@ class ProcessViewsTest(TestCase):
 
                 # test how hiring_end_date is displayed
                 response = self.client.get(next_url)
-                assert response.status_code == 200
                 # test case hiring_end_at
                 if hiring_end_at:
                     self.assertContains(response, f"Fin : {hiring_end_at.strftime('%d')}")
@@ -1096,7 +1093,6 @@ class ProcessViewsTest(TestCase):
         self.client.force_login(siae_user)
         url = reverse("apply:cancel", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, "Confirmer l'annulation de l'embauche")
         self.assertContains(
             response, "En validant, <b>vous renoncez aux aides au poste</b> liées à cette candidature pour tous"
@@ -1124,7 +1120,6 @@ class ProcessViewsTest(TestCase):
         self.client.force_login(siae_user)
         url = reverse("apply:cancel", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, "Confirmer l'annulation de l'embauche")
         self.assertNotContains(
             response, "En validant, <b>vous renoncez aux aides au poste</b> liées à cette candidature pour tous"

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -286,7 +286,6 @@ class ApplyAsJobSeekerTest(S3AccessingTestCase):
         # Step application's resume.
         # ----------------------------------------------------------------------
         response = self.client.get(next_url)
-        assert response.status_code == 200
         self.assertContains(response, "Envoyer la candidature")
 
         # Test fields mandatory to upload to S3
@@ -326,7 +325,6 @@ class ApplyAsJobSeekerTest(S3AccessingTestCase):
         # Step application's end.
         # ----------------------------------------------------------------------
         response = self.client.get(next_url)
-        assert response.status_code == 200
         # 1 in desktop header
         # + 1 in mobile header
         # + 1 in the page content
@@ -451,7 +449,6 @@ class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
         # ----------------------------------------------------------------------
 
         response = self.client.get(next_url)
-        assert response.status_code == 200
 
         next_url = reverse("apply:check_nir_for_sender", kwargs={"siae_pk": siae.pk})
         self.assertContains(response, "Status de prescripteur habilité non vérifié")
@@ -625,7 +622,6 @@ class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
         # Step application's resume.
         # ----------------------------------------------------------------------
         response = self.client.get(next_url)
-        assert response.status_code == 200
 
         # Test fields mandatory to upload to S3
         s3_upload = S3Upload(kind="resume")
@@ -869,7 +865,6 @@ class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
         # Step application's resume.
         # ----------------------------------------------------------------------
         response = self.client.get(next_url)
-        assert response.status_code == 200
 
         # Test fields mandatory to upload to S3
         s3_upload = S3Upload(kind="resume")
@@ -1180,7 +1175,6 @@ class ApplyAsPrescriberTest(S3AccessingTestCase):
         # Step application's resume.
         # ----------------------------------------------------------------------
         response = self.client.get(next_url)
-        assert response.status_code == 200
 
         # Test fields mandatory to upload to S3
         s3_upload = S3Upload(kind="resume")
@@ -1629,7 +1623,6 @@ class ApplyAsSiaeTest(S3AccessingTestCase):
         # Step application's resume.
         # ----------------------------------------------------------------------
         response = self.client.get(next_url)
-        assert response.status_code == 200
         self.assertContains(response, "Enregistrer")
 
         # Test fields mandatory to upload to S3
@@ -1774,7 +1767,6 @@ class ApplicationViewTest(S3AccessingTestCase):
         apply_session.save()
 
         response = self.client.get(reverse("apply:application_resume", kwargs={"siae_pk": siae.pk}))
-        assert response.status_code == 200
         self.assertContains(response, 'name="selected_jobs"')
         self.assertContains(response, 'name="resume_link"')
 
@@ -1890,7 +1882,6 @@ class LastCheckedAtViewTest(TestCase):
         self.job_seeker.last_checked_at -= datetime.timedelta(days=500)
         self.job_seeker.save(update_fields=["last_checked_at"])
         response = self.client.get(url)
-        assert response.status_code == 200
         warning_check = self.assertContains if sees_warning else self.assertNotContains
         warning_check(response, "Merci de vérifier la validité des informations")
         link_check(response, f'<a class="btn btn-link" href="{update_url}">Vérifier le profil</a>', html=True)
@@ -1970,7 +1961,6 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # STEP 1
         response = self.client.get(self.step_1_url)
-        assert response.status_code == 200
         self.assertContains(response, self.job_seeker.first_name)
         self.assertNotContains(response, self.INFO_MODIFIABLE_PAR_CANDIDAT_UNIQUEMENT)
 
@@ -1993,12 +1983,10 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # If you go back to step 1, new data is shown
         response = self.client.get(self.step_1_url)
-        assert response.status_code == 200
         self.assertContains(response, NEW_FIRST_NAME)
 
         # STEP 2
         response = self.client.get(self.step_2_url)
-        assert response.status_code == 200
         self.assertContains(response, self.job_seeker.phone)
         self.assertNotContains(response, self.INFO_MODIFIABLE_PAR_CANDIDAT_UNIQUEMENT)
 
@@ -2022,13 +2010,10 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # If you go back to step 2, new data is shown
         response = self.client.get(self.step_2_url)
-        assert response.status_code == 200
         self.assertContains(response, NEW_ADDRESS_LINE)
 
         # STEP 3
         response = self.client.get(self.step_3_url)
-        assert response.status_code == 200
-
         self.assertContains(response, "Niveau de formation")
 
         post_data = {
@@ -2065,13 +2050,10 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # If you go back to step 3, new data is shown
         response = self.client.get(self.step_3_url)
-        assert response.status_code == 200
         self.assertContains(response, '<option value="40" selected="">Formation de niveau BAC</option>', html=True)
 
         # Step END
         response = self.client.get(self.step_end_url)
-        assert response.status_code == 200
-
         self.assertContains(response, NEW_FIRST_NAME)
         self.assertContains(response, NEW_ADDRESS_LINE)
         self.assertContains(response, "Formation de niveau BAC")
@@ -2107,7 +2089,6 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # STEP 1
         response = self.client.get(self.step_1_url)
-        assert response.status_code == 200
         self.assertContains(response, self.job_seeker.first_name)
         self.assertContains(response, self.INFO_MODIFIABLE_PAR_CANDIDAT_UNIQUEMENT)
 
@@ -2120,7 +2101,6 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # STEP 2
         response = self.client.get(self.step_2_url)
-        assert response.status_code == 200
         self.assertContains(response, self.job_seeker.phone)
         self.assertContains(response, self.INFO_MODIFIABLE_PAR_CANDIDAT_UNIQUEMENT)
 
@@ -2132,8 +2112,6 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # STEP 3
         response = self.client.get(self.step_3_url)
-        assert response.status_code == 200
-
         self.assertContains(response, "Niveau de formation")
 
         post_data = {
@@ -2170,13 +2148,10 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # If you go back to step 3, new data is shown
         response = self.client.get(self.step_3_url)
-        assert response.status_code == 200
         self.assertContains(response, '<option value="40" selected="">Formation de niveau BAC</option>', html=True)
 
         # Step END
         response = self.client.get(self.step_end_url)
-        assert response.status_code == 200
-
         self.assertContains(response, "Formation de niveau BAC")
 
         previous_last_checked_at = self.job_seeker.last_checked_at
@@ -2298,8 +2273,6 @@ class UpdateJobSeekerStep3ViewTestCase(TestCase):
         response = self.client.get(
             reverse("apply:update_job_seeker_step_3", kwargs={"siae_pk": siae.pk, "job_seeker_pk": job_seeker.pk})
         )
-        assert response.status_code == 200
-
         self.assertContains(
             response,
             '<input type="checkbox" name="ass_allocation" class="form-check-input" id="id_ass_allocation" checked="">',
@@ -2389,8 +2362,6 @@ def test_detect_existing_job_seeker(client):
         "birthdate": job_seeker_profile.user.birthdate,
     }
     response = client.post(next_url, data=post_data)
-    assert response.status_code == 200
-
     assertContains(
         response,
         (
@@ -2521,7 +2492,6 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
             reverse("apply:application_geiq_eligibility", kwargs={"siae_pk": self.geiq.pk}), follow=True
         )
 
-        assert response.status_code == 200
         self.assertContains(response, "Éligibilité GEIQ confirmée")
         self.assertTemplateUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
 
@@ -2531,7 +2501,6 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
             reverse("apply:application_geiq_eligibility", kwargs={"siae_pk": self.geiq.pk}), follow=True
         )
 
-        assert response.status_code == 200
         self.assertContains(response, "Éligibilité GEIQ non confirmée")
         self.assertTemplateUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
 
@@ -2545,7 +2514,6 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         response = self.client.get(
             reverse("apply:application_geiq_eligibility", kwargs={"siae_pk": diagnosis.author_geiq.pk}), follow=True
         )
-        assert response.status_code == 200
         self.assertContains(response, "Éligibilité GEIQ non confirmée")
         self.assertTemplateUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
 
@@ -2579,7 +2547,6 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
                     data=post_data,
                     follow=True,
                 )
-                assert response.status_code == 200
                 self.assertTemplateUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
                 self.assertContains(response, "Incohérence dans les critères")
 

--- a/itou/www/approvals_views/tests/test_display.py
+++ b/itou/www/approvals_views/tests/test_display.py
@@ -25,7 +25,6 @@ class TestDisplayApproval(TestCase):
             reverse("approvals:display_printable_approval", kwargs={"approval_id": job_application.approval_id})
         )
 
-        assert response.status_code == 200
         assert response.context["approval"] == job_application.approval
         assert response.context["siae"] == job_application.to_siae
         self.assertContains(response, global_constants.ITOU_ASSISTANCE_URL)
@@ -49,7 +48,6 @@ class TestDisplayApproval(TestCase):
             reverse("approvals:display_printable_approval", kwargs={"approval_id": job_application.approval_id})
         )
 
-        assert response.status_code == 200
         assert response.context["approval"] == job_application.approval
         assert response.context["siae"] == job_application.to_siae
         self.assertContains(response, global_constants.ITOU_ASSISTANCE_URL)
@@ -81,7 +79,6 @@ class TestDisplayApproval(TestCase):
             reverse("approvals:display_printable_approval", kwargs={"approval_id": job_application.approval_id})
         )
 
-        assert response.status_code == 200
         assert response.context["approval"] == job_application.approval
         assert response.context["siae"] == job_application.to_siae
         self.assertContains(response, global_constants.ITOU_ASSISTANCE_URL)
@@ -104,7 +101,6 @@ class TestDisplayApproval(TestCase):
             reverse("approvals:display_printable_approval", kwargs={"approval_id": job_application.approval_id})
         )
 
-        assert response.status_code == 200
         assert response.context["approval"] == job_application.approval
         assert response.context["siae"] == job_application.to_siae
         self.assertContains(response, global_constants.ITOU_ASSISTANCE_URL)
@@ -127,7 +123,6 @@ class TestDisplayApproval(TestCase):
             reverse("approvals:display_printable_approval", kwargs={"approval_id": job_application.approval_id})
         )
 
-        assert response.status_code == 200
         assert response.context["approval"] == job_application.approval
         assert response.context["siae"] == job_application.to_siae
         self.assertContains(response, global_constants.ITOU_ASSISTANCE_URL)

--- a/itou/www/approvals_views/tests/test_prolongation.py
+++ b/itou/www/approvals_views/tests/test_prolongation.py
@@ -77,7 +77,6 @@ class ApprovalProlongationTest(TestCase):
             "preview": "1",
         }
         response = self.client.post(url, data=post_data)
-        assert response.status_code == 200
         self.assertContains(response, escape("Sélectionnez un choix valide."))
 
         # With valid reason

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -112,7 +112,6 @@ class DashboardViewTest(TestCase):
 
         url = reverse("dashboard:index")
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, "Gérer mes fiches salarié")
         self.assertNotContains(response, "badge-danger")
         assert response.context["num_rejected_employee_records"] == 0
@@ -134,7 +133,6 @@ class DashboardViewTest(TestCase):
         session[global_constants.ITOU_SESSION_CURRENT_SIAE_KEY] = siae.pk
         session.save()
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, "badge-danger")
         assert response.context["num_rejected_employee_records"] == 2
 
@@ -142,7 +140,6 @@ class DashboardViewTest(TestCase):
         session[global_constants.ITOU_SESSION_CURRENT_SIAE_KEY] = other_siae.pk
         session.save()
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, "badge-danger")
         assert response.context["num_rejected_employee_records"] == 1
 
@@ -667,7 +664,6 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         self.client.force_login(user)
         url = reverse("dashboard:edit_user_info")
         response = self.client.get(url)
-        assert response.status_code == 200
         # There's a specific view to edit the email so we don't show it here
         self.assertNotContains(response, "Adresse électronique")
         # Check that the NIR field is disabled
@@ -777,7 +773,6 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         self.client.force_login(user)
         url = reverse("dashboard:edit_user_info")
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, "Adresse électronique")
 
         post_data = {

--- a/itou/www/employee_record_views/tests/test_create.py
+++ b/itou/www/employee_record_views/tests/test_create.py
@@ -264,8 +264,6 @@ class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
         url = reverse("employee_record_views:create_step_2", args=(self.job_application.pk,))
         response = self.client.get(url)
 
-        assert response.status_code == 200
-
         self.assertContains(response, "Aucune adresse n'a été saisie sur les emplois de l'inclusion !")
         self.assertContains(response, "L'adresse du salarié n'a pu être vérifiée automatiquement.")
 
@@ -279,7 +277,6 @@ class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
         url = reverse("employee_record_views:create_step_3", args=(self.job_application.pk,))
         response = self.client.get(url)
 
-        assert response.status_code == 200
         self.assertNotContains(response, "L'adresse du salarié n'a pu être vérifiée automatiquement.")
         self.assertNotContains(response, "Aucune adresse n'a été saisie sur les emplois de l'inclusion !")
 
@@ -296,8 +293,6 @@ class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
         # Changed job application: new URL
         self.url = reverse("employee_record_views:create_step_2", args=(self.job_application.pk,))
         response = self.client.get(self.url)
-
-        assert response.status_code == 200
 
         # Check that when lookup fails, user is properly notified
         # to input employee address manually
@@ -574,7 +569,6 @@ class CreateEmployeeRecordStep3Test(AbstractCreateEmployeeRecordTest):
         employee_record.save()
 
         response = self.client.post(url, data)
-        assert response.status_code == 200
         self.assertContains(
             response,
             "Il est impossible de créer cette fiche salarié pour la raison suivante",

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -46,7 +46,6 @@ class ListEmployeeRecordsTest(TestCase):
 
         response = self.client.get(self.url)
 
-        assert response.status_code == 200
         self.assertContains(response, format_filters.format_approval_number(self.job_application.approval.number))
 
     def test_status_filter(self):
@@ -94,7 +93,6 @@ class ListEmployeeRecordsTest(TestCase):
 
         response = self.client.get(self.url)
 
-        assert response.status_code == 200
         self.assertContains(response, f"Fin de contrat :&nbsp;<b>{hiring_end_at.strftime('%e').lstrip()}")
 
     def test_employee_records_without_hiring_end_at(self):
@@ -104,7 +102,6 @@ class ListEmployeeRecordsTest(TestCase):
 
         response = self.client.get(self.url)
 
-        assert response.status_code == 200
         self.assertContains(response, "Fin de contrat :&nbsp;<b>Non renseigné")
 
     def test_employee_records_with_a_suspension_need_to_be_updated(self):
@@ -115,7 +112,6 @@ class ListEmployeeRecordsTest(TestCase):
 
         response = self.client.get(self.url + "?status=NEW")
 
-        assert response.status_code == 200
         self.assertContains(response, "Une action de votre part est nécessaire")
         self.assertContains(response, "Attention, nous avons détecté une ou plusieurs fiches salariés")
         self.assertContains(
@@ -132,7 +128,6 @@ class ListEmployeeRecordsTest(TestCase):
 
         response = self.client.get(self.url + "?status=NEW")
 
-        assert response.status_code == 200
         self.assertContains(response, "Une action de votre part est nécessaire")
         self.assertContains(response, "Attention, nous avons détecté une ou plusieurs fiches salariés")
         self.assertContains(
@@ -192,7 +187,6 @@ class ListEmployeeRecordsTest(TestCase):
         record.update_as_rejected("0012", "JSON Invalide", None)
 
         response = self.client.get(self.url + "?status=REJECTED")
-        assert response.status_code == 200
         self.assertContains(response, "Erreur 0012")
         self.assertContains(response, "JSON Invalide")
 
@@ -229,14 +223,12 @@ class ListEmployeeRecordsTest(TestCase):
                 record.update_as_rejected(err_code, err_message, "{}")
 
                 response = self.client.get(self.url + "?status=REJECTED")
-                assert response.status_code == 200
                 self.assertContains(response, f"Erreur {err_code}")
                 self.assertNotContains(response, err_message)
                 self.assertContains(response, custom_err_message)
 
     def _check_employee_record_order(self, url, first_job_application, second_job_application):
         response = self.client.get(url)
-        assert response.status_code == 200
         response_text = response.content.decode(response.charset)
         # The index method raises ValueError if the value isn't found
         first_job_seeker_position = response_text.index(

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -204,7 +204,6 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
 
         # User wants to join our website but it's too late!
         response = self.client.get(invitation.acceptance_link, follow=True)
-        assert response.status_code == 200
         self.assertContains(response, "expirée")
 
         user = SiaeStaffFactory(email=invitation.email)

--- a/itou/www/login/tests.py
+++ b/itou/www/login/tests.py
@@ -65,7 +65,6 @@ class PrescriberLoginTest(InclusionConnectBaseTestCase):
     def test_login_options(self):
         url = reverse("login:prescriber")
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, "Se connecter avec Inclusion Connect")
         self.assertContains(response, reverse("login:activate_prescriber_account"))
         self.assertContains(response, "Adresse e-mail")
@@ -74,7 +73,6 @@ class PrescriberLoginTest(InclusionConnectBaseTestCase):
         params = urlencode({"next": "/activate"})
         url = f"{reverse('login:prescriber')}?{params}"
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, f"{reverse('login:activate_prescriber_account')}?{params}")
 
     def test_login_using_django(self):
@@ -101,7 +99,6 @@ class PrescriberLoginTest(InclusionConnectBaseTestCase):
             "password": "a",
         }
         response = self.client.post(url, data=form_data)
-        assert response.status_code == 200
         self.assertContains(
             response, "Votre compte est relié à Inclusion Connect. Merci de vous connecter avec ce service."
         )
@@ -111,7 +108,6 @@ class SiaeStaffLoginTest(InclusionConnectBaseTestCase):
     def test_login_options(self):
         url = reverse("login:siae_staff")
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, "Se connecter avec Inclusion Connect")
         self.assertContains(response, f"{reverse('login:activate_siae_staff_account')}")
         self.assertContains(response, "Adresse e-mail")
@@ -121,7 +117,6 @@ class SiaeStaffLoginTest(InclusionConnectBaseTestCase):
 
         url = f"{reverse('login:siae_staff')}?{params}"
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, f"{reverse('login:activate_siae_staff_account')}?{params}")
 
     def test_login_using_django(self):
@@ -148,7 +143,6 @@ class SiaeStaffLoginTest(InclusionConnectBaseTestCase):
             "password": "a",
         }
         response = self.client.post(url, data=form_data)
-        assert response.status_code == 200
         self.assertContains(
             response, "Votre compte est relié à Inclusion Connect. Merci de vous connecter avec ce service."
         )
@@ -158,7 +152,6 @@ class LaborInspectorLoginTest(TestCase):
     def test_login_options(self):
         url = reverse("login:labor_inspector")
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertNotContains(response, "S'identifier avec Inclusion Connect")
         self.assertContains(response, "Adresse e-mail")
         self.assertContains(response, "Mot de passe")

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -207,7 +207,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
                 kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
             )
         )
-        assert response.status_code == 200
         self.assertContains(response, "Liste des Siae à contrôler", html=True, count=1)
 
         # institution with ended evaluation_campaign
@@ -219,7 +218,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
                 kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
             )
         )
-        assert response.status_code == 200
         self.assertContains(response, "Liste des Siae contrôlées", html=True, count=1)
 
     def test_recently_closed_campaign(self):
@@ -235,7 +233,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
                 kwargs={"evaluation_campaign_pk": evaluated_siae.evaluation_campaign_id},
             )
         )
-        assert response.status_code == 200
         url = reverse(
             "siae_evaluations_views:institution_evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
@@ -477,7 +474,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
                 kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
             )
         )
-        assert response.status_code == 200
         assert response.context["back_url"] == reverse("dashboard:index")
         self.assertContains(response, dateformat.format(evaluation_campaign.evaluations_asked_at, "d F Y"))
 
@@ -499,7 +495,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         )
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_siae)
         self.assertContains(response, en_attente)
         self.assertContains(
@@ -514,7 +509,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
             submitted_at=timezone.now(), proof_url="https://server.com/rocky-balboa.pdf"
         )
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, a_traiter)
 
         EvaluatedAdministrativeCriteria.objects.filter(
@@ -522,7 +516,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         ).update(review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED)
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, en_cours)
 
         EvaluatedAdministrativeCriteria.objects.filter(
@@ -530,7 +523,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         ).update(review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED)
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, en_cours)
 
         # REVIEWED
@@ -543,7 +535,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         ).update(review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED)
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, phase_contradictoire)
 
         EvaluatedAdministrativeCriteria.objects.filter(
@@ -553,7 +544,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         evaluated_siae.final_reviewed_at = review_time
         evaluated_siae.save(update_fields=["final_reviewed_at"])
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, resultat_positif)
 
     def test_num_queries(self):
@@ -635,7 +625,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluation_campaign.ended_at = timezone.now()
         evaluation_campaign.save(update_fields=["ended_at"])
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertNotContains(response, self.submit_text)
 
     def test_recently_closed_campaign(self):
@@ -652,7 +641,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
-        assert response.status_code == 200
         url = reverse(
             "siae_evaluations_views:institution_evaluated_job_application",
             kwargs={"evaluated_job_application_pk": job_app.pk},
@@ -918,7 +906,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         # EvaluatedAdministrativeCriteria not yet submitted
         pending_status = "En attente"
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_siae)
         formatted_number = format_approval_number(evaluated_job_application.job_application.approval.number)
         self.assertContains(response, formatted_number, html=True, count=1)
@@ -948,7 +935,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_administrative_criteria.proof_url = "https://server.com/rocky-balboa.pdf"
         evaluated_administrative_criteria.save(update_fields=["proof_url"])
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, back_url)
         self.assertContains(response, uploaded_status)
         self.assertContains(response, validation_button_disabled, html=True, count=1)
@@ -960,7 +946,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_administrative_criteria.submitted_at = timezone.now()
         evaluated_administrative_criteria.save(update_fields=["submitted_at"])
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
         self.assertNotContains(response, uploaded_status)
@@ -985,7 +970,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.assertContains(response, self.control_text)
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
         self.assertContains(response, validation_button, html=True, count=2)
@@ -1007,7 +991,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_siae.save(update_fields=["reviewed_at", "final_reviewed_at"])
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
         self.assertNotContains(response, self.submit_text)
@@ -1032,7 +1015,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_siae.save(update_fields=["reviewed_at", "final_reviewed_at"])
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
         self.assertContains(response, validation_button, html=True, count=2)
@@ -1053,7 +1035,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_siae.save(update_fields=["reviewed_at"])
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
         self.assertContains(response, validation_button_disabled, html=True, count=1)
@@ -1082,7 +1063,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
             update_fields=["proof_url", "review_state", "submitted_at", "uploaded_at"]
         )
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, validation_button_disabled, html=True, count=1)
         self.assertContains(response, back_url)
         self.assertContains(response, evaluated_job_application_url)
@@ -1093,7 +1073,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_administrative_criteria.submitted_at = timezone.now()
         evaluated_administrative_criteria.save(update_fields=["submitted_at"])
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
         self.assertNotContains(response, uploaded_status)
@@ -1108,7 +1087,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_administrative_criteria.save(update_fields=["review_state"])
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
         self.assertContains(response, validation_button, html=True, count=2)
@@ -1131,7 +1109,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_siae.save(update_fields=["reviewed_at", "final_reviewed_at"])
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
         self.assertNotContains(response, self.submit_text)
@@ -1157,7 +1134,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_administrative_criteria.save(update_fields=["review_state"])
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
         self.assertContains(response, validation_button, html=True, count=2)
@@ -1178,7 +1154,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_siae.save(update_fields=["final_reviewed_at"])
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, evaluated_job_application_url)
         self.assertContains(response, back_url)
         self.assertNotContains(response, self.submit_text)
@@ -1424,7 +1399,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
 
         # not yet submitted by Siae
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, en_attente)
 
         # submitted by Siae
@@ -1433,7 +1407,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         ).update(submitted_at=timezone.now(), proof_url="https://server.com/rocky-balboa.pdf")
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, a_traiter)
 
         # refused
@@ -1442,7 +1415,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         ).update(review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED)
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, refuse)
 
         # accepted
@@ -1451,7 +1423,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         ).update(review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED)
 
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, valide)
 
     def test_job_application_adversarial_stage(self):
@@ -2237,7 +2208,6 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
                 "temporary_suspension_to": datetime.date(2023, 1, 1),
             },
         )
-        assert response.status_code == 200
         self.assertContains(
             response,
             """
@@ -3077,7 +3047,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
                 kwargs={"evaluated_job_application_pk": job_app.pk},
             )
         )
-        assert response.status_code == 200
         self.assertContains(
             response,
             """
@@ -3140,7 +3109,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
                 kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
             )
         )
-        assert response.status_code == 200
         assert response.context["evaluated_job_application"] == evaluated_job_application
         assert response.context["evaluated_siae"] == evaluated_siae
         assert isinstance(response.context["form"], LaborExplanationForm)
@@ -3213,7 +3181,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
                 kwargs={"evaluated_job_application_pk": past_job_application.pk},
             )
         )
-        assert response.status_code == 200
         self.assertNotContains(response, self.save_text)
         self.assertContains(
             response,
@@ -3267,7 +3234,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_administrative_criteria.proof_url = "https://server.com/rocky-balboa.pdf"
         evaluated_administrative_criteria.save(update_fields=["submitted_at", "proof_url"])
         response = self.client.get(url_view)
-        assert response.status_code == 200
         self.assertContains(response, refuse_url)
         self.assertContains(response, accepte_url)
         self.assertNotContains(response, reinit_url)
@@ -3277,7 +3243,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_administrative_criteria.save(update_fields=["review_state"])
 
         response = self.client.get(url_view)
-        assert response.status_code == 200
         self.assertNotContains(response, refuse_url)
         self.assertNotContains(response, accepte_url)
         self.assertContains(response, reinit_url)
@@ -3290,7 +3255,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_administrative_criteria.save(update_fields=["review_state"])
 
         response = self.client.get(url_view)
-        assert response.status_code == 200
         self.assertNotContains(response, refuse_url)
         self.assertNotContains(response, accepte_url)
         self.assertContains(response, reinit_url)
@@ -3303,7 +3267,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_administrative_criteria.save(update_fields=["review_state"])
 
         response = self.client.get(url_view)
-        assert response.status_code == 200
         self.assertContains(response, refuse_url)
         self.assertContains(response, accepte_url)
         self.assertNotContains(response, reinit_url)
@@ -3315,7 +3278,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_administrative_criteria.save(update_fields=["review_state"])
 
         response = self.client.get(url_view)
-        assert response.status_code == 200
         self.assertNotContains(response, refuse_url)
         self.assertNotContains(response, accepte_url)
         self.assertNotContains(response, reinit_url)
@@ -3436,7 +3398,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
 
         # Unset
         response = self.client.get(url_view)
-        assert response.status_code == 200
         self.assertContains(response, "badge-pilotage")
         self.assertContains(response, "À traiter")
 
@@ -3444,7 +3405,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_administrative_criteria.review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED
         evaluated_administrative_criteria.save(update_fields=["review_state"])
         response = self.client.get(url_view)
-        assert response.status_code == 200
         self.assertContains(response, "badge-danger")
         self.assertContains(response, "Problème constaté")
 
@@ -3452,7 +3412,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_administrative_criteria.review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
         evaluated_administrative_criteria.save(update_fields=["review_state"])
         response = self.client.get(url_view)
-        assert response.status_code == 200
         self.assertContains(response, "badge-success")
         self.assertContains(response, "Validé")
 

--- a/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
@@ -103,7 +103,6 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
             response = self.client.get(self.url(evaluated_siae))
 
         assert evaluated_siae.evaluation_campaign.evaluations_asked_at == response.context["evaluations_asked_at"]
-        assert response.status_code == 200
         assert evaluated_job_application == response.context["evaluated_job_applications"][0]
         assert reverse("dashboard:index") == response.context["back_url"]
 
@@ -121,7 +120,6 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
 
         # no criterion selected
         response = self.client.get(self.url(evaluated_siae))
-        assert response.status_code == 200
         self.assertContains(
             response,
             reverse(
@@ -136,7 +134,6 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
             proof_url="",
         )
         response = self.client.get(self.url(evaluated_siae))
-        assert response.status_code == 200
         self.assertContains(
             response,
             reverse(
@@ -152,7 +149,6 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
         )
         self.client.force_login(self.user)
         response = self.client.get(self.url(evaluated_job_application.evaluated_siae))
-        assert response.status_code == 200
         self.assertContains(
             response,
             reverse(
@@ -496,7 +492,6 @@ class SiaeUploadDocsViewTest(S3AccessingTestCase):
             kwargs={"evaluated_administrative_criteria_pk": evaluated_administrative_criteria.pk},
         )
         response = self.client.get(url)
-        assert response.status_code == 200
 
         # Test fields mandatory to upload to S3
         s3_upload = S3Upload(kind="evaluations")

--- a/itou/www/siaes_views/tests/tests_views.py
+++ b/itou/www/siaes_views/tests/tests_views.py
@@ -37,7 +37,6 @@ class CardViewTest(TestCase):
         siae = SiaeFactory(with_membership=True)
         url = reverse("siaes_views:card", kwargs={"siae_id": siae.pk})
         response = self.client.get(url)
-        assert response.status_code == 200
         assert response.context["siae"] == siae
         self.assertContains(response, escape(siae.display_name))
         self.assertContains(response, siae.email)
@@ -537,7 +536,6 @@ class JobDescriptionCardViewTest(TestCase):
         job_description.save()
         url = reverse("siaes_views:job_description_card", kwargs={"job_description_id": job_description.pk})
         response = self.client.get(url)
-        assert response.status_code == 200
         assert response.context["job"] == job_description
         assert response.context["siae"] == siae
         self.assertContains(response, job_description.description)
@@ -717,7 +715,6 @@ class CreateSiaeViewTest(TestCase):
             "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         }
         response = self.client.post(url, data=post_data)
-        assert response.status_code == 200
 
         expected_message = f"Le SIRET doit commencer par le SIREN {siae.siren}"
         self.assertContains(response, escape(expected_message))
@@ -757,7 +754,6 @@ class CreateSiaeViewTest(TestCase):
             "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         }
         response = self.client.post(url, data=post_data)
-        assert response.status_code == 200
 
         expected_message = "Le SIRET doit commencer par le SIREN"
         self.assertNotContains(response, escape(expected_message))
@@ -792,7 +788,6 @@ class CreateSiaeViewTest(TestCase):
             "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         }
         response = self.client.post(url, data=post_data)
-        assert response.status_code == 200
 
         expected_message = "Le SIRET doit commencer par le SIREN"
         self.assertNotContains(response, escape(expected_message))
@@ -942,7 +937,6 @@ class EditSiaeViewTest(TestCase):
 
         url = reverse("siaes_views:edit_siae_step_contact_infos")
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, "Informations générales")
 
         post_data = {
@@ -958,7 +952,6 @@ class EditSiaeViewTest(TestCase):
         response = self.client.post(url, data=post_data)
 
         # Ensure form validation is done
-        assert response.status_code == 200
         self.assertContains(response, "Ce champ est obligatoire")
 
         # Go to next step: description
@@ -967,7 +960,6 @@ class EditSiaeViewTest(TestCase):
         self.assertRedirects(response, reverse("siaes_views:edit_siae_step_description"))
 
         response = self.client.post(url, data=post_data, follow=True)
-        assert response.status_code == 200
         self.assertContains(response, "Présentation de l'activité")
 
         # Go to next step: summary
@@ -980,13 +972,11 @@ class EditSiaeViewTest(TestCase):
         self.assertRedirects(response, reverse("siaes_views:edit_siae_step_preview"))
 
         response = self.client.post(url, data=post_data, follow=True)
-        assert response.status_code == 200
         self.assertContains(response, "Aperçu de la fiche")
 
         # Go back, should not be an issue
         step_2_url = reverse("siaes_views:edit_siae_step_description")
         response = self.client.get(step_2_url)
-        assert response.status_code == 200
         self.assertContains(response, "Présentation de l'activité")
         assert self.client.session["edit_siae_session_key"] == {
             "address_line_1": "1 Rue Jeanne d'Arc",
@@ -1004,7 +994,6 @@ class EditSiaeViewTest(TestCase):
 
         # Go forward again
         response = self.client.post(step_2_url, data=post_data, follow=True)
-        assert response.status_code == 200
         self.assertContains(response, "Aperçu de la fiche")
         self.assertContains(response, "On est très très forts pour tout")
 
@@ -1059,7 +1048,6 @@ class EditSiaeViewWithWrongAddressTest(TestCase):
 
         url = reverse("siaes_views:edit_siae_step_contact_infos")
         response = self.client.get(url)
-        assert response.status_code == 200
         self.assertContains(response, "Informations générales")
 
         post_data = {
@@ -1087,7 +1075,6 @@ class EditSiaeViewWithWrongAddressTest(TestCase):
 
         # Save the object for real
         response = self.client.post(response.redirect_chain[-1][0])
-        assert response.status_code == 200
         self.assertContains(response, "L'adresse semble erronée")
 
 

--- a/itou/www/signup/tests/test_job_seeker.py
+++ b/itou/www/signup/tests/test_job_seeker.py
@@ -284,7 +284,6 @@ class JobSeekerSignupTest(TestCase):
 
         url = reverse("signup:job_seeker")
         response = self.client.get(url)
-        assert response.status_code == 200
         fc_url = reverse("france_connect:authorize")
         self.assertContains(response, fc_url)
 
@@ -309,7 +308,6 @@ class JobSeekerSignupTest(TestCase):
         # Temporary NIR is not stored with user information.
         url = reverse("signup:job_seeker")
         response = self.client.get(url)
-        assert response.status_code == 200
         fc_url = reverse("france_connect:authorize")
         self.assertContains(response, fc_url)
 

--- a/itou/www/signup/tests/test_siae.py
+++ b/itou/www/signup/tests/test_siae.py
@@ -62,7 +62,6 @@ class SiaeSignupTest(InclusionConnectBaseTestCase):
 
         # No error when opening magic link a second time.
         response = self.client.get(magic_link)
-        assert response.status_code == 200
         self.assertContains(response, "logo-inclusion-connect-one-line.svg")
 
         # Check IC will redirect to the correct url
@@ -181,7 +180,6 @@ class SiaeSignupTest(InclusionConnectBaseTestCase):
         )
         response = self.client.post(url, data=post_data)
         mock_call_ban_geocoding_api.assert_not_called()
-        assert response.status_code == 200
         self.assertContains(response, f"SIRET « {FAKE_SIRET} » non reconnu.")
 
         # Mock a valid answer from the server


### PR DESCRIPTION
### Pourquoi ?

`assertContains` et `assertNotContains` vérifient le code de retour de la réponse.