### PR TITLE
BOOST : retrait du badge "Nouveau" pour les contrats PEC dans le filtre de recherche

### DIFF
--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -125,8 +125,5 @@
         });
 
         $("#siae-number-results").focus();
-        // FIXME(vperron): Remove this after March 2023; especially it might break the display if the number
-        // or order of the contract types filter changes.
-        $("#id_contract_types > div:nth-child(12) > label:nth-child(1)").append('<span class="badge badge-xs badge-pill badge-important ml-2 text-white">Nouveau</span>');
     </script>
 {% endblock %}


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/virer-le-tag-nouveau-du-filtre-PEC-boost-ccbb59a5ccc8486eb4eb180ce2c21c5d?pvs=4

### Pourquoi ?

C'est violet.

