### PR TITLE
templates: rendre job_seeker_info.html utilisable sans candidature

### DIFF
--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -2,33 +2,33 @@
 {% load str_filters %}
 <ul>
     <li>
-        Prénom : <b>{{ job_application.job_seeker.first_name|mask_unless:can_view_personal_information }}</b>
+        Prénom : <b>{{ job_seeker.first_name|mask_unless:can_view_personal_information }}</b>
     </li>
     <li>
-        Nom : <b>{{ job_application.job_seeker.last_name|mask_unless:can_view_personal_information }}</b>
+        Nom : <b>{{ job_seeker.last_name|mask_unless:can_view_personal_information }}</b>
     </li>
     <li>
         Numéro de sécurité sociale : 
-        {% if job_application.job_seeker.nir %}
-            <b>{{ job_application.job_seeker.nir|format_nir }}</b>
-        {% elif job_application.job_seeker.lack_of_nir_reason %}
-            <b>{{ job_application.job_seeker.get_lack_of_nir_reason_display }}</b>
+        {% if job_seeker.nir %}
+            <b>{{ job_seeker.nir|format_nir }}</b>
+        {% elif job_seeker.lack_of_nir_reason %}
+            <b>{{ job_seeker.get_lack_of_nir_reason_display }}</b>
         {% else %}
             <span>Non renseigné</span>
         {% endif %}
     </li>
     {% if can_view_personal_information %}
         <li>
-            Date de naissance : <b>{{ job_application.job_seeker.birthdate|date:"d/m/Y" }}</b>
+            Date de naissance : <b>{{ job_seeker.birthdate|date:"d/m/Y" }}</b>
         </li>
         <li>
-            E-mail : <a href="mailto:{{ job_application.job_seeker.email }}">{{ job_application.job_seeker.email }}</a>
+            E-mail : <a href="mailto:{{ job_seeker.email }}">{{ job_seeker.email }}</a>
         </li>
 
         <li>
             Téléphone : 
-            {% if job_application.job_seeker.phone %}
-                <a href="tel:{{ job_application.job_seeker.phone|cut:" " }}">{{ job_application.job_seeker.phone|format_phone }}</a>
+            {% if job_seeker.phone %}
+                <a href="tel:{{ job_seeker.phone|cut:" " }}">{{ job_seeker.phone|format_phone }}</a>
             {% else %}
                 <span>Non renseigné</span>
             {% endif %}
@@ -36,8 +36,8 @@
 
         <li>
             Adresse : 
-            {% if job_application.job_seeker.address_on_one_line %}
-                <b>{{ job_application.job_seeker.address_on_one_line }}</b>
+            {% if job_seeker.address_on_one_line %}
+                <b>{{ job_seeker.address_on_one_line }}</b>
             {% else %}
                 <span>Non renseignée</span>
             {% endif %}
@@ -45,8 +45,8 @@
 
         <li>
             Identifiant Pôle emploi : 
-            {% if job_application.job_seeker.pole_emploi_id %}
-                <b>{{ job_application.job_seeker.pole_emploi_id }}</b>
+            {% if job_seeker.pole_emploi_id %}
+                <b>{{ job_seeker.pole_emploi_id }}</b>
             {% else %}
                 <span>Non renseigné</span>
             {% endif %}
@@ -63,10 +63,10 @@
     {% endif %}
 </ul>
 <p>
-    <a href="{% if can_edit_personal_information %}{% url 'dashboard:edit_job_seeker_info' job_seeker_pk=job_application.job_seeker_id %}?back_url={{ request.get_full_path|urlencode }}&from_application={{ job_application.pk }}{% endif %}"
+    <a href="{% if can_edit_personal_information %}{% url 'dashboard:edit_job_seeker_info' job_seeker_pk=job_seeker.pk %}?back_url={{ request.get_full_path|urlencode }}{% if job_application %}&from_application={{ job_application.pk }}{% endif %}{% endif %}"
        class="btn btn-outline-primary{% if with_matomo_event %} matomo-event{% endif %}{% if not can_edit_personal_information %} disabled{% endif %}"
        {% if with_matomo_event %}data-matomo-category="salaries" data-matomo-action="clic" data-matomo-option="modfifier-les-informations-personnelles"{% endif %}
-       aria-label="Modifier les informations personnelles de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}">
+       aria-label="Modifier les informations personnelles de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}">
         Modifier les informations personnelles
     </a>
     {% if not can_edit_personal_information %}

--- a/itou/templates/apply/process_details_prescriber.html
+++ b/itou/templates/apply/process_details_prescriber.html
@@ -11,7 +11,7 @@
         <h2>Candidat</h2>
         <hr>
         <h3 >Informations personnelles</h3>
-        {% include "apply/includes/job_seeker_info.html" with job_application=job_application %}
+        {% include "apply/includes/job_seeker_info.html" with job_seeker=job_application.job_seeker job_application=job_application can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request only %}
         {% if job_application.to_siae.kind == SiaeKind.GEIQ and geiq_eligibility_diagnosis %}
  
             {# GEIQ eligibility details #}

--- a/itou/templates/apply/process_details_siae.html
+++ b/itou/templates/apply/process_details_siae.html
@@ -11,7 +11,7 @@
         <h2>Candidat</h2>
         <hr>
         <h3 >Informations personnelles</h3>
-        {% include "apply/includes/job_seeker_info.html" with job_application=job_application %}
+        {% include "apply/includes/job_seeker_info.html" with job_seeker=job_application.job_seeker job_application=job_application can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request only %}
         {% if job_application.to_siae.kind == SiaeKind.GEIQ %}
             {# GEIQ eligibility details #}
             {% include "apply/includes/geiq/geiq_diagnosis_details.html" with diagnosis=geiq_eligibility_diagnosis %}

--- a/itou/templates/approvals/detail.html
+++ b/itou/templates/approvals/detail.html
@@ -54,7 +54,7 @@
         <h2>Informations du salarié</h2>
         <hr>
         <h3>Informations personnelles</h3>
-        {% include "apply/includes/job_seeker_info.html" with with_matomo_event=True %}
+        {% include "apply/includes/job_seeker_info.html" with job_seeker=approval.user job_application=job_application with_matomo_event=True can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request only %}
         {# Eligibility ------------------------------------------------------------------------- #}
         {% include "apply/includes/eligibility_diagnosis.html" with eligibility_diagnosis=eligibility_diagnosis job_application=job_application %}
     </div>

--- a/itou/www/approvals_views/tests/test_detail.py
+++ b/itou/www/approvals_views/tests/test_detail.py
@@ -188,8 +188,6 @@ class TestApprovalDetailView:
             + 1  # template: approval.remainder fetches approval suspensions to compute remaining days
             + 1  # template: approval.suspensions_for_status_card lists approval suspensions
             + 1  # template: approval.prolongations_for_status_card
-            # template: apply/includes/job_seeker_info.html
-            + 1  # get job_seeker information (job_application.job_seeker)
             # template: eligibility_diagnosis.html
             + 1  # prescribers_prescriberorganization (job_application.is_sent_by_authorized_prescriber)
             + 1  # get user infos (eligibility_diagnosis.author.get_full_name)

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -69,14 +69,12 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["can_view_personal_information"] = True  # SIAE members have access to personal info
+        context["can_edit_personal_information"] = self.request.user.can_edit_personal_information(self.object.user)
         context["approval_can_be_suspended_by_siae"] = self.object.can_be_suspended_by_siae(self.siae)
         context["hire_by_other_siae"] = not self.object.user.last_hire_was_made_by_siae(self.siae)
         context["approval_can_be_prolonged_by_siae"] = self.object.can_be_prolonged_by_siae(self.siae)
         job_application = self.get_job_application(self.object)
         context["job_application"] = job_application
-        context["can_edit_personal_information"] = job_application and self.request.user.can_edit_personal_information(
-            self.object.user
-        )
         context["matomo_custom_title"] = "Profil salarié"
         if job_application:
             context["eligibility_diagnosis"] = job_application.get_eligibility_diagnosis()


### PR DESCRIPTION
### Pourquoi ?

Pour faciliter son utilisation dans le nouveau parcours de "Déclaration d'embauche".

En bonus, on aura maintenant plus d'informations affichées dans la page de détail des Pass sans candidature.


