### PR TITLE
Contrôle a posteriori: changer le statut “en attente” par “problème constaté” lors de la phase de blocage dans la liste des SIAEs controlées (coté DDETS)

### DIFF
--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
@@ -26,9 +26,17 @@
             {% endif %}
         {% else %}
             {% if state == "PENDING" or state == "PROCESSING" %}
-                <p class="badge badge-pill badge-emploi float-right">En attente</p>
+                {% if evaluated_siae.submission_freezed_at %}
+                    <p class="badge badge-pill badge-danger float-right">Justificatifs non transmis</p>
+                {% else %}
+                    <p class="badge badge-pill badge-emploi float-right">En attente</p>
+                {% endif %}
             {% elif state == "UPLOADED" %}
-                <p class="badge badge-pill badge-pilotage float-right">Justificatifs téléversés</p>
+                {% if evaluated_siae.submission_freezed_at %}
+                    <p class="badge badge-pill badge-danger float-right">Justificatifs non transmis</p>
+                {% else %}
+                    <p class="badge badge-pill badge-pilotage float-right">Justificatifs téléversés</p>
+                {% endif %}
             {% elif state == "SUBMITTED" %}
                 <p class="badge badge-pill badge-pilotage float-right">
                     {% if reviewed_at %}

--- a/itou/templates/siae_evaluations/includes/siae_infos.html
+++ b/itou/templates/siae_evaluations/includes/siae_infos.html
@@ -25,10 +25,7 @@
                     À traiter
                 </p>
             {% elif evaluated_siae.state == "REFUSED" or evaluated_siae.state == "ACCEPTED" %}
-                <p class="badge badge-pill badge-pilotage float-right">
-                    {% if evaluated_siae.reviewed_at %}Phase contradictoire -{% endif %}
-                    En cours
-                </p>
+                <p class="badge badge-pill badge-pilotage float-right">En cours</p>
             {% elif evaluated_siae.state == "ADVERSARIAL_STAGE" %}
                 <p class="badge badge-pill badge-marche-light float-right">Phase contradictoire</p>
             {% else %}

--- a/itou/templates/siae_evaluations/includes/siae_infos.html
+++ b/itou/templates/siae_evaluations/includes/siae_infos.html
@@ -2,7 +2,7 @@
     <div class="col-lg-9 col-md-9 col-8">
         <h3 >{{ evaluated_siae }}</h3>
     </div>
-    <div class="col-lg-3 col-md-3 col-4">
+    <div id="state_of_evaluated_siae-{{ evaluated_siae.pk }}" class="col-lg-3 col-md-3 col-4">
         {% if evaluated_siae.evaluation_is_final %}
             {# Only 3 states are possible when evaluation_is_final: ACCEPTED, NOTIFICATION_PENDING and REFUSED #}
             {% if evaluated_siae.state == "ACCEPTED" %}

--- a/itou/templates/siae_evaluations/includes/siae_infos.html
+++ b/itou/templates/siae_evaluations/includes/siae_infos.html
@@ -29,10 +29,18 @@
             {% elif evaluated_siae.state == "ADVERSARIAL_STAGE" %}
                 <p class="badge badge-pill badge-marche-light float-right">Phase contradictoire</p>
             {% else %}
-                <p class="badge badge-pill badge-emploi float-right">
-                    {% if evaluated_siae.reviewed_at %}Phase contradictoire -{% endif %}
-                    En attente
-                </p>
+                {# PENDING or SUBMITTABLE (NOTIFICATION_PENDING impossible without evaluation_is_final) #}
+                {% if evaluated_siae.submission_freezed_at %}
+                    <p class="badge badge-pill badge-danger float-right">
+                        {% if evaluated_siae.reviewed_at %}Phase contradictoire -{% endif %}
+                        Problème constaté
+                    </p>
+                {% else %}
+                    <p class="badge badge-pill badge-emploi float-right">
+                        {% if evaluated_siae.reviewed_at %}Phase contradictoire -{% endif %}
+                        En attente
+                    </p>
+                {% endif %}
             {% endif %}
         {% endif %}
     </div>

--- a/itou/www/siae_evaluations_views/tests/__snapshots__/tests_institutions_views.ambr
+++ b/itou/www/siae_evaluations_views/tests/__snapshots__/tests_institutions_views.ambr
@@ -18,10 +18,13 @@
   <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
           
               
-                  <p class="badge badge-pill badge-emploi float-right">
-                      
-                      En attente
-                  </p>
+                  
+                  
+                      <p class="badge badge-pill badge-emploi float-right">
+                          
+                          En attente
+                      </p>
+                  
               
           
       </div>
@@ -124,10 +127,13 @@
   <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
           
               
-                  <p class="badge badge-pill badge-emploi float-right">
-                      Phase contradictoire -
-                      En attente
-                  </p>
+                  
+                  
+                      <p class="badge badge-pill badge-emploi float-right">
+                          Phase contradictoire -
+                          En attente
+                      </p>
+                  
               
           
       </div>
@@ -177,9 +183,43 @@
   <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
           
               
-                  <p class="badge badge-pill badge-emploi float-right">
+                  
+                  
+                      <p class="badge badge-pill badge-emploi float-right">
+                          
+                          En attente
+                      </p>
+                  
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_infos_with_submission_freezed_at[identified issue state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+                  
+                  
+                      <p class="badge badge-pill badge-danger float-right">
+                          
+                          Problème constaté
+                      </p>
+                  
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_infos_with_submission_freezed_at[to process state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+                  <p class="badge badge-pill badge-pilotage float-right">
                       
-                      En attente
+                      À traiter
                   </p>
               
           

--- a/itou/www/siae_evaluations_views/tests/__snapshots__/tests_institutions_views.ambr
+++ b/itou/www/siae_evaluations_views/tests/__snapshots__/tests_institutions_views.ambr
@@ -152,10 +152,7 @@
   <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
           
               
-                  <p class="badge badge-pill badge-pilotage float-right">
-                      
-                      En cours
-                  </p>
+                  <p class="badge badge-pill badge-pilotage float-right">En cours</p>
               
           
       </div>

--- a/itou/www/siae_evaluations_views/tests/__snapshots__/tests_institutions_views.ambr
+++ b/itou/www/siae_evaluations_views/tests/__snapshots__/tests_institutions_views.ambr
@@ -1,0 +1,205 @@
+# serializer version: 1
+# name: InstitutionEvaluatedSiaeListViewTest.test_access[notification pending state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+              
+                  <p class="badge badge-pill badge-accent-03 text-primary float-right">
+                      <i class="ri-arrow-right-circle-line mr-1"></i> Notification à faire
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_access[waiting state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+                  <p class="badge badge-pill badge-emploi float-right">
+                      
+                      En attente
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_notified_siae[final refused state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+              
+                  <p class="badge badge-pill badge-danger float-right">
+                      <i class="ri-close-circle-line mr-1"></i> Résultat négatif
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_recently_closed_campaign[final accepted state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+              
+                  <p class="badge badge-pill badge-success float-right">
+                      <i class="ri-checkbox-circle-line mr-1"></i> Résultat positif
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_incomplete_refused_can_be_notified[notification pending state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+              
+                  <p class="badge badge-pill badge-accent-03 text-primary float-right">
+                      <i class="ri-arrow-right-circle-line mr-1"></i> Notification à faire
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_incomplete_refused_can_be_notified_after_review[notification pending state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+              
+                  <p class="badge badge-pill badge-accent-03 text-primary float-right">
+                      <i class="ri-arrow-right-circle-line mr-1"></i> Notification à faire
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_infos[adversarial in progress state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+                  <p class="badge badge-pill badge-marche-light float-right">Phase contradictoire</p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_infos[adversarial stage state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+                  <p class="badge badge-pill badge-marche-light float-right">Phase contradictoire</p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_infos[adversarial to process state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+                  <p class="badge badge-pill badge-pilotage float-right">
+                      Phase contradictoire -
+                      À traiter
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_infos[adversarial waiting state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+                  <p class="badge badge-pill badge-emploi float-right">
+                      Phase contradictoire -
+                      En attente
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_infos[final accepted state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+              
+                  <p class="badge badge-pill badge-success float-right">
+                      <i class="ri-checkbox-circle-line mr-1"></i> Résultat positif
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_infos[in progress state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+                  <p class="badge badge-pill badge-pilotage float-right">
+                      
+                      En cours
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_infos[to process state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+                  <p class="badge badge-pill badge-pilotage float-right">
+                      
+                      À traiter
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_infos[waiting state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+                  <p class="badge badge-pill badge-emploi float-right">
+                      
+                      En attente
+                  </p>
+              
+          
+      </div>
+  '''
+# ---
+# name: InstitutionEvaluatedSiaeListViewTest.test_siae_refused_can_be_notified[notification pending state]
+  '''
+  <div class="col-lg-3 col-md-3 col-4" id="state_of_evaluated_siae-1000">
+          
+              
+              
+                  <p class="badge badge-pill badge-accent-03 text-primary float-right">
+                      <i class="ri-arrow-right-circle-line mr-1"></i> Notification à faire
+                  </p>
+              
+          
+      </div>
+  '''
+# ---

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -1437,6 +1437,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
 
     def test_job_seeker_infos_for_institution_state(self):
         en_attente = "En attente"
+        uploaded = "Justificatifs téléversés"
         a_traiter = "À traiter"
         refuse = "Problème constaté"
         valide = "Validé"
@@ -1456,6 +1457,14 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         # not yet submitted by Siae
         response = self.client.get(url)
         self.assertContains(response, en_attente)
+
+        # submittable by SIAE
+        EvaluatedAdministrativeCriteria.objects.filter(
+            evaluated_job_application__evaluated_siae=evaluated_siae
+        ).update(proof_url="https://server.com/rocky-balboa.pdf")
+
+        response = self.client.get(url)
+        self.assertContains(response, uploaded)
 
         # submitted by Siae
         EvaluatedAdministrativeCriteria.objects.filter(


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/ECRAN-DDETS-PHASE-BIS-Adapter-les-statuts-Quand-une-SIAE-n-a-pas-soumis-validation-ses-justifi-54064c4551184b3189e361f014aca95c

### Pourquoi ?

Pour aider les DDETS à indentifier les SIAE n'ayant pas transmis de document.
Et pour avoir un peu plus de tests

