### PR TITLE
Candidature: empêcher les orienteurs de mettre à jour les données du candidat

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -1007,6 +1007,8 @@ class ApplicationEndView(ApplyStepBaseView):
         )
 
     def post(self, request, *args, **kwargs):
+        if not self.request.user.can_edit_personal_information(self.job_application.job_seeker):
+            raise PermissionDenied("Votre utilisateur n'est pas autorisé à modifier les informations de ce candidat")
         if self.form.is_valid():
             self.form.save()
             # Redirect to the same page, so we don't have a POST method


### PR DESCRIPTION
### Pourquoi ?

Empêcher les utilisateurs de faire des choses qu'ils ne sont pas censés pouvoir faire


