### PR TITLE
pytest: Monter le timeout à 30 secondes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,5 @@ addopts =
     --strict-markers
 markers =
     no_django_db: mark tests that should not be marked with django_db.
-timeout = 200
+timeout = 30
 timeout_method = thread


### PR DESCRIPTION
The timeout is good to detect frozen tests.

But it was set to 15 seconds, which too often on my machine is too slow to run the migrations locally and all the tests fail.

So I usually edit locally to be able to run my tests, until of course with my last PR the change made it to master.

So there is my proposal to make it a bit longer so that people like me stop editing it; a longer timeout does not harm by the way, as the only thing we want is to protect us from infinite loops, which do not happen that often. It will not make the tests any longer usually.


### Pourquoi ?
Cf. ci-dessus. A force de l'éditer manuellement puis de finir par me planter (malgré relecture) il serait pas mal de juste l'augmenter, je pense. Sans impact particulier.