### PR TITLE
Personnalisation de widgets de form field

### DIFF
--- a/itou/templates/django/forms/widgets/password.html
+++ b/itou/templates/django/forms/widgets/password.html
@@ -1,0 +1,9 @@
+<div class="input-group">
+    {% include "django/forms/widgets/input.html" %}
+    <div class="input-group-append">
+        <button class="btn btn-sm btn-link btn-ico" type="button" data-password="toggle">
+            <i class="ri-eye-line" aria-hidden="true"></i>
+            <span>Afficher</span>
+        </button>
+    </div>
+</div>


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Personnalisation-de-certains-bootstrap_field-17bf22aeb6ab4d90893c1a8da5e07f3f?pvs=4


### Pourquoi ?

Amélioration de l’ui et de l'inclusion automatique de l'input type="password"

### Comment 

En surchargant le templates dans le widgets du formulaire

### Captures d'écran <!-- optionnel -->
![capture 2023-05-11 à 16 09 15](https://github.com/betagouv/itou/assets/3874024/85e4e3ed-d469-49c5-af88-b3133d054e90)

### Remarque
Par contre, c'est un échec. Mis à part le password, je n'ai pas réussi à surcharger les autres inputs.

Explication >
Après quelques recherches et tests avec Romain. On peut conclure que certaines modifications pourront être faites directement avec de la surcharge de template dans les widgets. D'autres nécessiteraient de surcharger les renderer.py des django form et/ou de bootstrap form. Ces modifications impliquent une certaine charge de travail. Nous préférons donc attendre le passage à Bootstrap form 5 pour envisager cela.
