### PR TITLE
Exclusion des membres inactifs des exports CTA

### DIFF
--- a/itou/scripts/sql/cta_export.sql
+++ b/itou/scripts/sql/cta_export.sql
@@ -74,7 +74,7 @@ with siae_data as (
             on (siae_membership.user_id=u.id)
         inner join siaes_siae as siae
             on (siae.id=siae_membership.siae_id)
-    where u.kind='siae_staff'
+    where u.kind='siae_staff' and siae_membership.is_active
 ),
 
 org_data as (
@@ -106,7 +106,7 @@ org_data as (
             on (prescriber_membership.user_id=u.id)
         inner join prescribers_prescriberorganization as org
             on (org.id=prescriber_membership.organization_id)
-    where u.kind='prescriber'
+    where u.kind='prescriber' and prescriber_membership.is_active
 )
 
 select * from siae_data as siae


### PR DESCRIPTION
[Carte Notion](https://www.notion.so/plateforme-inclusion/061d460f790a4d12b02ffb1f58fa723e?v=5bba2284c4ef442f98d35080ff535d6c&p=68039c449cc54f0997ec049a0f76e9a9&pm=c)

### Pourquoi ?

Les membres inactifs (c'est-à-dire les membres dont la `membership` est inactive) figuraient dans l'export.