### PR TITLE
Supprimer la possibilité d'un jobseeker_profile vide, même dans les tests.

### DIFF
--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -1,11 +1,7 @@
 from django.contrib import admin, messages
-from django.urls import reverse
 from django.utils import timezone
-from django.utils.html import format_html
 
 import itou.employee_record.models as models
-from itou.users.models import JobSeekerProfile
-from itou.utils.urls import add_url_params
 
 from ..utils.admin import get_admin_view_link
 from ..utils.templatetags.str_filters import pluralizefr
@@ -149,14 +145,8 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
         return "-"
 
     def job_seeker_profile_link(self, obj):
-        try:
-            job_seeker_profile = obj.job_application.job_seeker.jobseeker_profile
-            return get_admin_view_link(job_seeker_profile, content=f"Profil salarié ID:{job_seeker_profile.pk}")
-        except JobSeekerProfile.DoesNotExist:
-            url = add_url_params(
-                reverse("admin:users_jobseekerprofile_add"), {"user": obj.job_application.job_seeker.pk}
-            )
-            return format_html('<a href="{}">{}</a>', url, "Ajouter un profil")
+        job_seeker_profile = obj.job_application.job_seeker.jobseeker_profile
+        return get_admin_view_link(job_seeker_profile, content=f"Profil salarié ID:{job_seeker_profile.pk}")
 
     def asp_processing_type(self, obj):
         if obj.processed_as_duplicate:

--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -78,7 +78,6 @@ class Command(BaseCommand):
         # Employee records in this case are switched back to status DISABLED for further processing by end-user.
         # Most frequent error cases are:
         # - no HEXA address
-        # - no profile at all (?)
 
         profile_selected = EmployeeRecord.objects.filter(status=Status.PROCESSED).select_related(
             "job_application",
@@ -89,8 +88,6 @@ class Command(BaseCommand):
             job_application__job_seeker__jobseeker_profile__hexa_commune__isnull=True
         )
         count_no_hexa_address = no_hexa_address.count()
-        no_job_seeker_profile = profile_selected.filter(job_application__job_seeker__jobseeker_profile__isnull=True)
-        count_no_job_seeker_profile = no_job_seeker_profile.count()
 
         self.stdout.write("* Checking employee records job seeker profile:")
 
@@ -107,22 +104,6 @@ class Command(BaseCommand):
             with transaction.atomic():
                 for without_address in no_hexa_address:
                     without_address.update_as_disabled()
-
-            self.stdout.write(" - done!")
-
-        if count_no_job_seeker_profile == 0:
-            self.stdout.write(" - no empty job seeker profile found (great!)")
-        else:
-            self.stdout.write(f" - found {count_no_job_seeker_profile} empty job seeker profile(s)")
-
-            if dry_run:
-                return
-
-            self.stdout.write(" - fixing missing jobseeker profiles: switching status to DISABLED")
-
-            with transaction.atomic():
-                for without_profile in no_job_seeker_profile:
-                    without_profile.update_as_disabled()
 
             self.stdout.write(" - done!")
 

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -177,8 +177,6 @@ class EmployeeRecord(ASPExchangeInformation):
     ERROR_JOB_APPLICATION_MUST_BE_ACCEPTED = "La candidature doit être acceptée"
     ERROR_JOB_APPLICATION_WITHOUT_APPROVAL = "L'embauche n'est pas reliée à un PASS IAE"
 
-    ERROR_JOB_SEEKER_HAS_NO_PROFILE = "Cet utilisateur n'a pas de profil de demandeur d'emploi enregistré"
-
     ERROR_EMPLOYEE_RECORD_IS_DUPLICATE = "Une fiche salarié pour ce PASS IAE et cette SIAE existe déjà"
     ERROR_EMPLOYEE_RECORD_INVALID_STATE = "La fiche salarié n'est pas dans l'état requis pour cette action"
 
@@ -275,9 +273,6 @@ class EmployeeRecord(ASPExchangeInformation):
 
         # Check if user is "clean"
         job_seeker.clean()
-
-        if not job_seeker.has_jobseeker_profile:
-            raise ValidationError(self.ERROR_JOB_SEEKER_HAS_NO_PROFILE)
 
         # Further validation in the job seeker profile
         # Note that the job seeker profile validation is done

--- a/itou/employee_record/tests/test_admin.py
+++ b/itou/employee_record/tests/test_admin.py
@@ -4,7 +4,6 @@ from django.contrib.admin import helpers
 from django.urls import reverse
 from pytest_django.asserts import assertContains
 
-from itou.users.factories import JobSeekerProfileFactory
 from itou.utils.test import assertMessages
 
 from .. import factories, models
@@ -64,20 +63,9 @@ def test_schedule_approval_update_notification_when_other_than_new_notification_
 
 
 def test_job_seeker_profile_from_employee_record(admin_client):
-    er = factories.EmployeeRecordFactory(job_application__job_seeker__jobseeker_profile=False)
+    er = factories.EmployeeRecordFactory()
     job_seeker = er.job_application.job_seeker
     employee_record_view_url = reverse("admin:employee_record_employeerecord_change", args=[er.pk])
-    add_jobseeker_profile_url = f"{reverse('admin:users_jobseekerprofile_add')}?user={job_seeker.pk}"
-
-    response = admin_client.get(employee_record_view_url)
-    assertContains(response, "Ajouter un profil")
-    assertContains(response, add_jobseeker_profile_url)
-
-    response = admin_client.get(add_jobseeker_profile_url)
-    assertContains(response, "Demandeur d&#x27;emploi")
-    assertContains(response, job_seeker.first_name)
-
-    JobSeekerProfileFactory(user=job_seeker)
     response = admin_client.get(employee_record_view_url)
     assertContains(response, "Profil salarié")
     assertContains(response, job_seeker.jobseeker_profile.pk)

--- a/itou/employee_record/tests/test_sanitize_employee_records.py
+++ b/itou/employee_record/tests/test_sanitize_employee_records.py
@@ -76,9 +76,7 @@ def test_orphans_check(command):
 def test_profile_errors_check(command):
     # Check for profile errors during sanitize_employee_records
 
-    employee_record = factories.EmployeeRecordFactory(
-        status=models.Status.PROCESSED, job_application__job_seeker__jobseeker_profile=False
-    )
+    employee_record = factories.EmployeeRecordFactory(status=models.Status.PROCESSED)
 
     command._check_jobseeker_profiles(dry_run=False)
 
@@ -88,9 +86,6 @@ def test_profile_errors_check(command):
         "* Checking employee records job seeker profile:",
         " - found 1 job seeker profile(s) without HEXA address",
         " - fixing missing address in profiles: switching status to DISABLED",
-        " - done!",
-        " - found 1 empty job seeker profile(s)",
-        " - fixing missing jobseeker profiles: switching status to DISABLED",
         " - done!",
         "",
     ]

--- a/itou/employee_record/tests/tests_models.py
+++ b/itou/employee_record/tests/tests_models.py
@@ -75,12 +75,6 @@ class EmployeeRecordModelTest(TestCase):
             # Must not
             EmployeeRecord.from_job_application(job_application)
 
-    def test_creation_without_jobseeker_profile(self):
-        # Job seeker has no existing profile (must be filled before creation)
-        with self.assertRaisesMessage(ValidationError, EmployeeRecord.ERROR_JOB_SEEKER_HAS_NO_PROFILE):
-            job_application = JobApplicationWithApprovalNotCancellableFactory(job_seeker__jobseeker_profile=False)
-            EmployeeRecord.from_job_application(job_application)
-
     def test_creation_from_job_application(self):
         """
         Employee record objects are created from a job application giving them access to:

--- a/itou/job_applications/factories.py
+++ b/itou/job_applications/factories.py
@@ -196,5 +196,4 @@ class JobApplicationWithCompleteJobSeekerProfileFactory(JobApplicationWithApprov
             # Simple build, do nothing.
             return
         # Create a profile for current user
-        # JobSeekerProfileWithHexaAddressFactory.build(user=self.job_seeker).save()
         self.job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory(user=self.job_seeker)

--- a/itou/users/factories.py
+++ b/itou/users/factories.py
@@ -142,6 +142,10 @@ class JobSeekerFactory(UserFactory):
 
         if create:
             if extracted is False:
+                # Note: we should never use this lightly. This is only kept for backward compatibility
+                # with JobApplicationWithCompleteJobSeekerProfileFactory that needs the creation of a specific
+                # profile, that can not easily be created from a test (because notably of Faker) and would
+                # make a lot of code less DRY.
                 obj.jobseeker_profile.delete()
                 obj.jobseeker_profile = None
             else:
@@ -219,17 +223,13 @@ class JobSeekerWithMockedAddressFactory(JobSeekerFactory):
         self.birth_country = CountryFranceFactory.build()
 
 
-class JobSeekerProfileFactory(factory.django.DjangoModelFactory):
+class JobSeekerProfileWithHexaAddressFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.JobSeekerProfile
 
-    user = factory.SubFactory(JobSeekerWithAddressFactory, jobseeker_profile=False)
     education_level = random.choice(EducationLevel.values)
     # JobSeeker are created with a Pôle emploi ID
     pole_emploi_since = AllocationDuration.MORE_THAN_24_MONTHS
-
-
-class JobSeekerProfileWithHexaAddressFactory(JobSeekerProfileFactory):
     # Adding a minimum profile with all mandatory fields
     # will avoid many mocks and convolutions during testing.
     hexa_lane_type = random.choice(LaneType.values)

--- a/itou/www/employee_record_views/tests/test_create.py
+++ b/itou/www/employee_record_views/tests/test_create.py
@@ -52,7 +52,6 @@ class AbstractCreateEmployeeRecordTest(TestCase):
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
             job_seeker_with_address=True,
-            job_seeker__jobseeker_profile=False,
         )
 
         self.job_seeker = self.job_application.job_seeker
@@ -79,6 +78,7 @@ class AbstractCreateEmployeeRecordTest(TestCase):
         url = reverse("employee_record_views:create_step_2", args=(self.job_application.id,))
         self.client.get(url)
 
+        self.job_seeker.jobseeker_profile.refresh_from_db()
         assert self.job_seeker.jobseeker_profile.hexa_address_filled
 
         url = reverse("employee_record_views:create_step_3", args=(self.job_application.id,))
@@ -289,11 +289,9 @@ class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
         # Job seeker has an address filled but can't be geolocated
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
-            job_seeker=JobSeekerWithAddressFactory(jobseeker_profile=False),
+            job_seeker=JobSeekerWithAddressFactory(),
         )
         self.job_seeker = self.job_application.job_seeker
-
-        assert not self.job_seeker.has_jobseeker_profile
 
         # Changed job application: new URL
         self.url = reverse("employee_record_views:create_step_2", args=(self.job_application.pk,))
@@ -421,7 +419,7 @@ class CreateEmployeeRecordStep3Test(AbstractCreateEmployeeRecordTest):
         super().setUp()
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
-            job_seeker=JobSeekerWithMockedAddressFactory(jobseeker_profile=False),
+            job_seeker=JobSeekerWithMockedAddressFactory(),
         )
         self.job_seeker = self.job_application.job_seeker
         self.url = reverse("employee_record_views:create_step_3", args=(self.job_application.id,))
@@ -590,7 +588,7 @@ class CreateEmployeeRecordStep4Test(AbstractCreateEmployeeRecordTest):
         super().setUp()
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
-            job_seeker=JobSeekerWithMockedAddressFactory(jobseeker_profile=False),
+            job_seeker=JobSeekerWithMockedAddressFactory(),
         )
         self.job_seeker = self.job_application.job_seeker
         self.url = reverse("employee_record_views:create_step_4", args=(self.job_application.id,))
@@ -620,7 +618,7 @@ class CreateEmployeeRecordStep5Test(AbstractCreateEmployeeRecordTest):
         super().setUp()
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
-            job_seeker=JobSeekerWithMockedAddressFactory(jobseeker_profile=False),
+            job_seeker=JobSeekerWithMockedAddressFactory(),
         )
         self.job_seeker = self.job_application.job_seeker
         self.url = reverse("employee_record_views:create_step_5", args=(self.job_application.id,))
@@ -668,7 +666,7 @@ class UpdateRejectedEmployeeRecordTest(AbstractCreateEmployeeRecordTest):
         super().setUp()
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_siae=self.siae,
-            job_seeker=JobSeekerWithMockedAddressFactory(jobseeker_profile=False),
+            job_seeker=JobSeekerWithMockedAddressFactory(),
         )
         self.job_seeker = self.job_application.job_seeker
         self.url = reverse("employee_record_views:create_step_5", args=(self.job_application.id,))

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -13,7 +13,6 @@ from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
 from itou.job_applications.models import JobApplication
 from itou.users.enums import LackOfNIRReason
-from itou.users.models import JobSeekerProfile
 from itou.utils.pagination import pager
 from itou.utils.perms.employee_record import can_create_employee_record, siae_is_allowed
 from itou.utils.perms.siae import get_current_siae_or_404
@@ -204,7 +203,7 @@ def create_step_2(request, job_application_id, template_name="employee_record/cr
     """
     job_application = can_create_employee_record(request, job_application_id)
     job_seeker = job_application.job_seeker
-    profile, _ = JobSeekerProfile.objects.get_or_create(user=job_seeker)
+    profile = job_seeker.jobseeker_profile
     address_filled = job_seeker.post_code and job_seeker.address_line_1
     form = NewEmployeeRecordStep2Form(data=request.POST or None, instance=profile)
 


### PR DESCRIPTION
Suite de la discussion entamée sur #tech-c1 .

Nous optons pour l'approche la plus simple pour l'instant.
