### PR TITLE
Modification UI/UX de la zone titre de la fiche de structure

### DIFF
--- a/itou/templates/siaes/card.html
+++ b/itou/templates/siaes/card.html
@@ -4,13 +4,25 @@
 
 {% block title %}{{ siae.display_name }} {{ block.super }}{% endblock %}
 
+
+{% block pre_content %}
+    <section class="s-title-01 p-0">
+        <div class="s-title-01__container container">
+            <div class="s-title-01__row row">
+                <div class="s-title-01__col col-12">
+                    <h1 class="s-title-01__title h1">
+                        <strong>{{ siae.display_name }}</strong>
+                    </h1>
+                    <h2 class="h5">{{ siae.get_kind_display }}</h2>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
 {% block content_container_css_classes %}s-section p-0{% endblock %}
 {% block content %}
     <div class="row">
-        <div class="col-12">
-            <span class="badge badge-sm badge-pill badge-info-light text-info">{{ siae.get_kind_display }}</span>
-            <h1 class="mt-1">{{ siae.display_name }}</h1>
-        </div>
         <div class="col-12 col-lg-8 order-2 order-lg-1 mt-3 mt-lg-0 {% if not siae.description and not siae.provided_support %}d-none d-lg-block{% endif %}">
             <div class="c-box p-3 h-100 {% if not siae.description and not siae.provided_support %}d-flex align-items-center justify-content-center{% endif %}">
                 {% if siae.description %}
@@ -42,7 +54,7 @@
                 {% endif %}
             </div>
         </div>
-        <div class="col-12 col-lg-4 order-1 order-lg-2 d-flex flex-column ">
+        <div class="col-12 col-lg-4 order-1 order-lg-2 d-flex flex-column">
             <h2 class="sr-only">Actions rapides</h2>
             <div class="c-card card rounded-lg mb-3 mb-lg-5">
                 <div class="card-body">


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Fiche-structure-modifier-le-badge-de-type-de-structure-et-le-placer-sous-le-H1-53d3e0af66bc48eab72d7015009731fe?pvs=4

### Pourquoi ?

Modifications à faire en vue de j’ajout futur de l’info PHC et Convergence 

