### PR TITLE
Améliorer l’UI de l’étape de confirmation de création de la fiche salarié

### DIFF
--- a/itou/templates/employee_record/includes/create_step_5.html
+++ b/itou/templates/employee_record/includes/create_step_5.html
@@ -9,59 +9,43 @@
                 Récapitulatif et validation de la fiche salarié
             </legend>
 
-            {% if employee_record.status == 'READY' %}
-                <div class="mb-3 mb-md-5">
-                    <p>
-                        <b>La création de cette fiche salariée est terminée.</b>
-                    </p>
-                    <p>
-                        Vous pouvez suivre l'avancement de son traitement par l'ASP via la liste récapitulative accessible depuis le tableau de bord.
-                    </p>
-                    <a href="{% url "employee_record_views:list" %}?status=NEW" class="btn btn-link pl-0">
-                        Retour à la liste des fiches salarié
-                    </a>
-                </div>
+            <div class="mb-3 mb-md-5">
+                <p>
+                    Si ce récapitulatif est conforme et complet, <strong>la fiche salarié sera envoyée pour validation à l'ASP</strong>.
+                </p>
+                <p>
+                    Le traitement est effectué à intervalle régulier et vous serez notifié du changement d'état
+                    de la fiche salarié sur la liste récapitulative accessible depuis le tableau de bord.
+                </p>
+                <p class="mb-0">
+                    <i class="ri-error-warning-line ri-lg mr-1"></i><strong>Après validation de la fiche salarié, la modification de la date de début du PASS IAE n'est plus possible.</strong>
+                </p>
+            </div>
 
-                {% include "employee_record/includes/employee_record_summary.html" %}
-            {% else %}
-                <div class="mb-3 mb-md-5">
-                    <p>
-                        Si ce récapitulatif est conforme et complet, <strong>la fiche salarié sera envoyée pour validation à l'ASP</strong>.
-                    </p>
-                    <p>
-                        Le traitement est effectué à intervalle régulier et vous serez notifié du changement d'état
-                        de la fiche salarié sur la liste récapitulative accessible depuis le tableau de bord.
-                    </p>
-                    <p class="mb-0">
-                        <i class="ri-error-warning-line ri-lg mr-1"></i><strong>Après validation de la fiche salarié, la modification de la date de début du PASS IAE n'est plus possible.</strong>
-                    </p>
-                </div>
+            {% include "employee_record/includes/employee_record_summary.html" %}
 
-                {% include "employee_record/includes/employee_record_summary.html" %}
-
-                <form method="post" action="{% url "employee_record_views:create_step_5" employee_record.job_application.id %}" class="js-prevent-multiple-submit">
-                    {% csrf_token %}
-                    <hr class="mb-3">
-                    <div class="row">
-                        <div class="col-12">
-                            <div class="form-row align-items-center justify-content-lg-between">
-                                <div class="form-group col-12 col-md-6 col-lg-auto order-3 order-md-1">
-                                    <a href="{% url "employee_record_views:create_step_4" employee_record.job_application.id %}" class="btn btn-block btn-ico btn-link pl-0 justify-content-center" aria-label="Retour à l'étape précédente">
-                                        <i class="ri-arrow-left-line ri-lg"></i>
-                                        <span>Étape précédente</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
-                                    <button type="submit" class="btn btn-block btn-ico btn-primary">
-                                        <span>Valider la fiche salarié</span>
-                                        <i class="ri-arrow-right-line ri-lg"></i>
-                                    </button>
-                                </div>
+            <form method="post" action="{% url "employee_record_views:create_step_5" employee_record.job_application.id %}" class="js-prevent-multiple-submit">
+                {% csrf_token %}
+                <hr class="mb-3">
+                <div class="row">
+                    <div class="col-12">
+                        <div class="form-row align-items-center justify-content-lg-between">
+                            <div class="form-group col-12 col-md-6 col-lg-auto order-3 order-md-1">
+                                <a href="{% url "employee_record_views:create_step_4" employee_record.job_application.id %}" class="btn btn-block btn-ico btn-link pl-0 justify-content-center" aria-label="Retour à l'étape précédente">
+                                    <i class="ri-arrow-left-line ri-lg"></i>
+                                    <span>Étape précédente</span>
+                                </a>
+                            </div>
+                            <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
+                                <button type="submit" class="btn btn-block btn-ico btn-primary">
+                                    <span>Valider la fiche salarié</span>
+                                    <i class="ri-arrow-right-line ri-lg"></i>
+                                </button>
                             </div>
                         </div>
                     </div>
-                </form>
-            {% endif %}
+                </div>
+            </form>
         </div>
     </div>
     <div class="col-12 col-lg-4 order-1 order-lg-2 mb-3">

--- a/itou/utils/perms/employee_record.py
+++ b/itou/utils/perms/employee_record.py
@@ -22,7 +22,6 @@ def tunnel_step_is_allowed(job_application):
 
     return employee_record.status in [
         Status.NEW,
-        Status.READY,
         Status.REJECTED,
         Status.DISABLED,
     ]
@@ -46,7 +45,7 @@ def can_create_employee_record(request, job_application_id) -> JobApplication:
 
     # SIAE is eligible to employee record ?
     if not siae.can_use_employee_record:
-        raise PermissionDenied("Cette stucture ne peut pas utiliser la gestion des fiches salarié'.")
+        raise PermissionDenied("Cette structure ne peut pas utiliser la gestion des fiches salarié'.")
 
     # We want to reuse a job application in view, but first check that all is ok
     job_application = get_object_or_404(

--- a/itou/www/employee_record_views/tests/__snapshots__/test_create.ambr
+++ b/itou/www/employee_record_views/tests/__snapshots__/test_create.ambr
@@ -1,0 +1,10 @@
+# serializer version: 1
+# name: CreateEmployeeRecordStep5Test.test_employee_record_status
+  Message(
+    extra_tags='toast',
+    level=25,
+    level_tag='success',
+    message="La création de cette fiche salariée est terminée||Vous pouvez suivre l'avancement de son traitement par l'ASP en sélectionnant les différents statuts.",
+    tags='toast success',
+  )
+# ---

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -351,8 +351,18 @@ def create_step_5(request, job_application_id, template_name="employee_record/cr
     employee_record = job_application.employee_record.full_fetch().exclude(status=Status.DISABLED).latest("created_at")
 
     if request.method == "POST":
+        back_url = f'{reverse("employee_record_views:list")}?status={employee_record.status}'
         employee_record.update_as_ready()
-        return HttpResponseRedirect(reverse("employee_record_views:create_step_5", args=(job_application.pk,)))
+        toast_title, toast_message = (
+            "La création de cette fiche salariée est terminée",
+            "Vous pouvez suivre l'avancement de son traitement par l'ASP en sélectionnant les différents statuts.",
+        )
+        messages.success(
+            request,
+            "||".join([toast_title, toast_message]),
+            extra_tags="toast",
+        )
+        return HttpResponseRedirect(back_url)
 
     context = {
         "employee_record": employee_record,


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Am-liorer-l-UI-de-l-tape-de-confirmation-de-cr-ation-de-la-fiche-salari-0766ffb579c649a69b81619274e1dad6**

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

- Trop de texte présent sur la page
- On ne voit pas facilement où est le lien de retour 
- le récap des infos du profil salarié ne sont plus nécessaires une fois la fiche envoyée

### Comment <!-- optionnel -->

Voir #2529 pour la mécanique des toasts

Commits : 
1. On ne gère plus le réaffichage de la FS en dernière étape
2. On n'autorise plus les FS prête à être envoyées d'être éditées dans le tunnel