### PR TITLE
Fiches Salarié : Dédoublonnage des `Status.DISABLED` 1/2

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -55,14 +55,19 @@ class JobApplicationInline(admin.StackedInline):
     # there is no direct relation between approvals and employee records
     # (YET...)
     @staticmethod
-    @admin.display(description="Statut de la fiche salarié")
+    @admin.display(description="Fiches salariés")
     def employee_record_status(obj):
-        if employee_record := obj.employee_record.first():
-            debug = f"ID: {employee_record.id}"
-            if employee_record.is_orphan:
-                debug += ", ORPHAN"
-            return get_admin_view_link(
-                employee_record, content=mark_safe(f"<b>{employee_record.get_status_display()} ({debug})</b>")
+        if obj.employee_record.exists():
+            return mark_safe(
+                ", ".join(
+                    get_admin_view_link(
+                        er,
+                        content=mark_safe(
+                            f"<b>{er.get_status_display()} (ID: {er.pk}{', ORPHAN' if er.is_orphan else ''})</b>"
+                        ),
+                    )
+                    for er in obj.employee_record.all()
+                )
             )
 
         if not obj.to_siae.can_use_employee_record:

--- a/itou/employee_record/management/commands/uniquify_employee_records.py
+++ b/itou/employee_record/management/commands/uniquify_employee_records.py
@@ -1,0 +1,51 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Count
+
+from itou.employee_record.models import EmployeeRecord, Status
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+
+        parser.add_argument("--wet-run", action="store_true")
+
+    @transaction.atomic()
+    def handle(self, *, wet_run, **options):
+        self.stdout.write("Start to uniquify employee records")
+
+        duplicates = (
+            EmployeeRecord.objects.values("asp_id", "approval_number")
+            .annotate(cnt=Count("pk"))
+            .filter(cnt__gt=1)
+            .order_by("-cnt", "asp_id", "approval_number")
+        )
+        self.stdout.write(f"Found {len(duplicates)} asp_id/approval_number pairs with multiple employee records")
+
+        for duplicate in duplicates:
+            asp_id, approval_number = duplicate["asp_id"], duplicate["approval_number"]
+            self.stdout.write(f"Handle {asp_id=}/{approval_number=} pairs")
+
+            employee_records = (
+                EmployeeRecord.objects.filter(asp_id=asp_id, approval_number=approval_number)
+                .order_by("pk")
+                .values_list("pk", "status", "updated_at", named=True)
+            )
+
+            if {er.status for er in employee_records} == {Status.DISABLED}:  # Only DISABLED
+                # The last one in use should be the last one modified
+                keep = sorted(employee_records, key=lambda er: er.updated_at)[-1]
+            else:  # n DISABLED, 1 of another status
+                keep = [er for er in employee_records if er.status != Status.DISABLED][0]
+            discard = [er for er in employee_records if er.pk not in keep]
+            self.stdout.write(f" > Keeping {keep}, discarding {discard}")
+
+            assert keep.updated_at > max(er.updated_at for er in discard), "The kept object is not the most recent one"
+            if wet_run:
+                _, deleted = (
+                    EmployeeRecord.objects.filter(asp_id=asp_id, approval_number=approval_number)
+                    .exclude(pk=keep.pk)
+                    .delete()
+                )
+                self.stdout.write(f" > Successfully deleted: {deleted}")

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -1034,11 +1034,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             self.approval_delivery_mode = ""
             self.approval_manually_delivered_by = None
 
-        # Delete matching employee record, if any
-        employee_record = self.employee_record.first()
-        if employee_record:
-            employee_record.delete()
-
         # Send notification.
         user = kwargs.get("user")
         send_email_messages([self.email_cancel(cancelled_by=user)])

--- a/itou/utils/perms/employee_record.py
+++ b/itou/utils/perms/employee_record.py
@@ -12,13 +12,10 @@ def tunnel_step_is_allowed(job_application):
     Check if some steps of the tunnel are reachable or not
     given the current employee record status
     """
-    # Count is cheaper than fetching nothing
-    no_employee_record_yet = job_application.employee_record.count() == 0
-    if no_employee_record_yet:
-        return True
 
-    # There is an employee record
-    employee_record = job_application.employee_record.first()
+    employee_record = job_application.employee_record.order_by("-created_at").first()
+    if not employee_record:
+        return True
 
     return employee_record.status in [
         Status.NEW,

--- a/tests/approvals/__snapshots__/tests.ambr
+++ b/tests/approvals/__snapshots__/tests.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: CustomApprovalAdminViewsTest.test_employee_record_status_with_multiple_employee_records
+  '<a href="/admin/employee_record/employeerecord/42/change/"><b>Désactivée (ID: 42)</b></a>, <a href="/admin/employee_record/employeerecord/21/change/"><b>Nouvelle (ID: 21)</b></a>'
+# ---

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -876,6 +876,7 @@ class AutomaticApprovalAdminViewsTest(TestCase):
         assert approval.origin == Origin.PE_APPROVAL
 
 
+@pytest.mark.usefixtures("unittest_compatibility")
 class CustomApprovalAdminViewsTest(TestCase):
     def test_manually_add_approval(self):
         # When a Pôle emploi ID has been forgotten and the user has no NIR, an approval must be delivered
@@ -1033,6 +1034,12 @@ class CustomApprovalAdminViewsTest(TestCase):
         )
         msg = JobApplicationInline.employee_record_status(job_application)
         assert msg == "Une fiche salarié existe déjà pour ce candidat"
+
+    def test_employee_record_status_with_multiple_employee_records(self):
+        employee_record = EmployeeRecordFactory(pk=21)
+        EmployeeRecordFactory(pk=42, job_application=employee_record.job_application, status=Status.DISABLED)
+
+        assert JobApplicationInline.employee_record_status(employee_record.job_application) == self.snapshot
 
 
 class SuspensionQuerySetTest(TestCase):

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -483,20 +483,15 @@ class EmployeeRecordLifeCycleTest(TestCase):
         self.employee_record.update_as_disabled()
         assert self.employee_record.status == Status.DISABLED
 
-        # Now, can create new employee record on same job_application
-        new_employee_record = EmployeeRecord.from_job_application(self.employee_record.job_application)
-        assert new_employee_record.status == Status.NEW
+        # Employee record in DISABLED state block creating a new one
+        with pytest.raises(ValidationError):
+            EmployeeRecord.from_job_application(self.employee_record.job_application)
 
-        # Employee record in NEW state can be disable
-        new_employee_record.update_as_disabled()
-        assert new_employee_record.status == Status.DISABLED
-
-        # Now, can create another one employee record on same job_application
-        new_employee_record = EmployeeRecord.from_job_application(new_employee_record.job_application)
-        assert new_employee_record.status == Status.NEW
-
-        new_employee_record.update_as_ready()
-        assert new_employee_record.status == Status.READY
+        # Employee record in NEW state can be disabled
+        self.employee_record.update_as_new()
+        assert self.employee_record.status == Status.NEW
+        self.employee_record.update_as_disabled()
+        assert self.employee_record.status == Status.DISABLED
 
     @mock.patch(
         "itou.common_apps.address.format.get_geocoding_data",
@@ -512,12 +507,6 @@ class EmployeeRecordLifeCycleTest(TestCase):
         self.employee_record.update_as_rejected("12", "JSON Invalide", None)
         self.employee_record.update_as_disabled()
         assert self.employee_record.status == Status.DISABLED
-
-        # Now, can create new employee record on same job_application
-        new_employee_record = EmployeeRecord.from_job_application(self.employee_record.job_application)
-        assert new_employee_record.status == Status.NEW
-        new_employee_record.update_as_ready()
-        assert new_employee_record.status == Status.READY
 
     @mock.patch(
         "itou.common_apps.address.format.get_geocoding_data",


### PR DESCRIPTION
### Pourquoi ?

Avoir de multiple FS avec le même couple `asp_id`/`approval_number` bloque leurs archivages car la contrainte d'unicité `unique_asp_id_approval_number` désigne seulement `DISABLED` comme exclusion.
Ajouter `ARCHIVED` comme statut exclus à la contrainte aurais été une alternative mais cela me semble plus pérenne d’arrêter de considérer `DISABLED` comme un statut à part, cela permet également d'aligner un peu plus la représentation de nos FS avec celle de l'ASP (ils n'ont pas d'état et seule 1 peux exister à tout moment), mais aussi de couper court à la technique de déclarer de nouvelle embauche (donc des `JobApplication`) afin de renvoyer de la donnée vers l'ASP.

Sachant que :
- Depuis quelque mois on ne propose pas la FS dans "Nouvelle" si une équivalente (même `asp_id`, `approval_number`) existe et ce quelque soit sont statut, cela a dû réduire le nombre de doublon et personnes n'y a trouver à redire.
- Certaines de nos procédures officielles (pour les renvoyer, MAJ le SIRET suite à son changement) sont de désactiver/réactiver la FS

Volumétrie :
160 couples `asp_id`/`approval_number` sont concernés sur les 300k+ existants
3/160 ayant 3 FS, 157/160 ayant 2 FS. On supprimerais donc au final 163 FS.
3 date de 2023 (et j'ai regardé leur cas, elles n'avaient pas besoin d'être créées), 134 de 2022, et 20 de 2021.

### Comment <!-- optionnel -->

Commits
1. Continuation de dce56ba27a1ee5a024074e700ee1325c9c5fdb5b
2. Suppression de code mort et dangereux si il venait à revenir à la vie :zombie:
3. On ne permet plus la création de doublon en excluant `DISABLED` des filtres
4. Ajout d'une _management command_ pour dédoublonner les FS déjà existantes

La partie 2 sera de supprimer la condition excluant `Status.DISABLED` de la contrainte `unique_asp_id_approval_number` une fois le script `uniquify_employee_records` passé.

