### PR TITLE
HTML:  Correction des href de téléphone

### DIFF
--- a/itou/templates/apply/includes/job_application_sender_info.html
+++ b/itou/templates/apply/includes/job_application_sender_info.html
@@ -36,7 +36,7 @@
     {% if job_application.sender.phone %}
         <li>
             Téléphone :
-            <a href="tel:{{ job_application.sender.phone }}">{{ job_application.sender.phone|format_phone }}</a>
+            <a href="tel:{{ job_application.sender.phone|cut:" " }}">{{ job_application.sender.phone|format_phone }}</a>
         </li>
     {% endif %}
 </ul>

--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -28,7 +28,7 @@
         <li>
             Téléphone : 
             {% if job_application.job_seeker.phone %}
-                <a href="tel:{{ job_application.job_seeker.phone }}">{{ job_application.job_seeker.phone|format_phone }}</a>
+                <a href="tel:{{ job_application.job_seeker.phone|cut:" " }}">{{ job_application.job_seeker.phone|format_phone }}</a>
             {% else %}
                 <span>Non renseigné</span>
             {% endif %}

--- a/itou/templates/prescribers/card.html
+++ b/itou/templates/prescribers/card.html
@@ -36,7 +36,7 @@
     {% if user.is_authenticated and prescriber_org.phone %}
         <p>
             <i class="ri-phone-line mr-1" aria-label="Téléphone"></i>
-            <a href="tel:{{ prescriber_org.phone }}">{{ prescriber_org.phone|format_phone }}</a>
+            <a href="tel:{{ prescriber_org.phone|cut:" " }}">{{ prescriber_org.phone|format_phone }}</a>
         </p>
     {% endif %}
 

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
@@ -48,7 +48,7 @@
                     </h3>
                     <p>
                         Numéro de téléphone à utiliser au besoin :
-                        <a aria-label="Contact téléphonique" href="tel:{{ evaluated_siae.siae.phone }}">
+                        <a aria-label="Contact téléphonique" href="tel:{{ evaluated_siae.siae.phone|cut:" " }}">
                             {{ evaluated_siae.siae.phone|format_phone }}
                         </a>
                     </p>

--- a/itou/templates/siaes/includes/_siae_details.html
+++ b/itou/templates/siaes/includes/_siae_details.html
@@ -12,7 +12,7 @@
 {% if siae.phone %}
     <p>
         <i class="ri-phone-line ri-xl mr-2"></i>
-        <a aria-label="Contact téléphonique" href="tel:{{ siae.phone }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
+        <a aria-label="Contact téléphonique" href="tel:{{ siae.phone|cut:" " }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
     </p>
 {% endif %}
 

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -108,7 +108,7 @@ class ProcessViewsTest(TestCase):
         self.assertContains(response, "Ce candidat a pris le contrôle de son compte utilisateur.")
         self.assertContains(response, format_nir(job_application.job_seeker.nir))
         self.assertContains(response, job_application.job_seeker.pole_emploi_id)
-        self.assertContains(response, job_application.job_seeker.phone)
+        self.assertContains(response, job_application.job_seeker.phone.replace(" ", ""))
         self.assertNotContains(response, PRIOR_ACTION_SECTION_TITLE)  # the SIAE is not a GEIQ
 
         job_application.job_seeker.created_by = siae_user


### PR DESCRIPTION
### Pourquoi ?

Les attributs href ne sont pas censés contenir d'espace.

On le fait déjà ici: https://github.com/betagouv/itou/blob/master/itou/templates/siaes/edit_siae_preview.html#L79
