### PR TITLE
Retrait de JS pour désactiver les boutons de formulaires

### DIFF
--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -5,30 +5,6 @@ htmx.onLoad((target) => {
 
     $(".js-display-if-javascript-enabled", target).css("display", "block");
 
-    /**
-     * JS to disable the submit button of the form when it's not valid
-     **/
-    function checkValidity(e) {
-        let submit = $(e.currentTarget).find('button[type="submit"]')
-        if (e.currentTarget.checkValidity()) {
-            submit.removeClass("disabled")
-        } else {
-            submit.addClass("disabled")
-        }
-    }
-
-    $(".js-enable-submit-when-valid", target).each(function () {
-        let form = $(this)
-        // Check the validity when something (possibly) change in the form.
-        form.on("change reset duetChange", (e) => {
-          // Use setTimeout() to execute checkValidity() in the next event cycle,
-          // when events *should* have done what they need to do.
-          window.setTimeout(checkValidity, 0, e)
-        })
-        // Check immediately
-        checkValidity({"currentTarget": this})
-    });
-
   /**
    * JS to swap elements based on CSS selectors
    */

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -67,7 +67,7 @@
                             <div class="c-form c-card--noshadow border-bottom {% if not form.is_bound %}d-none{% endif %}" data-swap-element-with="#informations">
                                 <h2 class="mb-5">{{ job_application.job_seeker.get_full_name }}</h2>
 
-                                <form method="post" class="js-enable-submit-when-valid">
+                                <form method="post">
                                     {% csrf_token %}
 
                                     {% bootstrap_field form.address_line_1 %}

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
@@ -57,7 +57,7 @@
                         {% endif %}
                         <hr class="mt-5">
                         {% bootstrap_form_errors form type="all" %}
-                        <form method="post" class="js-enable-submit-when-valid js-collapsable-subfields">
+                        <form method="post" class="js-collapsable-subfields">
                             {% csrf_token %}
 
                             {% block form_content %}{% endblock %}


### PR DESCRIPTION
### Pourquoi ?

La fonctionnalité n’apporte pas un vrai gain UX, les attributs `required` permettent au navigateur d’empêcher l’envoi.

Correction d’un bug UX lors de la sélection de la ville dans l’auto-complete. La sélection d’une valeur dans le champ ville ne débloque pas le bouton, il faut également déclencher l’évènement `blur` ou un autre changement.