### PR TITLE
scripts: lancement d'import_ea_eatt par le script imports-asp

### DIFF
--- a/scripts/imports-asp.sh
+++ b/scripts/imports-asp.sh
@@ -46,7 +46,7 @@ mkdir -p $OUTPUT_PATH/import_ea_eatt
 
 time ./manage.py populate_metabase_fluxiae --verbosity 2 |& tee -a "$OUTPUT_PATH/populate_metabase_fluxiae/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
 time ./manage.py import_siae --verbosity=2 |& tee -a "$OUTPUT_PATH/import_siae/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
-time ./manage.py import_ea_eatt --verbosity=2 |& tee -a "$OUTPUT_PATH/import_ea_eatt/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
+time ./manage.py import_ea_eatt --wet-run --verbosity=2 |& tee -a "$OUTPUT_PATH/import_ea_eatt/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
 
 # Destroy the cleartext ASP data
 rm -rf itou/siaes/management/commands/data/


### PR DESCRIPTION
### Pourquoi ?

Petit oubli dans 6f610d0699cdaf4f2cfb15f18


