### PR TITLE
Contrôle a posteriori: écran SIAE - renommage du statut "traité" en "justificatifs téléversés"

### DIFF
--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
@@ -14,7 +14,7 @@
             {% if state == "ACCEPTED" %}
                 <p class="badge badge-pill badge-success float-right">validé</p>
             {% elif state == "UPLOADED" %}
-                <p class="badge badge-pill badge-success float-right">traité</p>
+                <p class="badge badge-pill badge-success float-right">justificatifs téléversés</p>
             {% elif state == "SUBMITTED" %}
                 <p class="badge badge-pill badge-communaute-light float-right">transmis</p>
             {% else %}
@@ -27,7 +27,7 @@
             {% elif state == "PROCESSING" %}
                 <p class="badge badge-pill badge-pilotage float-right">en cours</p>
             {% elif state == "UPLOADED" %}
-                <p class="badge badge-pill badge-success float-right">traité</p>
+                <p class="badge badge-pill badge-success float-right">justificatifs téléversés</p>
             {% elif state == "SUBMITTED" or state == "REFUSED" or state == "ACCEPTED" %}
                 <p class="badge badge-pill badge-communaute-light float-right">transmis</p>
             {% endif %}

--- a/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_siaes_views.py
@@ -274,6 +274,9 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
         self.assertContains(response, submit_active, html=True, count=2)
         self.assertContains(response, select_criteria)
         self.assertContains(response, upload_proof)
+        self.assertContains(
+            response, '<p class="badge badge-pill badge-success float-right">justificatifs téléversés</p>'
+        )
 
         # criterion submitted
         evaluated_administrative_criteria.submitted_at = fake_now


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/ECRAN-SIAE-Changer-le-statut-trait-par-justificatifs-t-l-vers-s-451d213377ec4a57ba2e01d74e5ecbbe?pvs=4

### Pourquoi ?

"traité" est très vague


