### PR TITLE
BOOST: ne pas afficher les GEIQ, EA, EATT, OPCS comme étant des SIAE

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -28,7 +28,7 @@ from itou.job_applications.enums import (
     SenderKind,
 )
 from itou.job_applications.tasks import huey_notify_pole_emploi
-from itou.siaes.enums import ContractType, SiaeKind
+from itou.siaes.enums import SIAE_WITH_CONVENTION_KINDS, ContractType, SiaeKind
 from itou.siaes.models import Siae
 from itou.users.enums import UserKind
 from itou.utils.emails import get_email_message, send_email_messages
@@ -817,6 +817,9 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             not self.sender_prescriber_organization or not self.sender_prescriber_organization.is_authorized
         ):
             return "Orienteur"
+        elif self.sender_kind == SenderKind.SIAE_STAFF and self.to_siae.kind not in SIAE_WITH_CONVENTION_KINDS:
+            # Not an SIAE per se
+            return "Employeur"
         else:
             return SenderKind(self.sender_kind).label
 

--- a/itou/job_applications/tests/tests.py
+++ b/itou/job_applications/tests/tests.py
@@ -177,12 +177,17 @@ class JobApplicationModelTest(TestCase):
         assert not job_application2.candidate_has_employee_record
 
     def test_get_sender_kind_display(self):
+        non_siae_items = [
+            (JobApplicationSentBySiaeFactory(to_siae__kind=kind), "Employeur")
+            for kind in [SiaeKind.EA, SiaeKind.EATT, SiaeKind.GEIQ, SiaeKind.OPCS]
+        ]
         items = [
             [JobApplicationFactory(sent_by_authorized_prescriber_organisation=True), "Prescripteur"],
             [JobApplicationSentByPrescriberOrganizationFactory(), "Orienteur"],
             [JobApplicationSentBySiaeFactory(), "Employeur (SIAE)"],
             [JobApplicationSentByJobSeekerFactory(), "Demandeur d'emploi"],
-        ]
+        ] + non_siae_items
+
         for job_application, sender_kind_display in items:
             with self.subTest(sender_kind_display):
                 assert job_application.get_sender_kind_display() == sender_kind_display


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/Correction-du-type-d-employeur-dans-les-auto-prescriptions-boost-8c74736161a4417abd4bde54af91b9d6

### Pourquoi ?

N'afficher que la SIAE est ... une SIAE que lorsque c'est le cas dans le détail de la candidature
(les GEIQ, EA, EATT et OPCS ne sont pas des SIAE)

![image](https://github.com/betagouv/itou/assets/147232/7b1f8beb-c4b9-49bf-8e5b-a674d47830e4)


