### PR TITLE
Correction du choix de SIAEs à l'inscription

### DIFF
--- a/itou/www/signup/tests/test_siae.py
+++ b/itou/www/signup/tests/test_siae.py
@@ -323,6 +323,7 @@ class SiaeSignupTest(InclusionConnectBaseTestCase):
             SiaeWithMembershipAndJobsFactory(siret="40219166200003"),
             SiaeWithMembershipAndJobsFactory(siret="40219166200004"),
             SiaeWithMembershipAndJobsFactory(siret="40219166200005"),
+            SiaeWithMembershipAndJobsFactory(siret="40219166200005", kind=SiaeKind.AI),
         )
         # Add more than one member to all SIAE to test prefetch and distinct
         for siae in siaes:
@@ -342,9 +343,12 @@ class SiaeSignupTest(InclusionConnectBaseTestCase):
         ):
             response = self.client.get(url, {"siren": "402191662"})
         assert response.status_code == 200
-        self.assertContains(response, "402191662", count=6)  # 1 input + 5 results
-        for siae in siaes:
-            self.assertContains(response, siae.siret_nic, count=1)
+        self.assertContains(response, "402191662", count=7)  # 1 input + 6 results
+        self.assertContains(response, "00001", count=1)
+        self.assertContains(response, "00002", count=1)
+        self.assertContains(response, "00003", count=1)
+        self.assertContains(response, "00004", count=1)
+        self.assertContains(response, "00005", count=2)
 
 
 class SiaeSignupViewsExceptionsTest(TestCase):

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -167,7 +167,7 @@ def siae_select(request, template_name="signup/siae_select.html"):
     if request.method in ["GET", "POST"] and siren_form.is_valid():
         # Make sure to look only for active structures.
         siaes_for_siren = (
-            Siae.objects.active().filter(siret__startswith=siren_form.cleaned_data["siren"]).distinct("siret")
+            Siae.objects.active().filter(siret__startswith=siren_form.cleaned_data["siren"]).distinct("pk")
         )
         # A user cannot join structures that already have members.
         # Show these structures in the template to make that clear.


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/BUG-lors-de-l-inscription-nous-n-affichons-plus-toutes-les-entreprises-disponibles-en-base-4c1ddfd6f5f24f6e97f434cb19f29e0b?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Dans le cas où l'on a plusieurs SIAEs avec le même siret, on n'affichait qu'une seule (choisie aléatoirement par PSQL)
