### PR TITLE
Création automatique d'un profil de demandeur d'emploi à la création d'un demandeur d'emploi

### DIFF
--- a/itou/employee_record/tests/test_admin.py
+++ b/itou/employee_record/tests/test_admin.py
@@ -64,7 +64,7 @@ def test_schedule_approval_update_notification_when_other_than_new_notification_
 
 
 def test_job_seeker_profile_from_employee_record(admin_client):
-    er = factories.EmployeeRecordFactory()
+    er = factories.EmployeeRecordFactory(job_application__job_seeker__jobseeker_profile=False)
     job_seeker = er.job_application.job_seeker
     employee_record_view_url = reverse("admin:employee_record_employeerecord_change", args=[er.pk])
     add_jobseeker_profile_url = f"{reverse('admin:users_jobseekerprofile_add')}?user={job_seeker.pk}"

--- a/itou/employee_record/tests/test_sanitize_employee_records.py
+++ b/itou/employee_record/tests/test_sanitize_employee_records.py
@@ -76,8 +76,9 @@ def test_orphans_check(command):
 def test_profile_errors_check(command):
     # Check for profile errors during sanitize_employee_records
 
-    # This factory does not define a profile
-    employee_record = factories.EmployeeRecordFactory(status=models.Status.PROCESSED)
+    employee_record = factories.EmployeeRecordFactory(
+        status=models.Status.PROCESSED, job_application__job_seeker__jobseeker_profile=False
+    )
 
     command._check_jobseeker_profiles(dry_run=False)
 

--- a/itou/employee_record/tests/tests_models.py
+++ b/itou/employee_record/tests/tests_models.py
@@ -21,7 +21,6 @@ from itou.job_applications.factories import (
     JobApplicationFactory,
     JobApplicationWithApprovalNotCancellableFactory,
     JobApplicationWithCompleteJobSeekerProfileFactory,
-    JobApplicationWithJobSeekerProfileFactory,
     JobApplicationWithoutApprovalFactory,
 )
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
@@ -41,7 +40,7 @@ class EmployeeRecordModelTest(TestCase):
         with pytest.raises(ValidationError):
             # If the job seeker has no title (optional by default),
             # Then the job seeker profile must not be valid
-            job_application = JobApplicationWithJobSeekerProfileFactory()
+            job_application = JobApplicationWithApprovalNotCancellableFactory()
             job_application.job_seeker.title = None
             EmployeeRecord.from_job_application(job_application)
 
@@ -79,7 +78,7 @@ class EmployeeRecordModelTest(TestCase):
     def test_creation_without_jobseeker_profile(self):
         # Job seeker has no existing profile (must be filled before creation)
         with self.assertRaisesMessage(ValidationError, EmployeeRecord.ERROR_JOB_SEEKER_HAS_NO_PROFILE):
-            job_application = JobApplicationWithApprovalNotCancellableFactory()
+            job_application = JobApplicationWithApprovalNotCancellableFactory(job_seeker__jobseeker_profile=False)
             EmployeeRecord.from_job_application(job_application)
 
     def test_creation_from_job_application(self):
@@ -124,7 +123,7 @@ class EmployeeRecordModelTest(TestCase):
         - geoloc issues (no API mock on this test)
         """
         # Complete profile, but geoloc API not reachable
-        job_application = JobApplicationWithJobSeekerProfileFactory()
+        job_application = JobApplicationWithApprovalNotCancellableFactory()
 
         with pytest.raises(ValidationError):
             employee_record = EmployeeRecord.from_job_application(job_application)

--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -19,7 +19,6 @@ from itou.siaes.factories import SiaeFactory
 from itou.siaes.models import SiaeJobDescription
 from itou.users.factories import (
     JobSeekerFactory,
-    JobSeekerProfileFactory,
     JobSeekerProfileWithHexaAddressFactory,
     JobSeekerWithMockedAddressFactory,
     PrescriberFactory,
@@ -181,21 +180,6 @@ class JobApplicationWithApprovalNotCancellableFactory(JobApplicationFactory):
     hiring_end_at = factory.LazyFunction(lambda: datetime.now(timezone.utc).date() + relativedelta(years=2, days=-5))
 
 
-class JobApplicationWithJobSeekerProfileFactory(JobApplicationWithApprovalNotCancellableFactory):
-    """
-    This job application has a jobseeker with an EMPTY job seeker profile
-
-    Suitable for employee records tests
-    """
-
-    @factory.post_generation
-    def set_job_seeker_profile(self, create, extracted, **kwargs):
-        if not create:
-            # Simple build, do nothing.
-            return
-        JobSeekerProfileFactory(user=self.job_seeker).save()
-
-
 class JobApplicationWithCompleteJobSeekerProfileFactory(JobApplicationWithApprovalNotCancellableFactory):
     """
     This job application has a jobseeker with a COMPLETE job seeker profile
@@ -203,7 +187,7 @@ class JobApplicationWithCompleteJobSeekerProfileFactory(JobApplicationWithApprov
     Suitable for employee records tests
     """
 
-    job_seeker = factory.SubFactory(JobSeekerWithMockedAddressFactory)
+    job_seeker = factory.SubFactory(JobSeekerWithMockedAddressFactory, jobseeker_profile=False)
     sender_prescriber_organization = factory.SubFactory(PrescriberOrganizationWithMembershipFactory)
 
     @factory.post_generation
@@ -213,4 +197,4 @@ class JobApplicationWithCompleteJobSeekerProfileFactory(JobApplicationWithApprov
             return
         # Create a profile for current user
         # JobSeekerProfileWithHexaAddressFactory.build(user=self.job_seeker).save()
-        JobSeekerProfileWithHexaAddressFactory(user=self.job_seeker)
+        self.job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory(user=self.job_seeker)

--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -33,7 +33,6 @@ from itou.job_applications.factories import (
     JobApplicationSentByPrescriberOrganizationFactory,
     JobApplicationSentBySiaeFactory,
     JobApplicationWithApprovalNotCancellableFactory,
-    JobApplicationWithJobSeekerProfileFactory,
     JobApplicationWithoutApprovalFactory,
 )
 from itou.job_applications.models import JobApplication, JobApplicationTransitionLog, JobApplicationWorkflow
@@ -498,7 +497,7 @@ class JobApplicationQuerySetTest(TestCase):
         assert job_app in JobApplication.objects.eligible_as_employee_record(job_app.to_siae)
 
         # After employee record creation
-        job_app = JobApplicationWithJobSeekerProfileFactory()
+        job_app = JobApplicationWithApprovalNotCancellableFactory()
         employee_record = EmployeeRecordFactory(
             job_application=job_app,
             asp_id=job_app.to_siae.convention.asp_id,

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -1427,3 +1427,18 @@ def test_user_invalid_kind():
         match="Le type d’utilisateur est incorrect.",
     ):
         UserFactory(kind="")
+
+
+@pytest.mark.parametrize(
+    "user_kind,profile_expected",
+    [
+        (UserKind.JOB_SEEKER, True),
+        (UserKind.PRESCRIBER, False),
+        (UserKind.SIAE_STAFF, False),
+        (UserKind.LABOR_INSPECTOR, False),
+    ],
+)
+def test_save_creates_a_job_seeker_profile(user_kind, profile_expected):
+    user = User(kind=user_kind)
+    user.save()
+    assert hasattr(user, "jobseeker_profile") == profile_expected

--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -2167,7 +2167,6 @@ class UpdateJobSeekerViewTestCase(TestCase):
         }
         assert self.client.session[self.job_seeker_session_key] == expected_job_seeker_session
         self.job_seeker.refresh_from_db()
-        assert not self.job_seeker.has_jobseeker_profile
 
         # If you go back to step 3, new data is shown
         response = self.client.get(self.step_3_url)
@@ -2264,7 +2263,6 @@ class UpdateJobSeekerViewTestCase(TestCase):
         }
         assert self.client.session[self.job_seeker_session_key] == expected_job_seeker_session
         self.job_seeker.refresh_from_db()
-        assert not self.job_seeker.has_jobseeker_profile
 
         # If you go back to step 3, new data is shown
         response = self.client.get(self.step_3_url)
@@ -2384,8 +2382,7 @@ class UpdateJobSeekerViewTestCase(TestCase):
 class UpdateJobSeekerStep3ViewTestCase(TestCase):
     def test_job_seeker_with_profile_has_check_boxes_ticked_in_step3(self):
         siae = SiaeFactory(subject_to_eligibility=True, with_membership=True)
-        job_seeker = JobSeekerFactory()
-        JobSeekerProfileFactory(user=job_seeker, ass_allocation_since=AllocationDuration.FROM_6_TO_11_MONTHS)
+        job_seeker = JobSeekerFactory(jobseeker_profile__ass_allocation_since=AllocationDuration.FROM_6_TO_11_MONTHS)
 
         self.client.force_login(siae.members.first())
         apply_session = SessionNamespace(self.client.session, f"job_application-{siae.pk}")

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -638,7 +638,9 @@ class CreateJobSeekerStepEndForSenderView(CreateJobSeekerForSenderBaseView):
             messages.error(request, " ".join(e.messages))
             url = reverse("dashboard:index")
         else:
-            profile = JobSeekerProfile(user=user, **self._get_profile_data_from_session())
+            profile = user.jobseeker_profile
+            for k, v in self._get_profile_data_from_session().items():
+                setattr(profile, k, v)
             profile.save()
 
             try:

--- a/itou/www/employee_record_views/tests/test_create.py
+++ b/itou/www/employee_record_views/tests/test_create.py
@@ -52,6 +52,7 @@ class AbstractCreateEmployeeRecordTest(TestCase):
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
             job_seeker_with_address=True,
+            job_seeker__jobseeker_profile=False,
         )
 
         self.job_seeker = self.job_application.job_seeker
@@ -288,7 +289,7 @@ class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
         # Job seeker has an address filled but can't be geolocated
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
-            job_seeker=JobSeekerWithAddressFactory(),
+            job_seeker=JobSeekerWithAddressFactory(jobseeker_profile=False),
         )
         self.job_seeker = self.job_application.job_seeker
 
@@ -420,7 +421,7 @@ class CreateEmployeeRecordStep3Test(AbstractCreateEmployeeRecordTest):
         super().setUp()
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
-            job_seeker=JobSeekerWithMockedAddressFactory(),
+            job_seeker=JobSeekerWithMockedAddressFactory(jobseeker_profile=False),
         )
         self.job_seeker = self.job_application.job_seeker
         self.url = reverse("employee_record_views:create_step_3", args=(self.job_application.id,))
@@ -589,7 +590,7 @@ class CreateEmployeeRecordStep4Test(AbstractCreateEmployeeRecordTest):
         super().setUp()
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
-            job_seeker=JobSeekerWithMockedAddressFactory(),
+            job_seeker=JobSeekerWithMockedAddressFactory(jobseeker_profile=False),
         )
         self.job_seeker = self.job_application.job_seeker
         self.url = reverse("employee_record_views:create_step_4", args=(self.job_application.id,))
@@ -619,7 +620,7 @@ class CreateEmployeeRecordStep5Test(AbstractCreateEmployeeRecordTest):
         super().setUp()
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
-            job_seeker=JobSeekerWithMockedAddressFactory(),
+            job_seeker=JobSeekerWithMockedAddressFactory(jobseeker_profile=False),
         )
         self.job_seeker = self.job_application.job_seeker
         self.url = reverse("employee_record_views:create_step_5", args=(self.job_application.id,))
@@ -667,7 +668,7 @@ class UpdateRejectedEmployeeRecordTest(AbstractCreateEmployeeRecordTest):
         super().setUp()
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
-            job_seeker=JobSeekerWithMockedAddressFactory(),
+            job_seeker=JobSeekerWithMockedAddressFactory(jobseeker_profile=False),
         )
         self.job_seeker = self.job_application.job_seeker
         self.url = reverse("employee_record_views:create_step_5", args=(self.job_application.id,))

--- a/itou/www/signup/tests/test_job_seeker.py
+++ b/itou/www/signup/tests/test_job_seeker.py
@@ -117,6 +117,7 @@ class JobSeekerSignupTest(TestCase):
         job_seeker = User.objects.get(email=post_data["email"])
         assert nir == job_seeker.nir
         assert job_seeker.title == "M"
+        assert job_seeker.has_jobseeker_profile
 
     def test_job_seeker_temporary_nir(self):
         """
@@ -171,6 +172,7 @@ class JobSeekerSignupTest(TestCase):
         job_seeker = User.objects.get(email=post_data["email"])
         assert job_seeker.nir == ""
         assert job_seeker.title == "M"
+        assert job_seeker.has_jobseeker_profile
 
     def test_job_seeker_signup(self):
         """Job-seeker signup."""
@@ -212,6 +214,7 @@ class JobSeekerSignupTest(TestCase):
         assert user.username == uuid.UUID(user.username, version=4).hex
         assert user.kind == UserKind.JOB_SEEKER
         assert user.title == "M"
+        assert user.has_jobseeker_profile
 
         # Check `EmailAddress` state.
         assert user.emailaddress_set.count() == 1
@@ -290,6 +293,7 @@ class JobSeekerSignupTest(TestCase):
         mock_oauth_dance(self.client)
         job_seeker = User.objects.get(email=FC_USERINFO["email"])
         assert nir == job_seeker.nir
+        assert job_seeker.has_jobseeker_profile
 
     @respx.mock
     @override_settings(
@@ -314,3 +318,4 @@ class JobSeekerSignupTest(TestCase):
         mock_oauth_dance(self.client)
         job_seeker = User.objects.get(email=FC_USERINFO["email"])
         assert not job_seeker.nir
+        assert job_seeker.has_jobseeker_profile


### PR DESCRIPTION
### Pourquoi ?

Afin d'éviter de devoir vérifier si le profil existe partout, on souhaite généraliser son existence et cela commence par systématiquement en créer un.

Plutôt que d'aller le créer partout où on crée des `User` avec un `UserKind.JOB_SEEKER` (`CreateJobSeekerStepEndForSenderView`, 
`JobSeekerSignupForm`, `france_connect_callback`, l'admin et peut-être d'autres), il a semblé plus simple de systématiquement faire le `create` dans le  `User.save()`.

Cela a engendré quelques complications au niveau des factories (avec la `JobSeekerProfileFactory` qui crée un `User` comme dépendance, créant au passage un `JobSeekerProfile`, que la `JobSeekerProfileFactory` ne pourra plus créer mais qu'elle doit mettre à jour).

Comme un certain nombre de nos tests nécessitaient l'absence de `JobSeekerProfile`, je rajoute la clef `without_profile` pour facilement se débarasser du `JobSeekerProfile` en trop.