### PR TITLE
Inclusion connect: Retrait d’un assignement inutile

### DIFF
--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -53,7 +53,6 @@ class InclusionConnectSession:
 
     def bind_to_request(self, request):
         request.session[self.key] = dataclasses.asdict(self)
-        request.session.has_changed = True
 
 
 def _redirect_to_login_page_on_error(error_msg=None, request=None):


### PR DESCRIPTION
### Pourquoi ?

Voir le message de commit.