### PR TITLE
BOOST : GEIQ - correction de la validation du niveau de qualification

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -494,7 +494,7 @@ class AcceptForm(forms.ModelForm):
                         "hx-post": reverse(
                             "apply:reload_qualification_fields", kwargs={"job_application_id": job_application.pk}
                         ),
-                        "hx-swap": "outerHTML show:#id_qualification_type:top",
+                        "hx-swap": "outerHTML",
                         "hx-target": "#geiq_qualification_fields_block",
                     },
                 )

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -416,7 +416,6 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
 def reload_qualification_fields(
     request, job_application_id, template_name="apply/includes/geiq/geiq_qualification_fields.html"
 ):
-    # This is an HTMX part
     queryset = JobApplication.objects.siae_member_required(request.user)
     job_application = get_object_or_404(queryset, id=job_application_id)
     form_accept = AcceptForm(instance=job_application, data=request.POST or None)
@@ -424,6 +423,10 @@ def reload_qualification_fields(
         "form_accept": form_accept,
         "job_application": job_application,
     }
+
+    # we don't want to display error on this field for an HTMX reload:
+    form_accept.errors.pop("qualification_level", None)
+
     return render(request, template_name, ctx)
 
 


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=690529239c8b463bbb57d34ce1ecd83c&pm=c

### Pourquoi ?

Ce champ dynamique était revalidé systématiquement lors d'un rechargement HTMX , déclenché par une modification du champ "Type de qualification".
Une erreur de validation était affiché en dehors de la validation principale du formulaire.

### Comment 

Suppression des erreurs de validation pour ce champ dans un contexte de rechargement HTMX.



