### PR TITLE
Parcours de candidature: suppression de la clef back_url de l'apply_session

### DIFF
--- a/itou/templates/siaes/card.html
+++ b/itou/templates/siaes/card.html
@@ -57,9 +57,7 @@
                     <div class="c-card card rounded-lg mb-3 mb-lg-5">
                         <div class="card-body">
                             {% if not siae.block_job_applications %}
-                                <a class="btn btn-primary btn-block btn-ico justify-content-center"
-                                   href="{% url 'apply:start' siae_pk=siae.pk %}{% if back_url %}?back_url={{ back_url }}{% endif %}"
-                                   aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                                <a class="btn btn-primary btn-block btn-ico justify-content-center" href="{% url 'apply:start' siae_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                                     <i class="ri-draft-line"></i>
                                     <span>Postuler</span>
                                 </a>
@@ -161,9 +159,7 @@
                         {% endif %}
                         {% if not siae.block_job_applications %}
                             <div class="d-flex justify-content-end mt-3">
-                                <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
-                                   href="{% url 'apply:start' siae_pk=siae.pk %}{% if back_url %}?back_url={{ back_url }}{% endif %}"
-                                   aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                                <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" href="{% url 'apply:start' siae_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                                     <i class="ri-draft-line"></i>
                                     <span>Postuler</span>
                                 </a>

--- a/itou/templates/siaes/includes/_card_siae.html
+++ b/itou/templates/siaes/includes/_card_siae.html
@@ -55,9 +55,7 @@
             {% else %}
                 <div class="d-flex justify-content-between align-items-center">
                     <span>Cette structure vous intéresse ?</span>
-                    <a class="btn btn-sm btn-primary"
-                       href="{% url 'apply:start' siae_pk=siae.pk %}{% if back_url %}?back_url={{ back_url }}{% endif %}"
-                       aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                    <a class="btn btn-sm btn-primary" href="{% url 'apply:start' siae_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                         Postuler
                     </a>
                 </div>

--- a/itou/templates/siaes/job_description_card.html
+++ b/itou/templates/siaes/job_description_card.html
@@ -52,7 +52,7 @@
                                     </div>
                                     {% if job.is_active and not siae.block_job_applications %}
                                         <div class="col-auto text-right">
-                                            <a href="{% url "apply:start" siae_pk=siae.pk %}?job_description_id={{ job.pk }}&back_url={{ request.get_full_path|urlencode }}"
+                                            <a href="{% url "apply:start" siae_pk=siae.pk %}?job_description_id={{ job.pk }}"
                                                class="matomo-event btn btn-sm btn-primary"
                                                data-matomo-category="candidature"
                                                data-matomo-action="clic"


### PR DESCRIPTION
### Pourquoi ?

Plus aucune vue de `submit_views.py` (qui sont les vues utilisant/exigeant l'`apply_session`) n'utilise le `back_url` présent en session (depuis #2656, où `ApplicationJobsView` a arrêté de l'utiliser avec 271acef8ec9bb ).


Voici les URL de retour des différentes vues:

- start: pas de back_url (renvoit 403, 404 ou 302)
- pending_authorization_for_sender => "Revenir à la recherche" / `home:hp`
- check_nir_for_sender => "Retour" / `dashboard:index`
- search_by_email_for_sender => "Retour" / `apply:check_nir_for_sender`
- create_job_seeker_step_1_for_sender => "Retour" ou "Modifier l'email du candidat" / `apply:search_by_email_for_sender`
- create_job_seeker_step_2_for_sender => "Retour" / `apply:create_job_seeker_step_1_for_sender`
- create_job_seeker_step_2_for_sender => "Retour" / `apply:create_job_seeker_step_2_for_sender`
- create_job_seeker_step_end_for_sender => "Retour" / `apply:create_job_seeker_step_3_for_sender`
- check_nir_for_job_seeker => "Retour" / `dashboard:index`
- step_check_job_seeker_info => pas de bouton retour
- step_check_prev_applications => pas de bouton retour
- application_jobs => "Retour" / `apply:step_check_prev_applications` ou `apply:step_check_job_seeker_info`
- application_eligibility => "Retour" / `apply:application_jobs`
- application_geiq_eligibility => "Retour" / `apply:application_jobs`
- application_resume => "Retour" / `f"apply:application_{'jobs' if any(bypass_eligibility_conditions) else 'eligibility'}"` (cf #2664)
- application_end => "Revenir à la recherche" / `home:hp` ou "Tableau de bord" / `dashboard:index`
- update_job_seeker_step_1 =>"Retour" ou "Modifier l'email du candidat" / `apply:application_jobs`
- update_job_seeker_step_2 =>"Retour" / `apply:update_job_seeker_step_1`
- update_job_seeker_step_3 =>"Retour" / `apply:update_job_seeker_step_2`
- update_job_seeker_step_end => "Retour" / `apply:update_job_seeker_step_3`