### PR TITLE
Metabase : ajout d'une table utilisateurs avec *uniquement* les utilisateurs pros et leur email, pas les candidats

### DIFF
--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -33,6 +33,7 @@ if [[ "$1" == "--daily" ]]; then
     django-admin populate_metabase_emplois --mode=evaluated_siaes |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=evaluated_job_applications |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=evaluated_criteria |& tee -a "$OUTPUT_LOG"
+    django-admin populate_metabase_emplois --mode=users |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=final_tables |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=data_inconsistencies |& tee -a "$OUTPUT_LOG"
     django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -57,6 +57,7 @@ from itou.metabase.tables import (
     rome_codes,
     selected_jobs,
     siaes,
+    users,
 )
 from itou.metabase.tables.utils import get_active_siae_pks
 from itou.prescribers.models import PrescriberOrganization
@@ -97,6 +98,7 @@ class Command(BaseCommand):
             "evaluated_siaes": self.populate_evaluated_siaes,
             "evaluated_job_applications": self.populate_evaluated_job_applications,
             "evaluated_criteria": self.populate_evaluated_criteria,
+            "users": self.populate_users,
             "rome_codes": self.populate_rome_codes,
             "insee_codes": self.populate_insee_codes,
             "insee_codes_vs_post_codes": self.populate_insee_codes_vs_post_codes,
@@ -383,6 +385,12 @@ class Command(BaseCommand):
     def populate_evaluated_criteria(self):
         queryset = EvaluatedAdministrativeCriteria.objects.all()
         populate_table(evaluated_criteria.TABLE, batch_size=1000, querysets=[queryset])
+
+    def populate_users(self):
+        queryset = User.objects.filter(
+            kind__in=[UserKind.SIAE_STAFF, UserKind.PRESCRIBER, UserKind.LABOR_INSPECTOR], is_active=True
+        )
+        populate_table(users.TABLE, batch_size=1000, querysets=[queryset])
 
     def populate_rome_codes(self):
         queryset = Rome.objects.all()

--- a/itou/metabase/tables/users.py
+++ b/itou/metabase/tables/users.py
@@ -1,0 +1,16 @@
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.users.models import User
+
+
+def get_field(name):
+    return User._meta.get_field(name)
+
+
+TABLE = MetabaseTable(name="utilisateurs")
+TABLE.add_columns(
+    [
+        get_column_from_field(get_field("id"), name="id"),
+        get_column_from_field(get_field("email"), name="email"),
+        get_column_from_field(get_field("kind"), name="type"),
+    ]
+)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Ajouter-une-table-utilisateurs-avec-les-emails-pro-b0e49c5bd5544087a7e92300b8aa4840**

### Pourquoi ?

Pour aider les bizdev C2 à identifer l'email des utilisateurs pros (employeur, prescripteur, institution) à l'aide de leur ID C1 déjà disponibles à plusieurs endroits notamment dans le tracking Matomo (quel utilisateur a consulté quel TB) afin de faire des contacts et/ou des mailings ciblés.

### Comment

- attention on met seulement les utilisateurs pros, pas les candidats
  - car on part toujours du principe que Metabase peut être hacké et qu'il ne faut pas fuiter des données sensibles
- on ne met que les utilisateurs actifs

### Revue

En l'absence de Victor, c'est pour Supportix (donc Céline pour cette fois).