### PR TITLE
BOOST: format de la widget de suppression d'une action préalable

### DIFF
--- a/itou/templates/apply/includes/job_application_prior_action.html
+++ b/itou/templates/apply/includes/job_application_prior_action.html
@@ -12,7 +12,7 @@
         Date de fin : <b>{{ prior_action.dates.upper }}</b>
     </div>
     {% if job_application.can_change_prior_actions %}
-        <div class="my-3 text-right">
+        <div class="my-3">
             {# Delete button with its confirmation modal #}
             <button class="btn btn-link" data-toggle="modal" data-target="#delete_prior_action_{{ prior_action.pk }}_modal">
                 Supprimer
@@ -29,9 +29,6 @@
                         </div>
                         <div class="modal-body">
                             <div class="row">
-                                <div class="col-auto">
-                                    <i class="ri-information-fill ri-lg text-danger"></i>
-                                </div>
                                 <div class="col">
                                     <p>Voulez-vous supprimer cette action préalable ?</p>
                                 </div>


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=46402d04ea0043cb946f5e4117f939c3&pm=c

### Pourquoi ?

- mauvais alignement du texte
- suppression de l’icône

### Captures d'écran

![image](https://github.com/betagouv/itou/assets/147232/723ede0e-78f6-4abd-bdc8-15799c917084)
