### PR TITLE
En tant que SIAE je suis informée du nombre de jours restants sur le PASS IAE depuis l’attestation en ligne et via la notification email

### DIFF
--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -862,7 +862,7 @@ class JobApplicationNotificationsTest(TestCase):
         assert approval.user.get_full_name() in email.subject
         assert approval.number_with_spaces in email.body
         assert approval.start_at.strftime("%d/%m/%Y") in email.body
-        assert approval.end_at.strftime("%d/%m/%Y") in email.body
+        assert f"{approval.remainder.days} jours" in email.body
         assert approval.user.last_name in email.body
         assert approval.user.first_name in email.body
         assert approval.user.birthdate.strftime("%d/%m/%Y") in email.body

--- a/itou/templates/approvals/email/deliver_body.txt
+++ b/itou/templates/approvals/email/deliver_body.txt
@@ -31,8 +31,8 @@ Prenez 30 secondes pour nous donner votre avis ! Cliquez sur : {{ siae_survey_
 Merci de votre participation et à très bientôt sur les emplois de l'inclusion !
 
 
-* Le reliquat est calculé sur la base d’un nombre de jours calendaires : il décroit donc tous les jours
-(samedi, dimanche et jours fériés compris).
+* Le reliquat est calculé sur la base d’un nombre de jours calendaires.
+Si le PASS IAE n'est pas suspendu, il décroit donc tous les jours (samedi, dimanche et jours fériés compris).
 {% else %}
 Merci d'avoir confirmé l'embauche d'un candidat sur les emplois de l'inclusion.
 

--- a/itou/templates/approvals/email/deliver_body.txt
+++ b/itou/templates/approvals/email/deliver_body.txt
@@ -5,7 +5,7 @@
 Merci d'avoir confirmé l'embauche d'un candidat sur les emplois de l'inclusion. Vous trouverez ci-dessous votre PASS IAE (il équivaut à l'agrément Pôle emploi conformément aux articles L 5132-1 à L 5132-17 du code du travail) :
 
 PASS IAE N° : {{ job_application.approval.number_with_spaces }}
-Valide du {{ job_application.approval.start_at|date:"d/m/Y" }} au {{ job_application.approval.end_at|date:"d/m/Y" }}
+Nombre de jours restants sur le PASS IAE débutant le {{ job_application.approval.start_at|date:"d/m/Y" }} : {{ job_application.approval.remainder.days }} jours*.
 
 Délivré pour l'embauche de :
 Nom : {{ job_application.approval.user.last_name }}
@@ -23,14 +23,16 @@ Au sein de la structure :
 {{ job_application.to_siae.address_line_2 }}{% endif %}
 {{ job_application.to_siae.post_code }} {{ job_application.to_siae.city }}
 
-Pour le compte de Pôle emploi,
-
 Votre contact : {{ itou_assistance_url }}
 
 Afin de nous aider à évaluer la performance de notre service, accepteriez-vous de répondre à quelques questions ?
 Prenez 30 secondes pour nous donner votre avis ! Cliquez sur : {{ siae_survey_link }}
 
 Merci de votre participation et à très bientôt sur les emplois de l'inclusion !
+
+
+* Le reliquat est calculé sur la base d’un nombre de jours calendaires : il décroit donc tous les jours
+(samedi, dimanche et jours fériés compris).
 {% else %}
 Merci d'avoir confirmé l'embauche d'un candidat sur les emplois de l'inclusion.
 

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -65,7 +65,7 @@ Arguments:
             Reliquat : <span{% if common_approval.remainder %} class="text-success"{% endif %}>{{ common_approval.remainder.days }} jours restants</span>
             <i class="ri-information-line ri-xl"
                data-toggle="tooltip"
-               title="Le reliquat est calculé sur la base d'un nombre de jours calendaires : il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+               title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
         </li>
 
         {% if common_approval.is_pass_iae %}

--- a/itou/templates/approvals/printable_approval.html
+++ b/itou/templates/approvals/printable_approval.html
@@ -83,7 +83,7 @@
             </p>
             <p>Nombre de jours restants sur le PASS IAE : {{ approval.remainder.days }} jours*.</p>
             <p class="font-italic">
-                * Le reliquat est calculé sur la base d’un nombre de jours calendaires : il décroit
+                * Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroit
                 donc tous les jours (samedi, dimanche et jours fériés compris).
             </p>
         </section>

--- a/itou/templates/approvals/printable_approval.html
+++ b/itou/templates/approvals/printable_approval.html
@@ -39,6 +39,7 @@
                             {{ siae.post_code }} - {{ siae.city }}
                         </address>
                     {% endif %}
+                    <p class="my-4 text-justify">Paris, le {% now "d F Y" %}</p>
                 </div>
             </div>
         </section>
@@ -47,8 +48,8 @@
             <span class="d-block font-weight-bold">Références à rappeler :</span>
             <ul class="list-unstyled">
                 <li class="d-block">PASS IAE n° {{ approval.number|format_approval_number }}</li>
-                <li class="d-block">du {{ approval.start_at|date:"d/m/Y" }} au {{ approval.end_at|date:"d/m/Y" }}</li>
                 <li class="d-block">délivré par les emplois de l'inclusion</li>
+                <li class="d-block">Date de début : {{ approval.start_at|date:"d/m/Y" }}</li>
                 {% if approval.user.pole_emploi_id %}
                     <li class="d-block">Identifiant Pôle emploi : {{ approval.user.pole_emploi_id }}</li>
                 {% endif %}
@@ -57,8 +58,10 @@
 
         <section class="mt-5">
             <h1 class="ff-base fs-base">
-                Objet :<b>Décision d'agrément pour un parcours d'insertion par l'activité économique</b>
+                Objet : <b>Décision d'agrément pour un parcours d'insertion par l'activité économique</b>
             </h1>
+        </section>
+        <section class="mt-5">
             <p class="text-justify">
                 {% if diagnosis_author %}
                     Au vu du diagnostic individuel réalisé par {{ diagnosis_author|title }}
@@ -78,9 +81,10 @@
                 un PASS IAE pour un parcours d'insertion par l'activité économique,
                 conformément aux dispositions des articles L 5132-1 à L 5132-17 du code du travail.
             </p>
-            <p>
-                Ce PASS IAE, inscrit sous le numéro {{ approval.number_with_spaces }}, est valide du
-                {{ approval.start_at|date:"d/m/Y" }} au {{ approval.end_at|date:"d/m/Y" }}.
+            <p>Nombre de jours restants sur le PASS IAE : {{ approval.remainder.days }} jours*.</p>
+            <p class="font-italic">
+                * Le reliquat est calculé sur la base d’un nombre de jours calendaires : il décroit
+                donc tous les jours (samedi, dimanche et jours fériés compris).
             </p>
         </section>
 


### PR DESCRIPTION
[Carte Notion](https://www.notion.so/plateforme-inclusion/En-tant-que-SIAE-je-suis-inform-e-du-nombre-de-jours-restants-sur-le-PASS-IAE-depuis-l-attestation-e-376b318fd063427da458524743052c01)

### Pourquoi ?

La date de fin étant fluctuante, il vaut mieux envoyer le nombre de jours restant dans la version imprimable et dans l'e-mail envoyé à l'acceptation d'une candidature.

### Comment

Mise à jour de l'e-mail et de l'attestation.

### Captures d'écran

![image](https://user-images.githubusercontent.com/6150920/235095320-e07b2c81-346f-4e1e-b921-baa14858851f.png)



