### PR TITLE
Préférer localhost au lieu de 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ docker compose run --service-ports django
 ### Accéder au serveur de développement
 
 Une fois votre serveur de développement lancé, vous pouvez accéder au frontend à
-l'adresse http://127.0.0.1:8000/.
+l'adresse http://localhost:8000/.
 
 ### Peupler la base de données
 

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -66,7 +66,7 @@ REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] += [  # noqa: F405
 ASP_ITOU_PREFIX = "XXXXX"  # same as in our fixtures
 
 ITOU_PROTOCOL = "http"
-ITOU_FQDN = "127.0.0.1:8000"
+ITOU_FQDN = "localhost:8000"
 
 DATABASES["default"]["HOST"] = os.getenv("PGHOST", "127.0.0.1")  # noqa: F405
 DATABASES["default"]["PORT"] = os.getenv("PGPORT", "5432")  # noqa: F405

--- a/itou/api/README-FS-SSII.md
+++ b/itou/api/README-FS-SSII.md
@@ -45,7 +45,7 @@ Réponse :
 Notes :
 
 - [Vous devez encoder tout caractère spécial](https://fr.wikipedia.org/wiki/Encodage-pourcent) dans l'email et le mot de passe. Par exemple `+` devient `%2B`.
-- Pour les développeurs itou qui souhaitent utiliser l'API en local dev, remplacer `https://emplois.inclusion.beta.gouv.fr` par `http://127.0.0.1:8000`.
+- Pour les développeurs itou qui souhaitent utiliser l'API en local dev, remplacer `https://emplois.inclusion.beta.gouv.fr` par `http://localhost:8000`.
 
 
 ### Obtention des FS

--- a/itou/openid_connect/france_connect/tests.py
+++ b/itou/openid_connect/france_connect/tests.py
@@ -302,6 +302,6 @@ class FranceConnectTest(TestCase):
         response = self.client.get(url, data={"id_token": "123"})
         expected_url = (
             f"{constants.FRANCE_CONNECT_ENDPOINT_LOGOUT}?id_token_hint=123&state=&"
-            "post_logout_redirect_uri=http%3A%2F%2F127.0.0.1:8000%2F"
+            "post_logout_redirect_uri=http%3A%2F%2Flocalhost:8000%2F"
         )
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)

--- a/itou/siae_evaluations/tests/__snapshots__/test_emails.ambr
+++ b/itou/siae_evaluations/tests/__snapshots__/test_emails.ambr
@@ -14,7 +14,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: TestInstitutionEmailFactory.test_close_notifies_when_siae_has_negative_result[sanction notification email]
@@ -25,14 +25,14 @@
   Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
   
   Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
-  http://127.0.0.1:8000/siae_evaluation/institution_evaluated_siae_list/1/
+  http://localhost:8000/siae_evaluation/institution_evaluated_siae_list/1/
   
   Cordialement,
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: TestInstitutionEmailFactory.test_close_notify_when_siae_has_positive_result_in_adversarial_phase[accepted result email]
@@ -48,6 +48,6 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---

--- a/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
+++ b/itou/siae_evaluations/tests/__snapshots__/tests_models.ambr
@@ -12,7 +12,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_close_no_response[no docs email body]
@@ -32,7 +32,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_close_no_response[sanction notification email body]
@@ -43,14 +43,14 @@
   Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
   
   Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
-  http://127.0.0.1:8000/siae_evaluation/institution_evaluated_siae_list/1000/
+  http://localhost:8000/siae_evaluation/institution_evaluated_siae_list/1000/
   
   Cordialement,
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_close_refused_but_not_reviewed[refused email body]
@@ -68,7 +68,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_close_refused_but_not_reviewed[sanction notification email body]
@@ -79,14 +79,14 @@
   Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
   
   Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
-  http://127.0.0.1:8000/siae_evaluation/institution_evaluated_siae_list/1000/
+  http://localhost:8000/siae_evaluation/institution_evaluated_siae_list/1000/
   
   Cordialement,
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[accepted review email body]
@@ -102,7 +102,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[force accepted email body]
@@ -120,7 +120,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[institution summary email body]
@@ -148,7 +148,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[no docs email body]
@@ -161,7 +161,7 @@
   
   Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les petits jardins ID-2002 à la rubrique “Contrôle a posteriori > Campagne en cours”.
   
-  Accès direct à votre liste d’auto-prescriptions : http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1002/
+  Accès direct à votre liste d’auto-prescriptions : http://localhost:8000/siae_evaluation/siae_job_applications_list/1002/
   
   En cas de besoin, vous pouvez consulter ce mode d’emploi : https://documentation.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
   
@@ -170,7 +170,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[no response email body]
@@ -183,7 +183,7 @@
   
   Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les grands jardins ID-2001 à la rubrique “Contrôle a posteriori > Campagne en cours”.
   
-  Accès direct à votre liste d’auto-prescriptions : http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1001/
+  Accès direct à votre liste d’auto-prescriptions : http://localhost:8000/siae_evaluation/siae_job_applications_list/1001/
   
   En cas de besoin, vous pouvez consulter ce mode d’emploi : https://documentation.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
   
@@ -192,7 +192,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase[refused review email body]
@@ -216,7 +216,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_accepted_but_not_reviewed[positive review email body]
@@ -232,7 +232,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_force_accepted[force accepted email body]
@@ -250,7 +250,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_force_accepted[institution summary email body]
@@ -266,7 +266,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_forced_to_adversarial_stage[institution summary email body]
@@ -286,7 +286,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_forced_to_adversarial_stage[no response email body]
@@ -299,7 +299,7 @@
   
   Pour transmettre les justificatifs, rendez-vous sur le tableau de bord de EI Les grands jardins ID-2000 à la rubrique “Contrôle a posteriori > Campagne en cours”.
   
-  Accès direct à votre liste d’auto-prescriptions : http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/1000/
+  Accès direct à votre liste d’auto-prescriptions : http://localhost:8000/siae_evaluation/siae_job_applications_list/1000/
   
   En cas de besoin, vous pouvez consulter ce mode d’emploi : https://documentation.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
   
@@ -308,7 +308,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---
 # name: EvaluationCampaignManagerTest.test_transition_to_adversarial_phase_refused_but_not_reviewed[negative review email body]
@@ -332,6 +332,6 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://127.0.0.1:8000
+  http://localhost:8000
   '''
 # ---

--- a/itou/siae_evaluations/tests/test_management_commands.py
+++ b/itou/siae_evaluations/tests/test_management_commands.py
@@ -92,7 +92,7 @@ class TestManagementCommand:
             "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
             "7 novembre 2022.\n\n" in mail1.body
         )
-        assert f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae1.pk}/" in mail1.body
+        assert f"http://localhost:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae1.pk}/" in mail1.body
         assert mail2.subject == (
             "Contrôle a posteriori des auto-prescriptions : "
             "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 02"
@@ -106,7 +106,7 @@ class TestManagementCommand:
             "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
             "7 novembre 2022.\n\n" in mail2.body
         )
-        assert f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae2.pk}/" in mail2.body
+        assert f"http://localhost:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae2.pk}/" in mail2.body
         assert mail3.subject == (
             "Contrôle a posteriori des auto-prescriptions : "
             "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 02"
@@ -120,7 +120,7 @@ class TestManagementCommand:
             "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
             "7 novembre 2022.\n\n" in mail3.body
         )
-        assert f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae3.pk}/" in mail3.body
+        assert f"http://localhost:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae3.pk}/" in mail3.body
 
     @freeze_time("2022-12-07 11:11:11")
     def test_notify_fallback(self, capsys, mailoutbox):
@@ -157,7 +157,7 @@ class TestManagementCommand:
             "Nous vous rappelons que ce contrôle des DDETS doit être réalisé dans un délai de 6 semaines à compter du "
             "6 novembre 2022.\n\n" in mail.body
         )
-        assert f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae.pk}/" in mail.body
+        assert f"http://localhost:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae.pk}/" in mail.body
 
     @freeze_time("2022-12-07 11:11:11")
     def test_does_not_notify_twice(self, capsys, mailoutbox):
@@ -289,7 +289,7 @@ class TestManagementCommand:
             "7 novembre 2022.\n\n" in mail1.body
         )
         assert (
-            f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_no_proof.pk}/"
+            f"http://localhost:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_no_proof.pk}/"
             in mail1.body
         )
         assert mail2.subject == (
@@ -306,7 +306,7 @@ class TestManagementCommand:
             "7 novembre 2022.\n\n" in mail2.body
         )
         assert (
-            f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_not_submitted.pk}/"
+            f"http://localhost:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_not_submitted.pk}/"
             in mail2.body
         )
 
@@ -386,7 +386,7 @@ class TestManagementCommand:
             "19 décembre 2022.\n\n" in mail1.body
         )
         assert (
-            f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_no_answer.pk}/"
+            f"http://localhost:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_no_answer.pk}/"
             in mail1.body
         )
         assert mail2.subject == (
@@ -404,7 +404,7 @@ class TestManagementCommand:
             "19 décembre 2022.\n\n" in mail2.body
         )
         assert (
-            f"http://127.0.0.1:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_reviewed_quickly.pk}/"
+            f"http://localhost:8000/siae_evaluation/siae_job_applications_list/{evaluated_siae_reviewed_quickly.pk}/"
             in mail2.body
         )
 

--- a/itou/utils/urls.py
+++ b/itou/utils/urls.py
@@ -13,7 +13,7 @@ def get_safe_url(request, param_name=None, fallback_url=None, url=None):
 
     if url:
         if settings.DEBUG:
-            # In DEBUG mode the network location part `127.0.0.1:8000` contains
+            # In DEBUG mode the network location part `localhost:8000` contains
             # a port and fails the validation of `url_has_allowed_host_and_scheme`
             # since it's not a member of `allowed_hosts`:
             # https://github.com/django/django/blob/525274f/django/utils/http.py#L413
@@ -57,10 +57,10 @@ def add_url_params(url: str, params: dict[str, str]) -> str:
     :param params: dict containing requested params to be added
     :return: string with updated URL
 
-    >> url = 'http://127.0.0.1:8000/login/activate_siae_staff_account?next_url=%2Finvitations
+    >> url = 'http://localhost:8000/login/activate_siae_staff_account?next_url=%2Finvitations
     >> new_params = {'test': 'value' }
     >> add_url_params(url, new_params)
-    'http://127.0.0.1:8000/login/activate_siae_staff_account?next_url=%2Finvitations&test=value
+    'http://localhost:8000/login/activate_siae_staff_account?next_url=%2Finvitations&test=value
     """
 
     # Remove params with None values

--- a/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
+++ b/itou/www/siae_evaluations_views/tests/tests_institutions_views.py
@@ -2370,7 +2370,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://127.0.0.1:8000"
+            "http://localhost:8000"
         )
         assert evaluated_siae.sanctions.training_session == "RDV le lundi 8 à 15h à la DDETS"
         assert evaluated_siae.sanctions.suspension_dates is None
@@ -2427,7 +2427,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://127.0.0.1:8000"
+            "http://localhost:8000"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates == InclusiveDateRange(
@@ -2754,7 +2754,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://127.0.0.1:8000"
+            "http://localhost:8000"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates == InclusiveDateRange(datetime.date(2023, 1, 1))
@@ -2864,7 +2864,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://127.0.0.1:8000"
+            "http://localhost:8000"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates is None
@@ -3010,7 +3010,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://127.0.0.1:8000"
+            "http://localhost:8000"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates is None
@@ -3067,7 +3067,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://127.0.0.1:8000"
+            "http://localhost:8000"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates is None
@@ -3118,7 +3118,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://127.0.0.1:8000"
+            "http://localhost:8000"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates is None
@@ -3193,7 +3193,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://127.0.0.1:8000"
+            "http://localhost:8000"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates == InclusiveDateRange(datetime.date(2023, 1, 1))


### PR DESCRIPTION
## Pourquoi ?
`127.0.0.1` est tellement IPv4…

Une isntance locale d’inclusion connect requiert une liste de validation pour le schéma et les hôtes vers lesquels IC peut rediriger. Pour harmoniser, utilisons le nom le plus moderne pour la machine locale.