### PR TITLE
BOOST : modification du fichier des rejets, ajout de la raison sociale et du type de SIAE

### DIFF
--- a/itou/approvals/management/commands/export_pe_api_rejections.py
+++ b/itou/approvals/management/commands/export_pe_api_rejections.py
@@ -45,6 +45,8 @@ class Command(XlsxExportMixin, BaseCommand):
                     approval.user.last_name,
                     approval.user.first_name,
                     approval.user.birthdate.isoformat(),
+                    siae.kind,
+                    siae.name,
                     siae.department,
                 ]
             )
@@ -58,6 +60,8 @@ class Command(XlsxExportMixin, BaseCommand):
             "nom_naissance",
             "prenom",
             "date_naissance",
+            "siae_type",
+            "siae_raison_sociale",
             "siae_departement",
         ]
 

--- a/itou/approvals/tests/test_management_commands.py
+++ b/itou/approvals/tests/test_management_commands.py
@@ -26,6 +26,8 @@ class ExportPEApiRejectionsTestCase(TestCase):
             user__first_name='Jul"ie',
             with_jobapplication=True,
             with_jobapplication__to_siae__department=42,
+            with_jobapplication__to_siae__kind="EI",
+            with_jobapplication__to_siae__name="Ma petite entreprise",
         )
         stdout = io.StringIO()
         management.call_command("export_pe_api_rejections", stdout=stdout, stderr=io.StringIO())
@@ -40,6 +42,8 @@ class ExportPEApiRejectionsTestCase(TestCase):
                 "nom_naissance",
                 "prenom",
                 "date_naissance",
+                "siae_type",
+                "siae_raison_sociale",
                 "siae_departement",
             ],
             [
@@ -51,6 +55,8 @@ class ExportPEApiRejectionsTestCase(TestCase):
                 "Pers,e",
                 'Jul"ie',
                 str(approval.user.birthdate),
+                "EI",
+                "Ma petite entreprise",
                 "42",
             ],
         ]


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=253a71ea895340f8b811794567b0831b&pm=c

### Pourquoi ?

Demande Pôle emploi

### Comment 

Ajout de la raison sociale et du type de SIAE dans le fichier de rejet PE