### PR TITLE
Descente de version de sentry_sdk vers 1.18.0

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -87,3 +87,5 @@ METABASE_PORT = os.getenv("PGPORT", "5432")  # noqa: F405
 METABASE_USER = os.getenv("PGUSER", "postgres")  # noqa: F405o
 METABASE_PASSWORD = os.getenv("PGPASSWORD", "password")  # noqa: F405
 METABASE_DATABASE = os.getenv("PGDATABASE", "metabase")  # noqa: F405
+
+del SENTRY_DSN  # noqa: F821

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -113,4 +113,4 @@ python-dotenv  # https://github.com/theskumar/python-dotenv
 # Production requirements
 # ------------------------------------------------------------------------------
 uwsgi==2.0.*  # https://github.com/unbit/uwsgi
-sentry-sdk  # https://github.com/getsentry/sentry-python
+sentry-sdk==1.18.*  # https://github.com/getsentry/sentry-python

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -598,9 +598,9 @@ s3transfer==0.6.0 \
     --hash=sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd \
     --hash=sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947
     # via boto3
-sentry-sdk==1.20.0 \
-    --hash=sha256:0ad6bbbe78057b8031a07de7aca6d2a83234e51adc4d436eaf8d8c697184db71 \
-    --hash=sha256:a3410381ae769a436c0852cce140a5e5e49f566a07fb7c2ab445af1302f6ad89
+sentry-sdk==1.18.0 \
+    --hash=sha256:714203a9adcac4a4a35e348dc9d3e294ad0200a66cdca26c068967d728f34fcb \
+    --hash=sha256:d07b9569a151033b462f7a7113ada94cc41ecf49daa83d35f5f852a0b9cf3b44
     # via -r requirements/base.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1123,9 +1123,9 @@ s3transfer==0.6.0 \
     # via
     #   -r requirements/base.txt
     #   boto3
-sentry-sdk==1.20.0 \
-    --hash=sha256:0ad6bbbe78057b8031a07de7aca6d2a83234e51adc4d436eaf8d8c697184db71 \
-    --hash=sha256:a3410381ae769a436c0852cce140a5e5e49f566a07fb7c2ab445af1302f6ad89
+sentry-sdk==1.18.0 \
+    --hash=sha256:714203a9adcac4a4a35e348dc9d3e294ad0200a66cdca26c068967d728f34fcb \
+    --hash=sha256:d07b9569a151033b462f7a7113ada94cc41ecf49daa83d35f5f852a0b9cf3b44
     # via -r requirements/base.txt
 shellcheck-py==0.9.0.2 \
     --hash=sha256:1c29aa5864cc937f037b84b8e6b13b7016d25a45f7a07a1f1f16d38e387c76b4 \


### PR DESCRIPTION
### Pourquoi ?

La surveillance des crons est cassée avec `sentry_sdk>=1.19.0`.

https://github.com/getsentry/sentry-python/issues/2024