### PR TITLE
BOOST : améliorations diverses concernant le bilan de prolongation

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -287,6 +287,22 @@ class IsInProgressFilter(admin.SimpleListFilter):
         return queryset
 
 
+class HasReportFile(admin.SimpleListFilter):
+    title = "fichier bilan téléversé"
+    parameter_name = "report_file"
+
+    def lookups(self, request, model_admin):
+        return (("yes", "Oui"), ("no", "Non"))
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == "yes":
+            return queryset.exclude(report_file=None)
+        if value == "no":
+            return queryset.filter(report_file=None)
+        return queryset
+
+
 @admin.register(models.Suspension)
 class SuspensionAdmin(admin.ModelAdmin):
     list_display = (
@@ -347,6 +363,7 @@ class ProlongationAdmin(admin.ModelAdmin):
     exclude = ("report_file",)
     list_filter = (
         IsInProgressFilter,
+        HasReportFile,
         "reason",
     )
     date_hierarchy = "start_at"

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1137,6 +1137,9 @@ class Prolongation(models.Model):
         return f"{self.pk} {self.start_at.strftime('%d/%m/%Y')} - {self.end_at.strftime('%d/%m/%Y')}"
 
     def clean(self):
+        if not self.end_at:
+            raise ValidationError({"end_at": "La date de fin de prolongation est obligatoire."})
+
         # Min duration == 1 day.
         if self.end_at <= self.start_at:
             raise ValidationError({"end_at": "La durée minimale doit être d'au moins un jour."})

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -1481,6 +1481,22 @@ class ProlongationModelTest(TestCase):
             prolongation.clean()
         assert "La date de début doit être la même que la date de fin du PASS IAE" in error.value.message
 
+    def test_clean_with_no_end_at(self):
+        """
+        Checking `end_at` emptyness is now in clean model method, and not in forms anymore
+        to ensure single validation message (and more robust / cleaner btw).
+        """
+        approval = ApprovalFactory()
+        siae = SiaeFactory(with_membership=True)
+        start_at = approval.end_at - relativedelta(days=2)
+
+        # build: no need to save the prolongation
+        prolongation = ProlongationFactory.build(
+            start_at=start_at, end_at=None, approval=approval, declared_by_siae=siae
+        )
+        with pytest.raises(ValidationError, match="La date de fin de prolongation est obligatoire."):
+            prolongation.clean()
+
     def test_get_start_at(self):
 
         end_at = datetime.date(2021, 2, 1)

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -131,6 +131,8 @@ class DeclareProlongationForm(forms.ModelForm):
         )
 
         self.fields["end_at"].initial = None
+        # Checked by model clean(), avoid double validation message
+        self.fields["end_at"].required = False
         self.fields["end_at"].widget = DuetDatePickerWidget(
             {
                 "min": self.instance.start_at,

--- a/itou/www/approvals_views/tests/__snapshots__/test_prolongation.ambr
+++ b/itou/www/approvals_views/tests/__snapshots__/test_prolongation.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: ApprovalProlongationTest.test_check_invalid_prescriber[unknown authorized prescriber]
+  '<div class="invalid-feedback">Ce prescripteur n\'a pas de compte sur les emplois de l\'inclusion. Merci de renseigner l\'e-mail d\'un conseiller inscrit sur le service.</div>'
+# ---
+# name: ApprovalProlongationTest.test_check_multiple_prescriber_organization[prescriber is member of many organizations]
+  '<div class="invalid-feedback">Le prescripteur selectionné fait partie de plusieurs organisations. Veuillez en sélectionner une.</div>'
+# ---


### PR DESCRIPTION
Pas de carte notion

### Pourquoi ?

- suite à discussion concernant le suivi des bilans dans l'admin (n'ayant pas donné lieu à la création d'une carte)
- amélioration continue

### Comment
- ajout de tests sur la partie saisie du prescripteur dans la partie bilan de prolongation
- ajout d'un filtre dans l'admin
- correction de : https://itou.sentry.io/share/issue/764b73a484f14b969636eef5fffd2b25/



