### PR TITLE
Initialiser le SDK Sentry pour expire-elastic-indices

### DIFF
--- a/config/sentry.py
+++ b/config/sentry.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -35,9 +36,15 @@ sentry_logging = LoggingIntegration(
 )
 
 
-def sentry_init(dsn, traces_sample_rate):
+def sentry_init():
+    try:
+        traces_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", ""))
+    except ValueError:
+        traces_sample_rate = 0
+
     sentry_sdk.init(
-        dsn=dsn,
+        # DSN is read from the SENTRY_DSN environment variable.
+        #
         integrations=[sentry_logging, DjangoIntegration(), HttpxIntegration(), HueyIntegration(), RedisIntegration()],
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -7,6 +7,8 @@ import os
 
 from dotenv import load_dotenv
 
+from ..sentry import sentry_init
+
 
 load_dotenv()
 
@@ -355,18 +357,10 @@ ITOU_EMAIL_CONTACT = os.getenv("ITOU_EMAIL_CONTACT", "assistance@inclusion.beta.
 API_EMAIL_CONTACT = os.getenv("API_EMAIL_CONTACT", "api@inclusion.beta.gouv.fr")
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@inclusion.beta.gouv.fr")
 
-
+# Sentry
+# Expose the value through the settings_viewer app.
 SENTRY_DSN = os.getenv("SENTRY_DSN")
-try:
-    _sentry_traces_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", ""))
-except ValueError:
-    _sentry_traces_sample_rate = 0
-
-
-if SENTRY_DSN:
-    from ._sentry import sentry_init
-
-    sentry_init(dsn=SENTRY_DSN, traces_sample_rate=_sentry_traces_sample_rate)
+sentry_init()
 
 SHOW_TEST_ACCOUNTS_BANNER = ITOU_ENVIRONMENT in ("DEMO", "REVIEW-APP")
 

--- a/scripts/expire-elastic-indices
+++ b/scripts/expire-elastic-indices
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 import os
+import sys
 from datetime import date
+from pathlib import Path
 
 import httpx
 from dotenv import load_dotenv
@@ -27,5 +29,10 @@ def main():
 
 
 if __name__ == "__main__":
+    top_level_dir = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(top_level_dir))
+    from config.sentry import sentry_init
+
     load_dotenv()
+    sentry_init()
     main()


### PR DESCRIPTION
### Pourquoi ?

Envoyer les évènements du script à Sentry.