### PR TITLE
BOOST : retrait d'un message du tableau de bord concernant les fiches salarié

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -34,16 +34,6 @@
         </div>
     {% endif %}
 
-    {# Information pour les employeurs en cas d'absence d'annexe financière #}
-    {% if show_previous_year_financial_annex_info %}
-        <div class="alert alert-info">
-            <p class="mb-0">
-                La fin de validité des annexes financières de l'année précédente n'a pas d'incidence sur l'envoi de vos fiches salarié vers l'ASP.
-            </p>
-            <p class="mb-0">Vous pouvez donc continuer à recruter et générer vos fiches, il n'y a pas de blocage.</p>
-        </div>
-    {% endif %}
-
     {# Alerte pour les prescripteurs en cas d'absence ou de mauvais score de geocoding. #}
     {# Seuls les prescripteurs habilités apparaissent dans le moteur de recherche. #}
     {% if current_prescriber_organization and current_prescriber_organization.is_authorized and not current_prescriber_organization.has_reliable_coords_legacy %}

--- a/itou/www/dashboard/tests.py
+++ b/itou/www/dashboard/tests.py
@@ -501,26 +501,6 @@ class DashboardViewTest(TestCase):
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, TODO_BADGE, html=True)
 
-    def test_dashboard_siae_convention_without_financial_annex(self):
-        siae = SiaeFactory(with_membership=True)
-        user = siae.members.first()
-        self.client.force_login(user)
-
-        response = self.client.get(reverse("dashboard:index"))
-        self.assertNotContains(response, "La fin de validité des annexes financières")
-
-        # Remove active annexes
-        siae.convention.financial_annexes.all().delete()
-
-        response = self.client.get(reverse("dashboard:index"))
-        self.assertContains(response, "La fin de validité des annexes financières")
-
-        siae.kind = SiaeKind.EITI  # This kind cannot use employee records
-        siae.save()
-
-        response = self.client.get(reverse("dashboard:index"))
-        self.assertNotContains(response, "La fin de validité des annexes financières")
-
     def test_dora_card_is_not_shown_for_job_seeker(self):
         user = JobSeekerFactory()
         self.client.force_login(user)


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=ffcd93fbd0914b5e884c69459902222e&pm=c

### Pourquoi ?

Plus nécessaire
