### PR TITLE
Ajout d'un texte explicatif avant le formulaire d'inscription des facilitateurs

### DIFF
--- a/itou/templates/signup/facilitator_search.html
+++ b/itou/templates/signup/facilitator_search.html
@@ -14,6 +14,20 @@
 
     <h2 class="h1">Inscrire mon organisation porteuse de la clause sociale d’insertion</h2>
 
+    <p>
+        Cette inscription est soumise à des conditions qui ont été définies en lien avec nos partenaires publics et privés nationaux.
+    </p>
+    <p>
+        <span class="d-block">Les conditions suivantes sont nécessaires :</span>
+        <b>
+            La structure qui s’inscrit, pour un territoire donné, doit être porteuse d’un poste occupé par une personne ayant des compétences de facilitateur (reconnues et validées par le réseau national des facilitateurs) et s’engager à respecter les fondamentaux de la clause sociale.
+        </b>
+    </p>
+    <p>
+        Dans le cas contraire votre inscription sera déclarée non pertinente et votre compte sera désactivé.
+        Si vous souhaitez avoir davantage d’informations, vous pouvez contacter le réseau national des facilitateurs de la clause sociale, Alliance Villes Emploi : <a href="mailto:ave@ville-emploi.asso.fr" aria-label="Rédiger un e-mail à Alliance Villes Emploi">ave@ville-emploi.asso.fr</a>.
+    </p>
+
     <!-- this prevents the user from clicking on the "back" button of the browser -->
     <form method="post" class="js-prevent-multiple-submit">
 


### PR DESCRIPTION
[Carte Notion](https://www.notion.so/plateforme-inclusion/061d460f790a4d12b02ffb1f58fa723e?v=5bba2284c4ef442f98d35080ff535d6c&p=c36251e581a74c2683181105d33749b8&pm=c)

### Pourquoi ?

Les employeurs se trompent en se créant un compte facilitateur à tort.

### Captures d'écran

![image](https://github.com/betagouv/itou/assets/6150920/d555d18d-b5ee-4e9d-9012-69e49464b725)


