### PR TITLE
Increase realisms of some evaluation campaign tests

### DIFF
--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -1124,7 +1124,7 @@ class EvaluatedSiaeModelTest(TestCase):
             evaluated_job_application=evaluated_job_app,
             uploaded_at=timezone.now() - relativedelta(days=2),
             submitted_at=timezone.now() - relativedelta(days=1),
-            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED,
+            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2,
         )
         # Was not reviewed by the institution, assume valid (following rules in
         # most administrations).

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -801,7 +801,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
             evaluated_job_application=evaluated_job_app,
             uploaded_at=timezone.now() - relativedelta(days=2),
             submitted_at=timezone.now() - relativedelta(days=1),
-            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED,
+            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2,
         )
 
         self.client.force_login(self.user)


### PR DESCRIPTION
Documents refused after the reviewed_at (second phase) have their
criteria state at `REFUSED_2`, not `REFUSED`.