### PR TITLE
Retirer le badge “Nouveau” sur l’onglet “Postes ouverts au recrutement” des résultats de recherche d’emplois inclusifs

### DIFF
--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -50,9 +50,6 @@
                                     ({{ job_descriptions_count }} résultat{{ job_descriptions_count|pluralize }})
                                 </span>
                             {% endif %}
-                            <div class="d-none d-lg-block">
-                                <span class="badge badge-xs badge-pill badge-important ml-2 text-white">Nouveau</span>
-                            </div>
                         </a>
                     </li>
                     <li class="nav-item-dropdown dropdown">


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Retirer-le-badge-Nouveau-sur-l-onglet-Postes-ouverts-au-recrutement-des-r-sultats-de-recherche-d-c91d10b4950f4b21a897d6e56042a3bf?pvs=4

### Pourquoi ?

Ce n'est plus nouveau.

