### PR TITLE
Contrôle a posteriori: différer la transmission du résultat par mail

### DIFF
--- a/itou/siae_evaluations/tests/__snapshots__/test_emails.ambr
+++ b/itou/siae_evaluations/tests/__snapshots__/test_emails.ambr
@@ -1,4 +1,22 @@
 # serializer version: 1
+# name: TestInstitutionEmailFactory.test_close_notifies_when_siae_has_negative_result[refused result email]
+  '''
+  Bonjour,
+  
+  Vous trouverez ci-après le résultat du contrôle a posteriori sur vos auto-prescriptions réalisées entre le 23 Octobre 2022 et le 23 Décembre 2022.
+  
+  La DDETS 01 a vérifié les nouveaux justificatifs transmis par votre structure EI les petits jardins ID-1000 dans le cadre de la phase contradictoire du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le 23 Octobre 2022 et le 23 Décembre 2022.
+  
+  Un ou plusieurs de vos justificatifs n’ont pas été validés par conséquent votre résultat concernant cette procédure est négatif (vous serez alerté des sanctions éventuelles concernant votre SIAE prochainement) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
 # name: TestInstitutionEmailFactory.test_close_notifies_when_siae_has_negative_result[sanction notification email]
   '''
   Bonjour,
@@ -8,6 +26,22 @@
   
   Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
   http://127.0.0.1:8000/siae_evaluation/institution_evaluated_siae_list/1/
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: TestInstitutionEmailFactory.test_close_notify_when_siae_has_positive_result_in_adversarial_phase[accepted result email]
+  '''
+  Bonjour,
+  
+  La DDETS 01 a validé la conformité des nouveaux justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur les embauches réalisées en auto-prescription entre le 07 Mars 2023 et le 07 Mai 2023.
+  
+  Cette campagne de contrôle est terminée pour votre SIAE EI les petits jardins ID-1000.
   
   Cordialement,
   

--- a/itou/siae_evaluations/tests/__snapshots__/test_emails.ambr
+++ b/itou/siae_evaluations/tests/__snapshots__/test_emails.ambr
@@ -1,0 +1,19 @@
+# serializer version: 1
+# name: TestInstitutionEmailFactory.test_close_notifies_when_siae_has_negative_result[sanction notification email]
+  '''
+  Bonjour,
+  
+  Suite au dernier contrôle a posteriori, une ou plusieurs SIAE de votre département ont obtenu un résultat négatif.
+  Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
+  
+  Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
+  http://127.0.0.1:8000/siae_evaluation/institution_evaluated_siae_list/1/
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---

--- a/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
+++ b/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
@@ -1,4 +1,130 @@
 # serializer version: 1
+# name: EvaluationCampaignManagerTest.test_close[no docs email body]
+  '''
+  Bonjour,
+  
+  Sauf erreur de notre part, vous n’avez pas transmis les justificatifs demandés dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le 01 Janvier 2022 et le 30 Septembre 2022.
+  
+  La DDETS 01 ne peut donc pas faire de contrôle, par conséquent votre résultat concernant cette procédure est négatif (vous serez alerté des sanctions éventuelles concernant votre SIAE prochainement) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
+  
+  Pour plus d’informations, vous pouvez vous rapprocher de la DDETS 01.
+  
+  Si vous avez déjà pris contact avec votre DDETS, merci de ne pas tenir compte de ce courriel.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_close[sanction notification email body]
+  '''
+  Bonjour,
+  
+  Suite au dernier contrôle a posteriori, une ou plusieurs SIAE de votre département ont obtenu un résultat négatif.
+  Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
+  
+  Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
+  http://127.0.0.1:8000/siae_evaluation/institution_evaluated_siae_list/1000/
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[force accepted email body]
+  '''
+  Bonjour,
+  
+  La campagne de contrôle a posteriori sur les embauches réalisées en auto-prescription entre le 02 Octobre 2022 et le 02 Décembre 2022 entre en phase contradictoire.
+  
+  La DDETS 1 n’a pas étudié la conformité des justificatifs que vous avez transmis dans le délai imparti. Par conséquent, vos auto-prescriptions sont considérées comme conformes.
+  
+  Cette campagne de contrôle est terminée pour votre SIAE EI Prim’vert ID-2003.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[institution summary email body]
+  '''
+  Bonjour,
+  
+  Vous trouverez ci-dessous la liste des SIAE qui n’ont transmis aucun justificatif dans le cadre du contrôle a posteriori :
+  
+  - EI Les grands jardins ID-2001
+  
+  - EI Les petits jardins ID-2002
+  
+  Ces structures n’ayant pas transmis les justificatifs dans le délai des 6 semaines passent automatiquement en phase contradictoire et disposent à nouveau de 6 semaines pour se manifester.
+  
+  N’hésitez pas à les contacter afin de comprendre les éventuelles difficultés rencontrées pour transmettre les justificatifs.
+  
+  ---
+  
+  Les structures suivantes avaient transmis leurs justificatifs mais n’ont pas eu de retour de la DDETS, leur contrôle est considéré positif :
+  
+  - EI Prim’vert ID-2003
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[no docs email body]
+  '''
+  Bonjour,
+  
+  Sauf erreur de notre part, vous n’avez pas transmis les justificatifs dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription.
+  
+  La DDETS 1 ne peut donc pas faire de contrôle, par conséquent vous entrez dans une phase dite contradictoire de 6 semaines (durant laquelle il vous faut transmettre les justificatifs demandés) et qui se clôturera sur une décision (validation ou sanction pouvant aller jusqu’à un retrait d’aide au poste) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
+  
+  Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les petits jardins ID-2002 à la rubrique “Justifier mes auto-prescriptions”.
+  http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1002/
+  
+  En cas de besoin, vous pouvez consulter ce mode d’emploi.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[no response email body]
+  '''
+  Bonjour,
+  
+  Sauf erreur de notre part, vous n’avez pas transmis les justificatifs dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription.
+  
+  La DDETS 1 ne peut donc pas faire de contrôle, par conséquent vous entrez dans une phase dite contradictoire de 6 semaines (durant laquelle il vous faut transmettre les justificatifs demandés) et qui se clôturera sur une décision (validation ou sanction pouvant aller jusqu’à un retrait d’aide au poste) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
+  
+  Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les grands jardins ID-2001 à la rubrique “Justifier mes auto-prescriptions”.
+  http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1001/
+  
+  En cas de besoin, vous pouvez consulter ce mode d’emploi.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_accepted_but_not_reviewed[positive review email body]
   '''
   Bonjour,
@@ -6,6 +132,81 @@
   La DDETS 1 a validé la conformité des justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur les embauches réalisées en auto-prescription entre le 02 Octobre 2022 et le 02 Décembre 2022.
   
   Cette campagne de contrôle est terminée pour votre SIAE EI Prim’vert ID-1234.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_force_accepted[force accepted email body]
+  '''
+  Bonjour,
+  
+  La campagne de contrôle a posteriori sur les embauches réalisées en auto-prescription entre le 02 Octobre 2022 et le 02 Décembre 2022 entre en phase contradictoire.
+  
+  La DDETS 1 n’a pas étudié la conformité des justificatifs que vous avez transmis dans le délai imparti. Par conséquent, vos auto-prescriptions sont considérées comme conformes.
+  
+  Cette campagne de contrôle est terminée pour votre SIAE EI Prim’vert ID-2000.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_force_accepted[institution summary email body]
+  '''
+  Bonjour,
+  
+  Les structures suivantes avaient transmis leurs justificatifs mais n’ont pas eu de retour de la DDETS, leur contrôle est considéré positif :
+  
+  - EI Prim’vert ID-2000
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_forced_to_adversarial_stage[institution summary email body]
+  '''
+  Bonjour,
+  
+  Vous trouverez ci-dessous la liste des SIAE qui n’ont transmis aucun justificatif dans le cadre du contrôle a posteriori :
+  
+  - EI Les grands jardins ID-2000
+  
+  Ces structures n’ayant pas transmis les justificatifs dans le délai des 6 semaines passent automatiquement en phase contradictoire et disposent à nouveau de 6 semaines pour se manifester.
+  
+  N’hésitez pas à les contacter afin de comprendre les éventuelles difficultés rencontrées pour transmettre les justificatifs.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_forced_to_adversarial_stage[no response email body]
+  '''
+  Bonjour,
+  
+  Sauf erreur de notre part, vous n’avez pas transmis les justificatifs dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription.
+  
+  La DDETS 1 ne peut donc pas faire de contrôle, par conséquent vous entrez dans une phase dite contradictoire de 6 semaines (durant laquelle il vous faut transmettre les justificatifs demandés) et qui se clôturera sur une décision (validation ou sanction pouvant aller jusqu’à un retrait d’aide au poste) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
+  
+  Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les grands jardins ID-2000 à la rubrique “Justifier mes auto-prescriptions”.
+  http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1000/
+  
+  En cas de besoin, vous pouvez consulter ce mode d’emploi.
   
   Cordialement,
   

--- a/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
+++ b/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
@@ -37,6 +37,22 @@
   http://127.0.0.1:8000
   '''
 # ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[accepted review email body]
+  '''
+  Bonjour,
+  
+  La DDETS 1 a validé la conformité des justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur les embauches réalisées en auto-prescription entre le 02 Octobre 2022 et le 02 Décembre 2022.
+  
+  Cette campagne de contrôle est terminée pour votre SIAE EI Geo accepted ID-2004.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[force accepted email body]
   '''
   Bonjour,
@@ -116,6 +132,28 @@
   http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1001/
   
   En cas de besoin, vous pouvez consulter ce mode d’emploi.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[refused review email body]
+  '''
+  Bonjour,
+  
+  La DDETS 1 a vérifié tous les justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le 02 Octobre 2022 et le 02 Décembre 2022.
+  
+  Suite à cette vérification, un ou plusieurs justificatifs sont attendus par la DDETS 1.
+  
+  Rendez-vous sur le tableau de bord de EI Geo refused ID-2005 à la rubrique “Justifier mes auto-prescriptions”.
+  
+  Les embauches avec le statut “nouveaux justificatifs à traiter”, nécessitent la transmission d’un nouveau justificatif pour chaque critère concerné. Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
+  
+  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://communaute.inclusion.beta.gouv.fr/doc/non-knowledgebase/controle-a-posteriori-pour-les-siae/
   
   Cordialement,
   

--- a/itou/siae_evaluations/tests/test_emails.py
+++ b/itou/siae_evaluations/tests/test_emails.py
@@ -121,7 +121,7 @@ class TestInstitutionEmailFactory:
         evaluated_siae = EvaluatedSiaeFactory(
             siae=siae,
             evaluation_campaign=campaign,
-            reviewed_at=timezone.now() - relativedelta(days=50),
+            reviewed_at=timezone.now() - relativedelta(days=55),
             final_reviewed_at=timezone.now() - relativedelta(days=50),
         )
         evaluated_jobapp = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -3649,9 +3649,8 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
             [
                 (
                     messages.SUCCESS,
-                    "<b>Résultats transmis !</b><br>"
-                    "Merci d'avoir pris le temps de contrôler les pièces justificatives. "
-                    "Nous notifions par mail l'administrateur de la SIAE.",
+                    "<b>Résultats enregistrés !</b><br>"
+                    "Merci d'avoir pris le temps de contrôler les pièces justificatives.",
                 )
             ],
         )
@@ -3673,9 +3672,8 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
             [
                 (
                     messages.SUCCESS,
-                    "<b>Résultats transmis !</b><br>"
-                    "Merci d'avoir pris le temps de contrôler les pièces justificatives. "
-                    "Nous notifions par mail l'administrateur de la SIAE.",
+                    "<b>Résultats enregistrés !</b><br>"
+                    "Merci d'avoir pris le temps de contrôler les pièces justificatives.",
                 )
             ],
         )
@@ -3716,9 +3714,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             ),
         )
-        [email] = mail.outbox
-        assert f"Résultat du contrôle - EI Les petits jardins ID-{evaluated_siae.siae_id}" == email.subject
-        assert "a validé la conformité des justificatifs" in email.body
+        assert mail.outbox == []
 
     def test_accepted_after_adversarial(self):
         evaluated_siae = EvaluatedSiaeFactory.create(
@@ -3748,9 +3744,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             ),
         )
-        [email] = mail.outbox
-        assert f"Résultat du contrôle - EI Les petits jardins ID-{evaluated_siae.siae_id}" == email.subject
-        assert "a validé la conformité des nouveaux justificatifs" in email.body
+        assert mail.outbox == []
 
     def test_refused(self):
         evaluated_siae = EvaluatedSiaeFactory.create(
@@ -3779,9 +3773,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             ),
         )
-        [email] = mail.outbox
-        assert f"Résultat du contrôle - EI Les petits jardins ID-{evaluated_siae.siae_id}" == email.subject
-        assert "un ou plusieurs justificatifs sont attendus" in email.body
+        assert mail.outbox == []
 
     def test_refused_after_adversarial(self):
         evaluated_siae = EvaluatedSiaeFactory.create(
@@ -3811,6 +3803,4 @@ class InstitutionEvaluatedSiaeValidationViewTest(TestCase):
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             ),
         )
-        [email] = mail.outbox
-        assert f"Résultat du contrôle - EI Les petits jardins ID-{evaluated_siae.siae_id}" == email.subject
-        assert "plusieurs de vos justificatifs n’ont pas été validés" in email.body
+        assert mail.outbox == []

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -483,9 +483,8 @@ def institution_evaluated_siae_validation(request, evaluated_siae_pk):
         messages.success(
             request,
             mark_safe(
-                "<b>Résultats transmis !</b><br>"
-                "Merci d'avoir pris le temps de contrôler les pièces justificatives. "
-                "Nous notifions par mail l'administrateur de la SIAE."
+                "<b>Résultats enregistrés !</b><br>"
+                "Merci d'avoir pris le temps de contrôler les pièces justificatives."
             ),
         )
 


### PR DESCRIPTION
**Carte Notion : **
https://www.notion.so/plateforme-inclusion/1-2-Diff-rer-la-transmission-du-r-sultat-aux-SIAE-Stopper-la-transmission-du-r-sultat-du-contr-le--3d0ba94efb98496b8259c42414205062
https://www.notion.so/plateforme-inclusion/2-2-Diff-rer-la-transmission-du-r-sultat-aux-SIAE-Transmettre-les-r-sultats-apr-s-les-phases-bis-c00d6a8239064548a529b1cd73df4328

### Pourquoi ?

Maintenant qu'il y a des phases "strictes", on ne veut pas envoyer un mail à une SIAE et lui dire d'aller faire des modifs qu'elle ne pourra pas faire.

