### PR TITLE
Remove useless ls -d | xargs from populate_db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,12 @@ populate_db_with_cities:
 endif
 
 populate_db: populate_db_with_cities
-	$(EXEC_CMD) bash -c "ls -d itou/fixtures/django/*.json | xargs ./manage.py loaddata"
+	$(EXEC_CMD) bash -c "./manage.py loaddata itou/fixtures/django/*.json"
 	$(EXEC_CMD) bash -c "python itou/siae_evaluations/fixtures.py"
 
 populate_db_minimal: populate_db_with_cities
 	# Load reference data used by ASP-related code
-	$(EXEC_CMD) bash -c "ls -d itou/fixtures/django/*asp_INSEE*.json | xargs ./manage.py loaddata"
+	$(EXEC_CMD) bash -c "./manage.py loaddata itou/fixtures/django/*asp_INSEE*.json"
 
 COMMAND_GRAPH_MODELS := graph_models --group-models \
 	approvals \


### PR DESCRIPTION
Can directly list files with a glob, the order of expanded pathnames is
guaranteed by bash.