### PR TITLE
Revert "requirements: Add pytest-timeout"

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,3 @@ addopts =
     --strict-markers
 markers =
     no_django_db: mark tests that should not be marked with django_db.
-timeout = 15
-timeout_method = thread

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -33,7 +33,6 @@ freezegun  # https://github.com/spulec/freezegun
 pytest  # https://github.com/pytest-dev/pytest
 pytest-django # https://github.com/pytest-dev/pytest-django/
 pytest-mock  # https://github.com/pytest-dev/pytest-mock/
-pytest-timeout  # https://github.com/pytest-dev/pytest-timeout
 pytest-xdist  # https://pypi.org/project/pytest-xdist/
 respx  # https://lundberg.github.io/respx/
 syrupy  # https://github.com/tophat/syrupy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -913,7 +913,6 @@ pytest==7.3.1 \
     #   -r requirements/dev.in
     #   pytest-django
     #   pytest-mock
-    #   pytest-timeout
     #   pytest-xdist
     #   syrupy
 pytest-django==4.5.2 \
@@ -923,10 +922,6 @@ pytest-django==4.5.2 \
 pytest-mock==3.10.0 \
     --hash=sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b \
     --hash=sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f
-    # via -r requirements/dev.in
-pytest-timeout==2.1.0 \
-    --hash=sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9 \
-    --hash=sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6
     # via -r requirements/dev.in
 pytest-xdist==3.2.1 \
     --hash=sha256:1849bd98d8b242b948e472db7478e090bf3361912a8fed87992ed94085f54727 \


### PR DESCRIPTION
### Pourquoi ?

This reverts commit 2450bce82e35b6e38d07c87ed21f1c0a9db5bd9a.

The timeout includes the setup and teardown times. That’s what makes the
timeout the most useful, because e.g. a setup of fixtures can be
particularly slow and should be reported. Creating a test database and
populating it is considered part of the test setup (--create-db).

Some dev machines are particularly slow (e.g. a Mac M1 using docker with
amd64 emulation), and it takes more than 45 seconds for the first test
to start. Increasing the timeout to 60 seconds (lowest value for which
tests run reliably on said slow machine) loses most of the benefit of a
timeout.

https://github.com/betagouv/itou/pull/2346