### PR TITLE
Import SIAE : Résolution d'un souci technique mineur

### DIFF
--- a/itou/siaes/management/commands/_import_siae/convention.py
+++ b/itou/siaes/management/commands/_import_siae/convention.py
@@ -71,7 +71,9 @@ def update_existing_conventions():
         # TODO @dejafait DROP after 2023/05/31
         # 199 SIAE were deactivated on 2023/04/24 but per ASP's orders we have to keep them artifically alive
         # until at least 2023/05/31.
-        should_be_active = should_be_active or convention.deactivated_at.date() == datetime.date(2023, 4, 24)
+        should_be_active = should_be_active or (
+            convention.deactivated_at and convention.deactivated_at.date() == datetime.date(2023, 4, 24)
+        )
 
         if convention.is_active != should_be_active:
             if should_be_active:


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/C0412CTV63D/p1683554701418109**

### Pourquoi ?

L'import plante sur une nouvelle erreur (qui vient d'un oubli dans le code de ma PR 2445 du 24 avril, mea culpa) avec les données de cette semaine du 8 mai, et en fait cette erreur s'était aussi produite la semaine dernière le 4 mai mais n'avait pas été remontée par Supportix (ou alors j'ai loupé, pas taper). Le 25 avril l'erreur ne s'est pas produite.

Récapitulatif des évènements :

1) Le 24 avril on a brutalement repris le déconventionnement des SIAE mis en pause depuis le début d'année car on est enfin passé en dessous du seuil de 200 déconventionnements. On a donc déconventionné ce jour là 199 SIAE.

2) Le 25 avril retour en arrière sur ordre express de l'ASP, on doit étendre l'immunité à fin mai voir plus. J'ai fait cette PR https://github.com/betagouv/itou/pull/2445 en urgence pour réactiver les 199 conventions.

3) L'erreur `AttributeError: 'NoneType' object has no attribute 'date'` sur `convention.deactivated_at` s'est produite le 4 mai et le 8 mai. Elle vient d'un oubli d'un cas dans mon code (le cas d'un `convention.deactivated_at` à `None`) qui n'était pas facilement testable sur mon local dev le 25 avril, le cas où une convention qui était jusqu'ici valide est signalée par les nouvelles données ASP comme invalide. Bref, en même temps que l'ASP active au fur et à mesure les dernières conventions pour la nouvelle année, elle désactive aussi en continu tout au long de l'année d'autres conventions qui elles ne sont plus valides.

### Comment

Si je fixe naïvement le bug (voir mon premier commit ensuite écrasé), on procédera en pratique à 30 déconventionnements d'un coup (testé en local avec dernières données de prod). Ce sont 30 SIAE qui selon l'ASP étaient encore valides au 25 avril, mais ne le sont plus aujourd'hui. Il ne s'agit *pas* de SIAE qui n'ont pas encore eu leur conventionnement 2023, il s'agit de SIAE qui étaient bien valides tout début 2023 et ne le sont plus depuis très récemment.

Normalement déconventionner ces 30 SIAE devrait être OK, on devrait pouvoir compter sur l'ASP pour nous donner la bonne info. Mais je sens le coup fourré "On vous avait dit de mettre en pause les déconventionnements jusqu'à fin juin, pourquoi avez-vous fait ces 30 déconventionnements...".

Bref mon intuition me dit de changer mon fusil d'épaule et de tout simplement mettre en pause *tout* déconventionnement jusqu'à au moins fin mai. C'est ce que mon commit final fait.

### Notes

A la question : pourquoi n'aurait pas-t-on pu appliquer cette solution triviale de baisser le seuil à 1 dès l'incident du 24 avril ?

La réponse : on aurait uniquement pu si on avait eu l'instruction de l'ASP en avance de phase. Une fois les 199 conventions désactivées c'était trop tard, la présente PR ne les aurait pas réssucitées. ¯\_(ツ)_/¯

Si tout était à refaire, j'aurai fait dès le 24 avril le présent changement (seuil à 1) plus une migration pour ponctuellement réactiver les 199 conventions désactivées le 24 avril.