### PR TITLE
Contrôle a posteriori: possibilité de créer des campagnes pour certaines DDETS uniquement

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -51,9 +51,9 @@ def validate_institution(institution_id):
         raise ValidationError(f"Sélectionnez une institution de type {InstitutionKind.DDETS}")
 
 
-def create_campaigns(evaluated_period_start_at, evaluated_period_end_at, ratio_selection_end_at):
+def create_campaigns(evaluated_period_start_at, evaluated_period_end_at, ratio_selection_end_at, institution_ids=None):
     """
-    Create a campaign for each institution whose kind is DDETS.
+    Create a campaign for each institution whose kind is DDETS (possibly limited by institution_ids).
     This method is intented to be executed manually, until it will be automised.
     """
 
@@ -63,6 +63,8 @@ def create_campaigns(evaluated_period_start_at, evaluated_period_end_at, ratio_s
     )
 
     institutions = Institution.objects.filter(kind=InstitutionKind.DDETS)
+    if institution_ids:
+        institutions = institutions.filter(pk__in=institution_ids)
 
     evaluation_campaign_list = EvaluationCampaign.objects.bulk_create(
         EvaluationCampaign(

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -277,6 +277,20 @@ class EvaluationCampaignManagerTest(TestCase):
         email = mail.outbox[1]
         assert len(email.to) == 2
 
+    def test_create_campaigns_on_specific_DDETS(self):
+        evaluated_period_start_at = timezone.now() - relativedelta(months=2)
+        evaluated_period_end_at = timezone.now() - relativedelta(months=1)
+        ratio_selection_end_at = timezone.now() + relativedelta(months=1)
+
+        institution_ids = InstitutionWith2MembershipFactory.create_batch(2, kind=InstitutionKind.DDETS)
+        assert 1 == create_campaigns(
+            evaluated_period_start_at,
+            evaluated_period_end_at,
+            ratio_selection_end_at,
+            institution_ids=[institution_ids[0].pk],
+        )
+        assert 1 == EvaluationCampaign.objects.all().count()
+
     def test_eligible_siaes(self):
 
         evaluation_campaign = EvaluationCampaignFactory()


### PR DESCRIPTION
### Pourquoi ?

Pour la future campagne, les DDETS auront des périodes différentes en fonction de leur participation à la dernière campagne de janvier à septembre.
