### PR TITLE
Augmenter le nombre de dépendances mises à jour chaque semaine

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,5 @@ updates:
     # Only allow updates to the lockfile for pip and
     # ignore any version updates that affect the manifest
     versioning-strategy: lockfile-only
-    # Allow up to 10 concurrent open PRs
-    open-pull-requests-limit: 10
+    # Allow up to 20 concurrent open PRs
+    open-pull-requests-limit: 20


### PR DESCRIPTION
### Pourquoi ?

Le projet a environ 160 dépendances. À raison de 10 par semaines, il faut environ 4 mois pour faire le tour. En 4 mois, de nombreux changements peuvent arriver sur un projet. Essayons d’être plus assidus dans les mises à jour.