### PR TITLE
Affichage de la date de fin estimée du PASS IAE aux prescripteurs et employeurs

### DIFF
--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -51,7 +51,7 @@ Arguments:
     {% if common_approval.is_valid %}
         <p class="mb-1">Date de début : {{ common_approval.start_at|date:"d/m/Y" }}</p>
         <ul class="list-unstyled">
-            <li class="h4 mt-4 pb-2">
+            <li class="h4 mt-4 mb-2">
                 Nombre de jours restants sur le PASS IAE : {{ common_approval.remainder.days }} jour{{ common_approval.remainder.days|pluralize }} 
                 <i class="ri-information-line ri-xl"
                    data-toggle="tooltip"
@@ -61,6 +61,13 @@ Arguments:
             {% if job_application.is_pending and user.is_siae_staff %}
                 <li>
                     PASS IAE valide jusqu’au {{ common_approval.remainder_as_date|date:"d/m/Y" }}, si le contrat démarre aujourd’hui.
+                </li>
+            {% endif %}
+
+            {% if not job_application.is_pending and not user.is_job_seeker %}
+                <li class="pb-2">
+                    Date de fin prévisionnelle : {{ common_approval.end_at|date:"d/m/Y" }}
+                    <i class="ri-information-line ri-xl" data-toggle="tooltip" title="Cette date de fin est susceptible d'évoluer avec les éventuelles suspensions et prolongations du PASS IAE."></i>
                 </li>
             {% endif %}
         </ul>

--- a/itou/www/approvals_views/tests/test_detail.py
+++ b/itou/www/approvals_views/tests/test_detail.py
@@ -121,6 +121,10 @@ class TestApprovalDetailView:
             response,
             "PASS IAE valide jusqu’au 25/04/2025, si le contrat démarre aujourd’hui.",
         )
+        assertNotContains(
+            response,
+            "Date de fin prévisionnelle : 25/04/2025",
+        )
 
         job_application.state = JobApplicationWorkflow.STATE_ACCEPTED
         job_application.save()
@@ -214,7 +218,12 @@ class TestApprovalDetailView:
         response = client.get(url)
         assertNotContains(
             response,
-            "PASS IAE valide jusqu’au 25/04/2025, si le contrat démarre aujourd’hui.",
+            "PASS IAE valide jusqu’au 30/05/2025, si le contrat démarre aujourd’hui.",
+        )
+
+        assertContains(
+            response,
+            "Date de fin prévisionnelle : 30/05/2025",
         )
 
     def test_suspend_button(self, client):


### PR DESCRIPTION
[Carte Notion](https://www.notion.so/plateforme-inclusion/En-tant-que-SIAE-je-veux-voir-la-date-de-fin-pr-visionnelle-du-PASS-5a09e199a1004123892f570696fe08da)

### Pourquoi ?

Les employeurs se plaignent de la disparition de cette information.

### Captures d'écran

![image](https://github.com/betagouv/itou/assets/6150920/6c24a594-b4a4-45f7-a737-76378ea32eac)
