### PR TITLE
Utilisation des `messages` de Django afin d'afficher des toasts Bootstrap

### DIFF
--- a/itou/templates/bootstrap4/messages.html
+++ b/itou/templates/bootstrap4/messages.html
@@ -1,0 +1,9 @@
+{% load i18n bootstrap4 %}
+{% for message in messages %}
+    {% if "toast" not in message.tags %}
+        <div class="{{ message|bootstrap_message_classes }} alert-dismissible fade show" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="{% trans 'close' %}">&#215;</button>
+            {{ message }}
+        </div>
+    {% endif %}
+{% endfor %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -56,7 +56,7 @@
         {% include "layout/_header.html" %}
 
         <main id="main" role="main" class="s-main bg-gray-400">
-
+            <div class="toast-placement-wrapper" aria-live="polite" aria-atomic="true">{% include "utils/toasts.html" %}</div>
             <div class="container container-messages">
                 {% block messages %}
 
@@ -90,6 +90,14 @@
         <script src="{% static "vendor/jquery-ui-1.13.2/jquery-ui.min.js" %}"></script>
         <script src="{% static "vendor/theme-inclusion/javascripts/app.js" %}"></script>
 
+        <script nonce="{{ CSP_NONCE }}">
+            // Show any toasts that is already present in the DOM
+            $(document).ready(() => {
+                $(".toast-placement-wrapper").children(".toast").each(function () {
+                    $(this).toast("show");
+                });
+            });
+        </script>
         <script nonce="{{ CSP_NONCE }}">
 
             // Tarteaucitron's language is set according to the browser configuration

--- a/itou/templates/utils/toasts.html
+++ b/itou/templates/utils/toasts.html
@@ -1,0 +1,15 @@
+{% load theme_inclusion %}
+{% for message in messages %}
+    {% if "toast" in message.tags %}
+        <div class="toast {{ message|itou_toast_classes }}" role="status" aria-live="assertive" aria-atomic="true" data-autohide="false">
+            <div class="toast-header">
+                <i class="ri-check-line ri-lg mr-1" aria-hidden="true"></i>
+                <strong class="mr-auto">{{ message|itou_toast_title }}</strong>
+                <button type="button" class="close" data-dismiss="toast" aria-label="Fermer">
+                    <i class="ri-close-line"></i>
+                </button>
+            </div>
+            <div class="toast-body">{{ message|itou_toast_content }}</div>
+        </div>
+    {% endif %}
+{% endfor %}

--- a/itou/utils/templatetags/theme_inclusion.py
+++ b/itou/utils/templatetags/theme_inclusion.py
@@ -1,4 +1,5 @@
 from django import template
+from django.contrib.messages import constants as message_constants
 from django.templatetags.static import static
 
 
@@ -25,3 +26,26 @@ def static_theme_images(url_path):
         {% static_theme_images url_path %}
     """
     return static(f"{URL_THEME}images/{url_path}")
+
+
+TOAST_LEVEL_CLASSES = {
+    message_constants.INFO: "toast--info",
+    message_constants.SUCCESS: "toast--success",
+    message_constants.WARNING: "toast--warning",
+    message_constants.ERROR: "toast--danger",
+}
+
+
+@register.filter
+def itou_toast_classes(message):
+    return TOAST_LEVEL_CLASSES.get(message.level, "")
+
+
+@register.filter
+def itou_toast_title(message):
+    return message.message.split("||", maxsplit=1)[0]
+
+
+@register.filter
+def itou_toast_content(message):
+    return message.message.split("||", maxsplit=1)[1]


### PR DESCRIPTION
### Pourquoi ?

Afin de pouvoir afficher un toast après une action serveur, demandé dans un ticket par les UX pour remplacer une page de résumé en fin de parcours.

Cas d'utilisation : #2528 

