### PR TITLE
DDETS Logement Insertion : Ajout de leurs premières stats

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -105,6 +105,14 @@
                         </a>
                     </li>
                 {% endif %}
+                {% if can_view_stats_ddets_log %}
+                    <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="{% url 'stats:stats_ddets_log_state' %}" class="btn-link btn-ico">
+                            <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
+                            <span>Suivre les prescriptions des AHI de ma région</span>
+                        </a>
+                    </li>
+                {% endif %}
                 {% if can_view_stats_dreets_iae %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_dreets_iae_auto_prescription' %}" class="btn-link btn-ico">

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -771,15 +771,6 @@ class User(AbstractUser, AddressMixin):
             and not current_org.is_brsa
         )
 
-    def get_stats_cd_department(self, current_org):
-        """
-        Get department that the user has the permission to view for the CD stats page.
-        CD as in "Conseil Départemental".
-        """
-        if not self.can_view_stats_cd(current_org=current_org):
-            raise PermissionDenied
-        return current_org.department
-
     def can_view_stats_pe(self, current_org):
         return (
             self.is_prescriber
@@ -811,14 +802,6 @@ class User(AbstractUser, AddressMixin):
             and current_org.kind == InstitutionKind.DDETS_IAE
         )
 
-    def get_stats_ddets_iae_department(self, current_org):
-        """
-        Get department that the user has the permission to view for the DDETS IAE stats page.
-        """
-        if not self.can_view_stats_ddets_iae(current_org=current_org):
-            raise PermissionDenied
-        return current_org.department
-
     def can_view_stats_dreets_iae(self, current_org):
         """
         Users of a DREETS IAE can view the confidential DREETS IAE stats of their region only.
@@ -828,14 +811,6 @@ class User(AbstractUser, AddressMixin):
             and isinstance(current_org, Institution)
             and current_org.kind == InstitutionKind.DREETS_IAE
         )
-
-    def get_stats_dreets_iae_region(self, current_org):
-        """
-        Get region that the user has the permission to view for the DREETS IAE stats page.
-        """
-        if not self.can_view_stats_dreets_iae(current_org=current_org):
-            raise PermissionDenied
-        return current_org.region
 
     def can_view_stats_dgefp(self, current_org):
         """

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -721,6 +721,7 @@ class User(AbstractUser, AddressMixin):
             or self.can_view_stats_cd(current_org=current_org)
             or self.can_view_stats_pe(current_org=current_org)
             or self.can_view_stats_ddets_iae(current_org=current_org)
+            or self.can_view_stats_ddets_log(current_org=current_org)
             or self.can_view_stats_dreets_iae(current_org=current_org)
             or self.can_view_stats_dgefp(current_org=current_org)
             or self.can_view_stats_dihal(current_org=current_org)
@@ -800,6 +801,13 @@ class User(AbstractUser, AddressMixin):
             self.is_labor_inspector
             and isinstance(current_org, Institution)
             and current_org.kind == InstitutionKind.DDETS_IAE
+        )
+
+    def can_view_stats_ddets_log(self, current_org):
+        return (
+            self.is_labor_inspector
+            and isinstance(current_org, Institution)
+            and current_org.kind == InstitutionKind.DDETS_LOG
         )
 
     def can_view_stats_dreets_iae(self, current_org):

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -724,7 +724,6 @@ class ModelTest(TestCase):
         user = org.members.get()
         assert user.can_view_stats_cd(current_org=org)
         assert user.can_view_stats_dashboard_widget(current_org=org)
-        assert user.get_stats_cd_department(current_org=org) == org.department
 
         # Non admin prescriber can access as well.
         org = PrescriberOrganizationWithMembershipFactory(
@@ -837,7 +836,6 @@ class ModelTest(TestCase):
         user = institution.members.get()
         assert user.can_view_stats_ddets_iae(current_org=institution)
         assert user.can_view_stats_dashboard_widget(current_org=institution)
-        assert user.get_stats_ddets_iae_department(current_org=institution) == institution.department
 
         # Non admin member of DDETS IAE can access as well.
         institution = InstitutionWithMembershipFactory(
@@ -846,7 +844,6 @@ class ModelTest(TestCase):
         user = institution.members.get()
         assert user.can_view_stats_ddets_iae(current_org=institution)
         assert user.can_view_stats_dashboard_widget(current_org=institution)
-        assert user.get_stats_ddets_iae_department(current_org=institution) == institution.department
 
         # Member of institution of wrong kind cannot access.
         institution = InstitutionWithMembershipFactory(kind=InstitutionKind.OTHER, department="93")
@@ -860,7 +857,6 @@ class ModelTest(TestCase):
         user = institution.members.get()
         assert user.can_view_stats_dreets_iae(current_org=institution)
         assert user.can_view_stats_dashboard_widget(current_org=institution)
-        assert user.get_stats_dreets_iae_region(current_org=institution) == institution.region
 
         # Non admin member of DREETS IAE can access as well.
         institution = InstitutionWithMembershipFactory(
@@ -869,7 +865,6 @@ class ModelTest(TestCase):
         user = institution.members.get()
         assert user.can_view_stats_dreets_iae(current_org=institution)
         assert user.can_view_stats_dashboard_widget(current_org=institution)
-        assert user.get_stats_dreets_iae_region(current_org=institution) == institution.region
 
         # Member of institution of wrong kind cannot access.
         institution = InstitutionWithMembershipFactory(kind=InstitutionKind.OTHER, department="93")

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -96,6 +96,12 @@ METABASE_DASHBOARDS = {
         "tally_embed_form_id": "nPpXpQ",
     },
     #
+    # Institution stats - DDETS LOG - department level.
+    #
+    "stats_ddets_log_state": {
+        "dashboard_id": 310,
+    },
+    #
     # Institution stats - DREETS IAE - region level.
     #
     "stats_dreets_iae_auto_prescription": {

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -17,6 +17,7 @@ METABASE_DASHBOARDS = {
     "stats_public": {
         "dashboard_id": 119,
     },
+    #
     # Employer stats.
     #
     "stats_siae_etp": {
@@ -148,7 +149,7 @@ METABASE_DASHBOARDS = {
     # Institution stats - DIHAL - nation level.
     #
     "stats_dihal_state": {
-        "dashboard_id": 235,
+        "dashboard_id": 310,
     },
     #
     # Institution stats - IAE Network - nation level.

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -275,6 +275,13 @@ class DashboardViewTest(TestCase):
         self.assertNotContains(response, "Voir les données de ma structure (extranet ASP)")
         self.assertNotContains(response, reverse("stats:stats_siae_etp"))
 
+    def test_dashboard_ddets_log_institution_stats(self):
+        membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DDETS_LOG)
+        self.client.force_login(membershipfactory.user)
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertContains(response, "Suivre les prescriptions des AHI de ma région")
+        self.assertContains(response, reverse("stats:stats_ddets_log_state"))
+
     def test_dashboard_dihal_institution_stats(self):
         membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DIHAL)
         self.client.force_login(membershipfactory.user)

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -140,6 +140,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_view_stats_cd": request.user.can_view_stats_cd(current_org=current_org),
         "can_view_stats_pe": request.user.can_view_stats_pe(current_org=current_org),
         "can_view_stats_ddets_iae": request.user.can_view_stats_ddets_iae(current_org=current_org),
+        "can_view_stats_ddets_log": request.user.can_view_stats_ddets_log(current_org=current_org),
         "can_view_stats_dreets_iae": request.user.can_view_stats_dreets_iae(current_org=current_org),
         "can_view_stats_dgefp": request.user.can_view_stats_dgefp(current_org=current_org),
         "can_view_stats_dihal": request.user.can_view_stats_dihal(current_org=current_org),

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -41,6 +41,8 @@ urlpatterns = [
     path("ddets/iae", views.stats_ddets_iae_iae, name="stats_ddets_iae_iae"),
     path("ddets/siae_evaluation", views.stats_ddets_iae_siae_evaluation, name="stats_ddets_iae_siae_evaluation"),
     path("ddets/hiring", views.stats_ddets_iae_hiring, name="stats_ddets_iae_hiring"),
+    # Institution stats - DDETS LOG - department level.
+    path("ddets_log/state", views.stats_ddets_log_state, name="stats_ddets_log_state"),
     # Institution stats - DREETS IAE - region level.
     path(
         "dreets/auto_prescription",

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -511,7 +511,7 @@ def stats_dihal_state(request):
     context = {
         "page_title": "Suivi des prescriptions des AHI",
     }
-    return render_stats(request=request, context=context, params={})
+    return render_stats(request=request, context=context, params=get_params_for_whole_country())
 
 
 @login_required

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -62,16 +62,14 @@ def get_stats_ddets_iae_department(request):
     current_org = get_current_institution_or_404(request)
     if not request.user.can_view_stats_ddets_iae(current_org=current_org):
         raise PermissionDenied
-    department = request.user.get_stats_ddets_iae_department(current_org=current_org)
-    return department
+    return current_org.department
 
 
 def get_stats_dreets_iae_region(request):
     current_org = get_current_institution_or_404(request)
     if not request.user.can_view_stats_dreets_iae(current_org=current_org):
         raise PermissionDenied
-    region = request.user.get_stats_dreets_iae_region(current_org=current_org)
-    return region
+    return current_org.region
 
 
 def ensure_stats_dgefp_permission(request):
@@ -247,7 +245,7 @@ def stats_cd(request):
     current_org = get_current_org_or_404(request)
     if not request.user.can_view_stats_cd(current_org=current_org):
         raise PermissionDenied
-    department = request.user.get_stats_cd_department(current_org=current_org)
+    department = current_org.department
     params = get_params_for_departement(department)
     context = {
         "page_title": f"Données de mon département : {DEPARTMENTS[department]}",

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -398,6 +398,27 @@ def stats_ddets_iae_hiring(request):
     )
 
 
+@login_required
+def stats_ddets_log_state(request):
+    current_org = get_current_institution_or_404(request)
+    if not request.user.can_view_stats_ddets_log(current_org=current_org):
+        raise PermissionDenied
+    department = current_org.department
+    region = current_org.region
+    context = {
+        "page_title": f"Suivi des prescriptions des AHI de ma région ({region})",
+        # Tracking is based on ddets_log department even if we show stats for the whole region.
+        "department": department,
+        "matomo_custom_url_suffix": format_region_and_department_for_matomo(department),
+    }
+    params = get_params_for_region(region)
+    return render_stats(
+        request=request,
+        context=context,
+        params=params,
+    )
+
+
 def render_stats_dreets_iae(request, page_title):
     region = get_stats_dreets_iae_region(request)
     params = get_params_for_region(region)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Mettre-dispo-TB-Dihal-pour-les-DREET-DDETS-Logement-insertion-avec-une-vue-r-gionale-60760d61b8ef4614bb50c62bbb782769**

### Pourquoi ?

Pour que les DDETS LOG, et non plus seulement les DDETS IAE, aient accès à des stats pertinentes.

### Comment

- Cablage d'un nouveau TB 310 pour que chaque DDETS LOG puisse voir les données de toute sa région et filtrer par département, et non pas juste consulter les données de seulement son département comme on aurait pu s'y attendre.
- Recablage du TB DIHAL vers le nouveau TB 310 pour rester bien DNRY et pouvoir jeter l'ancien TB 235 obsolète.

### Captures d'écran

Vue d'une DDETS LOG :

<img width="926" alt="image" src="https://github.com/betagouv/itou/assets/10533583/b8dc69d6-1ee4-4e4a-b2bd-f8075121b677">
<img width="903" alt="image" src="https://github.com/betagouv/itou/assets/10533583/dc5d545e-cb0e-4b50-a44c-db0405c5c9a6">

Vue de la DIHAL :

<img width="880" alt="image" src="https://github.com/betagouv/itou/assets/10533583/80375d0a-0c35-49e2-ac64-301443d053a1">
<img width="919" alt="image" src="https://github.com/betagouv/itou/assets/10533583/c7cf268b-f1ba-400c-b1a2-0b8a66b80093">


