### PR TITLE
Charger les secrets depuis expire-elastic-indices

### DIFF
--- a/scripts/expire-elastic-indices
+++ b/scripts/expire-elastic-indices
@@ -4,6 +4,7 @@ import os
 from datetime import date
 
 import httpx
+from dotenv import load_dotenv
 from sentry_sdk.crons import monitor
 
 
@@ -26,4 +27,5 @@ def main():
 
 
 if __name__ == "__main__":
+    load_dotenv()
     main()


### PR DESCRIPTION
Autrement, les secrets `ELASTICSEARCH_*` ne sont pas disponibles.