### PR TITLE
Expiration des indexs ElasticSearch après un an

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -13,6 +13,7 @@
   "0 3 * * * $ROOT/clevercloud/run_management_command.sh clearsessions",
   "0 12 * * * $ROOT/clevercloud/run_management_command.sh evaluation_campaign_notify",
   "30 20 * * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --daily",
+  "15 3 * * * $ROOT/scripts/expire-elastic-indices",
 
   "25 8-18/2 * * 1-5 $ROOT/clevercloud/download_employee_records.sh",
   "55 8-18/2 * * 1-5 $ROOT/clevercloud/upload_employee_records.sh",

--- a/scripts/expire-elastic-indices
+++ b/scripts/expire-elastic-indices
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import os
+from datetime import date
+
+import httpx
+from sentry_sdk.crons import monitor
+
+
+@monitor(monitor_slug="expire-elasticsearch-indices")
+def main():
+    elastic_url = f"https://{os.environ['ELASTICSEARCH_DOMAIN']}"
+    elastic_user = os.environ["ELASTICSEARCH_USER"]
+    elastic_password = os.environ["ELASTICSEARCH_PASSWORD"]
+    today = date.today()
+    with httpx.Client(base_url=elastic_url, auth=(elastic_user, elastic_password)) as client:
+        response = client.get("/logstash-*")
+        response.raise_for_status()
+        response = response.json()
+        for indexname in response:
+            _logstash, year, month, day = indexname.split("-")
+            index_age = today - date(int(year), int(month), int(day))
+            if index_age.days > 365:  # Does not handle leap years, that’s fine.
+                print(f"Deleting index {indexname}.")
+                client.delete(f"/{indexname}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Retirer-les-logs-de-plus-de-12-mois-de-c1-elk-acc5250b39124afa88a3539f97b3615b**

### Pourquoi ?

Ils contiennent des données personnelles, et ont peu de chances d’être consultés au delà d’une année.