### PR TITLE
Parcours de candidature: récupération de l'id du candidat via l'URL

### DIFF
--- a/itou/www/apply/tests/tests_geiq.py
+++ b/itou/www/apply/tests/tests_geiq.py
@@ -206,11 +206,10 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
         cls.geiq = SiaeWithMembershipAndJobsFactory(kind=SiaeKind.GEIQ, with_jobs=True)
         cls.prescriber_org = PrescriberOrganizationWithMembershipFactory(authorized=True)
 
-    def _setup_session(self, job_seeker=None):
+    def _setup_session(self):
         apply_session = SessionNamespace(self.client.session, f"job_application-{self.geiq.pk}")
         apply_session.init(
             {
-                "job_seeker_pk": job_seeker or JobSeekerFactory(),
                 "selected_jobs": self.geiq.job_description_through.all(),
             }
         )
@@ -228,7 +227,7 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
 
     def test_job_seeker_not_resident_in_qpv_or_zrr_for_prescriber(self):
         self.client.force_login(self.prescriber_org.members.first())
-        self._setup_session(self.job_seeker)
+        self._setup_session()
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility",
@@ -253,7 +252,7 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
     def test_job_seeker_qpv_details_display_for_prescriber(self):
         # Check QPV fragment is displayed for prescriber:
         self.client.force_login(self.prescriber_org.members.first())
-        self._setup_session(self.job_seeker_in_qpv)
+        self._setup_session()
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility",
@@ -280,7 +279,7 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
     def test_job_seeker_zrr_details_display_for_prescriber(self):
         # Check QPV fragment is displayed for prescriber:
         self.client.force_login(self.prescriber_org.members.first())
-        self._setup_session(self.job_seeker_in_zrr)
+        self._setup_session()
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility",

--- a/itou/www/apply/tests/tests_geiq.py
+++ b/itou/www/apply/tests/tests_geiq.py
@@ -205,7 +205,6 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
         cls.job_seeker_in_zrr = JobSeekerWithAddressFactory(with_city_in_zrr=True)
         cls.geiq = SiaeWithMembershipAndJobsFactory(kind=SiaeKind.GEIQ, with_jobs=True)
         cls.prescriber_org = PrescriberOrganizationWithMembershipFactory(authorized=True)
-        cls.url_for_prescriber = reverse("apply:application_geiq_eligibility", kwargs={"siae_pk": cls.geiq.pk})
 
     def _setup_session(self, job_seeker=None):
         apply_session = SessionNamespace(self.client.session, f"job_application-{self.geiq.pk}")
@@ -230,7 +229,12 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
     def test_job_seeker_not_resident_in_qpv_or_zrr_for_prescriber(self):
         self.client.force_login(self.prescriber_org.members.first())
         self._setup_session(self.job_seeker)
-        response = self.client.get(self.url_for_prescriber)
+        response = self.client.get(
+            reverse(
+                "apply:application_geiq_eligibility",
+                kwargs={"siae_pk": self.geiq.pk, "job_seeker_pk": self.job_seeker.pk},
+            )
+        )
 
         self.assertTemplateNotUsed(response, "apply/includes/known_criteria.html")
 
@@ -250,7 +254,12 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
         # Check QPV fragment is displayed for prescriber:
         self.client.force_login(self.prescriber_org.members.first())
         self._setup_session(self.job_seeker_in_qpv)
-        response = self.client.get(self.url_for_prescriber)
+        response = self.client.get(
+            reverse(
+                "apply:application_geiq_eligibility",
+                kwargs={"siae_pk": self.geiq.pk, "job_seeker_pk": self.job_seeker_in_qpv.pk},
+            )
+        )
 
         self.assertTemplateUsed(response, "apply/includes/known_criteria.html")
         self.assertContains(response, "Résident QPV")
@@ -272,7 +281,12 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
         # Check QPV fragment is displayed for prescriber:
         self.client.force_login(self.prescriber_org.members.first())
         self._setup_session(self.job_seeker_in_zrr)
-        response = self.client.get(self.url_for_prescriber)
+        response = self.client.get(
+            reverse(
+                "apply:application_geiq_eligibility",
+                kwargs={"siae_pk": self.geiq.pk, "job_seeker_pk": self.job_seeker_in_zrr.pk},
+            )
+        )
 
         self.assertTemplateUsed(response, "apply/includes/known_criteria.html")
         self.assertContains(response, "Résident en ZRR")

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -141,7 +141,6 @@ def test_check_nir_job_seeker_with_lack_of_nir_reason(client):
     session_data = client.session[f"job_application-{siae.pk}"]
     assert session_data == {
         "back_url": "/",
-        "job_seeker_pk": user.pk,
         "nir": None,
         "selected_jobs": [],
     }
@@ -171,7 +170,6 @@ class ApplyAsJobSeekerTest(S3AccessingTestCase):
     def default_session_data(self):
         return {
             "back_url": "/",
-            "job_seeker_pk": None,
             "nir": None,
             "selected_jobs": [],
         }
@@ -207,10 +205,7 @@ class ApplyAsJobSeekerTest(S3AccessingTestCase):
         assert response.status_code == 302
 
         session_data = self.client.session[f"job_application-{siae.pk}"]
-        expected_session_data = self.default_session_data | {
-            "job_seeker_pk": user.pk,
-        }
-        assert session_data == expected_session_data
+        assert session_data == self.default_session_data
 
         next_url = reverse("apply:check_nir_for_job_seeker", kwargs={"siae_pk": siae.pk})
         assert response.url == next_url
@@ -231,10 +226,7 @@ class ApplyAsJobSeekerTest(S3AccessingTestCase):
         assert user.nir == nir
 
         session_data = self.client.session[f"job_application-{siae.pk}"]
-        expected_session_data = self.default_session_data | {
-            "job_seeker_pk": user.pk,
-        }
-        assert session_data == expected_session_data
+        assert session_data == self.default_session_data
 
         next_url = reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": siae.pk, "job_seeker_pk": user.pk})
         assert response.url == next_url
@@ -278,7 +270,6 @@ class ApplyAsJobSeekerTest(S3AccessingTestCase):
         assert response.status_code == 302
 
         assert self.client.session[f"job_application-{siae.pk}"] == self.default_session_data | {
-            "job_seeker_pk": user.pk,
             "selected_jobs": [siae.job_description_through.first().pk],
         }
 
@@ -430,7 +421,6 @@ class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
     def default_session_data(self):
         return {
             "back_url": "/",
-            "job_seeker_pk": None,
             "nir": None,
             "selected_jobs": [],
         }
@@ -600,7 +590,6 @@ class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
         new_job_seeker = User.objects.get(email=dummy_job_seeker_profile.user.email)
         expected_session_data = self.default_session_data | {
             "nir": dummy_job_seeker_profile.user.nir,
-            "job_seeker_pk": new_job_seeker.pk,
         }
         assert self.client.session[f"job_application-{siae.pk}"] == expected_session_data
 
@@ -618,7 +607,6 @@ class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
 
         assert self.client.session[f"job_application-{siae.pk}"] == self.default_session_data | {
             "nir": dummy_job_seeker_profile.user.nir,
-            "job_seeker_pk": new_job_seeker.pk,
             "selected_jobs": [siae.job_description_through.first().pk],
         }
 
@@ -839,7 +827,6 @@ class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
         new_job_seeker = User.objects.get(email=dummy_job_seeker_profile.user.email)
         expected_session_data = self.default_session_data | {
             "nir": dummy_job_seeker_profile.user.nir,
-            "job_seeker_pk": new_job_seeker.pk,
         }
         assert self.client.session[f"job_application-{siae.pk}"] == expected_session_data
 
@@ -857,7 +844,6 @@ class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
 
         assert self.client.session[f"job_application-{siae.pk}"] == self.default_session_data | {
             "nir": dummy_job_seeker_profile.user.nir,
-            "job_seeker_pk": new_job_seeker.pk,
             "selected_jobs": [siae.job_description_through.first().pk],
         }
 
@@ -974,7 +960,6 @@ class ApplyAsPrescriberTest(S3AccessingTestCase):
     def default_session_data(self):
         return {
             "back_url": "/",
-            "job_seeker_pk": None,
             "nir": None,
             "selected_jobs": [],
         }
@@ -1159,7 +1144,6 @@ class ApplyAsPrescriberTest(S3AccessingTestCase):
         new_job_seeker = User.objects.get(email=dummy_job_seeker_profile.user.email)
         expected_session_data = self.default_session_data | {
             "nir": dummy_job_seeker_profile.user.nir,
-            "job_seeker_pk": new_job_seeker.pk,
         }
         assert self.client.session[f"job_application-{siae.pk}"] == expected_session_data
 
@@ -1177,7 +1161,6 @@ class ApplyAsPrescriberTest(S3AccessingTestCase):
 
         assert self.client.session[f"job_application-{siae.pk}"] == self.default_session_data | {
             "nir": dummy_job_seeker_profile.user.nir,
-            "job_seeker_pk": new_job_seeker.pk,
             "selected_jobs": [siae.job_description_through.first().pk],
         }
 
@@ -1428,7 +1411,6 @@ class ApplyAsSiaeTest(S3AccessingTestCase):
     def default_session_data(self):
         return {
             "back_url": "/",
-            "job_seeker_pk": None,
             "nir": None,
             "selected_jobs": [],
         }
@@ -1615,7 +1597,6 @@ class ApplyAsSiaeTest(S3AccessingTestCase):
         new_job_seeker = User.objects.get(email=dummy_job_seeker_profile.user.email)
         expected_session_data = self.default_session_data | {
             "nir": dummy_job_seeker_profile.user.nir,
-            "job_seeker_pk": new_job_seeker.pk,
         }
         assert self.client.session[f"job_application-{siae.pk}"] == expected_session_data
 
@@ -1633,7 +1614,6 @@ class ApplyAsSiaeTest(S3AccessingTestCase):
 
         assert self.client.session[f"job_application-{siae.pk}"] == self.default_session_data | {
             "nir": dummy_job_seeker_profile.user.nir,
-            "job_seeker_pk": new_job_seeker.pk,
             "selected_jobs": [siae.job_description_through.first().pk],
         }
 
@@ -1774,7 +1754,6 @@ class ApplicationViewTest(S3AccessingTestCase):
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
         apply_session.init(
             {
-                "job_seeker_pk": job_seeker.pk,
                 "selected_jobs": siae.job_description_through.all(),
             }
         )
@@ -1796,7 +1775,6 @@ class ApplicationViewTest(S3AccessingTestCase):
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
         apply_session.init(
             {
-                "job_seeker_pk": job_seeker.pk,
                 "selected_jobs": siae.job_description_through.all(),
             }
         )
@@ -1814,7 +1792,7 @@ class ApplicationViewTest(S3AccessingTestCase):
 
         self.client.force_login(siae.members.first())
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
-        apply_session.init({"job_seeker_pk": job_seeker.pk})
+        apply_session.init({})  # We still need a session, even if empty
         apply_session.save()
 
         response = self.client.get(
@@ -1833,7 +1811,7 @@ class ApplicationViewTest(S3AccessingTestCase):
 
         self.client.force_login(prescriber)
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
-        apply_session.init({"job_seeker_pk": job_seeker.pk})
+        apply_session.init({})  # We still need a session, even if empty
         apply_session.save()
 
         response = self.client.get(
@@ -1851,7 +1829,7 @@ class ApplicationViewTest(S3AccessingTestCase):
 
         self.client.force_login(siae.members.first())
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
-        apply_session.init({"job_seeker_pk": eligibility_diagnosis.job_seeker})
+        apply_session.init({})  # We still need a session, even if empty
         apply_session.save()
 
         response = self.client.get(
@@ -1876,7 +1854,7 @@ class ApplicationViewTest(S3AccessingTestCase):
 
         self.client.force_login(prescriber)
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
-        apply_session.init({"job_seeker_pk": eligibility_diagnosis.job_seeker})
+        apply_session.init({})  # We still need a session, even if empty
         apply_session.save()
 
         # if "shrouded" is present then we don't update the eligibility diagnosis
@@ -1959,7 +1937,6 @@ class LastCheckedAtViewTest(TestCase):
         apply_session = SessionNamespace(self.client.session, f"job_application-{self.siae.pk}")
         apply_session.init(
             {
-                "job_seeker_pk": self.job_seeker.pk,
                 "selected_jobs": [],
             }
         )
@@ -2034,7 +2011,6 @@ class UpdateJobSeekerViewTestCase(TestCase):
         apply_session = SessionNamespace(self.client.session, f"job_application-{self.siae.pk}")
         apply_session.init(
             {
-                "job_seeker_pk": self.job_seeker.pk,
                 "selected_jobs": [],
             }
         )
@@ -2053,7 +2029,6 @@ class UpdateJobSeekerViewTestCase(TestCase):
         apply_session = SessionNamespace(self.client.session, f"job_application-{self.siae.pk}")
         apply_session.init(
             {
-                "job_seeker_pk": self.job_seeker.pk,
                 "selected_jobs": [],
             }
         )
@@ -2181,7 +2156,6 @@ class UpdateJobSeekerViewTestCase(TestCase):
         apply_session = SessionNamespace(self.client.session, f"job_application-{self.siae.pk}")
         apply_session.init(
             {
-                "job_seeker_pk": self.job_seeker.pk,
                 "selected_jobs": [],
             }
         )
@@ -2357,7 +2331,6 @@ class UpdateJobSeekerStep3ViewTestCase(TestCase):
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")
         apply_session.init(
             {
-                "job_seeker_pk": job_seeker.pk,
                 "selected_jobs": [],
             }
         )
@@ -2393,7 +2366,6 @@ def test_detect_existing_job_seeker(client):
 
     default_session_data = {
         "back_url": "/",
-        "job_seeker_pk": None,
         "nir": None,
         "selected_jobs": [],
     }
@@ -2509,11 +2481,10 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         cls.job_seeker_with_geiq_diagnosis = GEIQEligibilityDiagnosisFactory(with_prescriber=True).job_seeker
         cls.siae = SiaeFactory(with_membership=True, kind=SiaeKind.EI)
 
-    def _setup_session(self, job_seeker=None, siae_pk=None):
+    def _setup_session(self, siae_pk=None):
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae_pk or self.geiq.pk}")
         apply_session.init(
             {
-                "job_seeker_pk": job_seeker or JobSeekerFactory(),
                 "selected_jobs": self.geiq.job_description_through.all(),
             }
         )
@@ -2527,7 +2498,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
 
         # Redirect orienter
         self.client.force_login(self.orienter)
-        self._setup_session(job_seeker=job_seeker)
+        self._setup_session()
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility", kwargs={"siae_pk": self.geiq.pk, "job_seeker_pk": job_seeker.pk}
@@ -2545,7 +2516,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
     def test_bypass_geiq_diagnosis_for_staff_members(self):
         job_seeker = JobSeekerFactory()
         self.client.force_login(self.geiq.members.first())
-        self._setup_session(job_seeker=job_seeker)
+        self._setup_session()
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility", kwargs={"siae_pk": self.geiq.pk, "job_seeker_pk": job_seeker.pk}
@@ -2564,7 +2535,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         # A job seeker must not have access to GEIQ eligibility form
         job_seeker = JobSeekerFactory()
         self.client.force_login(job_seeker)
-        self._setup_session(job_seeker=job_seeker)
+        self._setup_session()
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility", kwargs={"siae_pk": self.geiq.pk, "job_seeker_pk": job_seeker.pk}
@@ -2584,7 +2555,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         # See comment im previous test:
         # assert we're not somewhere we don't belong to (non-GEIQ)
         self.client.force_login(self.siae.members.first())
-        self._setup_session(job_seeker=job_seeker, siae_pk=self.siae.pk)
+        self._setup_session(siae_pk=self.siae.pk)
 
         with self.assertRaisesRegex(ValueError, "This form is only for GEIQ"):
             self.client.get(
@@ -2597,7 +2568,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
     def test_access_as_authorized_prescriber(self):
         job_seeker = JobSeekerFactory()
         self.client.force_login(self.prescriber_org.members.first())
-        self._setup_session(job_seeker=job_seeker)
+        self._setup_session()
 
         response = self.client.get(
             reverse(
@@ -2612,7 +2583,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         self.client.force_login(self.prescriber_org.members.first())
 
         # Badge OK if job seeker has a valid eligibility diagnosis
-        self._setup_session(self.job_seeker_with_geiq_diagnosis)
+        self._setup_session()
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility",
@@ -2626,7 +2597,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
 
         # Badge KO if job seeker has no diagnosis
         job_seeker_without_diagnosis = JobSeekerFactory()
-        self._setup_session(job_seeker=job_seeker_without_diagnosis)
+        self._setup_session()
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility",
@@ -2644,7 +2615,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         assert not diagnosis.eligibility_confirmed
 
         self.client.force_login(self.prescriber_org.members.first())
-        self._setup_session(diagnosis.job_seeker, diagnosis.author_geiq.pk)
+        self._setup_session(diagnosis.author_geiq.pk)
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility",
@@ -2657,7 +2628,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
 
     def test_geiq_diagnosis_form_validation(self):
         self.client.force_login(self.prescriber_org.members.first())
-        self._setup_session(self.job_seeker_with_geiq_diagnosis)
+        self._setup_session()
 
         response = self.client.post(
             reverse(

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -54,13 +54,33 @@ urlpatterns = [
         name="step_check_job_seeker_info",
     ),
     path(
+        "<int:siae_pk>/create/<int:job_seeker_pk>/check_job_seeker_info",
+        submit_views.CheckJobSeekerInformations.as_view(),
+        name="step_check_job_seeker_info",
+    ),
+    path(
         "<int:siae_pk>/step_check_prev_applications",
+        submit_views.CheckPreviousApplications.as_view(),
+        name="step_check_prev_applications",
+    ),
+    path(
+        "<int:siae_pk>/create/<int:job_seeker_pk>/check_prev_applications",
         submit_views.CheckPreviousApplications.as_view(),
         name="step_check_prev_applications",
     ),
     path("<int:siae_pk>/application/jobs", submit_views.ApplicationJobsView.as_view(), name="application_jobs"),
     path(
+        "<int:siae_pk>/create/<int:job_seeker_pk>/select_jobs",
+        submit_views.ApplicationJobsView.as_view(),
+        name="application_jobs",
+    ),
+    path(
         "<int:siae_pk>/application/eligibility",
+        submit_views.ApplicationEligibilityView.as_view(),
+        name="application_eligibility",
+    ),
+    path(
+        "<int:siae_pk>/create/<int:job_seeker_pk>/eligibility",
         submit_views.ApplicationEligibilityView.as_view(),
         name="application_eligibility",
     ),
@@ -69,7 +89,17 @@ urlpatterns = [
         submit_views.ApplicationGEIQEligibilityView.as_view(),
         name="application_geiq_eligibility",
     ),
+    path(
+        "<int:siae_pk>/create/<int:job_seeker_pk>/geiq_eligibility",
+        submit_views.ApplicationGEIQEligibilityView.as_view(),
+        name="application_geiq_eligibility",
+    ),
     path("<int:siae_pk>/application/resume", submit_views.ApplicationResumeView.as_view(), name="application_resume"),
+    path(
+        "<int:siae_pk>/create/<int:job_seeker_pk>/resume",
+        submit_views.ApplicationResumeView.as_view(),
+        name="application_resume",
+    ),
     path(
         "<int:siae_pk>/application/<uuid:application_pk>/end",
         submit_views.ApplicationEndView.as_view(),

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -124,8 +124,11 @@ class ApplicationBaseView(ApplyStepBaseView):
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
+        # If no job_seeker_pk present in kwargs, fallback to active session
+        # This fallback will be removed in a followup commit
+        job_seeker_pk = kwargs.get("job_seeker_pk", self.apply_session.get("job_seeker_pk"))
 
-        self.job_seeker = get_object_or_404(User, pk=self.apply_session.get("job_seeker_pk"))
+        self.job_seeker = get_object_or_404(User, pk=job_seeker_pk)
         _check_job_seeker_approval(request, self.job_seeker, self.siae)
         if self.siae.kind == SiaeKind.GEIQ:
             self.geiq_eligibility_diagnosis = GEIQEligibilityDiagnosis.objects.valid_diagnoses_for(
@@ -254,19 +257,34 @@ class CheckNIRForJobSeekerView(ApplyStepForJobSeekerBaseView):
     def get(self, request, *args, **kwargs):
         # The NIR already exists, go to next step
         if self.job_seeker.nir:
-            return HttpResponseRedirect(reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": self.siae.pk}))
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:step_check_job_seeker_info",
+                    kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk},
+                )
+            )
 
         return super().get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
         if self.form.data.get("skip"):
-            return HttpResponseRedirect(reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": self.siae.pk}))
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:step_check_job_seeker_info",
+                    kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk},
+                )
+            )
 
         if self.form.is_valid():
             self.job_seeker.nir = self.form.cleaned_data["nir"]
             self.job_seeker.lack_of_nir_reason = ""
             self.job_seeker.save()
-            return HttpResponseRedirect(reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": self.siae.pk}))
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:step_check_job_seeker_info",
+                    kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk},
+                )
+            )
 
         return self.render_to_response(self.get_context_data(**kwargs))
 
@@ -306,7 +324,10 @@ class CheckNIRForSenderView(ApplyStepForSenderBaseView):
             if self.form.data.get("confirm"):
                 self.apply_session.set("job_seeker_pk", job_seeker.pk)
                 return HttpResponseRedirect(
-                    reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": self.siae.pk})
+                    reverse(
+                        "apply:step_check_job_seeker_info",
+                        kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": job_seeker.pk},
+                    )
                 )
 
             context = {
@@ -372,7 +393,10 @@ class CheckEmailForSenderView(ApplyStepForSenderBaseView):
 
                 if not can_add_nir:
                     return HttpResponseRedirect(
-                        reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": self.siae.pk})
+                        reverse(
+                            "apply:step_check_job_seeker_info",
+                            kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": job_seeker.pk},
+                        )
                     )
 
                 try:
@@ -390,7 +414,10 @@ class CheckEmailForSenderView(ApplyStepForSenderBaseView):
                     logger.exception("step_job_seeker: error when saving job_seeker=%s nir=%s", job_seeker, nir)
                 else:
                     return HttpResponseRedirect(
-                        reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": self.siae.pk})
+                        reverse(
+                            "apply:step_check_job_seeker_info",
+                            kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": job_seeker.pk},
+                        )
                     )
 
         return self.render_to_response(
@@ -615,7 +642,7 @@ class CreateJobSeekerStepEndForSenderView(CreateJobSeekerForSenderBaseView):
 
             self.apply_session.set("job_seeker_pk", profile.user.pk)
             self.job_seeker_session.delete()
-            url = reverse("apply:application_jobs", kwargs={"siae_pk": self.siae.pk})
+            url = reverse("apply:application_jobs", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": profile.user.pk})
         return HttpResponseRedirect(url)
 
     def get_context_data(self, **kwargs):
@@ -653,7 +680,10 @@ class CheckJobSeekerInformations(ApplicationBaseView):
         )
         if has_required_info:
             return HttpResponseRedirect(
-                reverse("apply:step_check_prev_applications", kwargs={"siae_pk": self.siae.pk})
+                reverse(
+                    "apply:step_check_prev_applications",
+                    kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk},
+                )
             )
 
         return super().get(request, *args, **kwargs)
@@ -662,7 +692,10 @@ class CheckJobSeekerInformations(ApplicationBaseView):
         if self.form.is_valid():
             self.form.save()
             return HttpResponseRedirect(
-                reverse("apply:step_check_prev_applications", kwargs={"siae_pk": self.siae.pk})
+                reverse(
+                    "apply:step_check_prev_applications",
+                    kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk},
+                )
             )
 
         return self.render_to_response(self.get_context_data(**kwargs))
@@ -692,7 +725,11 @@ class CheckPreviousApplications(ApplicationBaseView):
 
     def get(self, request, *args, **kwargs):
         if not self.previous_applications.exists():
-            return HttpResponseRedirect(reverse("apply:application_jobs", kwargs={"siae_pk": self.siae.pk}))
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:application_jobs", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk}
+                )
+            )
 
         # Limit the possibility of applying to the same SIAE for 24 hours.
         if not request.user.is_siae_staff and self.previous_applications.created_in_past(hours=24).exists():
@@ -708,7 +745,11 @@ class CheckPreviousApplications(ApplicationBaseView):
         # At this point we know that the candidate is applying to an SIAE where he or she has already applied.
         # Allow a new job application if the user confirm it despite the duplication warning.
         if request.POST.get("force_new_application") == "force":
-            return HttpResponseRedirect(reverse("apply:application_jobs", kwargs={"siae_pk": self.siae.pk}))
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:application_jobs", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk}
+                )
+            )
 
         return self.render_to_response(self.get_context_data(**kwargs))
 
@@ -742,7 +783,9 @@ class ApplicationJobsView(ApplicationBaseView):
             path_name = (
                 "application_geiq_eligibility" if self.siae.kind == SiaeKind.GEIQ else "application_eligibility"
             )
-            return HttpResponseRedirect(reverse("apply:" + path_name, kwargs={"siae_pk": self.siae.pk}))
+            return HttpResponseRedirect(
+                reverse("apply:" + path_name, kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk})
+            )
 
         return self.render_to_response(self.get_context_data(**kwargs))
 
@@ -789,7 +832,11 @@ class ApplicationEligibilityView(ApplicationBaseView):
             self.job_seeker.has_valid_common_approval,
         ]
         if any(bypass_eligibility_conditions):
-            return HttpResponseRedirect(reverse("apply:application_resume", kwargs={"siae_pk": self.siae.pk}))
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:application_resume", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk}
+                )
+            )
 
         return super().dispatch(request, *args, **kwargs)
 
@@ -800,7 +847,11 @@ class ApplicationEligibilityView(ApplicationBaseView):
                 EligibilityDiagnosis.create_diagnosis(self.job_seeker, user_info, self.form.cleaned_data)
             elif self.eligibility_diagnosis and not self.form.data.get("shrouded"):
                 EligibilityDiagnosis.update_diagnosis(self.eligibility_diagnosis, user_info, self.form.cleaned_data)
-            return HttpResponseRedirect(reverse("apply:application_resume", kwargs={"siae_pk": self.siae.pk}))
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:application_resume", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk}
+                )
+            )
 
         return self.render_to_response(self.get_context_data(**kwargs))
 
@@ -812,7 +863,9 @@ class ApplicationEligibilityView(ApplicationBaseView):
             "new_expires_at_if_updated": new_expires_at_if_updated,
             "progress": 50,
             "job_seeker": self.job_seeker,
-            "back_url": reverse("apply:application_jobs", kwargs={"siae_pk": self.siae.pk}),
+            "back_url": reverse(
+                "apply:application_jobs", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk}
+            ),
         }
 
 
@@ -835,21 +888,30 @@ class ApplicationGEIQEligibilityView(ApplicationBaseView):
                 if self.geiq_eligibility_diagnosis
                 else []
             ),
-            form_url=reverse("apply:application_geiq_eligibility", kwargs={"siae_pk": self.siae.pk}),
+            form_url=reverse(
+                "apply:application_geiq_eligibility",
+                kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk},
+            ),
             data=request.POST or None,
         )
 
     def dispatch(self, request, *args, **kwargs):
         # GEIQ eligibility form during job application process is only available to authorized prescribers
         if not request.user.is_prescriber_with_authorized_org:
-            return HttpResponseRedirect(reverse("apply:application_resume", kwargs={"siae_pk": self.siae.pk}))
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:application_resume", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk}
+                )
+            )
 
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         geo_criteria_detected = self.job_seeker.address_in_qpv or self.job_seeker.zrr_city_name
         return super().get_context_data(**kwargs) | {
-            "back_url": reverse("apply:application_jobs", kwargs={"siae_pk": self.siae.pk}),
+            "back_url": reverse(
+                "apply:application_jobs", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk}
+            ),
             "form": self.form,
             "full_content_width": True,
             "geo_criteria_detected": geo_criteria_detected,
@@ -877,7 +939,11 @@ class ApplicationGEIQEligibilityView(ApplicationBaseView):
                         self.geiq_eligibility_diagnosis, request.user, self.form.cleaned_data
                     )
 
-            return HttpResponseRedirect(reverse("apply:application_resume", kwargs={"siae_pk": self.siae.pk}))
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:application_resume", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk}
+                )
+            )
 
         return self.render_to_response(self.get_context_data(**kwargs))
 
@@ -979,7 +1045,7 @@ class ApplicationResumeView(ApplicationBaseView):
             ),
             "back_url": reverse(
                 f"apply:application_{'jobs' if any(bypass_eligibility_conditions) else 'eligibility'}",
-                kwargs={"siae_pk": self.siae.pk},
+                kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk},
             ),
             "progress": 75,
             "full_content_width": True,
@@ -1297,7 +1363,9 @@ class UpdateJobSeekerStepEndView(UpdateJobSeekerBaseView):
         else:
             self.profile.save()
             self.job_seeker_session.delete()
-            url = reverse("apply:application_jobs", kwargs={"siae_pk": self.siae.pk})
+            url = reverse(
+                "apply:application_jobs", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk}
+            )
         return HttpResponseRedirect(url)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
### Pourquoi ?

La session de candidature a comme clef `job_application-{siae.pk}` ce qui empêche de faire 2 parcours de candidatures pour 2 candidats différents sur la même SIAE.

Pour le nouveau parcours de Déclaration d'embauche j'aimerais réutiliser certaines briques du parcours de candidature sans utiliser de session, cette PR est donc une première étape dans cette direction.

Au passage, cerftaines URLs sont modifiées:

`<int:siae_pk>/step_check_job_seeker_info` -> `<int:siae_pk>/create/<int:job_seeker_pk>/check_job_seeker_info`
`<int:siae_pk>/step_check_prev_applications` ->`<int:siae_pk>/create/<int:job_seeker_pk>/check_prev_applications`
`<int:siae_pk>/application/jobs` -> `<int:siae_pk>/create/<int:job_seeker_pk>/select_jobs`
`<int:siae_pk>/application/eligibility` -> `<int:siae_pk>/create/<int:job_seeker_pk>/eligibility`
`<int:siae_pk>/application/geiq_eligibility` -> `<int:siae_pk>/create/<int:job_seeker_pk>/geiq_eligibility`
`<int:siae_pk>/application/resume` -> `<int:siae_pk>/create/<int:job_seeker_pk>/resume`

avec en objectif futur d'avoir ces mêmes URLs  `<int:siae_pk>/hire/<int:job_seeker_pk>/xxxx` pour le parcours de déclaration d'embauche.

Un fallback sur le `job_seeker_pk` présent en session est laissé (sans test) pour les quelques utilisateurs qui seraient en cours de parcours. Ce fallback sera retiré quelques jours après le déploiement.
