### PR TITLE
Modification de la déconnexion sur Inclusion Connect

### DIFF
--- a/itou/www/invitations_views/tests/tests_prescriber_organization.py
+++ b/itou/www/invitations_views/tests/tests_prescriber_organization.py
@@ -248,8 +248,8 @@ class TestAcceptPrescriberWithOrgInvitation(InclusionConnectBaseTestCase):
             previous_url=previous_url,
             next_url=next_url,
         )
-        # Follow the redirection.
-        response = self.client.get(response.url, follow=True)
+        # Inclusion connect redirects to previous_url
+        response = self.client.get(previous_url, follow=True)
         # Signup should have failed : as the email used in IC isn't the one from the invitation
         assertMessages(
             response,

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -193,8 +193,8 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
             previous_url=previous_url,
             next_url=next_url,
         )
-        # Follow the redirection.
-        response = self.client.get(response.url, follow=True)
+        # Inclusion connect redirects to previous_url
+        response = self.client.get(previous_url, follow=True)
         # Signup should have failed : as the email used in IC isn't the one from the invitation
         assertMessages(
             response,


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Inclusion-Connect-probl-me-avec-la-d-connexion-sur-la-refonte-Django-b6f9d0b71e1e4901aa840a4935c6ecbf?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Keycloak autorise un post sur l'URL de logout depuis le backend, ce qui n'est pas autorisé par les specs OIDC.

En prévision du déploiement de Inclusion Connect en django, cette PR rend le code compatible avec les specs OIDC.
