### PR TITLE
BOOST : Les critères adminitratifs ne peuvent pas être modifiés dans l'admin

### DIFF
--- a/itou/eligibility/admin.py
+++ b/itou/eligibility/admin.py
@@ -170,10 +170,16 @@ class AbstractAdministrativeCriteriaAdmin(admin.ModelAdmin):
     readonly_fields = ("created_at",)
     search_fields = ("name", "desc")
 
-    def save_model(self, request, obj, form, change):
-        if not change:
-            obj.created_by = request.user
-        super().save_model(request, obj, form, change)
+    # Administrative criteria are updated via fixtures
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
 
 
 @admin.register(models.AdministrativeCriteria)


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=22538e95ff154ef0b4e8cfdb6b0e1c2e&pm=c

### Pourquoi ?

Les critères administratifs (GEIQ et IAE) sont fixés par décret, dans leur texte et attributs. 
Ils ne sont pas modifiables.

### Comment 
Les critères administratifs sont ajoutés / modifiés par fixtures à chaque décret.


