### PR TITLE
Contrôle a posteriori: suppression d'une rétro-compatiblité inutile dans l'export metabase

### DIFF
--- a/itou/metabase/tables/evaluated_siaes.py
+++ b/itou/metabase/tables/evaluated_siaes.py
@@ -1,20 +1,9 @@
 from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
-from itou.siae_evaluations.enums import EvaluatedSiaeState
 from itou.siae_evaluations.models import EvaluatedSiae
 
 
 def get_field(name):
     return EvaluatedSiae._meta.get_field(name)
-
-
-def get_state(evaluated_siae):
-    # For backward compatibility, continue to output NOTIFICATION_PENDING state
-    # until the dashboards could be adapted (we might want to also output the notified_at column)
-    # TODO(xfernandez): return to lambda o:o.state once it isn't necessary anymore
-    state = evaluated_siae.state
-    if state == EvaluatedSiaeState.REFUSED and evaluated_siae.evaluation_is_final and not evaluated_siae.notified_at:
-        return "NOTIFICATION_PENDING"
-    return state
 
 
 TABLE = MetabaseTable(name="cap_structures")
@@ -27,7 +16,7 @@ TABLE.add_columns(
             "name": "état",
             "type": "varchar",
             "comment": "Etat du contrôle de la structure",
-            "fn": get_state,
+            "fn": lambda o: o.state,
         },
         get_column_from_field(get_field("reviewed_at"), name="date_contrôle"),
         get_column_from_field(get_field("final_reviewed_at"), name="date_définitive_contrôle"),


### PR DESCRIPTION
### Pourquoi ?

Ajouté dans b9026508a599a7925c pour que le changement soit transparent pour le pilotage.

Mais en fait, ils ont de leur coté un code qui transforme l'état `NOTIFICATION_PENDING` dans l'état `REFUSED`...

Donc, on peut dropper cette rétro-compatibilité et une fois ce changement en prod et l'export metabase effectué, @laurinehu pourra supprimer leur code d'équivalence `NOTIFICATION_PENDING` :arrow_right:  `REFUSED`
