### PR TITLE
Fiches Salarié : Suppression du champs `notification_type` 1/2

### DIFF
--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -42,7 +42,6 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
         for employee_record in queryset:
             _, created = models.EmployeeRecordUpdateNotification.objects.update_or_create(
                 employee_record=employee_record,
-                notification_type=models.NotificationType.APPROVAL,
                 status=Status.NEW,
                 defaults={"updated_at": timezone.now},
             )
@@ -177,15 +176,11 @@ class EmployeeRecordUpdateNotificationAdmin(admin.ModelAdmin):
         "pk",
         "created_at",
         "updated_at",
-        "notification_type",
         "asp_processing_code",
         "status",
     )
 
-    list_filter = (
-        "status",
-        "notification_type",
-    )
+    list_filter = ("status",)
 
     raw_id_fields = ("employee_record",)
 

--- a/itou/employee_record/enums.py
+++ b/itou/employee_record/enums.py
@@ -26,15 +26,6 @@ class NotificationStatus(models.TextChoices):
     REJECTED = "REJECTED", "En erreur"
 
 
-class NotificationType(models.TextChoices):
-    """
-    Add a new type for each new employee record update notification.
-    """
-
-    APPROVAL = "APPROVAL", "Modification du PASS IAE"
-    JOB_SEEKER = "JOB_SEEKER", "Modification de l'employé"
-
-
 class MovementType(models.TextChoices):
     CREATION = "C", "Création"
     UPDATE = "M", "Modification"

--- a/itou/employee_record/factories.py
+++ b/itou/employee_record/factories.py
@@ -1,6 +1,6 @@
 import factory
 
-from itou.employee_record.enums import NotificationStatus, NotificationType
+from itou.employee_record.enums import NotificationStatus
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordUpdateNotification
 from itou.job_applications.factories import (
     JobApplicationWithApprovalNotCancellableFactory,
@@ -48,7 +48,6 @@ class EmployeeRecordWithProfileFactory(EmployeeRecordFactory):
 
 class BareEmployeeRecordUpdateNotificationFactory(factory.django.DjangoModelFactory):
     employee_record = factory.SubFactory(BareEmployeeRecordFactory)
-    notification_type = NotificationType.APPROVAL
     status = NotificationStatus.NEW
 
     class Meta:

--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -6,7 +6,7 @@ from django.db.models.functions import Greatest
 from django.utils import timezone
 
 from itou.approvals.models import Approval
-from itou.employee_record.enums import NotificationType, Status
+from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordUpdateNotification
 
 
@@ -196,7 +196,6 @@ class Command(BaseCommand):
             for employee_record in employee_record_with_missing_notification:
                 _, created = EmployeeRecordUpdateNotification.objects.update_or_create(
                     employee_record=employee_record,
-                    notification_type=NotificationType.APPROVAL,
                     status=Status.NEW,
                     defaults={"updated_at": timezone.now},
                 )

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -8,7 +8,7 @@ from sentry_sdk.crons import monitor
 
 from itou.approvals.models import Approval
 from itou.employee_record import constants
-from itou.employee_record.enums import MovementType, NotificationType, Status
+from itou.employee_record.enums import MovementType, Status
 from itou.employee_record.exceptions import SerializationError
 from itou.employee_record.mocks.fake_serializers import TestEmployeeRecordBatchSerializer
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch, EmployeeRecordUpdateNotification
@@ -176,7 +176,6 @@ class Command(EmployeeRecordTransferCommand):
                                 # Mimic the SQL function "create_employee_record_approval_notification()"
                                 EmployeeRecordUpdateNotification.objects.update_or_create(
                                     employee_record=employee_record,
-                                    notification_type=NotificationType.APPROVAL,
                                     defaults={"updated_at": timezone.now},
                                 )
 

--- a/itou/employee_record/migrations/0005_stop_using_notification_type_field.py
+++ b/itou/employee_record/migrations/0005_stop_using_notification_type_field.py
@@ -1,0 +1,102 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("employee_record", "0004_asp_exchange_information_abstract_model"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="employeerecordupdatenotification",
+            name="notification_type",
+            field=models.CharField(blank=True, max_length=20, null=True, verbose_name="Type de notification"),
+        ),
+        migrations.AddConstraint(
+            model_name="employeerecordupdatenotification",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("status", "NEW")), fields=("employee_record",), name="unique_new_employee_record"
+            ),
+        ),
+        migrations.RunSQL(
+            sql="""
+            CREATE OR REPLACE FUNCTION create_employee_record_approval_notification()
+                RETURNS TRIGGER AS $approval_notification$
+                DECLARE
+                    -- Must be declared for iterations
+                    current_employee_record_id INT;
+                BEGIN
+                    -- If there is an "UPDATE" action on 'approvals_approval' table (Approval model object):
+                    -- create an `EmployeeRecordUpdateNotification` object for each PROCESSED `EmployeeRecord`
+                    -- linked to this approval
+                    IF (TG_OP = 'UPDATE') THEN
+                        -- Only for update operations:
+                        -- iterate through processed employee records linked to this approval
+                        FOR current_employee_record_id IN
+                            SELECT id FROM employee_record_employeerecord
+                            WHERE approval_number = NEW.number
+                            AND status = 'PROCESSED'
+                            LOOP
+                                -- Create `EmployeeRecordUpdateNotification` object
+                                -- with the correct type and status
+                                INSERT INTO employee_record_employeerecordupdatenotification
+                                    (employee_record_id, created_at, updated_at, status)
+                                SELECT current_employee_record_id, NOW(), NOW(), 'NEW'
+                                -- Update it if already created (UPSERT)
+                                -- On partial indexes conflict, the where clause of the index must be added here
+                                ON conflict(employee_record_id) WHERE status = 'NEW'
+                                DO
+                                -- Not exactly the same syntax as a standard update op
+                                UPDATE SET updated_at = NOW();
+                            END LOOP;
+                    END IF;
+                    RETURN NULL;
+                END;
+            $approval_notification$ LANGUAGE plpgsql;
+            """,
+            reverse_sql="""
+            CREATE OR REPLACE FUNCTION create_employee_record_approval_notification()
+                RETURNS TRIGGER AS $approval_notification$
+                DECLARE
+                    -- Must be declared for iterations
+                    current_employee_record_id INT;
+                BEGIN
+                    -- If there is an "UPDATE" action on 'approvals_approval' table (Approval model object):
+                    -- create an `EmployeeRecordUpdateNotification` object for each PROCESSED `EmployeeRecord`
+                    -- linked to this approval
+                    IF (TG_OP = 'UPDATE') THEN
+                        -- Only for update operations:
+                        -- iterate through processed employee records linked to this approval
+                        FOR current_employee_record_id IN
+                            SELECT id FROM employee_record_employeerecord
+                            WHERE approval_number = NEW.number
+                            AND status = 'PROCESSED'
+                            LOOP
+                                -- Create `EmployeeRecordUpdateNotification` object
+                                -- with the correct type and status
+                                INSERT INTO employee_record_employeerecordupdatenotification
+                                    (employee_record_id, created_at, updated_at, status, notification_type)
+                                SELECT current_employee_record_id, NOW(), NOW(), 'NEW', 'APPROVAL'
+                                -- Update it if already created (UPSERT)
+                                -- On partial indexes conflict, the where clause of the index must be added here
+                                ON conflict(employee_record_id, notification_type) WHERE status = 'NEW'
+                                DO
+                                -- Not exactly the same syntax as a standard update op
+                                UPDATE SET updated_at = NOW();
+                            END LOOP;
+                    END IF;
+                    RETURN NULL;
+                END;
+            $approval_notification$ LANGUAGE plpgsql;
+            """,
+        ),
+        migrations.RunSQL(
+            sql="DROP INDEX IF EXISTS partial_unique_new_notification;",
+            reverse_sql="""
+            CREATE UNIQUE INDEX partial_unique_new_notification
+            ON employee_record_employeerecordupdatenotification (employee_record_id, notification_type)
+            WHERE status = 'NEW';
+            """,
+        ),
+    ]

--- a/itou/employee_record/tests/test_admin.py
+++ b/itou/employee_record/tests/test_admin.py
@@ -22,7 +22,6 @@ def test_schedule_approval_update_notification_when_notification_do_not_exists(a
     )
     notification = models.EmployeeRecordUpdateNotification.objects.latest("created_at")
     assert notification.employee_record == employee_record
-    assert notification.notification_type == models.NotificationType.APPROVAL
     assert notification.status == models.Status.NEW
     assert list(messages.get_messages(response.wsgi_request)) == [
         storage.base.Message(messages.SUCCESS, "1 notification planifiée"),
@@ -64,7 +63,6 @@ def test_schedule_approval_update_notification_when_other_than_new_notification_
     created_notification = models.EmployeeRecordUpdateNotification.objects.latest("created_at")
     assert created_notification != notification
     assert created_notification.employee_record == notification.employee_record
-    assert created_notification.notification_type == notification.notification_type
     assert created_notification.status == models.Status.NEW
     assert list(messages.get_messages(response.wsgi_request)) == [
         storage.base.Message(messages.SUCCESS, "1 notification planifiée"),

--- a/itou/employee_record/tests/tests_management_commands.py
+++ b/itou/employee_record/tests/tests_management_commands.py
@@ -4,7 +4,7 @@ import freezegun
 import pytest
 from django.test.utils import override_settings
 
-from itou.employee_record.enums import NotificationType, Status
+from itou.employee_record.enums import Status
 from itou.employee_record.mocks.transfer_employee_records import (
     SFTPAllDupsConnectionMock,
     SFTPBadConnectionMock,
@@ -185,7 +185,6 @@ class EmployeeRecordManagementCommandTest(ManagementCommandTestCase):
         self.employee_record.refresh_from_db()
 
         assert self.employee_record.update_notifications.count() == 1
-        assert self.employee_record.update_notifications.first().notification_type == NotificationType.APPROVAL
 
     @mock.patch("pysftp.Connection", SFTPAllDupsConnectionMock)
     @mock.patch(
@@ -201,4 +200,3 @@ class EmployeeRecordManagementCommandTest(ManagementCommandTestCase):
         self.employee_record.refresh_from_db()
 
         assert self.employee_record.update_notifications.count() == 1
-        assert self.employee_record.update_notifications.first().notification_type == NotificationType.APPROVAL


### PR DESCRIPTION
### Pourquoi ?

Ce champs est globalement inutile donc autant s'en débarrasser.
Dans cette première PR on ne référence ni n'utilise plus le champ, il sera supprimer définitivement dans un second temps.