### PR TITLE
Modifier les informations personnelles: utilisation de la clef primaire du candidat au lieu de celle de la candidature

### DIFF
--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -63,7 +63,7 @@
     {% endif %}
 </ul>
 <p>
-    <a href="{% if can_edit_personal_information %}{% url 'dashboard:edit_job_seeker_info' job_application_id=job_application.pk %}?back_url={{ request.get_full_path|urlencode }}{% endif %}"
+    <a href="{% if can_edit_personal_information %}{% url 'dashboard:edit_job_seeker_info' job_seeker_pk=job_application.job_seeker_id %}?back_url={{ request.get_full_path|urlencode }}&from_application={{ job_application.pk }}{% endif %}"
        class="btn btn-outline-primary{% if with_matomo_event %} matomo-event{% endif %}{% if not can_edit_personal_information %} disabled{% endif %}"
        {% if with_matomo_event %}data-matomo-category="salaries" data-matomo-action="clic" data-matomo-option="modfifier-les-informations-personnelles"{% endif %}
        aria-label="Modifier les informations personnelles de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}">

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -2,13 +2,11 @@
 {% load bootstrap4 %}
 {% load static %}
 
-{% block title %}
-    Informations personnelles de {{ job_application.job_seeker.get_full_name|title }} {{ block.super }}
-{% endblock %}
+{% block title %}Informations personnelles de {{ job_seeker.get_full_name|title }} {{ block.super }}{% endblock %}
 
 {% block content %}
     <h1 class="h1-hero-c1">
-        Informations personnelles de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span>
+        Informations personnelles de <span class="text-muted">{{ job_seeker.get_full_name|title }}</span>
     </h1>
 
     <div class="alert alert-warning">

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -70,14 +70,11 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["can_view_personal_information"] = True  # SIAE members have access to personal info
+        context["can_edit_personal_information"] = self.request.user.can_edit_personal_information(self.object.user)
         context["approval_can_be_suspended_by_siae"] = self.object.can_be_suspended_by_siae(self.siae)
         context["hire_by_other_siae"] = not self.object.user.last_hire_was_made_by_siae(self.siae)
         context["approval_can_be_prolonged_by_siae"] = self.object.can_be_prolonged_by_siae(self.siae)
         job_application = self.get_job_application(self.object)
-        # For now, the view edit_job_seeker_info needs a job application to be able to edit personal information
-        context["can_edit_personal_information"] = job_application and self.request.user.can_edit_personal_information(
-            self.object.user
-        )
         context["job_application"] = job_application
         context["matomo_custom_title"] = "Profil salarié"
         if job_application:

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -840,8 +840,8 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
-        url = f"{url}?back_url={back_url}"
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = f"{url}?back_url={back_url}&from_application={job_application.pk}"
 
         response = self.client.get(url)
         self.assertContains(
@@ -904,7 +904,7 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
         url = f"{url}?back_url={back_url}"
 
         response = self.client.get(url)
@@ -949,7 +949,7 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
         url = f"{url}?back_url={back_url}"
 
         response = self.client.get(url)
@@ -1023,6 +1023,19 @@ class EditJobSeekerInfo(TestCase):
         job_application.job_seeker.save()
 
         self.client.force_login(user)
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        response = self.client.get(url)
+        assert response.status_code == 200
+
+    def test_edit_by_prescriber_with_job_application_URL(self):
+        job_application = JobApplicationFactory(sent_by_authorized_prescriber_organisation=True)
+        user = job_application.sender
+
+        # Ensure that the job seeker is not autonomous (i.e. he did not register by himself).
+        job_application.job_seeker.created_by = user
+        job_application.job_seeker.save()
+
+        self.client.force_login(user)
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
         response = self.client.get(url)
         assert response.status_code == 200
@@ -1041,7 +1054,7 @@ class EditJobSeekerInfo(TestCase):
             user=other_prescriber, organization=job_application.sender_prescriber_organization
         )
         self.client.force_login(other_prescriber)
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
         response = self.client.get(url)
         assert response.status_code == 200
 
@@ -1051,7 +1064,7 @@ class EditJobSeekerInfo(TestCase):
         user = job_application.sender
         self.client.force_login(user)
 
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
 
         response = self.client.get(url)
         assert response.status_code == 403
@@ -1063,7 +1076,7 @@ class EditJobSeekerInfo(TestCase):
         # Lambda prescriber not member of the sender organization
         prescriber = PrescriberFactory()
         self.client.force_login(prescriber)
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
 
         response = self.client.get(url)
         assert response.status_code == 403
@@ -1080,7 +1093,7 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
         url = f"{url}?back_url={back_url}"
 
         response = self.client.get(url)
@@ -1130,7 +1143,7 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
 
         back_url = reverse("apply:details_for_siae", kwargs={"job_application_id": job_application.id})
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_application_id": job_application.pk})
+        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
         url = f"{url}?back_url={back_url}"
 
         response = self.client.get(url)

--- a/itou/www/dashboard/urls.py
+++ b/itou/www/dashboard/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path("edit_user_info", views.edit_user_info, name="edit_user_info"),
     path("edit_user_notifications", views.edit_user_notifications, name="edit_user_notifications"),
     path("edit_job_seeker_info/<uuid:job_application_id>", views.edit_job_seeker_info, name="edit_job_seeker_info"),
+    path("edit_job_seeker_info/<int:job_seeker_pk>", views.edit_job_seeker_info, name="edit_job_seeker_info"),
     path("switch_siae", views.switch_siae, name="switch_siae"),
     path(
         "switch_prescriber_organization", views.switch_prescriber_organization, name="switch_prescriber_organization"


### PR DESCRIPTION
### Pourquoi ?

Cela facilitera la réutilisation du template `apply/includes/job_seeker_info.html` pour le parcours de "Déclaration d'embauche" où l'on ne dispose pas de candidature (créée uniquement à la fin du parcours)


