### PR TITLE
Retirer form_group_class="form-group" des bootstrap_field

### DIFF
--- a/itou/templates/account/activate_inclusion_connect_account.html
+++ b/itou/templates/account/activate_inclusion_connect_account.html
@@ -52,7 +52,7 @@
                             <fieldset>
                                 {% bootstrap_form_errors form type="all" %}
                                 {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
-                                {% bootstrap_field form.email form_group_class="form-group" %}
+                                {% bootstrap_field form.email %}
                             </fieldset>
                             <button type="submit"
                                     class="btn btn-block btn-primary matomo-event"

--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -102,7 +102,7 @@
                                                 <p class="h4">S’identifier avec vos identifiants</p>
                                                 {% bootstrap_form_errors form type="all" %}
                                                 {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
-                                                {% bootstrap_field form.login form_group_class="form-group" %}
+                                                {% bootstrap_field form.login %}
                                                 {% bootstrap_field form.password form_group_class="form-group mb-2" %}
                                                 <div class="form-group">
                                                     <a href="{% url 'account_reset_password' %}" class="btn-link fs-sm">Mot de passe oublié ?</a>
@@ -126,7 +126,7 @@
                                             <p class="h4">S’identifier avec vos identifiants</p>
                                             {% bootstrap_form_errors form type="all" %}
                                             {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
-                                            {% bootstrap_field form.login form_group_class="form-group" %}
+                                            {% bootstrap_field form.login %}
                                             {% bootstrap_field form.password form_group_class="form-group mb-2" %}
                                             <div class="form-group">
                                                 <a href="{% url 'account_reset_password' %}" class="btn-link fs-sm">Mot de passe oublié ?</a>

--- a/itou/templates/account/login_job_seeker.html
+++ b/itou/templates/account/login_job_seeker.html
@@ -74,7 +74,7 @@
                                         <p class="h4">S’identifier avec vos identifiants</p>
                                         {% bootstrap_form_errors form type="all" %}
                                         {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
-                                        {% bootstrap_field form.login form_group_class="form-group" %}
+                                        {% bootstrap_field form.login %}
                                         {% bootstrap_field form.password form_group_class="form-group mb-2" %}
                                         <div class="form-group">
                                             <a href="{% url 'account_reset_password' %}" class="btn-link fs-sm">Mot de passe oublié ?</a>

--- a/itou/templates/search/includes/prescribers_search_filters.html
+++ b/itou/templates/search/includes/prescribers_search_filters.html
@@ -5,6 +5,6 @@
         <i class="ri-filter-line"></i>
     </a>
     <div id="search-filter-form" class="card-body collapse show">
-        {% bootstrap_field form.distance form_group_class="form-group" label_class="h4 font-weight-bold text-muted" %}
+        {% bootstrap_field form.distance label_class="h4 font-weight-bold text-muted" %}
     </div>
 </div>


### PR DESCRIPTION
### Pourquoi ?

C’est la valeur par défaut.