### PR TITLE
Candidature: cacher les adresses emails aux candidats

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -26,6 +26,7 @@ from itou.siaes.enums import SIAE_WITH_CONVENTION_KINDS, ContractType, SiaeKind
 from itou.users.enums import UserKind
 from itou.users.models import JobSeekerProfile, User
 from itou.utils import constants as global_constants
+from itou.utils.emails import redact_email_address
 from itou.utils.types import InclusiveDateRange
 from itou.utils.validators import validate_nir, validate_pole_emploi_id
 from itou.utils.widgets import DuetDatePickerWidget
@@ -91,8 +92,8 @@ class CheckJobSeekerNirForm(forms.Form):
         if self.job_seeker:
             if existing_account:
                 error_message = (
-                    "Ce numéro de sécurité sociale est déjà utilisé par un autre compte. "
-                    f"Merci de vous reconnecter avec l'adresse e-mail <b>{existing_account.email}</b>. "
+                    "Ce numéro de sécurité sociale est déjà utilisé par un autre compte. Merci de vous "
+                    f"reconnecter avec l'adresse e-mail <b>{redact_email_address(existing_account.email)}</b>. "
                     "Si vous ne vous souvenez plus de votre mot de passe, vous pourrez "
                     "cliquer sur « mot de passe oublié ». "
                     f'En cas de souci, vous pouvez <a href="{global_constants.ITOU_ASSISTANCE_URL}" rel="noopener" '

--- a/itou/www/apply/tests/tests_forms.py
+++ b/itou/www/apply/tests/tests_forms.py
@@ -50,12 +50,15 @@ class CheckJobSeekerNirFormTest(TestCase):
 
     def test_form_not_valid(self):
         # Application sent by a job seeker whose NIR is already used by another account.
-        existing_account = JobSeekerFactory()
+        existing_account = JobSeekerFactory(email="unlikely@random.tld")
         user = JobSeekerFactory()
         form_data = {"nir": existing_account.nir}
         form = apply_forms.CheckJobSeekerNirForm(job_seeker=user, data=form_data)
         assert not form.is_valid()
-        assert "Ce numéro de sécurité sociale est déjà utilisé par un autre compte." in form.errors["nir"][0]
+        error_msg = form.errors["nir"][0]
+        assert "Ce numéro de sécurité sociale est déjà utilisé par un autre compte." in error_msg
+        assert existing_account.email not in error_msg
+        assert "u*******@r*****.t**" in error_msg
 
         existing_account = PrescriberFactory(nir=JobSeekerFactory.build().nir)
         form_data = {"nir": existing_account.nir}


### PR DESCRIPTION
### Pourquoi ?

Sinon, tout utilisateur se créant un compte sur les emplois peut récupérer à peu de frais un mapping NIR->email.