### PR TITLE
Rendre l’affichage des infos du PASS en cours plus claires avant que l’employeur valide l’embauche

### DIFF
--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -62,7 +62,7 @@ Arguments:
             Reliquat : <span{% if common_approval.remainder %} class="text-success"{% endif %}>{{ common_approval.remainder.days }} jours restants</span>
             <i class="ri-information-line ri-xl"
                data-toggle="tooltip"
-               title="Le reliquat est calculé sur la base d'un nombre de jours calendaires : il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+               title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
         </li>
 
         {% if common_approval.is_pass_iae %}


### PR DESCRIPTION
[Carte Notion](https://www.notion.so/plateforme-inclusion/Rendre-l-affichage-des-infos-du-PASS-en-cours-claires-avant-que-l-employeur-valide-l-embauche-50d114b4a4a2450f8d431d9c518996e4)

### Pourquoi ?

Indiquer le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements.

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

