### PR TITLE
Suppression des mentions de l'API Entreprise de `api.gouv.fr`

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -370,12 +370,12 @@ API_BAN_BASE_URL = os.getenv("API_BAN_BASE_URL")
 # https://api.gouv.fr/api/api-geo.html#doc_tech
 API_GEO_BASE_URL = os.getenv("API_GEO_BASE_URL")
 
+# https://api.insee.fr/catalogue/site/pages/list-apis.jag
 API_INSEE_BASE_URL = os.getenv("API_INSEE_BASE_URL")
 API_INSEE_CONSUMER_KEY = os.getenv("API_INSEE_CONSUMER_KEY")
 API_INSEE_CONSUMER_SECRET = os.getenv("API_INSEE_CONSUMER_SECRET")
-
-# https://api.gouv.fr/documentation/sirene_v3
-API_ENTREPRISE_BASE_URL = f"{API_INSEE_BASE_URL}/entreprises/sirene/V3"
+# https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=Sirene&version=V3&provider=insee
+API_INSEE_SIRENE_BASE_URL = f"{API_INSEE_BASE_URL}/entreprises/sirene/V3"
 
 # Pôle emploi's Emploi Store Dev aka ESD. There is a production AND a recette environment.
 # Key and secrets are stored on pole-emploi.io (prod and recette) accounts, the values are not the

--- a/itou/prescribers/tests.py
+++ b/itou/prescribers/tests.py
@@ -212,7 +212,7 @@ class PrescriberOrganizationModelTest(TestCase):
     @respx.mock
     @override_settings(
         API_INSEE_BASE_URL="https://insee.fake",
-        API_ENTREPRISE_BASE_URL="https://entreprise.fake",
+        API_INSEE_SIRENE_BASE_URL="https://entreprise.fake",
         API_INSEE_CONSUMER_KEY="foo",
         API_INSEE_CONSUMER_SECRET="bar",
     )
@@ -224,7 +224,7 @@ class PrescriberOrganizationModelTest(TestCase):
         siret = ETABLISSEMENT_API_RESULT_MOCK["etablissement"]["siret"]
         organization = PrescriberOrganizationFactory(siret=siret, is_head_office=False)
 
-        respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/siret/{siret}").mock(
+        respx.get(f"{settings.API_INSEE_SIRENE_BASE_URL}/siret/{siret}").mock(
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
         )
 

--- a/itou/status/probes.py
+++ b/itou/status/probes.py
@@ -67,7 +67,7 @@ class GeoApiProbe(HttpProbe):
 class EntrepriseApiProbe(HttpProbe):
     name = "api.entreprise"
     verbose_name = "Entreprise API"
-    url = settings.API_ENTREPRISE_BASE_URL
+    url = settings.API_INSEE_SIRENE_BASE_URL
 
 
 class EmploiStoreDevAuthApiProbe(HttpProbe):

--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -43,14 +43,14 @@ def get_access_token():
 def etablissement_get_or_error(siret):
     """
     Return a tuple (etablissement, error) where error is None on success.
-    https://api.gouv.fr/documentation/sirene_v3
+    https://www.sirene.fr/static-resources/htm/siret_unitaire_variables_reponse.html
     """
 
     access_token = get_access_token()
     if not access_token:
         return None, "Problème de connexion à la base Sirene. Essayez ultérieurement."
 
-    url = f"{settings.API_ENTREPRISE_BASE_URL}/siret/{siret}"
+    url = f"{settings.API_INSEE_SIRENE_BASE_URL}/siret/{siret}"
     try:
         r = httpx.get(
             url,

--- a/itou/utils/apis/test_entreprise_api.py
+++ b/itou/utils/apis/test_entreprise_api.py
@@ -51,7 +51,7 @@ class INSEEApiTest(SimpleTestCase):
 
 @override_settings(
     API_INSEE_BASE_URL="https://fake.insee.url",
-    API_ENTREPRISE_BASE_URL="https://api.entreprise.fake.com",
+    API_INSEE_SIRENE_BASE_URL="https://api.entreprise.fake.com",
     API_INSEE_CONSUMER_KEY="foo",
     API_INSEE_CONSUMER_SECRET="bar",
 )
@@ -64,7 +64,7 @@ class ApiEntrepriseTest(SimpleTestCase):
             json=INSEE_API_RESULT_MOCK,
         )
 
-        self.siret_endpoint = respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/siret/26570134200148")
+        self.siret_endpoint = respx.get(f"{settings.API_INSEE_SIRENE_BASE_URL}/siret/26570134200148")
 
     @respx.mock
     def test_etablissement_get_or_error(self):

--- a/itou/utils/mocks/pole_emploi.py
+++ b/itou/utils/mocks/pole_emploi.py
@@ -1,8 +1,3 @@
-"""
-Result for a call to:
-https://entreprise.api.gouv.fr/v2/etablissements/26570134200148
-"""
-
 API_RECHERCHE_RESULT_KNOWN = {
     "idNationalDE": "ruLuawDxNzERAFwxw6Na4V8A8UCXg6vXM_WKkx5j8UQ",
     "codeSortie": "S001",

--- a/itou/www/signup/tests/test_prescriber.py
+++ b/itou/www/signup/tests/test_prescriber.py
@@ -33,7 +33,7 @@ from itou.www.signup.forms import PrescriberChooseKindForm
 
 @override_settings(
     API_INSEE_BASE_URL="https://insee.fake",
-    API_ENTREPRISE_BASE_URL="https://entreprise.fake",
+    API_INSEE_SIRENE_BASE_URL="https://entreprise.fake",
     API_INSEE_CONSUMER_KEY="foo",
     API_INSEE_CONSUMER_SECRET="bar",
 )
@@ -44,7 +44,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         respx.post(f"{settings.API_INSEE_BASE_URL}/token").mock(
             return_value=httpx.Response(200, json=INSEE_API_RESULT_MOCK)
         )
-        respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/siret/26570134200148").mock(
+        respx.get(f"{settings.API_INSEE_SIRENE_BASE_URL}/siret/26570134200148").mock(
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
         )
 
@@ -540,7 +540,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
 
         # Same SIRET as mock.
         siret = "26570134200148"
-        respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/siret/{siret}").mock(
+        respx.get(f"{settings.API_INSEE_SIRENE_BASE_URL}/siret/{siret}").mock(
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
         )
         existing_org_with_siret = PrescriberOrganizationFactory(siret=siret, kind=PrescriberOrganizationKind.ML)
@@ -605,7 +605,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
 
         # Same SIRET as mock but with same expected kind.
         siret = "26570134200148"
-        respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/siret/{siret}").mock(
+        respx.get(f"{settings.API_INSEE_SIRENE_BASE_URL}/siret/{siret}").mock(
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
         )
         prescriber_organization = PrescriberOrganizationFactory(siret=siret, kind=PrescriberOrganizationKind.PLIE)

--- a/itou/www/signup/tests/test_siae.py
+++ b/itou/www/signup/tests/test_siae.py
@@ -190,7 +190,7 @@ class SiaeSignupTest(InclusionConnectBaseTestCase):
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
     @override_settings(
         API_INSEE_BASE_URL="https://insee.fake",
-        API_ENTREPRISE_BASE_URL="https://entreprise.fake",
+        API_INSEE_SIRENE_BASE_URL="https://entreprise.fake",
         API_INSEE_CONSUMER_KEY="foo",
         API_INSEE_CONSUMER_SECRET="bar",
     )
@@ -207,7 +207,7 @@ class SiaeSignupTest(InclusionConnectBaseTestCase):
         }
 
         # Mocks an invalid answer from the server
-        respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/siret/{FAKE_SIRET}").mock(
+        respx.get(f"{settings.API_INSEE_SIRENE_BASE_URL}/siret/{FAKE_SIRET}").mock(
             return_value=httpx.Response(404, json={})
         )
         response = self.client.post(url, data=post_data)
@@ -215,7 +215,7 @@ class SiaeSignupTest(InclusionConnectBaseTestCase):
         self.assertContains(response, f"SIRET « {FAKE_SIRET} » non reconnu.")
 
         # Mock a valid answer from the server
-        respx.get(f"{settings.API_ENTREPRISE_BASE_URL}/siret/{FAKE_SIRET}").mock(
+        respx.get(f"{settings.API_INSEE_SIRENE_BASE_URL}/siret/{FAKE_SIRET}").mock(
             return_value=httpx.Response(200, json=ETABLISSEMENT_API_RESULT_MOCK)
         )
         response = self.client.post(url, data=post_data)


### PR DESCRIPTION
### Pourquoi ?

Pour ne pas laisser croire qu'on utilise une autre API que celle de l'INSEE pour la recherche par SIRET.


