### PR TITLE
boost: La date de fin prévisionnelle du PASS IAE n’est pas visible pour le CANDIDAT

### DIFF
--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -64,7 +64,7 @@ Arguments:
                 </li>
             {% endif %}
 
-            {% if not job_application.is_pending and not user.is_job_seeker %}
+            {% if not job_application.is_pending %}
                 <li class="pb-2">
                     Date de fin prévisionnelle : {{ common_approval.end_at|date:"d/m/Y" }}
                     <i class="ri-information-line ri-xl" data-toggle="tooltip" title="Cette date de fin est susceptible d'évoluer avec les éventuelles suspensions et prolongations du PASS IAE."></i>

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -585,6 +585,7 @@ class DashboardViewTest(TestCase):
         self.assertContains(response, format_approval_number(approval))
         self.assertContains(response, "Date de début : 21/06/2022")
         self.assertContains(response, "Nombre de jours restants sur le PASS IAE : 82 jours")
+        self.assertContains(response, "Date de fin prévisionnelle : 06/12/2022")
 
     @override_settings(TALLY_URL="http://tally.fake")
     def test_prescriber_with_authorization_pending_dashboard_must_contain_tally_link(self):


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/BUG-La-date-de-fin-pr-visionnelle-du-PASS-IAE-n-est-pas-visible-dans-l-encart-du-PASS-cot-CANDIDA-e651b24e73004b73b897e7f4a9d67568

### Pourquoi ?

Le template d'affichage (en mode card) du PASS IAE n'affiche pas la date de fin prévisionnelle du contrat pour les candidats


![image](https://github.com/betagouv/itou/assets/147232/eba55d2c-a68d-4adf-86c0-93c0009c187c)

