### PR TITLE
Metabase : Simplification de la colonne organisations.type

### DIFF
--- a/itou/metabase/tables/organizations.py
+++ b/itou/metabase/tables/organizations.py
@@ -66,14 +66,6 @@ def get_org_last_job_application_creation_date(org):
     return None
 
 
-ORGANIZATION_KIND_TO_READABLE_KIND = {
-    PrescriberOrganizationKind.PE: "Pôle emploi",
-    PrescriberOrganizationKind.CAP_EMPLOI: "Cap emploi",
-    PrescriberOrganizationKind.ML: "Mission locale",
-    PrescriberOrganizationKind.DEPT: "Département",
-    PrescriberOrganizationKind.OTHER: "Autre",
-}
-
 TABLE = MetabaseTable(name="organisations")
 TABLE.add_columns(
     [
@@ -84,7 +76,7 @@ TABLE.add_columns(
             "name": "type",
             "type": "varchar",
             "comment": "Type organisation (abrégé)",
-            "fn": lambda o: ORGANIZATION_KIND_TO_READABLE_KIND.get(o.kind, o.kind),
+            "fn": lambda o: o.kind,
         },
         {
             "name": "type_complet",


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/C04SAGUGJFJ/p1682669892156689**

### Pourquoi ?

Historiquement on applique 5 exceptions dans le nommage de `organisations.type`. Ces exceptions ne sont pas appliquées partout du coup causent des céphalées inutiles à Laurine.

### Comment ?

On vire ces exceptions.

### Revue ?

Non car trivial. J'attends juste que les tests passent.