### PR TITLE
Controle a posteriori: vérification des conditions dans les vues en plus des templates

### DIFF
--- a/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
@@ -220,6 +220,10 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
         self.assertNotContains(response, select_criteria)
         self.assertNotContains(response, upload_proof)
 
+        # Once the criteria has been submitted, you can't reupload it anymore
+        response = self.client.get(upload_proof)
+        assert response.status_code == 403
+
 
 class SiaeSelectCriteriaViewTest(TestCase):
     def setUp(self):
@@ -484,7 +488,6 @@ class SiaeUploadDocsViewTest(S3AccessingTestCase):
             evaluated_job_application=evaluated_job_application,
             administrative_criteria=criterion.administrative_criteria,
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
-            submitted_at=fake_now - relativedelta(days=1),
             uploaded_at=fake_now - relativedelta(days=1),
         )
         url = reverse(

--- a/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
@@ -223,6 +223,9 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
         # Once the criteria has been submitted, you can't reupload it anymore
         response = self.client.get(upload_proof)
         assert response.status_code == 403
+        # and you can't change or add criteria
+        response = self.client.get(select_criteria)
+        assert response.status_code == 403
 
 
 class SiaeSelectCriteriaViewTest(TestCase):

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -549,6 +549,11 @@ def siae_select_criteria(
         evaluated_siae__siae=siae,
         evaluated_siae__evaluation_campaign__ended_at__isnull=True,
     )
+    if (
+        evaluated_job_application.should_select_criteria
+        == evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.NOTEDITABLE
+    ):
+        return HttpResponseForbidden()
     initial_data = {
         eval_criterion.administrative_criteria.key: True
         for eval_criterion in evaluated_job_application.evaluated_administrative_criteria.all()

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.db.models import Min, Q
-from django.http import Http404, HttpResponseRedirect
+from django.http import Http404, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_list_or_404, get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
@@ -619,6 +619,9 @@ def siae_upload_doc(
         evaluated_job_application__evaluated_siae__siae=get_current_siae_or_404(request),
         evaluated_job_application__evaluated_siae__evaluation_campaign__ended_at__isnull=True,
     )
+
+    if not evaluated_administrative_criteria.can_upload():
+        return HttpResponseForbidden()
 
     form = SubmitEvaluatedAdministrativeCriteriaProofForm(
         instance=evaluated_administrative_criteria, data=request.POST or None


### PR DESCRIPTION
### Pourquoi ?

Éviter qu'un utilisateur puisse forger des requêtes pour contourner les vérifications des templates.

