### PR TITLE
Parcours de candidature GEIQ: simplification/suppression de la vue remove continue_without_geiq_diagnosis

### DIFF
--- a/itou/templates/apply/includes/geiq/continue_without_geiq_diagnosis_form.html
+++ b/itou/templates/apply/includes/geiq/continue_without_geiq_diagnosis_form.html
@@ -6,7 +6,6 @@
 
 <div class="my-4 text-right">
     <a href="{{ back_url }}" class="btn btn-link">Annuler</a>
-    <input type="hidden" id="next_url" value="{{ next_url }}">
     <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#confirm_no_allowance_modal">
         Continuer sans valider les critères GEIQ
     </button>

--- a/itou/templates/apply/includes/geiq/continue_without_geiq_diagnosis_form.html
+++ b/itou/templates/apply/includes/geiq/continue_without_geiq_diagnosis_form.html
@@ -1,8 +1,6 @@
 {% load bootstrap4 %}
 
-{% if request.htmx %}
-    {% include "apply/includes/geiq/progress_bar.html" %}
-{% endif %}
+{% include "apply/includes/geiq/progress_bar.html" %}
 
 <hr>
 

--- a/itou/templates/apply/includes/geiq/continue_without_geiq_diagnosis_form.html
+++ b/itou/templates/apply/includes/geiq/continue_without_geiq_diagnosis_form.html
@@ -1,14 +1,14 @@
 {% load bootstrap4 %}
 
-{% include "apply/includes/geiq/progress_bar.html" %}
+{% include "apply/includes/geiq/progress_bar.html" with progress=progress only %}
 
 <hr>
 
 <div class="my-4 text-right">
-    <a href="{{ back_url }}" class="btn btn-link">Annuler</a>
+    <a href="" class="btn btn-link">Annuler</a>
     <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#confirm_no_allowance_modal">
         Continuer sans valider les critères GEIQ
     </button>
 </div>
 
-{% include "apply/includes/geiq/no_allowance_modal.html" %}
+{% include "apply/includes/geiq/no_allowance_modal.html" with next_url=next_url only %}

--- a/itou/templates/apply/process_geiq_eligibility.html
+++ b/itou/templates/apply/process_geiq_eligibility.html
@@ -47,8 +47,6 @@
                                 <form id="check_geiq_eligibility" hx-target="#geiq_form">
                                     {% csrf_token %}
                                     {% bootstrap_field form.choice form_check_class="form-check-inline mr-4" show_label=False %}
-                                    {% bootstrap_field form.back_url %}
-                                    {% bootstrap_field form.next_url %}
                                 </form>
                             </div>
                             <div class="col">{% include "apply/includes/geiq/legislative_text_link.html" %}</div>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -969,13 +969,9 @@ class PrescriberFilterJobApplicationsForm(SiaePrescriberFilterJobApplicationsFor
 
 class CheckJobSeekerGEIQEligibilityForm(forms.Form):
     choice = forms.BooleanField(required=False, widget=forms.RadioSelect(choices=((True, "Oui"), (False, "Non"))))
-    back_url = forms.CharField(widget=forms.HiddenInput)
-    next_url = forms.CharField(widget=forms.HiddenInput)
 
-    def __init__(self, job_application, back_url, next_url, *args, **kwargs):
+    def __init__(self, job_application, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["choice"].widget.attrs.update(
             {"hx-post": reverse("apply:geiq_eligibility", kwargs={"job_application_id": job_application.pk})}
         )
-        self.fields["back_url"].initial = back_url
-        self.fields["next_url"].initial = next_url

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -145,11 +145,6 @@ urlpatterns = [
         process_views.geiq_eligibility_criteria,
         name="geiq_eligibility_criteria",
     ),
-    path(
-        "<uuid:job_application_id>/siae/continue_without_geiq_diagnosis",
-        process_views.continue_without_geiq_diagnosis,
-        name="continue_without_geiq_diagnosis",
-    ),
     path("<uuid:job_application_id>/siae/refuse", process_views.refuse, name="refuse"),
     path("<uuid:job_application_id>/siae/postpone", process_views.postpone, name="postpone"),
     path("<uuid:job_application_id>/siae/accept", process_views.accept, name="accept"),

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -612,13 +612,11 @@ def geiq_eligibility(request, job_application_id, template_name="apply/process_g
 @login_required
 @require_safe
 def continue_without_geiq_diagnosis(
-    request, job_application_id, template_name="apply/includes/geiq/continue_without_geiq_diagnosis_form.html"
+    request, _job_application_id, template_name="apply/includes/geiq/continue_without_geiq_diagnosis_form.html"
 ):
-    job_application = get_object_or_404(JobApplication, pk=job_application_id)
     next_url = request.session.get("next_url")
 
     context = {
-        "job_application": job_application,
         "next_url": next_url,
         "progress": 66,
     }

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -12,7 +12,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
-from django.views.decorators.http import require_POST, require_safe
+from django.views.decorators.http import require_POST
 from django_htmx.http import HttpResponseClientRedirect
 from django_xworkflows import models as xwf_models
 
@@ -586,9 +586,13 @@ def geiq_eligibility(request, job_application_id, template_name="apply/process_g
                 reverse("apply:geiq_eligibility_criteria", kwargs={"job_application_id": job_application.pk})
             )
         else:
-            return HttpResponseRedirect(
-                reverse("apply:continue_without_geiq_diagnosis", kwargs={"job_application_id": job_application.pk})
-                + f"?next_url={request.session.get('next_url')}"
+            return render(
+                request,
+                "apply/includes/geiq/continue_without_geiq_diagnosis_form.html",
+                context={
+                    "next_url": request.session.get("next_url"),  # set previously by the GET request
+                    "progress": 66,
+                },
             )
 
     navigation = {"next_url": next_url, "back_url": back_url}
@@ -607,21 +611,6 @@ def geiq_eligibility(request, job_application_id, template_name="apply/process_g
 
 
 # HTMX fragments
-
-
-@login_required
-@require_safe
-def continue_without_geiq_diagnosis(
-    request, _job_application_id, template_name="apply/includes/geiq/continue_without_geiq_diagnosis_form.html"
-):
-    next_url = request.session.get("next_url")
-
-    context = {
-        "next_url": next_url,
-        "progress": 66,
-    }
-
-    return render(request, template_name, context)
 
 
 @login_required

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -578,7 +578,7 @@ def geiq_eligibility(request, job_application_id, template_name="apply/process_g
         "apply:details_for_siae", kwargs={"job_application_id": job_application.pk}
     )
     next_url = request.GET.get("next_url")
-    form = CheckJobSeekerGEIQEligibilityForm(job_application, back_url, next_url, data=request.POST or None)
+    form = CheckJobSeekerGEIQEligibilityForm(job_application, data=request.POST or None)
 
     if request.method == "POST" and form.is_valid() and request.htmx:
         if form.cleaned_data["choice"]:

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -12,7 +12,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
-from django.views.decorators.http import require_http_methods
+from django.views.decorators.http import require_POST
 from django_htmx.http import HttpResponseClientRedirect
 from django_xworkflows import models as xwf_models
 
@@ -176,7 +176,7 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
 
 
 @login_required
-@require_http_methods(["POST"])
+@require_POST
 def process(request, job_application_id):
     queryset = JobApplication.objects.siae_member_required(request.user)
     job_application = get_object_or_404(queryset, id=job_application_id)
@@ -458,7 +458,7 @@ def cancel(request, job_application_id, template_name="apply/process_cancel.html
     return render(request, template_name, context)
 
 
-@require_http_methods(["POST"])
+@require_POST
 @login_required
 def archive(request, job_application_id):
     """
@@ -677,7 +677,7 @@ def geiq_eligibility_criteria(
     return render(request, template_name, context)
 
 
-@require_http_methods(["POST"])
+@require_POST
 def delete_prior_action(request, job_application_id, prior_action_id):
     queryset = JobApplication.objects.siae_member_required(request.user)
     job_application = get_object_or_404(

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -12,7 +12,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_POST, require_safe
 from django_htmx.http import HttpResponseClientRedirect
 from django_xworkflows import models as xwf_models
 
@@ -610,15 +610,12 @@ def geiq_eligibility(request, job_application_id, template_name="apply/process_g
 
 
 @login_required
+@require_safe
 def continue_without_geiq_diagnosis(
     request, job_application_id, template_name="apply/includes/geiq/continue_without_geiq_diagnosis_form.html"
 ):
     job_application = get_object_or_404(JobApplication, pk=job_application_id)
     next_url = request.session.get("next_url")
-
-    if request.method == "POST":
-        del request.session["next_url"]
-        return HttpResponseRedirect(next_url)
 
     context = {
         "job_application": job_application,


### PR DESCRIPTION
### Pourquoi ?

Je vais avoir besoin de réutiliser l'équivalent des vues `eligibility` et `geiq_eligibility` pour le parcours de déclaration d'embauche alors j'essaie de simplifier au maximum.

