### PR TITLE
BOOST : ajout de champ par défaut pour l'affichage si les descriptions de la fiche de poste sont absentes

### DIFF
--- a/itou/templates/siaes/includes/_job_description_details.html
+++ b/itou/templates/siaes/includes/_job_description_details.html
@@ -29,11 +29,13 @@
     <div class="mb-4">{{ job.market_context_description|linebreaks }}</div>
 {% endif %}
 
-<h3>Description du poste</h3>
-{% if job.description %}<div class="mb-4">{{ job.description|linebreaks }}</div>{% endif %}
+{% with no_content_message="La structure n'a pas encore renseigné cette rubrique" %}
+    <h3>Description du poste</h3>
+    <div class="mb-4">{{ job.description|default:no_content_message|linebreaks }}</div>
 
-<h3>Profil recherché et prérequis</h3>
-{% if job.profile_description %}<div class="mb-4">{{ job.profile_description|linebreaks }}</div>{% endif %}
+    <h3>Profil recherché et prérequis</h3>
+    <div class="mb-4">{{ job.profile_description|default:no_content_message|linebreaks }}</div>
+{% endwith %}
 
 {% if job.is_resume_mandatory %}
     <div class="alert alert-warning mb-4">

--- a/itou/www/siaes_views/tests/tests_job_description_views.py
+++ b/itou/www/siaes_views/tests/tests_job_description_views.py
@@ -480,3 +480,25 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             response = self.client.get(self.url)
 
         self.assertContains(response, "Postuler")
+
+    def test_display_placeholder_for_empty_fields(self):
+        response = self._login(self.user)
+        response = self.client.get(self.url)
+
+        # Job description created in setup has empty description fields
+        self.assertContains(response, "La structure n'a pas encore renseigné cette rubrique", count=2)
+
+        self.job_description.description = "a job description"
+        self.job_description.save()
+        response = self.client.get(self.url)
+
+        self.assertContains(response, "a job description")
+        self.assertContains(response, "La structure n'a pas encore renseigné cette rubrique")
+
+        self.job_description.profile_description = "a profile description"
+        self.job_description.save()
+        response = self.client.get(self.url)
+
+        self.assertContains(response, "a job description")
+        self.assertContains(response, "a profile description")
+        self.assertNotContains(response, "La structure n'a pas encore renseigné cette rubrique")


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/Fiche-de-poste-r-gles-d-affichage-lorsque-la-description-ou-certains-champs-sont-vides-boost-fc4c7bd2f7d647d995c415baa3719bd6

### Pourquoi ?

Si aucune description n'est saisie dans la fiche de poste, seul les titres de paragraphes sont affichés (moche).

### Captures d'écran 
![image](https://github.com/betagouv/itou/assets/147232/a6f0ac85-f2c2-4c82-8798-ffc2f744d4ce)

