### PR TITLE
Tentative de correction d'un test échouant aléatoirement

### DIFF
--- a/itou/www/signup/tests/test_siae.py
+++ b/itou/www/signup/tests/test_siae.py
@@ -268,7 +268,9 @@ class SiaeSignupTest(InclusionConnectBaseTestCase):
         ):
             response = self.client.get(url, {"siren": "402191662"})
         assert response.status_code == 200
-        self.assertContains(response, "EI", count=5)
+        self.assertContains(response, "402191662", count=6)  # 1 input + 5 results
+        for siae in siaes:
+            self.assertContains(response, siae.siret_nic, count=1)
 
 
 class SiaeSignupViewsExceptionsTest(TestCase):


### PR DESCRIPTION
### Pourquoi ?

CI en échec car il y a parfois 6 "EI", je suspecte que l'on retrouve parfois cette suite dans un nom de structure. Vu qu'on se fiche de vérifier précisément le type autant utilisé ce qu'on sais être unique et fixe.