### PR TITLE
Permettre le Site Search de Matomo par les villes

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -194,7 +194,7 @@
 
         {% if MATOMO_BASE_URL %}
             {# Matomo/Piwik open source web analytics #}
-            <script nonce="{{ CSP_NONCE }}">
+            <script id="matomo-custom-init" nonce="{{ CSP_NONCE }}">
                 window._paq = window._paq || [];
                 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
 

--- a/itou/utils/__snapshots__/tests.ambr
+++ b/itou/utils/__snapshots__/tests.ambr
@@ -26,3 +26,21 @@
 # name: test_job_application_state_badge_processing[refused]
   '<span id="state_00000000-0000-0000-0000-000000000000" class="badge badge-sm badge-pill text-wrap mb-1 badge-danger">Candidature déclinée</span>'
 # ---
+# name: test_matomo_context_processor[matomo custom init]
+  '''
+  <script id="matomo-custom-init" nonce="NORMALIZED_CSP_NONCE">
+                  window._paq = window._paq || [];
+                  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  
+                  window._paq.push(['setUserId', '99999']);
+  
+                  
+                      window._paq.push(['setCustomUrl', new URL('siae/&lt;int:siae_id&gt;/card?city=paris&amp;mtm_bar=bidule&amp;mtm_foo=truc', window.location.origin).href]);
+                  
+  
+                  
+                      window._paq.push(['setDocumentTitle', 'Fiche de la structure d&#x27;insertion']);
+                  
+              </script>
+  '''
+# ---

--- a/itou/utils/context_processors.py
+++ b/itou/utils/context_processors.py
@@ -26,8 +26,8 @@ def matomo(request):
     context = {}
     if request.resolver_match:
         url = request.resolver_match.route
-        # only keep Matomo-related GET params for now
-        params = {k: v for k, v in request.GET.lists() if k.startswith(("utm_", "mtm_", "piwik_"))}
+        # only keep Matomo-related and "city" (for Site Search) GET params for now
+        params = {k: v for k, v in request.GET.lists() if k in ["city"] or k.startswith(("utm_", "mtm_", "piwik_"))}
         if params:
             url = f"{url}?{urlencode(sorted(params.items()), doseq=True)}"
         context["matomo_custom_url"] = url

--- a/itou/utils/test.py
+++ b/itou/utils/test.py
@@ -37,6 +37,10 @@ def parse_response_to_soup(response, selector=None, no_html_body=False):
         [soup] = soup.select(selector)
     for csrf_token_input in soup.find_all("input", attrs={"name": "csrfmiddlewaretoken"}):
         csrf_token_input["value"] = "NORMALIZED_CSRF_TOKEN"
+    if "nonce" in soup.attrs:
+        soup["nonce"] = "NORMALIZED_CSP_NONCE"
+    for csp_nonce_script in soup.find_all("script", {"nonce": True}):
+        csp_nonce_script["nonce"] = "NORMALIZED_CSP_NONCE"
     return soup
 
 

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -1266,8 +1266,6 @@ def test_matomo_context_processor(client, settings):
     settings.MATOMO_BASE_URL = "https://fake.matomo.url"
     siae = SiaeFactory(with_membership=True)
     user = siae.members.first()
-    user.asp_uid = "1234567890"
-    user.save(update_fields=["asp_uid"])
     client.force_login(user)
 
     # check that we don't crash when the route is not resolved

--- a/itou/utils/tests.py
+++ b/itou/utils/tests.py
@@ -1276,17 +1276,17 @@ def test_matomo_context_processor(client, settings):
 
     # canonical case
     url = reverse("siaes_views:card", kwargs={"siae_id": siae.pk})
-    response = client.get(f"{url}?foo=bar&mtm_foo=truc&mtm_bar=bidule")
+    response = client.get(f"{url}?foo=bar&mtm_foo=truc&mtm_bar=bidule&city=paris")
     assert response.status_code == 200
     assert response.context["siae"] == siae
-    assert response.context["matomo_custom_url"] == "siae/<int:siae_id>/card?mtm_bar=bidule&mtm_foo=truc"
+    assert response.context["matomo_custom_url"] == "siae/<int:siae_id>/card?city=paris&mtm_bar=bidule&mtm_foo=truc"
     assert response.context["matomo_custom_title"] == "Fiche de la structure d'insertion"
     assert response.context["matomo_user_id"] == user.pk
     str_content = response.content.decode("utf-8")
     assert f"window._paq.push(['setUserId', '{user.pk}']);" in str_content
     assert (
         "window._paq.push(['setCustomUrl', "
-        "new URL('siae/&lt;int:siae_id&gt;/card?mtm_bar=bidule&amp;mtm_foo=truc', "
+        "new URL('siae/&lt;int:siae_id&gt;/card?city=paris&mtm_bar=bidule&amp;mtm_foo=truc', "
         "window.location.origin).href]);"
     ) in str_content
     assert "window._paq.push(['setDocumentTitle', 'Fiche de la structure d&#x27;insertion']);" in str_content


### PR DESCRIPTION
Pas de carte Notion, toujorus dans le cadre de l'amélioration de Matomo.

### Pourquoi ?

Matomo propose une fonctionnalité de "Site Search" qui permet de tracer les utilisations des recherches intra-site.
Nous en avons une évidente avec notre recherche par villes. Cela permettra de débloquer d'autres analyses intéressantes.

### Comment
On autorise un nouveau query param dans le context processor de Matomo.

