### PR TITLE
Contrôle a posteriori: validation automatique des revues complètes de la DDETS lors de la clôture de la campagne

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -560,18 +560,6 @@ class EvaluatedSiae(models.Model):
         if self.reviewed_at and not self.evaluation_is_final:
             return evaluation_enums.EvaluatedSiaeState.ADVERSARIAL_STAGE
 
-        if (
-            self.final_reviewed_at is None
-            and self.evaluation_campaign.ended_at
-            # reviewed_at is always set during the campaign.
-            and any(
-                eval_admin_crit.submitted_at > self.reviewed_at
-                for eval_job_app in self.evaluated_job_applications.all()
-                for eval_admin_crit in eval_job_app.evaluated_administrative_criteria.all()
-            )
-        ):
-            return evaluation_enums.EvaluatedSiaeState.ACCEPTED
-
         if state_from_applications == evaluation_enums.EvaluatedSiaeState.REFUSED:
             if self.evaluation_is_final:
                 return NOTIFICATION_PENDING_OR_REFUSED

--- a/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
+++ b/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
@@ -1,5 +1,21 @@
 # serializer version: 1
-# name: EvaluationCampaignManagerTest.test_close[no docs email body]
+# name: EvaluationCampaignManagerTest.test_close_accepted_but_not_reviewed[accepted email body]
+  '''
+  Bonjour,
+  
+  La DDETS 01 a validé la conformité des nouveaux justificatifs que vous avez transmis dans le cadre du contrôle a posteriori sur les embauches réalisées en auto-prescription entre le 01 Janvier 2022 et le 30 Septembre 2022.
+  
+  Cette campagne de contrôle est terminée pour votre SIAE EI Les petits jardins ID-2000.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_close_no_response[no docs email body]
   '''
   Bonjour,
   
@@ -19,7 +35,43 @@
   http://127.0.0.1:8000
   '''
 # ---
-# name: EvaluationCampaignManagerTest.test_close[sanction notification email body]
+# name: EvaluationCampaignManagerTest.test_close_no_response[sanction notification email body]
+  '''
+  Bonjour,
+  
+  Suite au dernier contrôle a posteriori, une ou plusieurs SIAE de votre département ont obtenu un résultat négatif.
+  Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
+  
+  Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
+  http://127.0.0.1:8000/siae_evaluation/institution_evaluated_siae_list/1000/
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_close_refused_but_not_reviewed[refused email body]
+  '''
+  Bonjour,
+  
+  Vous trouverez ci-après le résultat du contrôle a posteriori sur vos auto-prescriptions réalisées entre le 01 Janvier 2022 et le 30 Septembre 2022.
+  
+  La DDETS 01 a vérifié les nouveaux justificatifs transmis par votre structure EI Les petits jardins ID-2000 dans le cadre de la phase contradictoire du contrôle a posteriori sur vos embauches réalisées en auto-prescription entre le 01 Janvier 2022 et le 30 Septembre 2022.
+  
+  Un ou plusieurs de vos justificatifs n’ont pas été validés par conséquent votre résultat concernant cette procédure est négatif (vous serez alerté des sanctions éventuelles concernant votre SIAE prochainement) conformément à l’instruction N° DGEFP/SDPAE/MIP/2022/83 du 5 avril 2022 relative à la mise en œuvre opérationnelle du contrôle a posteriori des recrutements en auto-prescription prévu par les articles R. 5132-1-12 à R. 5132-1-17 du code du travail.
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://127.0.0.1:8000
+  '''
+# ---
+# name: EvaluationCampaignManagerTest.test_close_refused_but_not_reviewed[sanction notification email body]
   '''
   Bonjour,
   

--- a/itou/siae_evaluations/tests/tests_models.py
+++ b/itou/siae_evaluations/tests/tests_models.py
@@ -1135,21 +1135,6 @@ class EvaluatedSiaeModelTest(TestCase):
         )
         assert evaluated_job_app.evaluated_siae.state == evaluation_enums.EvaluatedSiaeState.REFUSED
 
-    def test_state_on_closed_campaign_criteria_refused_review_not_validated(self):
-        evaluated_job_app = EvaluatedJobApplicationFactory(
-            evaluated_siae__evaluation_campaign__ended_at=timezone.now(),
-            evaluated_siae__reviewed_at=timezone.now() - relativedelta(days=5),
-        )
-        EvaluatedAdministrativeCriteriaFactory(
-            evaluated_job_application=evaluated_job_app,
-            uploaded_at=timezone.now() - relativedelta(days=2),
-            submitted_at=timezone.now() - relativedelta(days=1),
-            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2,
-        )
-        # Was not reviewed by the institution, assume valid (following rules in
-        # most administrations).
-        assert evaluated_job_app.evaluated_siae.state == evaluation_enums.EvaluatedSiaeState.ACCEPTED
-
     def test_state_on_closed_campaign_criteria_refused_review_validated(self):
         evaluated_job_app = EvaluatedJobApplicationFactory(
             evaluated_siae__reviewed_at=timezone.now(),

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -697,9 +697,9 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         )
         self.assertNotContains(response, self.control_text)
         self.assertNotContains(response, self.submit_text)
-        # Was not reviewed by the institution, assume valid (following rules in
-        # most administrations).
-        self.assertContains(response, self.forced_positive_text, html=True, count=1)
+        # The institution reviewed but forgot to validate
+        # auto-validation kicked in and the final result is refused
+        self.assertNotContains(response, self.forced_positive_text, html=True)
         self.assertNotContains(response, self.forced_positive_text_transition_to_adversarial_stage, html=True)
         self.assertNotContains(response, self.forced_negative_text, html=True)
 

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -666,7 +666,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluation_campaign = EvaluationCampaignFactory(
             institution=self.institution,
             evaluations_asked_at=timezone.now() - relativedelta(weeks=6),
-            ended_at=timezone.now(),
             name="Contrôle Test",
         )
         evaluated_siae = EvaluatedSiaeFactory(
@@ -681,6 +680,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
             submitted_at=timezone.now() - relativedelta(days=1),
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2,
         )
+        evaluation_campaign.close()
 
         self.client.force_login(self.user)
         response = self.client.get(
@@ -787,7 +787,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluation_campaign = EvaluationCampaignFactory(
             institution=self.institution,
             evaluations_asked_at=timezone.now() - relativedelta(weeks=6),
-            ended_at=timezone.now(),
             name="Contrôle Test",
         )
         evaluated_siae = EvaluatedSiaeFactory(
@@ -801,8 +800,8 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
             evaluated_job_application=evaluated_job_app,
             uploaded_at=timezone.now() - relativedelta(days=2),
             submitted_at=timezone.now() - relativedelta(days=1),
-            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2,
         )
+        evaluation_campaign.close()
 
         self.client.force_login(self.user)
         response = self.client.get(
@@ -813,7 +812,11 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         )
         self.assertContains(
             response,
-            '<p class="badge badge-pill badge-danger float-right">Problème constaté</p>',
+            """
+            <p class="badge badge-pill badge-info-light text-primary float-right">
+             Justificatifs non contrôlés
+            </p>
+            """,
             html=True,
             count=1,
         )


### PR DESCRIPTION
### Pourquoi ?

Pour rester cohérent avec la phase 2

Et en bonus, cela permet de simplifier le code de calcul du `state` :tada: 
