### PR TITLE
crons : Uniformisation des wrappers shell afin qu'ils ne puissent pas être lancé plusieurs fois en parallèle

### DIFF
--- a/clevercloud/archive_employee_records.sh
+++ b/clevercloud/archive_employee_records.sh
@@ -6,8 +6,7 @@ if [[ "$EMPLOYEE_RECORD_CRON_ENABLED" != "1" ]]; then
 fi
 
 # About clever cloud cronjobs:
-# https://www.clever-cloud.com/doc/tools/crons/
-
+# https://www.clever-cloud.com/doc/administrate/cron/#deduplicating-crons
 if [[ "$INSTANCE_NUMBER" != "0" ]]; then
     echo "Instance number is ${INSTANCE_NUMBER}. Stop here."
     exit 0

--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -4,7 +4,7 @@ if [[ "$CRON_ENABLED" != "1" ]]; then
     exit 0
 fi
 
-cd "$APP_HOME" || exit 1
+cd "$APP_HOME" || exit
 
 set -o pipefail
 set -o errexit

--- a/clevercloud/crons/populate_metabase_matomo.sh
+++ b/clevercloud/crons/populate_metabase_matomo.sh
@@ -4,7 +4,7 @@ if [[ "$CRON_ENABLED" != "1" ]]; then
     exit 0
 fi
 
-cd "$APP_HOME" || exit 1
+cd "$APP_HOME" || exit
 
 set -o pipefail
 set -o errexit

--- a/clevercloud/download_employee_records.sh
+++ b/clevercloud/download_employee_records.sh
@@ -8,8 +8,7 @@ if [[ "$EMPLOYEE_RECORD_CRON_ENABLED" != "1" ]]; then
 fi
 
 # About clever cloud cronjobs:
-# https://www.clever-cloud.com/doc/tools/crons/
-
+# https://www.clever-cloud.com/doc/administrate/cron/#deduplicating-crons
 if [[ "$INSTANCE_NUMBER" != "0" ]]; then
     echo "Instance number is ${INSTANCE_NUMBER}. Stop here."
     exit 0

--- a/clevercloud/expire-elastic-indices.sh
+++ b/clevercloud/expire-elastic-indices.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/bash -l
 
+if [[ "$CRON_ENABLED" != "1" ]]; then
+    echo "Crons not enabled."
+    exit 0
+fi
+
+# About clever cloud cronjobs:
+# https://www.clever-cloud.com/doc/administrate/cron/#deduplicating-crons
+if [[ "$INSTANCE_NUMBER" != "0" ]]; then
+    echo "Instance number is ${INSTANCE_NUMBER}. Stop here."
+    exit 0
+fi
+
 cd "${APP_HOME}" || exit
 scripts/expire-elastic-indices

--- a/clevercloud/run_management_command.sh
+++ b/clevercloud/run_management_command.sh
@@ -7,5 +7,12 @@ if [[ "$CRON_ENABLED" != "1" ]]; then
     exit 0
 fi
 
+# About clever cloud cronjobs:
+# https://www.clever-cloud.com/doc/administrate/cron/#deduplicating-crons
+if [[ "$INSTANCE_NUMBER" != "0" ]]; then
+    echo "Instance number is ${INSTANCE_NUMBER}. Stop here."
+    exit 0
+fi
+
 cd "$APP_HOME"
 django-admin "$@"

--- a/clevercloud/send_approvals_to_pe.sh
+++ b/clevercloud/send_approvals_to_pe.sh
@@ -9,6 +9,6 @@ if [[ "$INSTANCE_NUMBER" != "0" ]]; then
     exit 0
 fi
 
-cd "$APP_HOME" || exit 1
+cd "$APP_HOME" || exit
 
 django-admin send_approvals_to_pe --wet-run --delay=1

--- a/clevercloud/status-probes.sh
+++ b/clevercloud/status-probes.sh
@@ -9,6 +9,6 @@ if [[ "$INSTANCE_NUMBER" != "0" ]]; then
     exit 0
 fi
 
-cd "$APP_HOME" || exit 1
+cd "$APP_HOME" || exit
 
 django-admin run_status_probes

--- a/clevercloud/upload_employee_records.sh
+++ b/clevercloud/upload_employee_records.sh
@@ -8,8 +8,7 @@ if [[ "$EMPLOYEE_RECORD_CRON_ENABLED" != "1" ]]; then
 fi
 
 # About clever cloud cronjobs:
-# https://www.clever-cloud.com/doc/tools/crons/
-
+# https://www.clever-cloud.com/doc/administrate/cron/#deduplicating-crons
 if [[ "$INSTANCE_NUMBER" != "0" ]]; then
     echo "Instance number is ${INSTANCE_NUMBER}. Stop here."
     exit 0


### PR DESCRIPTION
### Pourquoi ?

`expire-elastic-indices` est lancé 2 fois, sur `c1-prod` et `c1-worker` a priori.