### PR TITLE
Candidature: nettoyage du NIR en session

### DIFF
--- a/itou/www/apply/tests/tests_submit.py
+++ b/itou/www/apply/tests/tests_submit.py
@@ -148,7 +148,6 @@ def test_check_nir_job_seeker_with_lack_of_nir_reason(client):
     session_data = client.session[f"job_application-{siae.pk}"]
     assert session_data == {
         "back_url": "/",
-        "nir": None,
         "selected_jobs": [],
     }
 
@@ -177,7 +176,6 @@ class ApplyAsJobSeekerTest(S3AccessingTestCase):
     def default_session_data(self):
         return {
             "back_url": "/",
-            "nir": None,
             "selected_jobs": [],
         }
 
@@ -426,7 +424,6 @@ class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
     def default_session_data(self):
         return {
             "back_url": "/",
-            "nir": None,
             "selected_jobs": [],
         }
 
@@ -978,7 +975,6 @@ class ApplyAsPrescriberTest(S3AccessingTestCase):
     def default_session_data(self):
         return {
             "back_url": "/",
-            "nir": None,
             "selected_jobs": [],
         }
 
@@ -1446,7 +1442,6 @@ class ApplyAsSiaeTest(S3AccessingTestCase):
     def default_session_data(self):
         return {
             "back_url": "/",
-            "nir": None,
             "selected_jobs": [],
         }
 
@@ -2423,7 +2418,6 @@ def test_detect_existing_job_seeker(client):
 
     default_session_data = {
         "back_url": "/",
-        "nir": None,
         "selected_jobs": [],
     }
 

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -220,7 +220,6 @@ class StartView(ApplyStepBaseView):
         self.apply_session.init(
             {
                 "back_url": self._coalesce_back_url(),
-                "nir": None,
                 "selected_jobs": [request.GET["job_description_id"]] if "job_description_id" in request.GET else [],
             }
         )


### PR DESCRIPTION
### Pourquoi ?

Oubli dans e11e45fb4d2aeed


