### PR TITLE
Fiches salarié : Suppression de la désactivation automatique des fiches avec un `JobSeekerProfile()` incorrect

### DIFF
--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -75,14 +75,12 @@ class Command(BaseCommand):
 
     def _check_jobseeker_profiles(self, dry_run):
         # Check incoherence in user profile leading to validation errors at processing time.
-        # Employee records in this case are switched back to status NEW for further processing by end-user.
+        # Employee records in this case are switched back to status DISABLED for further processing by end-user.
         # Most frequent error cases are:
         # - no HEXA address
         # - no profile at all (?)
 
-        profile_selected = EmployeeRecord.objects.filter(
-            status__in=EmployeeRecord.CAN_BE_DISABLED_STATES
-        ).select_related(
+        profile_selected = EmployeeRecord.objects.filter(status=Status.PROCESSED).select_related(
             "job_application",
             "job_application__job_seeker__jobseeker_profile",
             "job_application__job_seeker__jobseeker_profile__hexa_commune",

--- a/itou/employee_record/tests/test_sanitize_employee_records.py
+++ b/itou/employee_record/tests/test_sanitize_employee_records.py
@@ -76,7 +76,7 @@ def test_profile_errors_check(command):
     # Check for profile errors during sanitize_employee_records
 
     # This factory does not define a profile
-    employee_record = factories.EmployeeRecordFactory()
+    employee_record = factories.EmployeeRecordFactory(status=models.Status.PROCESSED)
 
     command._check_jobseeker_profiles(dry_run=False)
 


### PR DESCRIPTION
### Pourquoi ?

En regardant le code je me suis rendu compte qu'on pourrais tout simplement supprimer la désactivation pour les `NEW` et `REJECTED` car ces statut vont faire passer l'utilisateur dans le tunnel de création et donc un `JobSeekerProfile()` sera créé au passage.
https://github.com/betagouv/itou/blob/50f1a0322f0de11187692dc167448ab7985226f7/itou/www/employee_record_views/views.py#L207

Cas pratique : Une SIAE change de SIRET, elle doit renvoyer une FS pour tout les salariés encore présent dans la structure, certain peuvent avoir été embauché avant l'interopérabilité, on doit donc créer une FS manuellement, ce salarié n'ayant jamais eu de FS auparavant il n'a pas de `JobSeekerProfile()`, la FS se retrouve `DISABLED` au prochain passage de `sanitize_employee_records`, l'employeur ne comprend pas où est la FS et si il faut bien la renvoyer ou pas.