### PR TITLE
Parcours de candidature: suppression de l'action du formulaire

### DIFF
--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -5,7 +5,7 @@
 {% load static %}
 
 {% block left_column %}
-    <form method="post" action="{{ form_action }}" class="js-prevent-multiple-submit js-format-nir">
+    <form method="post" class="js-prevent-multiple-submit js-format-nir">
         <div class="card c-card p-3">
             <div class="card-body">
 

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -285,7 +285,6 @@ class CheckNIRForJobSeekerView(ApplyStepForJobSeekerBaseView):
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
             "form": self.form,
-            "form_action": reverse("apply:check_nir_for_job_seeker", kwargs={"siae_pk": self.siae.pk}),
         }
 
 
@@ -348,7 +347,6 @@ class CheckNIRForSenderView(ApplyStepForSenderBaseView):
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
             "form": self.form,
-            "form_action": reverse("apply:check_nir_for_sender", kwargs={"siae_pk": self.siae.pk}),
         }
 
 


### PR DESCRIPTION
### Pourquoi ?

Dans les deux cas, cela correspond à l'URL de la page visitée le rendant inutile (et complexifiant le code inutilement, surtout lorsque l'on souhaite réutiliser ce même template dans une autre URL - :wave: Déclaration d'embauche)

