### PR TITLE
Parcours de candidature: passer le NIR via des POST (et plus en session)

### DIFF
--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
@@ -43,7 +43,7 @@
                             {# Go to the next step. #}
                             <button type="submit" name="confirm" value="1" class="btn btn-sm btn-link">Poursuivre la création du compte</button>
                             {# Reload this page with a new form. #}
-                            <a href="{% url 'apply:check_email_for_sender' siae_pk=siae.pk %}?email={{ email_to_create|urlencode }}" class="btn btn-sm btn-primary">Modifier l'email du candidat</a>
+                            <a href="{% url 'apply:check_nir_for_sender' siae_pk=siae.pk %}?from_session={{ session_uuid }}" class="btn btn-sm btn-primary">Modifier l'email du candidat</a>
                         </div>
                     </div>
                 </div>

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -2,7 +2,6 @@
 {% load bootstrap4 %}
 {% load format_filters %}
 {% load str_filters %}
-{% load redirection_fields %}
 {% load static %}
 
 {% block left_column %}
@@ -15,8 +14,6 @@
                 {% bootstrap_form_errors form type="all" %}
 
                 {% bootstrap_form form %}
-
-                {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
 
                 {% if form.errors %}
                     <div class="alert alert-info">

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -8,41 +8,87 @@
     <form method="post" class="js-prevent-multiple-submit js-format-nir">
         <div class="card c-card p-3">
             <div class="card-body">
-                {% if nir %}
-                    <div class="form-group form-group-required">
-                        <label for="id_nir">Numéro de sécurité sociale du candidat</label>
-                        <input id="id_nir" name="nir" class="form-control" disabled value="{{ nir }}">
-                    </div>
-                {% endif %}
-
-                <div class="alert alert-info mt-4 mb-4">
-                    <div class="row">
-                        <div class="col-auto pr-0">
-                            <i class="ri-information-line ri-xl"></i>
-                        </div>
-                        <div class="col">
-                            <p class="mb-2">
-                                <strong>Créer un compte pour votre candidat</strong>
-                            </p>
-                            <p class="mb-0">
-                                Aucun utilisateur n'est inscrit avec ce numéro de sécurité sociale. Merci de renseigner l'adresse e-mail de votre candidat pour l'inscrire.
-                            </p>
-                        </div>
-                    </div>
-                </div>
-
                 {% csrf_token %}
 
-                {% bootstrap_form form alert_error_type="all" %}
+                {% if form.with_email %}
+                    {% if nir %}
+                        <div class="form-group form-group-required">
+                            <label for="id_ro_nir">Numéro de sécurité sociale du candidat</label>
+                            <input id="id_ro_nir" name="nir" class="form-control" disabled value="{{ nir }}">
+                        </div>
+                    {% endif %}
 
-                <div>{% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}</div>
+                    <div class="alert alert-info mt-4 mb-4">
+                        <div class="row">
+                            <div class="col-auto pr-0">
+                                <i class="ri-information-line ri-xl"></i>
+                            </div>
+                            <div class="col">
+                                <p class="mb-2">
+                                    <strong>Créer un compte pour votre candidat</strong>
+                                </p>
+                                <p class="mb-0">
+                                    Aucun utilisateur n'est inscrit avec ce numéro de sécurité sociale. Merci de renseigner l'adresse e-mail de votre candidat pour l'inscrire.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div>{% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}</div>
+                {% endif %}
+
+                {% bootstrap_form_errors form type="all" %}
+
+                {% bootstrap_form form %}
+
+                {% if not form.with_email %}
+                    {% if form.errors %}
+                        <div class="alert alert-info">
+                            <div class="row">
+                                <div class="col-auto pr-0">
+                                    <i class="ri-information-line ri-xl text-info"></i>
+                                </div>
+                                <div class="col">
+                                    <p class="mb-0">
+                                        Vous possédez un numéro de sécurité sociale temporaire ?
+                                        <button type="submit" name="step" value="email" class="btn btn-link p-0 matomo-event" data-matomo-category="nir-temporaire" data-matomo-action="etape-suivante" data-matomo-option="candidature">
+                                            Cliquez ici pour accéder à l'étape suivante.
+                                        </button>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    {% else %}
+                        <div class="alert alert-info">
+                            <div class="row">
+                                <div class="col-auto pr-0">
+                                    <i class="ri-information-line ri-xl text-info"></i>
+                                </div>
+                                <div class="col">
+                                    <p class="mb-0">
+                                        Le candidat n'a pas de numéro de sécurité sociale ?
+                                        <br>
+                                        <a href="https://www.ameli.fr/assure/droits-demarches/principes/numero-securite-sociale"
+                                           aria-label="ameli.fr, article concernant le numéro de sécurité sociale (ouverture dans un nouvel onglet)"
+                                           rel="noopener"
+                                           target="_blank">ameli.fr</a><i class="ri-external-link-line ml-1"></i>, le site de l'assurance maladie, vous explique comment l'obtenir.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
+                {% endif %}
 
                 {% buttons %}
                     <hr class="my-3 my-lg-5">
 
                     <div class="row mt-3 mt-lg-5 justify-content-end">
                         <div class="col-6 col-lg-auto">
-                            <a href="{% url 'apply:check_nir_for_sender' siae_pk=siae.pk %}" class="btn btn-link" aria-label="Retourner à l'étape précédente">Retour</a>
+                            {% if form.with_email %}
+                                <a class="btn btn-link" aria-label="Retourner à l'étape précédente" href="{% url 'apply:check_nir_for_sender' siae_pk=siae.pk %}">Retour</a>
+                            {% else %}
+                                <a class="btn btn-link" aria-label="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
+                            {% endif %}
                         </div>
                         <div class="col-6 col-lg-auto">
                             {# Reload this page and show a modal containing more information about the job seeker. #}
@@ -54,7 +100,7 @@
                 {% endbuttons %}
             </div>
         </div>
-        {% if preview_mode %}
+        {% if preview_mode == "email" %}
             <!-- Modal -->
             <div class="modal" id="email-confirmation-modal" tabindex="-1" role="dialog" aria-labelledby="email-confirmation-label" aria-modal="true">
                 <div class="modal-dialog">
@@ -92,6 +138,36 @@
                     </div>
                 </div>
             </div>
+        {% elif preview_mode == "nir" %}
+            <!-- Modal -->
+            <div class="modal" id="nir-confirmation-modal" tabindex="-1" role="dialog" aria-labelledby="nir-confirmation-label" aria-modal="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h3 class="modal-title" id="nir-confirmation-label">Utilisateur trouvé</h3>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
+                                <i class="ri-close-line"></i>
+                            </button>
+                        </div>
+                        <div class="modal-body">
+                            <p>
+                                Le numéro {{ form.nir.value|format_nir }} est associé au compte de <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>.
+                            </p>
+                            <p>
+                                Si cette candidature n'est pas pour <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>, cliquez sur « Ce n'est pas mon candidat » afin de modifier le numéro de sécurité sociale.
+                            </p>
+                        </div>
+                        <div class="modal-footer">
+                            {% buttons %}
+                                {# Reload this page with a new form. #}
+                                <button type="submit" name="cancel" value="1" class="btn btn-sm btn-secondary">Ce n'est pas mon candidat</button>
+                                {# Go to the next step. #}
+                                <button type="submit" name="confirm" value="1" class="btn btn-sm btn-primary">Continuer</button>
+                            {% endbuttons %}
+                        </div>
+                    </div>
+                </div>
+            </div>
         {% endif %}
     </form>
 {% endblock %}
@@ -103,6 +179,7 @@
         <script nonce="{{ CSP_NONCE }}">
             // Adding the "show" CSS class is not enough and not documented.
             // A JS initialization is recommended.
+            $("#nir-confirmation-modal").modal("show");
             $("#email-confirmation-modal").modal("show");
         </script>
     {% endif %}

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -2,6 +2,7 @@
 {% load bootstrap4 %}
 {% load format_filters %}
 {% load static %}
+{% load str_filters %}
 
 {% block left_column %}
     <form method="post" class="js-prevent-multiple-submit js-format-nir">
@@ -66,11 +67,11 @@
                         </div>
                         <div class="modal-body">
                             <p>
-                                L'adresse {{ form.email.value }} est associée au compte de <b>{{ job_seeker_name }}</b>.
+                                L'adresse {{ form.email.value }} est associée au compte de <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>.
                             </p>
                             <p>
                                 L'identité du candidat est une information clé pour la structure.
-                                Si cette candidature n'est pas pour <b>{{ job_seeker_name }}</b>, cliquez sur
+                                Si cette candidature n'est pas pour <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>, cliquez sur
                                 « Ce n'est pas mon candidat » afin d'enregistrer ses informations
                                 personnelles.
                             </p>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -116,6 +116,20 @@ class CheckJobSeekerNirForm(forms.Form):
         return self.job_seeker
 
 
+class CheckJobSeekerForSenderForm(CheckJobSeekerNirForm, UserExistsForm):
+    def __init__(self, *args, with_email, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.with_email = with_email
+
+        if not with_email:
+            self.fields["email"].required = False
+            self.fields["email"].widget = forms.HiddenInput()
+        else:
+            self.fields["nir"].required = False
+            self.fields["nir"].widget = forms.HiddenInput()
+
+
 class CheckJobSeekerInfoForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -15,11 +15,10 @@ urlpatterns = [
         submit_views.PendingAuthorizationForSender.as_view(),
         name="pending_authorization_for_sender",
     ),
-    path("<int:siae_pk>/sender/check_nir", submit_views.CheckNIRForSenderView.as_view(), name="check_nir_for_sender"),
     path(
-        "<int:siae_pk>/sender/check_email",
-        submit_views.CheckEmailForSenderView.as_view(),
-        name="check_email_for_sender",
+        "<int:siae_pk>/sender/check_nir",
+        submit_views.CheckJobSeekerForSenderView.as_view(),
+        name="check_nir_for_sender",
     ),
     path(
         "<int:siae_pk>/sender/create_job_seeker/<uuid:session_uuid>/1",

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -358,7 +358,7 @@ class CheckEmailForSenderView(ApplyStepForSenderBaseView):
     def post(self, request, *args, **kwargs):
         can_add_nir = False
         preview_mode = False
-        job_seeker_name = None
+        job_seeker = None
 
         if self.form.is_valid():
             job_seeker = self.form.get_user()
@@ -379,11 +379,6 @@ class CheckEmailForSenderView(ApplyStepForSenderBaseView):
             # Ask the sender to confirm the email we found is associated to the correct user
             if self.form.data.get("preview"):
                 preview_mode = True
-                # Don't display personal information to unauthorized members.
-                if self.sender.is_prescriber and not self.sender.is_prescriber_with_authorized_org:
-                    job_seeker_name = f"{job_seeker.first_name[0]}… {job_seeker.last_name[0]}…"
-                else:
-                    job_seeker_name = job_seeker.get_full_name()
 
             # The email we found is correct
             if self.form.data.get("confirm"):
@@ -422,7 +417,8 @@ class CheckEmailForSenderView(ApplyStepForSenderBaseView):
             | {
                 "can_add_nir": can_add_nir,
                 "preview_mode": preview_mode,
-                "job_seeker_name": job_seeker_name,
+                "job_seeker": job_seeker,
+                "can_view_personal_information": job_seeker and self.sender.can_view_personal_information(job_seeker),
             }
         )
 

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -33,13 +33,13 @@ from itou.utils.storage.s3 import S3Upload
 from itou.utils.urls import get_safe_url
 from itou.www.apply.forms import (
     ApplicationJobsForm,
+    CheckJobSeekerForSenderForm,
     CheckJobSeekerInfoForm,
     CheckJobSeekerNirForm,
     CreateOrUpdateJobSeekerStep1Form,
     CreateOrUpdateJobSeekerStep2Form,
     CreateOrUpdateJobSeekerStep3Form,
     SubmitJobApplicationForm,
-    UserExistsForm,
 )
 from itou.www.apply.views import constants as apply_view_constants
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm
@@ -224,7 +224,6 @@ class StartView(ApplyStepBaseView):
         self.apply_session.init(
             {
                 "back_url": self._coalesce_back_url(),
-                "nir": None,
                 "selected_jobs": [request.GET["job_description_id"]] if "job_description_id" in request.GET else [],
             }
         )
@@ -294,123 +293,133 @@ class CheckNIRForJobSeekerView(ApplyStepForJobSeekerBaseView):
         }
 
 
-class CheckNIRForSenderView(ApplyStepForSenderBaseView):
-    template_name = "apply/submit_step_check_job_seeker_nir.html"
-
-    def __init__(self):
-        super().__init__()
-        self.form = None
-
-    def setup(self, request, *args, **kwargs):
-        super().setup(request, *args, **kwargs)
-        self.form = CheckJobSeekerNirForm(job_seeker=None, data=request.POST or None)
-
-    def post(self, request, *args, **kwargs):
-        if self.form.data.get("skip"):
-            # Redirect to search by e-mail address.
-            return HttpResponseRedirect(reverse("apply:check_email_for_sender", kwargs={"siae_pk": self.siae.pk}))
-
-        context = {}
-        if self.form.is_valid():
-            job_seeker = self.form.get_job_seeker()
-
-            # No user found with that NIR, save the NIR in the session and redirect to search by e-mail address.
-            if not job_seeker:
-                self.apply_session.set("nir", self.form.cleaned_data["nir"])
-                return HttpResponseRedirect(reverse("apply:check_email_for_sender", kwargs={"siae_pk": self.siae.pk}))
-
-            # The NIR we found is correct
-            if self.form.data.get("confirm"):
-                return HttpResponseRedirect(
-                    reverse(
-                        "apply:step_check_job_seeker_info",
-                        kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": job_seeker.pk},
-                    )
-                )
-
-            context = {
-                # Ask the sender to confirm the NIR we found is associated to the correct user
-                "preview_mode": bool(self.form.data.get("preview")),
-                "job_seeker": job_seeker,
-                "can_view_personal_information": self.sender.can_view_personal_information(job_seeker),
-            }
-
-        return self.render_to_response(self.get_context_data(**kwargs) | context)
-
-    def get_context_data(self, **kwargs):
-        return super().get_context_data(**kwargs) | {
-            "form": self.form,
-            "form_action": reverse("apply:check_nir_for_sender", kwargs={"siae_pk": self.siae.pk}),
-        }
-
-
-class CheckEmailForSenderView(ApplyStepForSenderBaseView):
+class CheckJobSeekerForSenderView(ApplyStepForSenderBaseView):
     template_name = "apply/submit_step_job_seeker.html"
 
     def __init__(self):
         super().__init__()
         self.form = None
+        self.nir = None
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
-        self.form = UserExistsForm(initial=request.GET, data=request.POST or None)
+        initial = {}
+        if session_uuid := request.GET.get("from_session"):
+            # Similar job seeker found in create step 1
+            # User is coming back: retrieve nir & email from session if supplied
+            job_seeker_session = SessionNamespace(request.session, session_uuid)
+            if job_seeker_session.exists():
+                if nir := job_seeker_session.get("user", {}).get("nir"):
+                    initial["nir"] = nir
+                    self.nir = nir
+                if email := job_seeker_session.get("user", {}).get("email"):
+                    initial["email"] = email
+
+        self.form = CheckJobSeekerForSenderForm(
+            initial=initial,
+            data=request.POST or None,
+            with_email=(
+                # The user filled the email field
+                request.POST.get("email")
+                # The user clicked the button "Cliquez ici pour accéder à l'étape suivante"
+                or request.POST.get("step") == "email"
+                # The user is coming back from create user step 1
+                or "email" in initial
+            ),
+        )
 
     def post(self, request, *args, **kwargs):
         can_add_nir = False
-        preview_mode = False
+        preview_mode = ""
         job_seeker = None
+        nir = None
 
         if self.form.is_valid():
-            job_seeker = self.form.get_user()
-            nir = self.apply_session.get("nir") or ""
-            can_add_nir = nir and self.sender.can_add_nir(job_seeker)
+            if not self.form.with_email:
+                job_seeker = self.form.get_job_seeker()
 
-            # No user found with that email, redirect to create a new account.
-            if not job_seeker:
-                job_seeker_session = SessionNamespace.create_temporary(request.session)
-                job_seeker_session.init({"user": {"email": self.form.cleaned_data["email"], "nir": nir}})
-                return HttpResponseRedirect(
-                    reverse(
-                        "apply:create_job_seeker_step_1_for_sender",
-                        kwargs={"siae_pk": self.siae.pk, "session_uuid": job_seeker_session.name},
-                    )
-                )
-
-            # Ask the sender to confirm the email we found is associated to the correct user
-            if self.form.data.get("preview"):
-                preview_mode = True
-
-            # The email we found is correct
-            if self.form.data.get("confirm"):
-
-                if not can_add_nir:
-                    return HttpResponseRedirect(
-                        reverse(
-                            "apply:step_check_job_seeker_info",
-                            kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": job_seeker.pk},
+                if job_seeker is not None:
+                    # The NIR we found is correct
+                    if self.form.data.get("confirm"):
+                        return HttpResponseRedirect(
+                            reverse(
+                                "apply:step_check_job_seeker_info",
+                                kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": job_seeker.pk},
+                            )
                         )
-                    )
-
-                try:
-                    job_seeker.nir = nir
-                    job_seeker.lack_of_nir_reason = ""
-                    job_seeker.save(update_fields=["nir", "lack_of_nir_reason"])
-                except ValidationError:
-                    msg = mark_safe(
-                        f"Le<b> numéro de sécurité sociale</b> renseigné ({ nir }) est "
-                        "déjà utilisé par un autre candidat sur la Plateforme.<br>"
-                        "Merci de renseigner <b>le numéro personnel et unique</b> "
-                        "du candidat pour lequel vous souhaitez postuler."
-                    )
-                    messages.warning(request, msg)
-                    logger.exception("step_job_seeker: error when saving job_seeker=%s nir=%s", job_seeker, nir)
+                    if self.form.data.get("preview"):
+                        preview_mode = "nir"
                 else:
+                    # The NIR is valid but no job seeker found, let's try with an email
+                    self.form = CheckJobSeekerForSenderForm(
+                        {"nir": self.form.cleaned_data["nir"]},
+                        with_email=True,
+                    )
+                    # The template will check for errors but the user did not have the chance
+                    # to fill the email: hide the "required field" error preemptively
+                    self.form.full_clean()
+                    del self.form.errors["email"]
+
+            else:
+                job_seeker = self.form.get_user()
+                nir = self.form.cleaned_data.get("nir")
+                can_add_nir = nir and self.sender.can_add_nir(job_seeker)
+
+                # No user found with that email, redirect to create a new account.
+                if not job_seeker:
+                    job_seeker_session = SessionNamespace.create_temporary(request.session)
+                    job_seeker_session.init({"user": {"email": self.form.cleaned_data["email"], "nir": nir}})
                     return HttpResponseRedirect(
                         reverse(
-                            "apply:step_check_job_seeker_info",
-                            kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": job_seeker.pk},
+                            "apply:create_job_seeker_step_1_for_sender",
+                            kwargs={"siae_pk": self.siae.pk, "session_uuid": job_seeker_session.name},
                         )
                     )
+
+                # Ask the sender to confirm the email we found is associated to the correct user
+                if self.form.data.get("preview"):
+                    preview_mode = "email"
+
+                # The email we found is correct
+                if self.form.data.get("confirm"):
+
+                    if not can_add_nir:
+                        return HttpResponseRedirect(
+                            reverse(
+                                "apply:step_check_job_seeker_info",
+                                kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": job_seeker.pk},
+                            )
+                        )
+
+                    try:
+                        job_seeker.nir = nir
+                        job_seeker.lack_of_nir_reason = ""
+                        job_seeker.save(update_fields=["nir", "lack_of_nir_reason"])
+                    except ValidationError:
+                        msg = mark_safe(
+                            f"Le<b> numéro de sécurité sociale</b> renseigné ({ nir }) est "
+                            "déjà utilisé par un autre candidat sur la Plateforme.<br>"
+                            "Merci de renseigner <b>le numéro personnel et unique</b> "
+                            "du candidat pour lequel vous souhaitez postuler."
+                        )
+                        messages.warning(request, msg)
+                        logger.exception("step_job_seeker: error when saving job_seeker=%s nir=%s", job_seeker, nir)
+                    else:
+                        return HttpResponseRedirect(
+                            reverse(
+                                "apply:step_check_job_seeker_info",
+                                kwargs={"siae_pk": self.siae.pk, "job_seeker_pk": job_seeker.pk},
+                            )
+                        )
+        elif request.POST.get("step") == "email":
+            # Invalid from coming from "Cliquez ici pour accéder à l'étape suivante" button:
+            # - the provided nir was invalid: remove it
+            self.form.data |= {"nir": ""}
+            # - the user did not have the chance to fill the email: hide the "required field" error
+            del self.form.errors["email"]
+
+        if hasattr(self.form, "cleaned_data") and self.form.cleaned_data.get("nir"):
+            self.nir = self.form.cleaned_data.get("nir")
 
         return self.render_to_response(
             self.get_context_data(**kwargs)
@@ -425,8 +434,8 @@ class CheckEmailForSenderView(ApplyStepForSenderBaseView):
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
             "form": self.form,
-            "nir": self.apply_session.get("nir"),
             "siae": self.siae,
+            "nir": self.nir,
         }
 
 
@@ -469,7 +478,7 @@ class CreateJobSeekerStep1ForSenderView(CreateJobSeekerForSenderBaseView):
                 # If an existing job seeker matches the info, a confirmation is required
                 context["confirmation_needed"] = True
                 context["redacted_existing_email"] = redact_email_address(existing_job_seeker.email)
-                context["email_to_create"] = self.job_seeker_session.get("user", {}).get("email", "")
+                context["session_uuid"] = kwargs["session_uuid"]
 
             if not context["confirmation_needed"]:
                 self.job_seeker_session.set("user", self.job_seeker_session.get("user", {}) | self.form.cleaned_data)


### PR DESCRIPTION
### Pourquoi ?

Limite les risques de sessions concurrentes avec le NIR d'un onglet finissant sur le candidat d'un autre onglet.

Et à terme, on se rapproche de la suppression définitive de cette apply_session.
