### PR TITLE
Ajout des diagnostics GEIQ dans le script merge_organizations

### DIFF
--- a/itou/prescribers/management/commands/merge_organizations.py
+++ b/itou/prescribers/management/commands/merge_organizations.py
@@ -58,6 +58,11 @@ def organization_merge_into(from_id, to_id, *, wet_run):
     diagnoses = eligibility_models.EligibilityDiagnosis.objects.filter(author_prescriber_organization_id=from_id)
     logger.info("| Diagnoses: %s", diagnoses.count())
 
+    geiq_diagnoses = eligibility_models.GEIQEligibilityDiagnosis.objects.filter(
+        author_prescriber_organization_id=from_id
+    )
+    logger.info("| GEIQ Diagnoses: %s", geiq_diagnoses.count())
+
     # Don't move invitations for existing members
     # The goal is to keep information about the original information
     invitations = invitations_models.PrescriberWithOrgInvitation.objects.filter(organization_id=from_id).exclude(
@@ -79,6 +84,7 @@ def organization_merge_into(from_id, to_id, *, wet_run):
             job_applications.update(sender_prescriber_organization_id=to_id)
             members.update(organization_id=to_id)
             diagnoses.update(author_prescriber_organization_id=to_id)
+            geiq_diagnoses.update(author_prescriber_organization_id=to_id)
             invitations.update(organization_id=to_id)
             from_organization.delete()
     else:

--- a/itou/prescribers/management/commands/merge_organizations.py
+++ b/itou/prescribers/management/commands/merge_organizations.py
@@ -21,7 +21,30 @@ HELP_TEXT = """
 """
 
 
+def _model_sanity_check():
+    # Sanity check to prevent dangerous deletes
+    relation_fields = {
+        field.name
+        for field in prescribers_models.PrescriberOrganization._meta.get_fields()
+        if field.is_relation and not field.many_to_one
+    }
+    expected_fields = {
+        "eligibilitydiagnosis",
+        "geiqeligibilitydiagnosis",
+        "invitations",
+        "jobapplication",
+        "members",
+        "prescribermembership",
+    }
+    if relation_fields != expected_fields:
+        raise RuntimeError(
+            f"Extra relations found, please update this script to handle: {relation_fields - expected_fields}"
+        )
+
+
 def organization_merge_into(from_id, to_id, *, wet_run):
+    _model_sanity_check()
+
     if from_id == to_id:
         logger.error("Unable to use the same organization as source and destination (ID %s)", from_id)
         return


### PR DESCRIPTION
### Pourquoi ?

Pour éviter des suppressions de diagnostics non-souhaités

### Comment

Et je rajoute un check pour limiter les chances qu'on oublie à nouveau.

