### PR TITLE
Fiches salariés : Ne plus bloquer l'archivage quand seulement une échoue

### DIFF
--- a/itou/employee_record/management/commands/archive_employee_records.py
+++ b/itou/employee_record/management/commands/archive_employee_records.py
@@ -22,28 +22,14 @@ class Command(BaseCommand):
         self.stdout.write(f"Found {len(archivable)} archivable employee record(s)")
 
         archived_employee_records = []
-        # A bulk update will increase performance if there are a lot of employee records to update.
-        # However, if there is no performance issue, it is preferable to keep the archiving
-        # and validation logic in the model (update_as_archived).
-        # Update: let's bulk, with a batch size of 100 records
         for employee_record in archivable:
-            try:
-                # Do not trigger a save() call on the object
-                self.stdout.write(f"Archiving {employee_record.pk=}")
-                employee_record.update_as_archived(save=False)
-            except Exception as ex:
-                self.stdout.write(f"Can't archive {employee_record.pk=} {ex=}")
-            else:
-                archived_employee_records.append(employee_record)
+            self.stdout.write(f"Archiving {employee_record.pk=}")
+            if wet_run:
+                try:
+                    employee_record.update_as_archived()
+                except Exception as ex:
+                    self.stdout.write(f"Can't archive {employee_record.pk=} {ex=}")
+                else:
+                    archived_employee_records.append(employee_record)
 
-        self.stdout.write(f"{len(archived_employee_records)}/{len(archivable)} employee record(s) can be archived")
-
-        if wet_run:
-            updated = EmployeeRecord.objects.bulk_update(
-                archived_employee_records,
-                ["status", "updated_at", "archived_json"],
-                batch_size=100,
-            )
-            self.stdout.write(
-                f"{updated}/{len(archived_employee_records)}/{len(archivable)} employee record(s) were archived"
-            )
+        self.stdout.write(f"{len(archived_employee_records)}/{len(archivable)} employee record(s) were archived")

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -392,10 +392,7 @@ class EmployeeRecord(ASPExchangeInformation):
         self.status = Status.NEW
         self.save()
 
-    def update_as_archived(self, save=True):
-        """
-        :param save: Tell the method to call `.save()`
-        """
+    def update_as_archived(self):
         # We only archive an employee record when the job seeker's approval is expired and can not longer be prolonged
         if self.job_application.approval.is_valid() or self.job_application.approval.can_be_prolonged:
             raise InvalidStatusError(self.ERROR_EMPLOYEE_RECORD_INVALID_STATE)
@@ -404,11 +401,8 @@ class EmployeeRecord(ASPExchangeInformation):
         self.status = Status.ARCHIVED
         self.archived_json = None
 
-        if save:
+        with transaction.atomic():  # In case we failed the "unique_asp_id_approval_number" constraint
             self.save()
-        else:
-            # Override .save() update of `updated_at` when using bulk updates
-            self.updated_at = timezone.now()
 
     def update_as_processed_as_duplicate(self, archive):
         """

--- a/itou/employee_record/tests/__snapshots__/test_archive_employee_records.ambr
+++ b/itou/employee_record/tests/__snapshots__/test_archive_employee_records.ambr
@@ -4,7 +4,7 @@
   Start archiving employee records
   Found 1 archivable employee record(s)
   Archiving employee_record.pk=42
-  1/1 employee record(s) can be archived
+  0/1 employee record(s) were archived
   
   '''
 # ---
@@ -13,8 +13,7 @@
   Start archiving employee records
   Found 1 archivable employee record(s)
   Archiving employee_record.pk=42
-  1/1 employee record(s) can be archived
-  1/1/1 employee record(s) were archived
+  1/1 employee record(s) were archived
   
   '''
 # ---

--- a/itou/employee_record/tests/__snapshots__/test_archive_employee_records.ambr
+++ b/itou/employee_record/tests/__snapshots__/test_archive_employee_records.ambr
@@ -1,0 +1,20 @@
+# serializer version: 1
+# name: test_management_command_default_run
+  '''
+  Start archiving employee records
+  Found 1 archivable employee record(s)
+  Archiving employee_record.pk=42
+  1/1 employee record(s) can be archived
+  
+  '''
+# ---
+# name: test_management_command_wet_run
+  '''
+  Start archiving employee records
+  Found 1 archivable employee record(s)
+  Archiving employee_record.pk=42
+  1/1 employee record(s) can be archived
+  1/1/1 employee record(s) were archived
+  
+  '''
+# ---

--- a/itou/employee_record/tests/test_archive_employee_records.py
+++ b/itou/employee_record/tests/test_archive_employee_records.py
@@ -14,39 +14,26 @@ def command_fixture():
     return archive_employee_records.Command(stdout=io.StringIO(), stderr=io.StringIO())
 
 
-def test_management_command_default_run(command):
-    employee_record = factories.EmployeeRecordFactory(archivable=True)
+def test_management_command_default_run(command, snapshot):
+    employee_record = factories.EmployeeRecordFactory(pk=42, archivable=True)
     assert list(EmployeeRecord.objects.archivable()) == [employee_record]
 
     command.handle(wet_run=False)
     employee_record.refresh_from_db()
 
     assert employee_record.status != Status.ARCHIVED
-    assert command.stdout.getvalue().split("\n") == [
-        "Start archiving employee records",
-        "Found 1 archivable employee record(s)",
-        f"Archiving {employee_record.pk=}",
-        "1/1 employee record(s) can be archived",
-        "",
-    ]
+    assert command.stdout.getvalue() == snapshot
 
 
-def test_management_command_wet_run(command):
-    employee_record = factories.EmployeeRecordFactory(archivable=True)
+def test_management_command_wet_run(command, snapshot):
+    employee_record = factories.EmployeeRecordFactory(pk=42, archivable=True)
 
     command.handle(wet_run=True)
     employee_record.refresh_from_db()
 
     assert employee_record.status == Status.ARCHIVED
     assert employee_record.archived_json is None
-    assert command.stdout.getvalue().split("\n") == [
-        "Start archiving employee records",
-        "Found 1 archivable employee record(s)",
-        f"Archiving {employee_record.pk=}",
-        "1/1 employee record(s) can be archived",
-        "1/1/1 employee record(s) were archived",
-        "",
-    ]
+    assert command.stdout.getvalue() == snapshot
 
 
 def test_management_command_name(faker):


### PR DESCRIPTION

### Pourquoi ?

Pour ne pas bloquer l'archivage de toutes les FS si 1 seule échoue, et vu que le nombre de FS à archiver n'est pas énorme (74 en attente entre le 05/05 et le 10/05 donc ~15 par jour) la suppression du `bulk_update()` ne devrais pas être trop visible au niveau des performances.

Le cas rencontré est un PASS IAE avec 2 candidatures et 2 FS (1 `Intégrée` et 1 `Désactivée`), les 2 FS sont donc archivable mais la contrainte `unique_asp_id_approval_number` nous bloque car on se retrouve avec 2 FS ayant le même couple `asp_id`/`approval_number` et dont le statut n'est pas `Désactivée`.
Le changement ne corrige pas ce problème (devrais arriver dans un second temps) mais permet déjà de ne plus tout bloquer.
