### PR TITLE
Améliorations UI/UX et correction de bogue

### DIFF
--- a/itou/templates/apply/submit/application/eligibility.html
+++ b/itou/templates/apply/submit/application/eligibility.html
@@ -39,28 +39,62 @@
 {% endblock %}
 
 {% block form_content %}
-    <div{% if eligibility_diagnosis and not form.is_bound %} class="js-shroud"{% endif %}>
-        <fieldset>
-            <legend class="h3">
-                Critères administratifs de niveau 1
-            </legend>
-            {% for field in form %}
-                {% if form.LEVEL_1_PREFIX in field.name %}
-                    {% bootstrap_field field %}
-                {% endif %}
-            {% endfor %}
-        </fieldset>
+    <div class="d-flex flex-column flex-lg-row">
+        {% if is_subject_to_eligibility_rules and request.user.is_prescriber %}
+            <div class="order-0 order-lg-1">
+                <div class="alert alert-primary bg-white py-0" role="status">
+                    <div class="row">
+                        <div class="col-auto pr-0">
+                            <i class="ri-lightbulb-line ri-xl"></i>
+                        </div>
+                        <div class="col">
+                            <p class="mb-2">
+                                <strong>Bon à savoir</strong>
+                            </p>
+                            <p class="mb-0">
+                                Pour valider l'éligibilité IAE du candidat :
+                                <ol>
+                                    <li>
+                                        Veuillez vous assurer d’avoir réalisé un diagnostic socio-professionnel dans le cadre d'un entretien individuel.
+                                        Vous pouvez vous appuyer sur le document
+                                        <a class="text-important"
+                                           href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/diagnostic-socio-professionnel/"
+                                           target="_blank"
+                                           rel="noreferrer noopener"
+                                           aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.
+                                    </li>
+                                    <li>Il est recommandé de sélectionner le(s) critères(s) administratifs d’éligibilité correspondants.</li>
+                                </ol>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+        <div class="col-12 col-lg-7 pl-0{% if eligibility_diagnosis and not form.is_bound %} js-shroud{% endif %}">
+            <fieldset>
+                <legend class="h3">
+                    Critères administratifs de niveau 1
+                </legend>
+                {% for field in form %}
+                    {% if form.LEVEL_1_PREFIX in field.name %}
+                        {% bootstrap_field field %}
+                    {% endif %}
+                {% endfor %}
+            </fieldset>
 
-        <fieldset>
-            <legend class="h3">
-                Critères administratifs de niveau 2
-            </legend>
-            {% for field in form %}
-                {% if form.LEVEL_2_PREFIX in field.name %}
-                    {% bootstrap_field field %}
-                {% endif %}
-            {% endfor %}
-        </fieldset>
-        <input type="hidden" name="shrouded" value="1" data-shroud-input />
+            <fieldset>
+                <legend class="h3">
+                    Critères administratifs de niveau 2
+                </legend>
+                {% for field in form %}
+                    {% if form.LEVEL_2_PREFIX in field.name %}
+                        {% bootstrap_field field %}
+                    {% endif %}
+                {% endfor %}
+            </fieldset>
+
+            <input type="hidden" name="shrouded" value="1" data-shroud-input />
+        </div>
     </div>
 {% endblock %}

--- a/itou/templates/apply/submit_base_two_columns.html
+++ b/itou/templates/apply/submit_base_two_columns.html
@@ -13,8 +13,6 @@
                 <div class="col-12 col-lg-6 order-md-1 pr-lg-5 mt-4">
                     <h1>{% include 'apply/includes/_submit_title.html' %}</h1>
 
-                    {% include "approvals/includes/card.html" with common_approval=job_seeker.latest_common_approval %}
-
                     <div class="card c-card c-card--emploi mb-3 mb-lg-5">
                         <div class="card-body">
                             <p>

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -1,5 +1,5 @@
 {% extends "layout/content_small.html" %}
-{% load bootstrap4 tally %}
+{% load bootstrap4 tally str_filters %}
 
 {% block title %}Employeur solidaire - Inscription {{ block.super }}{% endblock %}
 
@@ -17,9 +17,11 @@
 
         {% bootstrap_form siren_form alert_error_type="all" %}
 
-        {% buttons %}
-            <button type="submit" class="btn btn-primary">Rechercher</button>
-        {% endbuttons %}
+        <div class="text-right">
+            {% buttons %}
+                <button type="submit" class="btn btn-primary">Rechercher</button>
+            {% endbuttons %}
+        </div>
 
     </form>
 
@@ -63,13 +65,9 @@
     {% if siaes_without_members and siae_select_form %}
         <div class="mt-5">
 
-            <h3 class="h2">Entreprises disponibles</h3>
+            <h3 class="h2">Entreprise{{ siaes_without_members|pluralizefr }} disponible{{ siaes_without_members|pluralizefr }}</h3>
 
-            <div class="alert alert-emploi" role="status">
-                <p class="mb-0">
-                    <i>Les données sont fournies par la DGEFP, et les extranets IAE 2.0 et EA 2 de l’ASP.</i>
-                </p>
-            </div>
+            <p class="text-muted">Les données sont fournies par la DGEFP et les extranets IAE 2.0 et EA 2 de l’ASP.</p>
 
             <form method="post" class="js-prevent-multiple-submit">
 
@@ -84,34 +82,30 @@
             The best solution I've yet found to display more info to the user than just a
             label is to manually render the inputs.
                 {% endcomment %}
-                <ul>
-                    {% for siae in siaes_without_members %}
-                        <li>
-                            <p>
-                                <label for="id_{{ siae_select_form.siaes.html_name }}_{{ forloop.counter0 }}" class="align-top">
-                                    <input type="radio" name="{{ siae_select_form.siaes.html_name }}" value="{{ siae.pk }}" id="id_{{ siae_select_form.siaes.html_name }}_{{ forloop.counter0 }}" required>
-                                    <b>{{ siae.siren }} {{ siae.siret_nic }}</b> - {{ siae.kind }}
-                                    <br>
-                                    {{ siae.display_name }}
-                                    <br>
-                                    {{ siae.address_line_1 }},
-                                    {% if siae.address_line_2 %}{{ siae.address_line_2 }},{% endif %}
-                                    {{ siae.post_code }} {{ siae.city }}
-                                </label>
-                            </p>
-                        </li>
-                    {% endfor %}
-                </ul>
-
-                <div class="alert alert-warning pb-0">
+                {% for siae in siaes_without_members %}
                     <p>
-                        Pour sécuriser l'inscription, un e-mail de confirmation sera envoyé au correspondant technique référencé dans l'extranet IAE 2.0 de l'ASP. Il permettra de poursuivre la procédure.
+                        <label for="id_{{ siae_select_form.siaes.html_name }}_{{ forloop.counter0 }}" class="align-top">
+                            <input type="radio" name="{{ siae_select_form.siaes.html_name }}" value="{{ siae.pk }}" id="id_{{ siae_select_form.siaes.html_name }}_{{ forloop.counter0 }}" required>
+                            <b>{{ siae.siren }} {{ siae.siret_nic }}</b> - {{ siae.kind }}
+                            <br>
+                            {{ siae.display_name }}
+                            <br>
+                            {{ siae.address_line_1 }},
+                            {% if siae.address_line_2 %}{{ siae.address_line_2 }},{% endif %}
+                            {{ siae.post_code }} {{ siae.city }}
+                        </label>
                     </p>
+                    <hr/>
+                {% endfor %}
+
+                <p>
+                    En cliquant sur "Envoyer ma demande de validation", un e-mail contenant un lien de confirmation sera envoyé au <b>correspondant technique de votre entreprise référencé dans l’extranet IAE 2.0 ou EA 2 de l'ASP</b>.
+                </p>
+                <div class="text-right">
                     {% buttons %}
-                        <button type="submit" class="btn btn-primary">Continuer l'inscription</button>
+                        <button type="submit" class="btn btn-primary">Envoyer ma demande de validation</button>
                     {% endbuttons %}
                 </div>
-
             </form>
 
         </div>
@@ -121,44 +115,49 @@
     {% if siaes_with_members %}
         <div class="mt-5">
 
-            <h3 class="h2">Entreprises déjà inscrites</h3>
+            <h3 class="h2">Entreprise{{ siaes_with_members|pluralizefr }} déjà inscrite{{ siaes_with_members|pluralizefr }}</h3>
 
-            <div class="alert alert-emploi" role="status">
-                <p class="mb-0">
-                    <i>Par sécurité vous devez obtenir une invitation pour rejoindre ces structures.</i>
-                </p>
-            </div>
+            <p class="text-muted">
+                Par mesure de sécurité, vous devez obtenir une invitation pour rejoindre
+                {% if siaes_with_members|length == 1 %}
+                    cette
+                {% else %}
+                    ces
+                {% endif %}
+                structure{{ siaes_with_members|pluralizefr }}.
+            </p>
 
-            <ul>
-                {% for siae in siaes_with_members %}
-                    <li>
-                        <p>
-                            <b>{{ siae.siren }} {{ siae.siret_nic }}</b> - {{ siae.kind }}
-                            <br>
-                            {{ siae.display_name }}
-                            <br>
-                            {{ siae.address_line_1 }},
-                            {% if siae.address_line_2 %}{{ siae.address_line_2 }},{% endif %}
-                            {{ siae.post_code }} {{ siae.city }}
-                            <br>
-                            {# note: memberships.first does not work, it does not take the prefetch into account. #}
-                            {% with siae.memberships.all.0.user as admin %}
-                                {# For security, display only the first char of the last name. #}
-                                <i>Pour obtenir une invitation, contactez {{ admin.first_name|title }} {{ admin.last_name|slice:1 }}.</i>
-                            {% endwith %}
-                        </p>
-                    </li>
-                {% endfor %}
-            </ul>
+            {% for siae in siaes_with_members %}
+                <div>
+                    <p>
+                        <b>{{ siae.siren }} {{ siae.siret_nic }}</b> - {{ siae.kind }}
+                    </p>
+                    <p>
+                        {{ siae.display_name }}
+                        <br>
+                        {{ siae.address_line_1 }},
+                        {% if siae.address_line_2 %}{{ siae.address_line_2 }},{% endif %}
+                        {{ siae.post_code }} {{ siae.city }}
+                    </p>
+                    <p>
+                        {# note: memberships.first does not work, it does not take the prefetch into account. #}
+                        {% with siae.memberships.all.0.user as admin %}
+                            {# For security, display only the first char of the last name. #}
+                            Pour obtenir une invitation, <b>veuillez contacter {{ admin.first_name|title }} {{ admin.last_name|slice:1 }}</b>.
+                        {% endwith %}
+                    </p>
+                </div>
+                <hr/>
+            {% endfor %}
 
         </div>
     {% endif %}
 
 
     {% if siaes_without_members or siaes_with_members %}
-        <div class="mt-5">
+        <div class="mt-5 text-right">
             <p>
-                En cas de problème contactez-nous : <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" aria-label="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_ASSISTANCE_URL }}</a>
+                En cas de problème <a href="{{ ITOU_ASSISTANCE_URL }}" target="_blank" rel="noopener" aria-label="{{ ITOU_ASSISTANCE_URL }} (ouverture dans un nouvel onglet)">contactez-nous</a>.
             </p>
         </div>
     {% endif %}

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -862,6 +862,7 @@ class ApplicationEligibilityView(ApplicationBaseView):
             "back_url": reverse(
                 "apply:application_jobs", kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": self.job_seeker.pk}
             ),
+            "full_content_width": True,
         }
 
 

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -172,7 +172,9 @@ def siae_select(request, template_name="signup/siae_select.html"):
     # The SIREN, when available, is always passed in the querystring.
     if request.method in ["GET", "POST"] and siren_form.is_valid():
         # Make sure to look only for active structures.
-        siaes_for_siren = Siae.objects.active().filter(siret__startswith=siren_form.cleaned_data["siren"])
+        siaes_for_siren = (
+            Siae.objects.active().filter(siret__startswith=siren_form.cleaned_data["siren"]).distinct("siret")
+        )
         # A user cannot join structures that already have members.
         # Show these structures in the template to make that clear.
         siaes_with_members = (


### PR DESCRIPTION
**Carte Notion :**
1. [En tant que prescripteur habilité, je veux accéder au diagnostic socio-pro de référence depuis la page dédiée à la situation administrative du candidat](https://www.notion.so/plateforme-inclusion/En-tant-que-prescripteur-habilit-je-veux-acc-der-au-diagnostic-socio-pro-de-r-f-rence-depuis-la-pa-d0722f1eaf3c40c1b87398fc1f44afb3)
2. [Bug d'affichage lorsque je cherche a postuler pour un candidat qui est reconnu dans le système](https://www.notion.so/plateforme-inclusion/BUG-D-AFFICHAGE-Bug-lorsque-je-cherche-a-postuler-pour-un-candidat-qui-est-reconnu-dans-le-syst-me-61e34a334f464688a3b3b90eabb057b1?pvs=4)
3. [Ajouter “Extranet EA 2” dans une bannière d’info présente lors de l’inscription](https://www.notion.so/plateforme-inclusion/Ajouter-Extranet-EA-2-dans-une-banni-re-d-info-pr-sente-lors-de-l-inscription-877e00f9f4e6463cbef76ac8c20ce61b?pvs=4)

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Diverses améliorations qui traînaient dans le milieu de la pile :).

### Captures d'écran <!-- optionnel -->

1 - Desktop
![application_eligibility_ph_helper_d](https://user-images.githubusercontent.com/20045330/235919933-1c0c36ea-fbd6-4a0e-9936-f092f874e8bf.png)

1- Mobile
![application_eligibility_ph_helper_m](https://user-images.githubusercontent.com/20045330/235919925-5a259d22-374e-408a-a6aa-834b57d26298.png)

3 - Desktop
![signup_siae_select_siren](https://user-images.githubusercontent.com/20045330/235978792-194ef9b3-aeca-444c-8d77-363cd797f2b8.png)
