### PR TITLE
Rendre l’affichage des infos du PASS en cours plus clair avant que l’employeur valide l’embauche

### DIFF
--- a/itou/approvals/factories.py
+++ b/itou/approvals/factories.py
@@ -78,8 +78,12 @@ class ProlongationFactory(factory.django.DjangoModelFactory):
     @factory.post_generation
     def set_validated_by(self, create, extracted, **kwargs):
         if not create:
-            # Simple build, do nothing.
             return
+        # Ignore setting validated_by:
+        # ProlongationFactory(set_validated_by=False)
+        if extracted is False:
+            return
+
         authorized_prescriber_org = PrescriberOrganizationWithMembershipFactory(authorized=True)
         self.validated_by = authorized_prescriber_org.members.first()
 

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -93,12 +93,13 @@ class CommonApprovalMixin(models.Model):
             obj.start_at - timezone.localdate(), datetime.timedelta(0)
         )
 
-    @property
+    @cached_property
     def remainder(self):
         """
         Return the remaining time of an Approval, we don't count future suspended periods.
         """
         result = self._get_obj_remainder(self)
+
         if hasattr(self, "suspension_set"):
             # PoleEmploiApprovals don't have suspensions
             result -= sum(
@@ -107,7 +108,7 @@ class CommonApprovalMixin(models.Model):
             )
         return result
 
-    @property
+    @cached_property
     def remainder_as_date(self):
         """
         Return an estimated end date if this approval was "activated" today:

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -556,6 +556,8 @@ class ApprovalModelTest(TestCase):
             start_at=datetime.date(2022, 11, 1),
             end_at=datetime.date(2022, 12, 1),
         )
+        # Clear cache
+        del approval.remainder
         # Substract to remainder the relaining suspension time
         assert approval.remainder == datetime.timedelta(days=109)
 

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -559,6 +559,17 @@ class ApprovalModelTest(TestCase):
         # Substract to remainder the relaining suspension time
         assert approval.remainder == datetime.timedelta(days=109)
 
+    @freeze_time("2023-04-26")
+    def test_remainder_as_date(self):
+        """
+        Only test return type and value as the algorithm is already tested in `self.test_remainder`.
+        """
+        approval = ApprovalFactory(
+            start_at=datetime.date(2021, 7, 26),
+            end_at=datetime.date(2023, 7, 25),
+        )
+        assert approval.remainder_as_date == datetime.date(2023, 7, 25)
+
 
 class PoleEmploiApprovalModelTest(TestCase):
     def test_format_name_as_pole_emploi(self):

--- a/itou/templates/apply/includes/eligibility_diagnosis.html
+++ b/itou/templates/apply/includes/eligibility_diagnosis.html
@@ -6,6 +6,7 @@
                 hiérarchisée afin de ne pas induire les employeurs en erreur.
                 Avec des critères hiérarchisés, ils ont tendance à penser que le candidat n'est pas éligible car pas suffisamment de critère de niveau 2 par exemple
             {% endcomment %}
+
             <hr>
             <h3>Éligibilité à l'IAE</h3>
             <p>

--- a/itou/templates/approvals/detail.html
+++ b/itou/templates/approvals/detail.html
@@ -15,7 +15,7 @@
             <div class="d-flex justify-content-between mb-3">
                 {% if approval_can_be_suspended_by_siae %}
                     <a href="{% url 'approvals:suspend' approval_id=approval.id %}?back_url={{ request.get_full_path|urlencode }}"
-                       class="btn btn-link"
+                       class="btn btn-outline-primary"
                        aria-label="Suspendre le PASS IAE de {{ approval.user.get_full_name }}">
                         Suspendre
                     </a>
@@ -25,12 +25,12 @@
                 {% endif %}
                 {% if approval_can_be_prolonged_by_siae %}
                     <a href="{% url 'approvals:declare_prolongation' approval_id=approval.id %}?back_url={{ request.get_full_path|urlencode }}"
-                       class="btn btn-link"
+                       class="btn btn-outline-primary"
                        aria-label="Prolonger le PASS IAE de {{ approval.user.get_full_name }}">
                         Prolonger
                     </a>
                 {% endif %}
-                <a class="btn btn-outline-primary matomo-event"
+                <a class="btn btn-primary matomo-event"
                    data-matomo-action="telechargement-pdf"
                    data-matomo-category="agrement"
                    data-matomo-option="detail-agrement"

--- a/itou/templates/approvals/detail.html
+++ b/itou/templates/approvals/detail.html
@@ -37,7 +37,7 @@
                    href="{% url 'approvals:display_printable_approval' approval_id=approval.id %}"
                    target="_blank"
                    aria-label="Afficher le PASS IAE de {{ approval.user.get_full_name }}">
-                    Afficher le PASS IAE
+                    Afficher l'attestation
                 </a>
             </div>
         {% endif %}

--- a/itou/templates/approvals/includes/prolongations_list.html
+++ b/itou/templates/approvals/includes/prolongations_list.html
@@ -1,0 +1,13 @@
+<ul class="list-unstyled">
+    {% for p in prolongations %}
+        <li>
+            du {{ p.start_at|date:"d/m/Y" }} au {{ p.end_at|date:"d/m/Y" }}
+            <small class="ml-3">{{ p.get_reason_display }}</small>
+            {% if p.validated_by %}
+                <small class="d-block mb-2">
+                    Autorisation par <i>{{ p.validated_by.get_full_name|title }}</i> ({{ p.validated_by.email }})
+                </small>
+            {% endif %}
+        </li>
+    {% endfor %}
+</ul>

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -111,7 +111,7 @@ Arguments:
                     </ul>
                 {% endif %}
                 {% if suspensions.older %}
-                    <p class="mb-1">Suspensions passées :</p>
+                    <p class="mb-1">Suspension{{ suspensions.older|pluralize }} passée{{ suspensions.older|pluralize }} :</p>
                     <ul class="list-unstyled">
                         {% for s in suspensions.older %}
                             <li>
@@ -133,7 +133,9 @@ Arguments:
                     {% include "approvals/includes/prolongations_list.html" with prolongations=prolongations.in_progress %}
                 {% endif %}
                 {% if prolongations.not_in_progress %}
-                    <p class="mb-1">Prolongations passées ou à venir :</p>
+                    <p class="mb-1">
+                        Prolongation{{ prolongations.not_in_progress|pluralize }} passée{{ prolongations.not_in_progress|pluralize }} ou à venir :
+                    </p>
                     {% include "approvals/includes/prolongations_list.html" with prolongations=prolongations.not_in_progress %}
                 {% endif %}
             </div>

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -29,9 +29,9 @@ Arguments:
 <div class="pl-2 border-left approval-left-border">
     <p class="mb-1">
         {% if common_approval.is_pass_iae %}
-            PASS IAE disponible :
+            Numéro de PASS IAE :
         {% else %}
-            Agrément existant :
+            Numéro d'agrément :
         {% endif %}
         {% if user.is_siae_staff and job_application.is_pending %}
             {% comment %}

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -92,7 +92,7 @@ Arguments:
     {# Suspensions history. #}
     {% with common_approval.suspensions_for_status_card as suspensions %}
         {% if suspensions.last_in_progress or suspensions.older %}
-            <div class="pl-2 border-left approval-left-border">
+            <div id="suspensions-list" class="pl-2 border-left approval-left-border">
                 {% if suspensions.last_in_progress %}
                     <p class="mb-1">Suspension en cours :</p>
                     <ul class="list-unstyled">

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -132,8 +132,10 @@ Arguments:
                     <p class="mb-1">Prolongation en cours :</p>
                     {% include "approvals/includes/prolongations_list.html" with prolongations=prolongations.in_progress %}
                 {% endif %}
-                <p class="mb-1">Prolongations passées :</p>
-                {% include "approvals/includes/prolongations_list.html" with prolongations=prolongations.older %}
+                {% if prolongations.not_in_progress %}
+                    <p class="mb-1">Prolongations passées ou à venir :</p>
+                    {% include "approvals/includes/prolongations_list.html" with prolongations=prolongations.not_in_progress %}
+                {% endif %}
             </div>
         {% endif %}
     {% endwith %}

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -26,110 +26,45 @@ Arguments:
     </p>
 {% endif %}
 
-<p class="mb-0">
-    {% if common_approval.is_pass_iae %}
-        PASS IAE disponible :
-    {% else %}
-        Agrément existant :
-    {% endif %}
-</p>
-
-{% if user.is_siae_staff and job_application.is_pending %}
-    {% comment %}
-    If the PASS IAE number is displayed at this time, some employers think that there is
-    no need to validate the application because a number is already assigned.
-    {% endcomment %}
-    <p>
-        <b>Pour obtenir son numéro, vous devez valider l'embauche et demander l'obtention d'un PASS IAE.</b>
-    </p>
-{% else %}
-    <p>
-        <b>{{ common_approval.number|format_approval_number }}</b>
-    </p>
-{% endif %}
-
-{% if job_application.origin == JobApplicationOrigin.PE_APPROVAL %}
-    <p>Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
-{% endif %}
-
-{% if common_approval.is_valid %}
-
-    <ul class="list-unstyled pl-2 border-left approval-left-border">
-
-        <li>Date de début : {{ common_approval.start_at|date:"d/m/Y" }}</li>
-        <li>
-            Date de fin prévisionnelle : {{ common_approval.end_at|date:"d/m/Y" }}
-            <i class="ri-information-line ri-xl" data-toggle="tooltip" title="La date de fin prévisionnelle est amenée à évoluer si le PASS IAE est prolongé ou suspendu."></i>
-        </li>
-        <li>
-            Reliquat : <span{% if common_approval.remainder %} class="text-success"{% endif %}>{{ common_approval.remainder.days }} jours restants</span>
-            <i class="ri-information-line ri-xl"
-               data-toggle="tooltip"
-               title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
-        </li>
-
+<div class="pl-2 border-left approval-left-border">
+    <p class="mb-1">
         {% if common_approval.is_pass_iae %}
-            {# Suspensions history. #}
-            {% with common_approval.suspensions_by_start_date_asc as suspensions %}
-                {% if suspensions %}
-                    <li>
-                        Suspensions :
-                        <ul>
-                            {% for s in suspensions %}
-                                <li>
-                                    <span{% if s.is_in_progress %} class="text-danger"{% endif %}>
-                                        du {{ s.start_at|date:"d/m/Y" }} au {{ s.end_at|date:"d/m/Y" }}
-                                    </span>
-                                    {% if s.is_in_progress %}
-                                        <small>
-                                            <b>En cours</b>
-                                        </small>
-                                    {% endif %}
-                                    {% if current_siae %}
-                                        {% call_method s "can_be_handled_by_siae" current_siae as can_be_handled %}
-                                            {% if can_be_handled %}
-                                                <small>
-                                                    <a href="{% url 'approvals:suspension_update' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">Modifier</a>
-                                                    <a href="{% url 'approvals:suspension_delete' suspension_id=s.pk %}?back_url={{ request.get_full_path|urlencode }}">Annuler</a>
-                                                </small>
-                                            {% endif %}
-                                        {% endif %}
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        </li>
-                    {% endif %}
-                {% endwith %}
+            PASS IAE disponible :
+        {% else %}
+            Agrément existant :
+        {% endif %}
+        {% if user.is_siae_staff and job_application.is_pending %}
+            {% comment %}
+            If the PASS IAE number is displayed at this time, some employers think that there is
+            no need to validate the application because a number is already assigned.
+            {% endcomment %}
+            <b>pour obtenir son numéro, vous devez valider l'embauche et demander l'obtention d'un PASS IAE.</b>
+        {% else %}
+            <b>{{ common_approval.number|format_approval_number }}</b>
+        {% endif %}
+    </p>
 
-                {# Prolongations history. #}
-                {% with common_approval.prolongations_by_start_date_asc as prolongations %}
-                    {% if prolongations %}
-                        <li>
-                            Prolongations :
-                            <ul>
-                                {% for p in prolongations %}
-                                    <li{% if p.is_in_progress %} class="font-weight-bold"{% endif %}>
-                                        du {{ p.start_at|date:"d/m/Y" }} au {{ p.end_at|date:"d/m/Y" }}
-                                        <br>
-                                        <small>{{ p.get_reason_display }}</small>
-                                        {% if p.validated_by %}
-                                            <br>
-                                            <small>
-                                                Autorisation par <i>{{ p.validated_by.get_full_name|title }}</i> ({{ p.validated_by.email }})
-                                            </small>
-                                        {% endif %}
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        </li>
-                    {% endif %}
-                {% endwith %}
+    {% if job_application.origin == JobApplicationOrigin.PE_APPROVAL %}
+        <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+    {% endif %}
+
+    {% if common_approval.is_valid %}
+        <p class="mb-1">Date de début : {{ common_approval.start_at|date:"d/m/Y" }}</p>
+        <ul class="list-unstyled">
+            <li class="h4 mt-4 pb-2">
+                Nombre de jours restants sur le PASS IAE : {{ common_approval.remainder.days }} jour{{ common_approval.remainder.days|pluralize }} 
+                <i class="ri-information-line ri-xl"
+                   data-toggle="tooltip"
+                   title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+            </li>
+
+            {% if job_application.is_pending and user.is_siae_staff %}
+                <li>
+                    PASS IAE valide jusqu’au {{ common_approval.remainder_as_date|date:"d/m/Y" }}, si le contrat démarre aujourd’hui.
+                </li>
             {% endif %}
-
         </ul>
-
     {% elif common_approval.is_in_waiting_period %}
-
         <p class="text-danger">
             <b>Expiré</b> le {{ common_approval.end_at|date:"d/m/Y" }} (depuis {{ common_approval.end_at|timesince }})
         </p>
@@ -151,3 +86,65 @@ Arguments:
             {% endif %}
         {% endif %}
     {% endif %}
+</div>
+
+{% if common_approval.is_valid and common_approval.is_pass_iae %}
+    {# Suspensions history. #}
+    {% with common_approval.suspensions_for_status_card as suspensions %}
+        {% if suspensions.last_in_progress or suspensions.older %}
+            <div class="pl-2 border-left approval-left-border">
+                {% if suspensions.last_in_progress %}
+                    <p class="mb-1">Suspension en cours :</p>
+                    <ul class="list-unstyled">
+                        <li>
+                            <b>du {{ suspensions.last_in_progress.start_at|date:"d/m/Y" }} au {{ suspensions.last_in_progress.end_at|date:"d/m/Y" }}</b>
+                            {% if current_siae %}
+                                <!-- djlint:off -->{% call_method suspensions.last_in_progress "can_be_handled_by_siae" current_siae as can_be_handled %}<!-- djlint:on -->
+                                {% if can_be_handled %}
+                                    <small>
+                                        <a class="ml-3" href="{% url 'approvals:suspension_update' suspension_id=suspensions.last_in_progress.pk %}?back_url={{ request.get_full_path|urlencode }}">Modifier</a>
+                                        <a class="ml-3" href="{% url 'approvals:suspension_delete' suspension_id=suspensions.last_in_progress.pk %}?back_url={{ request.get_full_path|urlencode }}">Annuler</a>
+                                    </small>
+                                {% endif %}
+                            {% endif %}
+                        </li>
+                    </ul>
+                {% endif %}
+                {% if suspensions.older %}
+                    <p class="mb-1">Suspensions passées :</p>
+                    <ul class="list-unstyled">
+                        {% for s in suspensions.older %}
+                            <li>
+                                <span>du {{ s.start_at|date:"d/m/Y" }} au {{ s.end_at|date:"d/m/Y" }}</span>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endwith %}
+
+    {# Prolongations history. #}
+    {% with common_approval.prolongations_by_start_date_asc as prolongations %}
+        {% if prolongations %}
+            <div class="pl-2 border-left approval-left-border">
+                <p class="mb-1">Prolongations :</p>
+                <ul class="list-unstyled">
+                    {% for p in prolongations %}
+                        <li{% if p.is_in_progress %} class="font-weight-bold"{% endif %}>
+                            du {{ p.start_at|date:"d/m/Y" }} au {{ p.end_at|date:"d/m/Y" }}
+                            <br>
+                            <small>{{ p.get_reason_display }}</small>
+                            {% if p.validated_by %}
+                                <br>
+                                <small>
+                                    Autorisation par <i>{{ p.validated_by.get_full_name|title }}</i> ({{ p.validated_by.email }})
+                                </small>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
+    {% endwith %}
+{% endif %}

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -125,25 +125,15 @@ Arguments:
     {% endwith %}
 
     {# Prolongations history. #}
-    {% with common_approval.prolongations_by_start_date_asc as prolongations %}
+    {% with common_approval.prolongations_for_status_card as prolongations %}
         {% if prolongations %}
-            <div class="pl-2 border-left approval-left-border">
-                <p class="mb-1">Prolongations :</p>
-                <ul class="list-unstyled">
-                    {% for p in prolongations %}
-                        <li{% if p.is_in_progress %} class="font-weight-bold"{% endif %}>
-                            du {{ p.start_at|date:"d/m/Y" }} au {{ p.end_at|date:"d/m/Y" }}
-                            <br>
-                            <small>{{ p.get_reason_display }}</small>
-                            {% if p.validated_by %}
-                                <br>
-                                <small>
-                                    Autorisation par <i>{{ p.validated_by.get_full_name|title }}</i> ({{ p.validated_by.email }})
-                                </small>
-                            {% endif %}
-                        </li>
-                    {% endfor %}
-                </ul>
+            <div id="prolongations-list" class="pl-2 border-left approval-left-border">
+                {% if prolongations.in_progress %}
+                    <p class="mb-1">Prolongation en cours :</p>
+                    {% include "approvals/includes/prolongations_list.html" with prolongations=prolongations.in_progress %}
+                {% endif %}
+                <p class="mb-1">Prolongations passées :</p>
+                {% include "approvals/includes/prolongations_list.html" with prolongations=prolongations.older %}
             </div>
         {% endif %}
     {% endwith %}

--- a/itou/www/apply/tests/tests_process.py
+++ b/itou/www/apply/tests/tests_process.py
@@ -191,7 +191,7 @@ class ProcessViewsTest(TestCase):
         # Job seeker nir is displayed
         self.assertContains(response, format_nir(job_application.job_seeker.nir))
         # Approval is displayed
-        self.assertContains(response, "PASS IAE disponible")
+        self.assertContains(response, "Numéro de PASS IAE")
 
         self.assertContains(response, "Adresse : <span>Non renseignée</span>", html=True)
         self.assertContains(response, "CV : <span>Non renseigné</span>", html=True)

--- a/itou/www/approvals_views/tests/__snapshots__/test_detail.ambr
+++ b/itou/www/approvals_views/tests/__snapshots__/test_detail.ambr
@@ -1,4 +1,43 @@
 # serializer version: 1
+# name: TestApprovalDetailView.test_approval_status_includes[Approval prolongations list]
+  '''
+  <div class="pl-2 border-left approval-left-border" id="prolongations-list">
+                  
+                      <p class="mb-1">Prolongation en cours :</p>
+                      <ul class="list-unstyled">
+      
+          <li>
+              du 19/04/2023 au 29/04/2023
+              <br/>
+              <small>Fin d'une formation</small>
+              
+          </li>
+      
+  </ul>
+  
+                  
+                  <p class="mb-1">Prolongations passées :</p>
+                  <ul class="list-unstyled">
+      
+          <li>
+              du 27/03/2023 au 06/04/2023
+              <br/>
+              <small>Fin d'une formation</small>
+              
+          </li>
+      
+          <li>
+              du 25/02/2023 au 07/03/2023
+              <br/>
+              <small>Fin d'une formation</small>
+              
+          </li>
+      
+  </ul>
+  
+              </div>
+  '''
+# ---
 # name: TestApprovalDetailView.test_approval_status_includes[Approval suspensions list]
   '''
   <div class="pl-2 border-left approval-left-border" id="suspensions-list">
@@ -11,8 +50,8 @@
                                   <!-- djlint:off --><!-- djlint:on -->
                                   
                                       <small>
-                                          <a href="/approvals/suspension/210/edit?back_url=/approvals/detail/335">Modifier</a>
-                                          <a href="/approvals/suspension/210/delete?back_url=/approvals/detail/335">Annuler</a>
+                                          <a href="/approvals/suspension/1/edit?back_url=/approvals/detail/1">Modifier</a>
+                                          <a href="/approvals/suspension/1/delete?back_url=/approvals/detail/1">Annuler</a>
                                       </small>
                                   
                               

--- a/itou/www/approvals_views/tests/__snapshots__/test_detail.ambr
+++ b/itou/www/approvals_views/tests/__snapshots__/test_detail.ambr
@@ -8,40 +8,38 @@
       
           <li>
               du 19/04/2023 au 29/04/2023
-              <br/>
-              <small>Fin d'une formation</small>
+              <small class="ml-3">Fin d'une formation</small>
               
           </li>
       
   </ul>
   
                   
-                  <p class="mb-1">Prolongations passées ou à venir :</p>
-                  <ul class="list-unstyled">
+                  
+                      <p class="mb-1">Prolongations passées ou à venir :</p>
+                      <ul class="list-unstyled">
       
           <li>
               du 09/05/2023 au 14/05/2023
-              <br/>
-              <small>Fin d'une formation</small>
+              <small class="ml-3">Fin d'une formation</small>
               
           </li>
       
           <li>
               du 27/03/2023 au 06/04/2023
-              <br/>
-              <small>Fin d'une formation</small>
+              <small class="ml-3">Fin d'une formation</small>
               
           </li>
       
           <li>
               du 25/02/2023 au 07/03/2023
-              <br/>
-              <small>Fin d'une formation</small>
+              <small class="ml-3">Fin d'une formation</small>
               
           </li>
       
   </ul>
   
+                  
               </div>
   '''
 # ---
@@ -57,8 +55,8 @@
                                   <!-- djlint:off --><!-- djlint:on -->
                                   
                                       <small>
-                                          <a href="/approvals/suspension/1/edit?back_url=/approvals/detail/1">Modifier</a>
-                                          <a href="/approvals/suspension/1/delete?back_url=/approvals/detail/1">Annuler</a>
+                                          <a class="ml-3" href="/approvals/suspension/1/edit?back_url=/approvals/detail/1">Modifier</a>
+                                          <a class="ml-3" href="/approvals/suspension/1/delete?back_url=/approvals/detail/1">Annuler</a>
                                       </small>
                                   
                               

--- a/itou/www/approvals_views/tests/__snapshots__/test_detail.ambr
+++ b/itou/www/approvals_views/tests/__snapshots__/test_detail.ambr
@@ -16,7 +16,9 @@
   
                   
                   
-                      <p class="mb-1">Prolongations passées ou à venir :</p>
+                      <p class="mb-1">
+                          Prolongations passées ou à venir :
+                      </p>
                       <ul class="list-unstyled">
       
           <li>
@@ -64,7 +66,7 @@
                       </ul>
                   
                   
-                      <p class="mb-1">Suspensions passées :</p>
+                      <p class="mb-1">Suspension passée :</p>
                       <ul class="list-unstyled">
                           
                               <li>

--- a/itou/www/approvals_views/tests/__snapshots__/test_detail.ambr
+++ b/itou/www/approvals_views/tests/__snapshots__/test_detail.ambr
@@ -1,0 +1,34 @@
+# serializer version: 1
+# name: TestApprovalDetailView.test_approval_status_includes[Approval suspensions list]
+  '''
+  <div class="pl-2 border-left approval-left-border" id="suspensions-list">
+                  
+                      <p class="mb-1">Suspension en cours :</p>
+                      <ul class="list-unstyled">
+                          <li>
+                              <b>du 19/04/2023 au 29/04/2023</b>
+                              
+                                  <!-- djlint:off --><!-- djlint:on -->
+                                  
+                                      <small>
+                                          <a href="/approvals/suspension/210/edit?back_url=/approvals/detail/335">Modifier</a>
+                                          <a href="/approvals/suspension/210/delete?back_url=/approvals/detail/335">Annuler</a>
+                                      </small>
+                                  
+                              
+                          </li>
+                      </ul>
+                  
+                  
+                      <p class="mb-1">Suspensions passées :</p>
+                      <ul class="list-unstyled">
+                          
+                              <li>
+                                  <span>du 27/03/2023 au 06/04/2023</span>
+                              </li>
+                          
+                      </ul>
+                  
+              </div>
+  '''
+# ---

--- a/itou/www/approvals_views/tests/__snapshots__/test_detail.ambr
+++ b/itou/www/approvals_views/tests/__snapshots__/test_detail.ambr
@@ -3,7 +3,7 @@
   '''
   <div class="pl-2 border-left approval-left-border" id="prolongations-list">
                   
-                      <p class="mb-1">Prolongation en cours :</p>
+                      <p class="mb-1">Prolongation en cours :</p>
                       <ul class="list-unstyled">
       
           <li>
@@ -16,8 +16,15 @@
   </ul>
   
                   
-                  <p class="mb-1">Prolongations passées :</p>
+                  <p class="mb-1">Prolongations passées ou à venir :</p>
                   <ul class="list-unstyled">
+      
+          <li>
+              du 09/05/2023 au 14/05/2023
+              <br/>
+              <small>Fin d'une formation</small>
+              
+          </li>
       
           <li>
               du 27/03/2023 au 06/04/2023
@@ -42,7 +49,7 @@
   '''
   <div class="pl-2 border-left approval-left-border" id="suspensions-list">
                   
-                      <p class="mb-1">Suspension en cours :</p>
+                      <p class="mb-1">Suspension en cours :</p>
                       <ul class="list-unstyled">
                           <li>
                               <b>du 19/04/2023 au 29/04/2023</b>
@@ -59,7 +66,7 @@
                       </ul>
                   
                   
-                      <p class="mb-1">Suspensions passées :</p>
+                      <p class="mb-1">Suspensions passées :</p>
                       <ul class="list-unstyled">
                           
                               <li>

--- a/itou/www/approvals_views/tests/test_detail.py
+++ b/itou/www/approvals_views/tests/test_detail.py
@@ -11,6 +11,7 @@ from itou.job_applications.factories import JobApplicationFactory, JobApplicatio
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.prescribers.factories import PrescriberFactory, PrescriberOrganizationFactory
 from itou.utils.templatetags.format_filters import format_approval_number
+from itou.utils.test import parse_response_to_soup
 
 
 class TestApprovalDetailView:
@@ -64,7 +65,7 @@ class TestApprovalDetailView:
         assertContains(response, '<i class="ri-group-line mr-2" aria-hidden="true"></i>Orienteur', count=1)
 
     @freeze_time("2023-04-26")
-    def test_approval_status_includes(self, client):
+    def test_approval_status_includes(self, client, snapshot):
         """
         templates/approvals/includes/status.html
         This template is used in approval views but also in many other places.
@@ -154,13 +155,8 @@ class TestApprovalDetailView:
         with assertNumQueries(expected_num_queries):  # pylint: disable=not-context-manager
             response = client.get(url)
 
-        # TODO(cms): maybe use a snapshot instead.
-        assertContains(response, "Suspension en cours")
-        assertContains(response, "du 19/04/2023 au 29/04/2023")
-        assertContains(response, "Suspensions passées")
-        assertContains(response, "du 27/03/2023 au 06/04/2023")
-        assertContains(response, "Modifier")
-        assertContains(response, "Annuler")
+        suspensions_section = parse_response_to_soup(response, selector="#suspensions-list")
+        assert str(suspensions_section) == snapshot(name="Approval suspensions list")
 
         # Prescriber version
         user = job_application.sender

--- a/itou/www/approvals_views/tests/test_detail.py
+++ b/itou/www/approvals_views/tests/test_detail.py
@@ -49,7 +49,7 @@ class TestApprovalDetailView:
 
         url = reverse("approvals:detail", kwargs={"pk": approval.pk})
         response = client.get(url)
-        assertContains(response, "PASS IAE disponible")
+        assertContains(response, "Numéro de PASS IAE")
         assertContains(response, "Informations du salarié")
         assertContains(response, "Éligibilité à l'IAE")
         assertContains(response, "Candidatures de ce salarié")

--- a/itou/www/approvals_views/tests/test_detail.py
+++ b/itou/www/approvals_views/tests/test_detail.py
@@ -170,7 +170,7 @@ class TestApprovalDetailView:
             "approval": approval,
         }
         # Valid
-        ProlongationFactory(
+        active_prolongation = ProlongationFactory(
             id=1,
             start_at=timezone.localdate() - relativedelta(days=7),
             end_at=timezone.localdate() + relativedelta(days=3),
@@ -188,6 +188,14 @@ class TestApprovalDetailView:
             id=3,
             start_at=timezone.localdate() - relativedelta(days=60),
             end_at=timezone.localdate() - relativedelta(days=50),
+            **default_kwargs,
+        )
+
+        # In the future
+        ProlongationFactory(
+            id=4,
+            start_at=active_prolongation.end_at + relativedelta(days=10),
+            end_at=active_prolongation.end_at + relativedelta(days=15),
             **default_kwargs,
         )
 

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -52,7 +52,12 @@ class ApprovalBaseViewMixin(LoginRequiredMixin):
                 to_siae=self.siae,
                 approval=approval,
             )
-            .select_related("eligibility_diagnosis")
+            .select_related(
+                "eligibility_diagnosis",
+                "eligibility_diagnosis__author_siae",
+                "eligibility_diagnosis__author_prescriber_organization",
+                "eligibility_diagnosis__job_seeker",
+            )
             .first()
         )
 
@@ -73,6 +78,7 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
         context["matomo_custom_title"] = "Profil salarié"
         if job_application:
             context["eligibility_diagnosis"] = job_application.get_eligibility_diagnosis()
+
         context["all_job_applications"] = (
             JobApplication.objects.filter(
                 job_seeker=self.object.user,

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -557,9 +557,8 @@ class DashboardViewTest(TestCase):
         response = self.client.get(url)
         self.assertContains(response, "PASS IAE disponible :")
         self.assertContains(response, format_approval_number(approval))
-        self.assertContains(response, "Date de début : 21/06/2022")
-        self.assertContains(response, "Date de fin prévisionnelle : 06/12/2022")
-        self.assertContains(response, 'Reliquat : <span class="text-success">82 jours restants</span>')
+        self.assertContains(response, "Date de début du PASS IAE : 21/06/2022")
+        self.assertContains(response, "Nombre de jours restants sur le PASS IAE : 82 jours")
 
     @override_settings(TALLY_URL="http://tally.fake")
     def test_prescriber_with_authorization_pending_dashboard_must_contain_tally_link(self):

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -555,9 +555,9 @@ class DashboardViewTest(TestCase):
         self.client.force_login(approval.user)
         url = reverse("dashboard:index")
         response = self.client.get(url)
-        self.assertContains(response, "PASS IAE disponible :")
+        self.assertContains(response, "Numéro de PASS IAE")
         self.assertContains(response, format_approval_number(approval))
-        self.assertContains(response, "Date de début du PASS IAE : 21/06/2022")
+        self.assertContains(response, "Date de début : 21/06/2022")
         self.assertContains(response, "Nombre de jours restants sur le PASS IAE : 82 jours")
 
     @override_settings(TALLY_URL="http://tally.fake")


### PR DESCRIPTION
[Carte Notion](https://www.notion.so/plateforme-inclusion/Rendre-l-affichage-des-infos-du-PASS-en-cours-claires-avant-que-l-employeur-valide-l-embauche-50d114b4a4a2450f8d431d9c518996e4)

### Pourquoi ?

Il est difficile de comprendre qu'un PASS IAE peut finir à une autre date que la date de fin.

### Comment

Mise à jour de l'affichage de la date de fin prévisionnelle des PASS IAE.

### Captures d'écran
![image](https://user-images.githubusercontent.com/6150920/236475387-11c98087-110f-465e-89cb-b9f07cd61f24.png)



### Script pour la recette jetable

```
from datetime import date
from dateutil.relativedelta import relativedelta
from itou.siaes.models import Siae 
from itou.approvals.models import Suspension, Prolongation, Approval

approval = Approval.objects.get(pk=1)
siae = Siae.objects.get(pk=3850)
Suspension.objects.create(start_at=date(2022,12,3), end_at=date(2022,12,31), siae=None, approval=approval)
Suspension.objects.create(start_at=date(2023,1,3), end_at=date(2023,1,10), siae=None, approval=approval)
# Active suspension
Suspension.objects.create(start_at=date(2023,4,3), end_at=date.today()+ relativedelta(days=30), siae=None, approval=approval)
Prolongation.objects.create(start_at=date(2023,4,3), end_at=date(2023,4,5), approval=approval)
Prolongation.objects.create(start_at=date(2021,4,20), end_at=date(2021,4,26), approval=approval)
# Active prolongation
Prolongation.objects.create(start_at=date(2023,4,20), end_at=date.today()+ relativedelta(days=30),  approval=approval)
```
