### PR TITLE
Controle a posteriori: simplification de code

### DIFF
--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -28,7 +28,7 @@
                     <div class="row mt-3">
                         <div class="col-12">
                             <p class="h2">Liste de mes auto-prescriptions à justifier</p>
-                            <p>Contrôle initié le {{ evaluations_asked_at|date:"d F Y" }}</p>
+                            <p>Contrôle initié le {{ evaluated_siae.evaluation_campaign.evaluations_asked_at|date:"d F Y" }}</p>
                         </div>
                     </div>
                     <div class="row">

--- a/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
@@ -90,7 +90,6 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
             + 2  # fetch siae membership and siae infos
             + 1  # fetch evaluated siae
             + 2  # fetch evaluatedjobapplication and its prefetched evaluatedadministrativecriteria
-            + 1  # aggregate min evaluation_campaign notification date
             + 1  # weird fetch siae membership
             # NOTE(vperron): the prefecth is necessary to check the SUBMITTABLE state of the evaluated siae
             # We do those requests "two times" but at least it's now accurate information, and we get
@@ -102,7 +101,6 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
         ):
             response = self.client.get(self.url(evaluated_siae))
 
-        assert evaluated_siae.evaluation_campaign.evaluations_asked_at == response.context["evaluations_asked_at"]
         assert evaluated_job_application == response.context["evaluated_job_applications"][0]
         assert reverse("dashboard:index") == response.context["back_url"]
 

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
-from django.db.models import Min, Q
+from django.db.models import Q
 from django.http import Http404, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_list_or_404, get_object_or_404, render
 from django.urls import reverse
@@ -522,16 +522,11 @@ def siae_job_applications_list(
         .prefetch_related("evaluated_administrative_criteria")
     )
 
-    evaluations_asked_at = evaluated_job_applications.aggregate(
-        date=Min("evaluated_siae__evaluation_campaign__evaluations_asked_at")
-    ).get("date")
-
     back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
 
     context = {
         "evaluated_siae": evaluated_siae,
         "evaluated_job_applications": evaluated_job_applications,
-        "evaluations_asked_at": evaluations_asked_at,
         "is_submittable": evaluated_siae.state == evaluation_enums.EvaluatedSiaeState.SUBMITTABLE,
         "back_url": back_url,
     }


### PR DESCRIPTION
### Pourquoi ?

Moins de requête, plus simple.
