### PR TITLE
Controle a posteriori: mise à jour des icones sur le tableau de bord

### DIFF
--- a/itou/templates/dashboard/includes/labor_inspector_evaluation_campains_card.html
+++ b/itou/templates/dashboard/includes/labor_inspector_evaluation_campains_card.html
@@ -12,12 +12,12 @@
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             {% if active_campaign.evaluations_asked_at %}
                                 <a href="{% url 'siae_evaluations_views:institution_evaluated_siae_list' active_campaign.pk %}" class="btn-link btn-ico">
-                                    <i class="ri-file-copy-2-line ri-lg font-weight-normal"></i>
+                                    <i class="ri-list-check-3 ri-lg font-weight-normal"></i>
                                     <span>Campagne en cours</span>
                                 </a>
                             {% else %}
                                 <a href="{% url 'siae_evaluations_views:samples_selection' %}" class="btn-link btn-ico">
-                                    <i class="ri-line-chart-line ri-lg font-weight-normal"></i>
+                                    <i class="ri-list-check-3 ri-lg font-weight-normal"></i>
                                     <span>Campagne en cours</span>
                                 </a>
                             {% endif %}

--- a/itou/templates/dashboard/includes/siae_evaluation_campains_card.html
+++ b/itou/templates/dashboard/includes/siae_evaluation_campains_card.html
@@ -10,7 +10,7 @@
                 {% for evaluated_siae in active_campaigns %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'siae_evaluations_views:siae_job_applications_list' evaluated_siae.pk %}" class="btn-link btn-ico">
-                            <i class="ri-file-copy-2-line ri-lg font-weight-normal"></i>
+                            <i class="ri-list-check-3 ri-lg font-weight-normal"></i>
                             <span>Justifier mes auto-prescriptions</span>
                         </a>
                         {# note vincentporte: static icon, will be displayed dynamically later.#}


### PR DESCRIPTION
### Pourquoi ?

L'icone `ri-line-chart-line` est déjà utilisée pour les tableaux de bord