### PR TITLE
Controle a posteriori: validation automatique des revues complètes de la DDETS lors du passage en phase contradictoire

### DIFF
--- a/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
+++ b/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
@@ -1,0 +1,39 @@
+# serializer version: 1
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_accepted_but_not_reviewed[positive review email body]
+  '''
+  Bonjour,
+  
+  La DDETS 1 a validé la conformité des justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur les embauches réalisées en auto-prescription entre le 02 Octobre 2022 et le 02 Décembre 2022.
+  
+  Cette campagne de contrôle est terminée pour votre SIAE EI Prim’vert ID-1234.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_refused_but_not_reviewed[negative review email body]
+  '''
+  Bonjour,
+  
+  La DDETS 1 a vérifié tous les justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le 02 Octobre 2022 et le 02 Décembre 2022.
+  
+  Suite à cette vérification, un ou plusieurs justificatifs sont attendus par la DDETS 1.
+  
+  Rendez-vous sur le tableau de bord de EI Prim’vert ID-1234 à la rubrique “Justifier mes auto-prescriptions”.
+  
+  Les embauches avec le statut “nouveaux justificatifs à traiter”, nécessitent la transmission d’un nouveau justificatif pour chaque critère concerné. Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
+  
+  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://communaute.inclusion.beta.gouv.fr/doc/non-knowledgebase/controle-a-posteriori-pour-les-siae/
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---

--- a/itou/templates/siae_evaluations/email/to_siae_adversarial_stage_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_adversarial_stage_body.txt
@@ -2,7 +2,7 @@
 {% block body %}
 Bonjour,
 
-La {{evaluation_campaign.institution.name}} a vérifié tous les justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le {{evaluation_campaign.evaluated_period_start_at|date:"d E Y"}} et le {{evaluation_campaign.evaluated_period_end_at|date:"d E Y"}}
+La {{evaluation_campaign.institution.name}} a vérifié tous les justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le {{evaluation_campaign.evaluated_period_start_at|date:"d E Y"}} et le {{evaluation_campaign.evaluated_period_end_at|date:"d E Y"}}.
 
 Suite à cette vérification, un ou plusieurs justificatifs sont attendus par la {{evaluation_campaign.institution.name}}.
 


### PR DESCRIPTION
### Pourquoi ?

Si la DDETS a effectué toutes les revues mais a oublié de soumettre le résultat, la validation de leur contrôle est automatique à la fin de la phase 2 bis. Cela permet de s'assurer que toutes les SIAEs passent en phase contradictoire et qu'aucune ne reste en phase amiable.
