### PR TITLE
Correction d'une typo dans un tag <img>

### DIFF
--- a/itou/templates/inclusion_connect/includes/description.html
+++ b/itou/templates/inclusion_connect/includes/description.html
@@ -16,7 +16,7 @@
            data-matomo-option="se-connecter-avec-inclusion-connect">
             <picture>
                 <source srcset="{% static_theme_images 'logo-inclusion-connect-one-line.svg' %}" height="14" width="286" type="image/svg+xml" media="(min-width: 30em)">
-                <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" height="37" width="142" " alt="Se connecter avec Inclusion Connect">
+                <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" height="37" width="142" alt="Se connecter avec Inclusion Connect">
             </picture>
         </a>
         <br>


### PR DESCRIPTION
### Pourquoi ?

Car l'HTML valide, c'est mieux.