### PR TITLE
Correction du script merge-organizations

### DIFF
--- a/itou/prescribers/management/commands/merge_organizations.py
+++ b/itou/prescribers/management/commands/merge_organizations.py
@@ -137,4 +137,4 @@ class Command(BaseCommand):
         parser.add_argument("--wet-run", action=argparse.BooleanOptionalAction, default=False)
 
     def handle(self, from_id, to_id, *, wet_run, **options):
-        organization_merge_into(from_id, to_id, wet_run)
+        organization_merge_into(from_id, to_id, wet_run=wet_run)


### PR DESCRIPTION
### Pourquoi ?

Le script est cassé à cause d'un paramètre qui est considéré comme `positional` alors que c'est un `keyword only`.

