### PR TITLE
User.has_data_changed() : être plus clair sur les cas positifs

### DIFF
--- a/itou/users/factories.py
+++ b/itou/users/factories.py
@@ -149,6 +149,7 @@ class JobSeekerFactory(UserFactory):
                 obj.jobseeker_profile.delete()
                 obj.jobseeker_profile = None
             else:
+                obj._saved_obfuscated_nir = obj.jobseeker_profile.pe_obfuscated_nir
                 obj.jobseeker_profile.save(update_fields=kwargs.keys())
 
 

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -358,15 +358,10 @@ class User(AbstractUser, AddressMixin):
 
     def has_data_changed(self, fields):
         if hasattr(self, "_old_values"):
-            if not self.pk or not self._old_values:
-                return True
-
             for field in fields:
                 if getattr(self, field) != self._old_values[field]:
                     return True
-            return False
-
-        return True
+        return False
 
     def clean(self):
         """

--- a/itou/users/tests/test_models.py
+++ b/itou/users/tests/test_models.py
@@ -43,7 +43,7 @@ from itou.users.factories import (
     SiaeStaffFactory,
     UserFactory,
 )
-from itou.users.models import User
+from itou.users.models import JobSeekerProfile, User
 from itou.utils.mocks.address_format import BAN_GEOCODING_API_RESULTS_MOCK, RESULTS_BY_ADDRESS
 from itou.utils.test import TestCase
 
@@ -1467,3 +1467,12 @@ def test_save_erases_pe_obfuscated_nir_if_details_change():
     assert user.jobseeker_profile.pe_last_certification_attempt_at == datetime.datetime(
         2022, 8, 10, 0, 0, 0, 0, tzinfo=timezone.utc
     )
+
+
+def test_jobseeker_factory_works_alongside_user_has_data_changed():
+    js = JobSeekerFactory(jobseeker_profile__pe_obfuscated_nir="JAIME_LES_CHATS")
+    assert js._saved_obfuscated_nir == "JAIME_LES_CHATS"
+    assert js.jobseeker_profile.pe_obfuscated_nir == "JAIME_LES_CHATS"
+    profile = JobSeekerProfile.objects.get(user=js)
+    assert profile.pe_obfuscated_nir == "JAIME_LES_CHATS"
+    assert profile.pk == js.jobseeker_profile.pk

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,5 @@ addopts =
     --strict-markers
 markers =
     no_django_db: mark tests that should not be marked with django_db.
-timeout = 15
+timeout = 200
 timeout_method = thread


### PR DESCRIPTION
La façon dont la logique de `User.has_data_changed()` était implémentée pouvait retourner `True` alors que en pratique aucun champ n'a changé ou  même n'existe encore en mémoire ou en base de données.

Changer cela pour que cela corresponde plus à notre intuition et corrige du même coup la `JobSeekerProfileFactory`.
