### PR TITLE
Candidature: ajout des informations de NIR dans les parcours de création/mise à jour des profils de demandeur d'emploi

### DIFF
--- a/itou/common_apps/nir/forms.py
+++ b/itou/common_apps/nir/forms.py
@@ -56,14 +56,17 @@ class JobSeekerNIRUpdateMixin:
             # Disable NIR editing altogether if the job seeker already has one
             self.fields["nir"].disabled = True
             self.fields["lack_of_nir"].widget = forms.HiddenInput()
-            if not self.instance.is_handled_by_proxy and self.instance != editor:
-                nir_help_text = (
-                    "Ce candidat a pris le contrôle de son compte utilisateur. "
-                    "Vous ne pouvez pas modifier ses informations."
-                )
-            else:
-                nir_help_text = tally_link
-            self.fields["nir"].help_text = nir_help_text
+            if self.instance.pk:
+                # These messages should only appear when updating a job seeker
+                # and not when creating one
+                if not self.instance.is_handled_by_proxy and self.instance != editor:
+                    nir_help_text = (
+                        "Ce candidat a pris le contrôle de son compte utilisateur. "
+                        "Vous ne pouvez pas modifier ses informations."
+                    )
+                else:
+                    nir_help_text = tally_link
+                self.fields["nir"].help_text = nir_help_text
         else:
             self.fields["nir"].help_text = "Numéro à 15 chiffres."
 

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
@@ -12,6 +12,9 @@
         {% bootstrap_field form.title %}
         {% bootstrap_field form.first_name %}
         {% bootstrap_field form.last_name %}
+        {% bootstrap_field form.nir %}
+        {% bootstrap_field form.lack_of_nir %}
+        {% bootstrap_field form.lack_of_nir_reason form_group_class=form.lack_of_nir_reason.field.form_group_class %}
         {% bootstrap_field form.birthdate %} {# TODO: Duet border-color button is not of the correct color #}
     </fieldset>
 

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load bootstrap4 %}
+{% load static %}
 
 {% block title %}
     {% if update_job_seeker %}
@@ -57,7 +58,7 @@
                         {% endif %}
                         <hr class="mt-5">
                         {% bootstrap_form_errors form type="all" %}
-                        <form method="post" class="js-collapsable-subfields">
+                        <form method="post" class="js-collapsable-subfields js-format-nir">
                             {% csrf_token %}
 
                             {% block form_content %}{% endblock %}
@@ -79,6 +80,8 @@
 
 {% block script %}
     {{ block.super }}
+    <script src="{% static 'js/split_nir.js' %}"></script>
+
     <script nonce="{{ CSP_NONCE }}">
         $(document).ready(() => {
             /**

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html
@@ -28,6 +28,16 @@
                                     <b>{{ profile.user.get_title_display }} {{ profile.user.get_full_name }}</b>
                                 </li>
                                 <li class="mb-3">
+                                    Numéro de sécurité sociale : 
+                                    {% if profile.user.nir %}
+                                        <b>{{ profile.user.nir|format_nir }}</b>
+                                    {% elif profile.user.lack_of_nir_reason %}
+                                        <b>{{ profile.user.get_lack_of_nir_reason_display }}</b>
+                                    {% else %}
+                                        <span>Non renseigné</span>
+                                    {% endif %}
+                                </li>
+                                <li class="mb-3">
                                     Date de naissance : <b>le {{ profile.user.birthdate }}</b>
                                 </li>
                             </ul>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -144,7 +144,7 @@ class CheckJobSeekerInfoForm(forms.ModelForm):
         self._meta.model.clean_pole_emploi_fields(self.cleaned_data)
 
 
-class CreateOrUpdateJobSeekerStep1Form(forms.ModelForm):
+class CreateOrUpdateJobSeekerStep1Form(JobSeekerNIRUpdateMixin, forms.ModelForm):
 
     REQUIRED_FIELDS = [
         "title",
@@ -170,6 +170,8 @@ class CreateOrUpdateJobSeekerStep1Form(forms.ModelForm):
     class Meta:
         model = User
         fields = [
+            "nir",
+            "lack_of_nir_reason",
             "title",
             "first_name",
             "last_name",

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -592,7 +592,7 @@ class CreateJobSeekerStepEndForSenderView(CreateJobSeekerForSenderBaseView):
         self.profile = None
 
     def _get_user_data_from_session(self):
-        return {k: v for k, v in self.job_seeker_session.get("user").items() if k not in ["city_slug"]}
+        return {k: v for k, v in self.job_seeker_session.get("user").items() if k not in ["city_slug", "lack_of_nir"]}
 
     def _get_profile_data_from_session(self):
         # Dummy fields used by CreateOrUpdateJobSeekerStep3Form()


### PR DESCRIPTION
**Carte Notion : ** En préambule du pack "Déclaration d'embauche" (cf maquettes de https://www.notion.so/plateforme-inclusion/1-8-D-claration-d-embauche-rapide-Transformer-le-parcours-actuel-D-clarer-une-embauche-par-En-65bddac801ed4e2ca502eb981113ef72 et suivantes)

### Pourquoi ?

Pour pouvoir utiliser l'écran final comme récapitulatif des informations du candidat.

