### PR TITLE
Stats : Ajout d'encarts Tally pour alimenter les KPI en bas des pages

### DIFF
--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -36,6 +36,22 @@
 {% endblock %}
 
 {% block post_content %}
+
+    {% if tally_embed_form_id %}
+        <section class="s-section mt-0 pt-0">
+            <div class="s-section__container container">
+                <iframe data-tally-src="https://tally.so/embed/{{ tally_embed_form_id }}?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1"
+                        loading="lazy"
+                        width="100%"
+                        height="189"
+                        frameborder="0"
+                        marginheight="0"
+                        marginwidth="0"
+                        title="Aidez-nous à améliorer votre outil !">
+                </iframe>
+            </div>
+        </section>
+    {% endif %}
     <section class="s-section mt-0 pt-0">
         <div class="s-section__container container">
             <div class="s-section__row row row-cols-1 row-cols-md-2 row-cols-lg-3">
@@ -136,17 +152,19 @@
         });
     </script>
 
-    {% if tally_form_id %}
+    {% if tally_popup_form_id or tally_embed_form_id %}
         {# Do not use `async` here otherwise the Tally popup will randomly fail to load. #}
         <script src="https://tally.so/widgets/embed.js"></script>
+    {% endif %}
 
+    {% if tally_popup_form_id %}
         {# `defer` ensures the script runs *after* embed.js above has been loaded. #}
         <script defer nonce="{{ CSP_NONCE }}">
 
             // Any given Tally popup will not be shown more than once every `minDaysBetweenDisplays` days.
             const minDaysBetweenDisplays = 14;
             const delayBeforeShowingPopupInSeconds = 45;
-            const formId = '{{ tally_form_id }}';
+            const formId = '{{ tally_popup_form_id }}';
             const key = 'statsTallyPopupLastShown-' + formId;
             const todaysDate = new Date();
 

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -23,7 +23,8 @@ METABASE_DASHBOARDS = {
     },
     "stats_siae_hiring": {
         "dashboard_id": 185,
-        "tally_form_id": "waQPkB",
+        "tally_popup_form_id": "waQPkB",
+        "tally_embed_form_id": "nG6J62",
     },
     #
     # Prescriber stats - CD.
@@ -36,39 +37,45 @@ METABASE_DASHBOARDS = {
     #
     "stats_pe_delay_main": {
         "dashboard_id": 168,
-        "tally_form_id": "3lb9XW",
+        "tally_popup_form_id": "3lb9XW",
+        "tally_embed_form_id": "meM7DE",
     },
     "stats_pe_delay_raw": {
         "dashboard_id": 180,
     },
     "stats_pe_conversion_main": {
         "dashboard_id": 169,
-        "tally_form_id": "mODeK8",
+        "tally_popup_form_id": "mODeK8",
+        "tally_embed_form_id": "3xrPjJ",
     },
     "stats_pe_conversion_raw": {
         "dashboard_id": 182,
     },
     "stats_pe_state_main": {
         "dashboard_id": 149,
-        "tally_form_id": "mRG61J",
+        "tally_popup_form_id": "mRG61J",
+        "tally_embed_form_id": "3qLKad",
     },
     "stats_pe_state_raw": {
         "dashboard_id": 183,
     },
     "stats_pe_tension": {
         "dashboard_id": 162,
-        "tally_form_id": "wobaYV",
+        "tally_popup_form_id": "wobaYV",
+        "tally_embed_form_id": "3EKJ5q",
     },
     #
     # Institution stats - DDETS - department level.
     #
     "stats_ddets_auto_prescription": {
         "dashboard_id": 267,
-        "tally_form_id": "3qLpE2",
+        "tally_popup_form_id": "3qLpE2",
+        "tally_embed_form_id": "nG6gBj",
     },
     "stats_ddets_follow_siae_evaluation": {
         "dashboard_id": 265,
-        "tally_form_id": "w2XZxV",
+        "tally_popup_form_id": "w2XZxV",
+        "tally_embed_form_id": "n9Ba6G",
     },
     "stats_ddets_iae": {
         "dashboard_id": 117,
@@ -78,36 +85,42 @@ METABASE_DASHBOARDS = {
     },
     "stats_ddets_hiring": {
         "dashboard_id": 160,
-        "tally_form_id": "mVLBXv",
+        "tally_popup_form_id": "mVLBXv",
+        "tally_embed_form_id": "nPpXpQ",
     },
     #
     # Institution stats - DREETS - region level.
     #
     "stats_dreets_auto_prescription": {
         "dashboard_id": 267,
-        "tally_form_id": "3qLpE2",
+        "tally_popup_form_id": "3qLpE2",
+        "tally_embed_form_id": "nG6gBj",
     },
     "stats_dreets_follow_siae_evaluation": {
         "dashboard_id": 265,
-        "tally_form_id": "w2XZxV",
+        "tally_popup_form_id": "w2XZxV",
+        "tally_embed_form_id": "n9Ba6G",
     },
     "stats_dreets_iae": {
         "dashboard_id": 117,
     },
     "stats_dreets_hiring": {
         "dashboard_id": 160,
-        "tally_form_id": "mVLBXv",
+        "tally_popup_form_id": "mVLBXv",
+        "tally_embed_form_id": "nPpXpQ",
     },
     #
     # Institution stats - DGEFP - nation level.
     #
     "stats_dgefp_auto_prescription": {
         "dashboard_id": 267,
-        "tally_form_id": "3qLpE2",
+        "tally_popup_form_id": "3qLpE2",
+        "tally_embed_form_id": "nG6gBj",
     },
     "stats_dgefp_follow_siae_evaluation": {
         "dashboard_id": 265,
-        "tally_form_id": "w2XZxV",
+        "tally_popup_form_id": "w2XZxV",
+        "tally_embed_form_id": "n9Ba6G",
     },
     "stats_dgefp_iae": {
         "dashboard_id": 117,

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -107,14 +107,17 @@ def render_stats(request, context, params=None, template_name="stats/stats.html"
         params = {}
     view_name = get_view_name(request)
     metabase_dashboard = METABASE_DASHBOARDS.get(view_name)
-    tally_form_id = None
+    tally_popup_form_id = None
+    tally_embed_form_id = None
     if settings.TALLY_URL and metabase_dashboard:
-        tally_form_id = metabase_dashboard.get("tally_form_id")
+        tally_popup_form_id = metabase_dashboard.get("tally_popup_form_id")
+        tally_embed_form_id = metabase_dashboard.get("tally_embed_form_id")
 
     base_context = {
         "iframeurl": metabase_embedded_url(request=request, params=params),
         "stats_base_url": settings.METABASE_SITE_URL,
-        "tally_form_id": tally_form_id,
+        "tally_popup_form_id": tally_popup_form_id,
+        "tally_embed_form_id": tally_embed_form_id,
     }
 
     # Key value pairs in context override preexisting pairs in base_context.


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Mettre-embed-KPI-Utilisation-bas-de-page-des-Tb-priv-s-e911710c612c4ce9ac8ac8bed15666f2**

Cet encart ("embed") est affiché en permanence et s'ajoute au popup Tally déjà existant.

### Pourquoi ?

Pour rester iso avec le site statique Pilotage qui le fait déjà pour les TB publics, par exemple https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/auto-prescription/

### Captures d'écran

![image](https://user-images.githubusercontent.com/10533583/233317436-fc47d313-f599-4db9-a72d-da4212f675c9.png)

