### PR TITLE
Airflow : Résolution d'un souci technique avec les vues

### DIFF
--- a/itou/metabase/db.py
+++ b/itou/metabase/db.py
@@ -63,14 +63,15 @@ def get_old_table_name(table_name):
 
 def rename_table_atomically(from_table_name, to_table_name):
     """
-    Rename from_table_name into to_table_name.
+    Rename from_table_name to to_table_name.
     Most of the time, we replace an existing table, so we will first rename
-    to_table_name into z_old_<to_table_name>.
-    This allows to take our time filling the new table without locking the current one.
+    to_table_name to z_old_<to_table_name>. Of course we first delete z_old_<to_table_name> if it exists.
+    This allows us to take our time filling the new table without locking the current one.
+    Note that the old table z_old_<to_table_name> is *not* deleted this time but will be at the beginning of
+    the next call of this function.
     """
 
     with MetabaseDatabaseCursor() as (cur, conn):
-        # Make sure the old table was deleted previously
         cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(get_old_table_name(to_table_name))))
         conn.commit()
         cur.execute(
@@ -85,8 +86,6 @@ def rename_table_atomically(from_table_name, to_table_name):
                 sql.Identifier(to_table_name),
             )
         )
-        conn.commit()
-        cur.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(get_old_table_name(to_table_name))))
         conn.commit()
 
 


### PR DESCRIPTION
Some airflow views (e.g. stg_structures) are built directly on top of C1 tables built by populate_metabase_emplois.py (e.g. structures). When the C1 table is being rebuilt (e.g. structures) the old version (e.g. z_old_structures) cannot and should not be deleted because a view (e.g. stg_structures) still depends on it. It will be deleted the next run, no biggie.

**Fil slack : https://itou-inclusion.slack.com/archives/C050D9JNJ9Z/p1683837006366749**

### Pourquoi ?

La MAJ C1 quotidienne casse actuellement quand elle reconstruit la table `structures` :

```
psycopg2.errors.DependentObjectsStillExist: cannot drop table z_old_structures because other objects depend on it
DETAIL:  view stg_structures depends on table z_old_structures
```

C'est nouveau parce qu'une PR récente a introduit pour la première fois une vue (staging) basée directement sur une table C1.

### Comment

En repoussant la suppression de l'ancienne table C1 au prochain run de `populate_metabase_emplois.py`.