### PR TITLE
[BOOST] Controle à posteriori: modifier le wording sur certains mails

### DIFF
--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -1,3 +1,5 @@
+import urllib.parse
+
 from django.urls import reverse
 
 from itou.utils import constants as global_constants
@@ -10,9 +12,8 @@ class CampaignEmailFactory:
         self.evaluation_campaign = evaluation_campaign
         self.recipients = evaluation_campaign.institution.active_members.values_list("email", flat=True)
 
-    def ratio_to_select(self, ratio_selection_end_at):
+    def ratio_to_select(self):
         context = {
-            "ratio_selection_end_at": ratio_selection_end_at,
             "dashboard_url": get_absolute_url(reverse("dashboard:index")),
         }
         subject = "siae_evaluations/email/to_institution_ratio_to_select_subject.txt"
@@ -21,9 +22,12 @@ class CampaignEmailFactory:
 
     def selected_siae(self):
         context = {
-            "end_date": self.evaluation_campaign.adversarial_stage_start_date,
             "evaluated_period_start_at": self.evaluation_campaign.evaluated_period_start_at,
             "evaluated_period_end_at": self.evaluation_campaign.evaluated_period_end_at,
+            "ddets_evaluation_handbook_url": urllib.parse.urljoin(
+                global_constants.ITOU_DOCS_URL,
+                "/doc/emplois/mode-demploi-sur-le-controle-a-posteriori-pour-les-ddets/",
+            ),
         }
         subject = "siae_evaluations/email/to_institution_selected_siae_subject.txt"
         body = "siae_evaluations/email/to_institution_selected_siae_body.txt"
@@ -80,7 +84,6 @@ class SIAEEmailFactory:
         context = {
             "campaign": self.evaluated_siae.evaluation_campaign,
             "siae": self.evaluated_siae.siae,
-            "end_date": self.evaluated_siae.evaluation_campaign.adversarial_stage_start_date,
             "url": get_absolute_url(evaluated_siae_url),
         }
         subject = "siae_evaluations/email/to_siae_selected_subject.txt"
@@ -139,6 +142,10 @@ class SIAEEmailFactory:
             "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
             "siae": self.evaluated_siae.siae,
             "auto_prescription_url": get_absolute_url(auto_prescription_url),
+            "siae_evaluation_handbook_url": urllib.parse.urljoin(
+                global_constants.ITOU_DOCS_URL,
+                "/doc/emplois/controle-a-posteriori-pour-les-siae/",
+            ),
         }
         subject = "siae_evaluations/email/to_siae_forced_to_adversarial_stage_subject.txt"
         body = "siae_evaluations/email/to_siae_forced_to_adversarial_stage_body.txt"

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -49,7 +49,7 @@ def validate_institution(institution_id):
         raise ValidationError(f"Sélectionnez une institution de type {InstitutionKind.DDETS}")
 
 
-def create_campaigns(evaluated_period_start_at, evaluated_period_end_at, ratio_selection_end_at, institution_ids=None):
+def create_campaigns(evaluated_period_start_at, evaluated_period_end_at, institution_ids=None):
     """
     Create a campaign for each institution whose kind is DDETS (possibly limited by institution_ids).
     This method is intented to be executed manually, until it will be automised.
@@ -77,7 +77,7 @@ def create_campaigns(evaluated_period_start_at, evaluated_period_end_at, ratio_s
     # Send notification.
     if evaluation_campaign_list:
         send_email_messages(
-            CampaignEmailFactory(evaluation_campaign).ratio_to_select(ratio_selection_end_at)
+            CampaignEmailFactory(evaluation_campaign).ratio_to_select()
             for evaluation_campaign in evaluation_campaign_list
         )
 
@@ -374,7 +374,6 @@ class EvaluatedSiaeQuerySet(models.QuerySet):
 
 
 class EvaluatedSiae(models.Model):
-
     evaluation_campaign = models.ForeignKey(
         EvaluationCampaign,
         verbose_name="Contrôle",
@@ -471,7 +470,6 @@ class EvaluatedSiae(models.Model):
     # fixme vincentporte : rsebille suggests to replace cached_property with prefetch_related
     @cached_property
     def state(self):
-
         # assuming the EvaluatedSiae instance is fully hydrated with its evaluated_job_applications
         # and evaluated_administrative_criteria before being called,
         # to prevent tons of additional queries in db.
@@ -558,7 +556,6 @@ class EvaluatedJobApplicationQuerySet(models.QuerySet):
 
 
 class EvaluatedJobApplication(models.Model):
-
     job_application = models.ForeignKey(
         "job_applications.JobApplication",
         verbose_name="Candidature",
@@ -638,7 +635,6 @@ class EvaluatedJobApplication(models.Model):
         #    It contains new AND removed choices.
 
         with transaction.atomic():
-
             EvaluatedAdministrativeCriteria.objects.filter(
                 pk__in=(
                     eval_criterion.pk
@@ -663,7 +659,6 @@ class EvaluatedAdministrativeCriteriaQuerySet(models.QuerySet):
 
 
 class EvaluatedAdministrativeCriteria(models.Model):
-
     administrative_criteria = models.ForeignKey(
         "eligibility.AdministrativeCriteria",
         verbose_name="Critère administratif",

--- a/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
+++ b/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
@@ -107,10 +107,11 @@
   
   La DDETS 1 ne peut donc pas faire de contrôle, par conséquent vous entrez dans une phase dite contradictoire de 6 semaines (durant laquelle il vous faut transmettre les justificatifs demandés) et qui se clôturera sur une décision (validation ou sanction pouvant aller jusqu’à un retrait d’aide au poste) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
   
-  Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les petits jardins ID-2002 à la rubrique “Justifier mes auto-prescriptions”.
-  http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1002/
+  Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les petits jardins ID-2002 à la rubrique “Contrôle a posteriori > Campagne en cours”.
   
-  En cas de besoin, vous pouvez consulter ce mode d’emploi.
+  Accès direct à votre liste d’auto-prescriptions : http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1002/
+  
+  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://documentation.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
   
   Cordialement,
   
@@ -128,10 +129,11 @@
   
   La DDETS 1 ne peut donc pas faire de contrôle, par conséquent vous entrez dans une phase dite contradictoire de 6 semaines (durant laquelle il vous faut transmettre les justificatifs demandés) et qui se clôturera sur une décision (validation ou sanction pouvant aller jusqu’à un retrait d’aide au poste) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
   
-  Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les grands jardins ID-2001 à la rubrique “Justifier mes auto-prescriptions”.
-  http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1001/
+  Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les grands jardins ID-2001 à la rubrique “Contrôle a posteriori > Campagne en cours”.
   
-  En cas de besoin, vous pouvez consulter ce mode d’emploi.
+  Accès direct à votre liste d’auto-prescriptions : http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1001/
+  
+  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://documentation.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
   
   Cordialement,
   
@@ -149,9 +151,11 @@
   
   Suite à cette vérification, un ou plusieurs justificatifs sont attendus par la DDETS 1.
   
-  Rendez-vous sur le tableau de bord de EI Geo refused ID-2005 à la rubrique “Justifier mes auto-prescriptions”.
+  Rendez-vous sur le tableau de bord de EI Geo refused ID-2005 à la rubrique “Campagne en cours”.
   
-  Les embauches avec le statut “nouveaux justificatifs à traiter”, nécessitent la transmission d’un nouveau justificatif pour chaque critère concerné. Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
+  Une ou plusieurs de vos auto-prescriptions nécessitent la transmission de nouveaux justificatifs.
+  
+  Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
   
   En cas de besoin, vous pouvez consulter ce mode d’emploi : https://communaute.inclusion.beta.gouv.fr/doc/non-knowledgebase/controle-a-posteriori-pour-les-siae/
   
@@ -241,10 +245,11 @@
   
   La DDETS 1 ne peut donc pas faire de contrôle, par conséquent vous entrez dans une phase dite contradictoire de 6 semaines (durant laquelle il vous faut transmettre les justificatifs demandés) et qui se clôturera sur une décision (validation ou sanction pouvant aller jusqu’à un retrait d’aide au poste) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
   
-  Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les grands jardins ID-2000 à la rubrique “Justifier mes auto-prescriptions”.
-  http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1000/
+  Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les grands jardins ID-2000 à la rubrique “Contrôle a posteriori > Campagne en cours”.
   
-  En cas de besoin, vous pouvez consulter ce mode d’emploi.
+  Accès direct à votre liste d’auto-prescriptions : http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1000/
+  
+  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://documentation.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
   
   Cordialement,
   
@@ -262,9 +267,11 @@
   
   Suite à cette vérification, un ou plusieurs justificatifs sont attendus par la DDETS 1.
   
-  Rendez-vous sur le tableau de bord de EI Prim’vert ID-1234 à la rubrique “Justifier mes auto-prescriptions”.
+  Rendez-vous sur le tableau de bord de EI Prim’vert ID-1234 à la rubrique “Campagne en cours”.
   
-  Les embauches avec le statut “nouveaux justificatifs à traiter”, nécessitent la transmission d’un nouveau justificatif pour chaque critère concerné. Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
+  Une ou plusieurs de vos auto-prescriptions nécessitent la transmission de nouveaux justificatifs.
+  
+  Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
   
   En cas de besoin, vous pouvez consulter ce mode d’emploi : https://communaute.inclusion.beta.gouv.fr/doc/non-knowledgebase/controle-a-posteriori-pour-les-siae/
   

--- a/itou/siae_evaluations/tests/test_emails.py
+++ b/itou/siae_evaluations/tests/test_emails.py
@@ -23,16 +23,12 @@ class TestInstitutionEmailFactory:
         institution = InstitutionWith2MembershipFactory()
         evaluation_campaign = EvaluationCampaignFactory(institution=institution)
 
-        date = timezone.localdate()
-        email = CampaignEmailFactory(evaluation_campaign).ratio_to_select(date)
+        email = CampaignEmailFactory(evaluation_campaign).ratio_to_select()
 
         assert email.to == list(u.email for u in institution.active_members)
         assert reverse("dashboard:index") in email.body
-        assert (
-            f"Le choix du taux de SIAE à contrôler est possible jusqu’au {dateformat.format(date, 'd E Y')}"
-            in email.body
-        )
-        assert f"avant le {dateformat.format(date, 'd E Y')}" in email.subject
+        assert "Vous disposez de 4 semaines pour choisir votre taux de SIAE à contrôler." in email.body
+        assert "Vous disposez de 4 semaines pour sélectionner votre échantillon." in email.subject
 
     def test_selected(self):
         siae = SiaeWith2MembershipsFactory()
@@ -48,7 +44,6 @@ class TestInstitutionEmailFactory:
         assert siae.name in email.body
         assert siae.kind in email.body
         assert siae.convention.siret_signature in email.body
-        assert dateformat.format(timezone.now() + relativedelta(weeks=6), "d E Y") in email.body
 
     def test_selected_siae(self):
         fake_now = timezone.now()
@@ -57,7 +52,6 @@ class TestInstitutionEmailFactory:
 
         email = CampaignEmailFactory(evaluation_campaign).selected_siae()
         assert email.to == list(u.email for u in institution.active_members)
-        assert dateformat.format(fake_now + relativedelta(weeks=6), "d E Y") in email.body
         assert dateformat.format(evaluation_campaign.evaluated_period_start_at, "d E Y") in email.body
         assert dateformat.format(evaluation_campaign.evaluated_period_end_at, "d E Y") in email.body
 

--- a/itou/siae_evaluations/tests/test_management_commands.py
+++ b/itou/siae_evaluations/tests/test_management_commands.py
@@ -383,11 +383,7 @@ class TestManagementCommand:
             "Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez "
             "enregistrés lors de ces embauches.\n"
             "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
-            "19 décembre 2022.\n\n"
-            "Ce délai comprend la transmission de vos justificatifs ET le contrôle effectué par votre DDETS.\n"
-            "Attention : si vous transmettez vos justificatifs en dernière minute, la DDETS risque de ne pas avoir le "
-            "temps de valider ou invalider vos justificatifs ; auquel cas, le contrôle sera automatiquement clôturé "
-            "avec un résultat négatif.\n\n" in mail1.body
+            "19 décembre 2022.\n\n" in mail1.body
         )
         assert (
             f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_no_answer.pk}/"
@@ -405,11 +401,7 @@ class TestManagementCommand:
             "Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez "
             "enregistrés lors de ces embauches.\n"
             "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
-            "19 décembre 2022.\n\n"
-            "Ce délai comprend la transmission de vos justificatifs ET le contrôle effectué par votre DDETS.\n"
-            "Attention : si vous transmettez vos justificatifs en dernière minute, la DDETS risque de ne pas avoir le "
-            "temps de valider ou invalider vos justificatifs ; auquel cas, le contrôle sera automatiquement clôturé "
-            "avec un résultat négatif.\n\n" in mail2.body
+            "19 décembre 2022.\n\n" in mail2.body
         )
         assert (
             f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_reviewed_quickly.pk}/"

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -226,7 +226,6 @@ class TestEvaluationCampaignManagerEligibleJobApplication:
 @pytest.mark.usefixtures("unittest_compatibility")
 class EvaluationCampaignManagerTest(TestCase):
     def test_validate_institution(self):
-
         with pytest.raises(ValidationError):
             validate_institution(0)
 
@@ -254,21 +253,18 @@ class EvaluationCampaignManagerTest(TestCase):
     def test_create_campaigns(self):
         evaluated_period_start_at = timezone.now() - relativedelta(months=2)
         evaluated_period_end_at = timezone.now() - relativedelta(months=1)
-        ratio_selection_end_at = timezone.now() + relativedelta(months=1)
 
         # not DDETS
         for kind in [k for k in InstitutionKind if k != InstitutionKind.DDETS]:
             with self.subTest(kind=kind):
                 InstitutionFactory(kind=kind)
-                assert 0 == create_campaigns(
-                    evaluated_period_start_at, evaluated_period_end_at, ratio_selection_end_at
-                )
+                assert 0 == create_campaigns(evaluated_period_start_at, evaluated_period_end_at)
                 assert 0 == EvaluationCampaign.objects.all().count()
                 assert len(mail.outbox) == 0
 
         # institution DDETS
         InstitutionWith2MembershipFactory.create_batch(2, kind=InstitutionKind.DDETS)
-        assert 2 == create_campaigns(evaluated_period_start_at, evaluated_period_end_at, ratio_selection_end_at)
+        assert 2 == create_campaigns(evaluated_period_start_at, evaluated_period_end_at)
         assert 2 == EvaluationCampaign.objects.all().count()
 
         # An email should have been sent to the institution members.
@@ -281,19 +277,16 @@ class EvaluationCampaignManagerTest(TestCase):
     def test_create_campaigns_on_specific_DDETS(self):
         evaluated_period_start_at = timezone.now() - relativedelta(months=2)
         evaluated_period_end_at = timezone.now() - relativedelta(months=1)
-        ratio_selection_end_at = timezone.now() + relativedelta(months=1)
 
         institution_ids = InstitutionWith2MembershipFactory.create_batch(2, kind=InstitutionKind.DDETS)
         assert 1 == create_campaigns(
             evaluated_period_start_at,
             evaluated_period_end_at,
-            ratio_selection_end_at,
             institution_ids=[institution_ids[0].pk],
         )
         assert 1 == EvaluationCampaign.objects.all().count()
 
     def test_eligible_siaes(self):
-
         evaluation_campaign = EvaluationCampaignFactory()
 
         # siae1 got 1 job application

--- a/itou/templates/siae_evaluations/email/to_institution_ratio_to_select_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_ratio_to_select_body.txt
@@ -9,7 +9,7 @@ Vous trouverez dans votre tableau de bord ({{ dashboard_url }}), la liste de tou
 
 Vous pouvez consulter cette liste et ensuite choisir le taux de SIAE à contrôler.
 
-Le choix du taux de SIAE à contrôler est possible jusqu’au {{ratio_selection_end_at|date:"d E Y"}}. Passé ce délai, le taux de 30% sera appliqué par défaut.
+Vous disposez de 4 semaines pour choisir votre taux de SIAE à contrôler. Passé ce délai, le taux de 30% sera appliqué par défaut.
 
 Cordialement,
 

--- a/itou/templates/siae_evaluations/email/to_institution_ratio_to_select_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_ratio_to_select_subject.txt
@@ -1,6 +1,6 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
 
-Lancement du contrôle a posteriori : Sélectionnez votre échantillon avant le {{ratio_selection_end_at|date:"d E Y"}}
+Lancement du contrôle a posteriori : Vous disposez de 4 semaines pour sélectionner votre échantillon.
 
 {% endblock %}

--- a/itou/templates/siae_evaluations/email/to_institution_selected_siae_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_selected_siae_body.txt
@@ -8,22 +8,26 @@ La procédure de transmission des justificatifs dans le cadre du contrôle a pos
 
 Vous pouvez consulter la liste des SIAE qui ont été aléatoirement sélectionnées pour cette campagne de contrôle. Cette liste a été établie sur la base du taux de SIAE à contrôler que vous aviez préalablement validé.
 
-Cette phase de transmission et vérification des justificatifs est ouverte jusqu’au {{ end_date|date:"d E Y" }}. Passé ce délai les justificatifs non fournis par les SIAE seront enregistrés comme manquants.
+Les SIAE disposent d’un délai de 6 semaines pour transmettre les justificatifs. Passé ce délai les justificatifs non fournis par les SIAE seront enregistrés comme manquants.
+
+Les DDETS disposent d’un délai supplémentaire pour contrôler les justificatifs.
+
+Vous trouverez le calendrier de la campagne de contrôle a posteriori dans votre espace des emplois de l’inclusion.
 
 Comment ça marche ?
 
 1- Consultez la liste des SIAE soumises au contrôle et suivez l’avancée du dossier
-Dans votre tableau de bord, à la rubrique “ Contrôler les pièces justificatives” vous trouverez la liste des SIAE qui doivent justifier certaines de leurs auto-prescriptions.
+Dans votre tableau de bord, à la rubrique “Contrôle a posteriori > Campagne en cours” vous trouverez la liste des SIAE qui doivent justifier certaines de leurs auto-prescriptions.
 
 2- Suivez et vérifiez les pièces justificatives transmises par les SIAE
 Vous recevez une notification e-mail chaque fois qu’une SIAE transmet l’intégralité des justificatifs demandés.
-Vous pouvez consulter les justificatifs pour chaque salarié, les valider ou les rejeter en expliquant la raison.
+Vous pouvez consulter les justificatifs pour chaque salarié, les accepter ou les refuser en expliquant la raison.
 
 3- Valider le contrôle
 Après avoir traité toutes les justificatifs d’une SIAE, vous pouvez finaliser le contrôle en cliquant sur le bouton “Valider”. La SIAE sera automatiquement notifiée.
 
 
-Vous trouverez plus d’informations dans ce mode d’emploi : https://communaute.inclusion.beta.gouv.fr/doc/emplois/mode-demploi-sur-le-controle-a-posteriori-pour-les-ddets/
+Vous trouverez plus d’informations dans ce mode d’emploi : {{ ddets_evaluation_handbook_url }}
 
 Cordialement,
 

--- a/itou/templates/siae_evaluations/email/to_siae_adversarial_stage_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_adversarial_stage_body.txt
@@ -6,9 +6,11 @@ La {{evaluation_campaign.institution.name}} a vérifié tous les justificatifs q
 
 Suite à cette vérification, un ou plusieurs justificatifs sont attendus par la {{evaluation_campaign.institution.name}}.
 
-Rendez-vous sur le tableau de bord de {{ siae.kind }} {{ siae.name }} ID-{{siae.id}} à la rubrique “Justifier mes auto-prescriptions”.
+Rendez-vous sur le tableau de bord de {{ siae.kind }} {{ siae.name }} ID-{{siae.id}} à la rubrique “Campagne en cours”.
 
-Les embauches avec le statut “nouveaux justificatifs à traiter”, nécessitent la transmission d’un nouveau justificatif pour chaque critère concerné. Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
+Une ou plusieurs de vos auto-prescriptions nécessitent la transmission de nouveaux justificatifs.
+
+Dans la page de chaque auto-prescription, un commentaire concernant le refus du premier justificatif peut être présent afin de vous fournir plus de précisions.
 
 En cas de besoin, vous pouvez consulter ce mode d’emploi : {{ itou_community_url }}/doc/non-knowledgebase/controle-a-posteriori-pour-les-siae/
 

--- a/itou/templates/siae_evaluations/email/to_siae_forced_to_adversarial_stage_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_forced_to_adversarial_stage_body.txt
@@ -6,10 +6,11 @@ Sauf erreur de notre part, vous n’avez pas transmis les justificatifs dans le 
 
 La {{ evaluation_campaign.institution }} ne peut donc pas faire de contrôle, par conséquent vous entrez dans une phase dite contradictoire de 6 semaines (durant laquelle il vous faut transmettre les justificatifs demandés) et qui se clôturera sur une décision (validation ou sanction pouvant aller jusqu’à un retrait d’aide au poste) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
 
-Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de {{ siae.kind }} {{ siae.name }} ID-{{ siae.pk }} à la rubrique “Justifier mes auto-prescriptions”.
-{{ auto_prescription_url }}
+Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de {{ siae.kind }} {{ siae.name }} ID-{{ siae.pk }} à la rubrique “Contrôle a posteriori > Campagne en cours”.
 
-En cas de besoin, vous pouvez consulter ce mode d’emploi.
+Accès direct à votre liste d’auto-prescriptions : {{ auto_prescription_url }}
+
+En cas de besoin, vous pouvez consulter ce mode d’emploi : {{ siae_evaluation_handbook_url }}
 
 Cordialement,
 {% endblock %}

--- a/itou/templates/siae_evaluations/email/to_siae_notify_before_adversarial_stage_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_notify_before_adversarial_stage_body.txt
@@ -1,4 +1,4 @@
-{% extends "layout/base_email_text_body.txt" %}
+% extends "layout/base_email_text_body.txt" %}
 {% block body %}
 Bonjour,
 
@@ -9,15 +9,11 @@ Nous vous rappelons que votre structure {{ siae.kind }} {{ siae.name }} ID-{{ si
 Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez enregistrés lors de ces embauches.
 Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du {{ evaluation_campaign.evaluations_asked_at|date }}.
 
-Ce délai comprend la transmission de vos justificatifs ET le contrôle effectué par votre DDETS.
-Attention : si vous transmettez vos justificatifs en dernière minute, la DDETS risque de ne pas avoir le temps de valider ou invalider vos justificatifs ; auquel cas, vous passerez systématiquement en phase contradictoire.
-
 Comment ça marche ?
 
 1- Visualiser la liste des embauches concernées par la procédure de contrôle :
 
-Depuis le tableau de bord de votre structure à la rubrique “Contrôle a posteriori”,
-cliquez sur “Justifier mes auto-prescriptions”.
+Depuis le tableau de bord de votre structure à la rubrique “Contrôle a posteriori”, cliquez sur “Campagne en cours”.
 La liste des embauches concernées par la procédure est affichée.
 
 Accès direct à votre liste d’auto-prescriptions : {{ evaluated_job_app_list_url }}

--- a/itou/templates/siae_evaluations/email/to_siae_notify_before_campaign_close_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_notify_before_campaign_close_body.txt
@@ -9,11 +9,9 @@ Nous vous rappelons que votre structure {{ siae.kind }} {{ siae.name }} ID-{{ si
 Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez enregistrés lors de ces embauches.
 Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du {{ adversarial_stage_start|date }}.
 
-Ce délai comprend la transmission de vos justificatifs ET le contrôle effectué par votre DDETS.
-Attention : si vous transmettez vos justificatifs en dernière minute, la DDETS risque de ne pas avoir le temps de valider ou invalider vos justificatifs ; auquel cas, le contrôle sera automatiquement clôturé avec un résultat négatif.
+Pour transmettre les justificatifs demandés : RDV dans votre tableau de bord à la rubrique “Contrôle a posteriori” puis cliquez sur “Campagne en cours”.
 
-Pour transmettre les justificatifs demandés : RDV dans votre tableau de bord à la rubrique “Contrôle a posteriori” puis cliquez sur “Justifier mes auto-prescriptions”.
-{{ evaluated_job_app_list_url }}
+Accès direct à votre liste d'auto-prescriptions : {{ evaluated_job_app_list_url }}
 
 Voir le mode d’emploi : {{ itou_community_url }}/doc/emplois/controle-a-posteriori-pour-les-siae/
 

--- a/itou/templates/siae_evaluations/email/to_siae_selected_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_selected_body.txt
@@ -7,15 +7,14 @@ Votre structure {{ siae.kind }} ID {{siae.id}} {{ siae.name }} (SIRET : {{ siae.
 
 Vous devrez fournir les justificatifs des critères administratifs d’éligibilité IAE que vous aviez enregistrés lors de ces embauches.
 
-Vous avez jusqu’au {{ end_date|date:"d E Y" }} (6 semaines) pour transmettre les justificatifs à votre DDETS.
+Vous disposez de 6 semaines pour transmettre vos justificatifs à votre DDETS.
 
 Comment ça marche ?
 
 
 1- Visualiser la liste des embauches concernées par la procédure de contrôle :
+Depuis le tableau de bord de votre structure à la rubrique “Contrôle a posteriori” cliquez sur “Campagne en cours”
 
-Depuis le tableau de bord de votre structure à la rubrique “ Contrôle a posteriori”
-cliquez sur “Justifier mes auto-prescriptions”.
 La liste des embauches concernées par la procédure est affichée.
 
 Accès direct à votre liste d’auto-prescriptions : {{ url }}

--- a/itou/utils/constants.py
+++ b/itou/utils/constants.py
@@ -1,5 +1,6 @@
 ITOU_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/aide/emplois"
 ITOU_COMMUNITY_URL = "https://communaute.inclusion.beta.gouv.fr"
+ITOU_DOCS_URL = "https://documentation.inclusion.beta.gouv.fr"
 ITOU_EMAIL_PROLONGATION = "prolongation@inclusion.beta.gouv.fr"
 PILOTAGE_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/aide/pilotage"
 PILOTAGE_SITE_URL = "https://pilotage.inclusion.beta.gouv.fr"


### PR DESCRIPTION
**[Carte Notion](https://www.notion.so/plateforme-inclusion/URGENT-Retirer-les-dates-indiqu-es-dans-les-emails-du-contr-le-a-posteriori-02876e096ba04800becf08812634ff56?d=2ad2b4b8065d42fa9900690dca62290c)**

### Pourquoi ?
On a besoin d'éviter de faire apparaître en toutes lettres les dates finales de certaines échéances et laisser l'utilisateur calculer lui-même.

De plus d'autres wordings sont retirés ou modifiés, et on corrige une erreur concernant la documentation qui est mal redirigée pour les DDETS.

On introduit la notion de ITOU_DOCS_URL mais on ne la corrige pas partout; ce sera l'objet d'une autre PR.
