### PR TITLE
Gestion des salariés et PASS IAE: vérifier la présence d'une candidature pour éditer les infos personnelles d'un candidat

### DIFF
--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -70,11 +70,14 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["can_view_personal_information"] = True  # SIAE members have access to personal info
-        context["can_edit_personal_information"] = self.request.user.can_edit_personal_information(self.object.user)
         context["approval_can_be_suspended_by_siae"] = self.object.can_be_suspended_by_siae(self.siae)
         context["hire_by_other_siae"] = not self.object.user.last_hire_was_made_by_siae(self.siae)
         context["approval_can_be_prolonged_by_siae"] = self.object.can_be_prolonged_by_siae(self.siae)
         job_application = self.get_job_application(self.object)
+        # For now, the view edit_job_seeker_info needs a job application to be able to edit personal information
+        context["can_edit_personal_information"] = job_application and self.request.user.can_edit_personal_information(
+            self.object.user
+        )
         context["job_application"] = job_application
         context["matomo_custom_title"] = "Profil salarié"
         if job_application:


### PR DESCRIPTION
### Pourquoi ?

Suite de https://github.com/betagouv/itou/pull/2535 qui a causé https://itou.sentry.io/issues/4207043425/?project=6164438

La vue `edit_job_seeker_info` a pour le moment besoin d'une candidature pour fonctionner donc on vérifie son existence avant d'y donner accès.

En cible bientôt, `edit_job_seeker_info` utiliser la pk du job seeker ce qui résoudra ce soucis.


