### PR TITLE
Autoriser les utilisateurs Inclusion Connect à valider leur email sur un autre navigateur

### DIFF
--- a/itou/openid_connect/constants.py
+++ b/itou/openid_connect/constants.py
@@ -1,7 +1,10 @@
 import datetime
 
 
-# This expiration time has been set to 24 hours because Inclusion Connect's
-# email adress verification link is valid 24 hours.
-OIDC_STATE_EXPIRATION = datetime.timedelta(hours=24)
-OIDC_STATE_CLEANUP = datetime.timedelta(days=30)
+# This expiration time has been set to 1 month.
+# This will allow to help users that don't receive the email.
+# IC support team will manually validate the email in IC and ask the user to log in IC.
+# IC will then automatically redirect the user to our callback view, and it may be more than
+# 1 day after the state was generated, so keeping it "open" for a month is simpler.
+OIDC_STATE_EXPIRATION = datetime.timedelta(days=30)
+OIDC_STATE_CLEANUP = datetime.timedelta(days=30 * 2)

--- a/itou/openid_connect/france_connect/tests.py
+++ b/itou/openid_connect/france_connect/tests.py
@@ -95,7 +95,7 @@ class FranceConnectTest(TestCase):
             assert FranceConnectState.get_from_csrf(state).is_valid()
 
             state = FranceConnectState.save_state()
-        with freeze_time("2022-09-14 12:00:01"):
+        with freeze_time("2022-10-13 12:00:01"):
             assert not FranceConnectState.get_from_csrf(state).is_valid()
 
     def test_authorize(self):

--- a/itou/www/invitations_views/tests/tests_siae_accept.py
+++ b/itou/www/invitations_views/tests/tests_siae_accept.py
@@ -44,7 +44,7 @@ class TestAcceptInvitation(InclusionConnectBaseTestCase):
         assert current_siae in user.siae_set.all()
 
     @respx.mock
-    def test_accept_invitation_signup_(self):
+    def test_accept_invitation_signup(self):
         invitation = SentSiaeStaffInvitationFactory(email=OIDC_USERINFO["email"])
         response = self.client.get(invitation.acceptance_link, follow=True)
         self.assertContains(response, "logo-inclusion-connect-one-line.svg")

--- a/itou/www/signup/tests/test_prescriber.py
+++ b/itou/www/signup/tests/test_prescriber.py
@@ -121,10 +121,8 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         user = User.objects.get(email=email)
         assert user.kind == UserKind.PRESCRIBER
 
-        user_emails = user.emailaddress_set.all()
         # Emails are not checked in Django anymore.
-        # Make sure no confirmation email is sent.
-        assert len(user_emails) == 0
+        assert not user.emailaddress_set.exists()
 
         # Check organization.
         assert organization.is_authorized
@@ -135,6 +133,9 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         assert user.prescribermembership_set.count() == 1
         assert user.prescribermembership_set.get().organization_id == organization.pk
         assert user.siae_set.count() == 0
+
+        # No email has been sent to support (validation/refusal of authorisation not needed).
+        assert len(mail.outbox) == 0
 
     @respx.mock
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
@@ -190,11 +191,8 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         user = User.objects.get(email=OIDC_USERINFO["email"])
         assert user.kind == UserKind.PRESCRIBER
 
-        # Check `EmailAddress` state.
-        user_emails = user.emailaddress_set.all()
         # Emails are not checked in Django anymore.
-        # Make sure no confirmation email is sent.
-        assert len(user_emails) == 0
+        assert not user.emailaddress_set.exists()
 
         # Check organization.
         org = PrescriberOrganization.objects.get(siret=siret)
@@ -206,6 +204,11 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         assert user.prescribermembership_set.count() == 1
         membership = user.prescribermembership_set.get(organization=org)
         assert membership.is_admin
+
+        # Check email has been sent to support (validation/refusal of authorisation needed).
+        assert len(mail.outbox) == 1
+        subject = mail.outbox[0].subject
+        assert "Vérification de l'habilitation d'une nouvelle organisation" in subject
 
     @respx.mock
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
@@ -263,11 +266,8 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         user = User.objects.get(email=OIDC_USERINFO["email"])
         assert user.kind == UserKind.PRESCRIBER
 
-        # Check `EmailAddress` state.
-        user_emails = user.emailaddress_set.all()
         # Emails are not checked in Django anymore.
-        # Make sure no confirmation email is sent.
-        assert len(user_emails) == 0
+        assert not user.emailaddress_set.exists()
 
         # Check organization.
         org = PrescriberOrganization.objects.get(siret=siret)
@@ -279,6 +279,11 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         assert user.prescribermembership_set.count() == 1
         membership = user.prescribermembership_set.get(organization=org)
         assert membership.is_admin
+
+        # Check email has been sent to support (validation/refusal of authorisation needed).
+        assert len(mail.outbox) == 1
+        subject = mail.outbox[0].subject
+        assert "Vérification de l'habilitation d'une nouvelle organisation" in subject
 
     @respx.mock
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
@@ -353,11 +358,8 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         user = User.objects.get(email=OIDC_USERINFO["email"])
         assert user.kind == UserKind.PRESCRIBER
 
-        # Check `EmailAddress` state.
-        user_emails = user.emailaddress_set.all()
         # Emails are not checked in Django anymore.
-        # Make sure no confirmation email is sent.
-        assert len(user_emails) == 0
+        assert not user.emailaddress_set.exists()
 
         # Check organization.
         org = PrescriberOrganization.objects.get(siret=siret)
@@ -439,11 +441,8 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         user = User.objects.get(email=OIDC_USERINFO["email"])
         assert user.kind == UserKind.PRESCRIBER
 
-        # Check `EmailAddress` state.
-        user_emails = user.emailaddress_set.all()
         # Emails are not checked in Django anymore.
-        # Make sure no confirmation email is sent.
-        assert len(user_emails) == 0
+        assert not user.emailaddress_set.exists()
 
         # Check organization.
         org = PrescriberOrganization.objects.get(siret=siret)
@@ -579,11 +578,8 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         user = User.objects.get(email=OIDC_USERINFO["email"])
         assert user.kind == UserKind.PRESCRIBER
 
-        # Check `EmailAddress` state.
-        user_emails = user.emailaddress_set.all()
         # Emails are not checked in Django anymore.
-        # Make sure no confirmation email is sent.
-        assert len(user_emails) == 0
+        assert not user.emailaddress_set.exists()
 
         # Check membership.
         assert 0 == user.prescriberorganization_set.count()


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/BUG-Certains-de-nos-utilisateurs-ne-parviennent-pas-rejoindre-leur-organisation-lorsqu-ils-cr-ent-3bf1d9d4fa424087bd739c2638504403

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Gros irritant pour le support et les utilisateurs.
En attente du déploiement d'Inclusion Connect en Django 

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

