### PR TITLE
tests: ajout d'un test sur la suppression des fiches de poste ...

### DIFF
--- a/itou/www/siaes_views/tests/tests_job_description_views.py
+++ b/itou/www/siaes_views/tests/tests_job_description_views.py
@@ -92,6 +92,12 @@ class JobDescriptionListViewTest(JobDescriptionAbstractTest):
                 self.assertContains(response, f"/job_description/{job.pk}/card")
                 self.assertContains(response, f"toggle_job_description_form_{job.pk}")
                 self.assertContains(response, f"#_delete_modal_{job.pk}")
+                self.assertContains(
+                    response,
+                    f"""<input type="hidden" name="job_description_id" value="{job.pk}"/>""",
+                    html=True,
+                    count=2,
+                )
 
     def test_block_job_applications(self):
         response = self._login(self.user)


### PR DESCRIPTION
... qui étaient cassées depuis un bail. 

### Pourquoi ?
PR qui vient en complément du [bugfix commité directement sur master](https://github.com/betagouv/itou/commit/1bb59c0d2802b22f71c568343f21b1c1e87f2efd) (oui, je sais l'apéro est encore loin).
Mais bon, le fix fonctionne et voici le test correspondant.

### Comment 
Avec de plates excuses :0


