### PR TITLE
Gestion des salariés et PASS IAE: correction d'un crash pour les Pass sans candidature

### DIFF
--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -69,12 +69,14 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["can_view_personal_information"] = True  # SIAE members have access to personal info
-        context["can_edit_personal_information"] = self.request.user.can_edit_personal_information(self.object.user)
         context["approval_can_be_suspended_by_siae"] = self.object.can_be_suspended_by_siae(self.siae)
         context["hire_by_other_siae"] = not self.object.user.last_hire_was_made_by_siae(self.siae)
         context["approval_can_be_prolonged_by_siae"] = self.object.can_be_prolonged_by_siae(self.siae)
         job_application = self.get_job_application(self.object)
         context["job_application"] = job_application
+        context["can_edit_personal_information"] = job_application and self.request.user.can_edit_personal_information(
+            self.object.user
+        )
         context["matomo_custom_title"] = "Profil salarié"
         if job_application:
             context["eligibility_diagnosis"] = job_application.get_eligibility_diagnosis()


### PR DESCRIPTION
### Pourquoi ?

Suite de https://github.com/betagouv/itou/pull/2560

Quand il n'y a pas de candidature liée, il ne faut pas essayer d'autoriser l'édition.

Cf https://itou.sentry.io/issues/4207043425/activity/?project=6164438


