### PR TITLE
admin: ajout du bouton détourner sur la vue de détails d'un utilisateur

### DIFF
--- a/itou/templates/admin/users/change_form.html
+++ b/itou/templates/admin/users/change_form.html
@@ -1,0 +1,13 @@
+{% extends 'admin/change_form.html' %}
+{% load hijack %}
+
+{% block object-tools-items %}
+
+    {% url 'account_login' as login_url %}
+    {% if request.user|can_hijack:original %}
+        <li>{% include 'hijack/contrib/admin/button.html' with another_user=original is_user_admin=True next=login_url %}</li>
+    {% endif %}
+
+    {{ block.super }}
+
+{% endblock %}

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -241,6 +241,7 @@ class CreatedByProxyFilter(admin.SimpleListFilter):
 @admin.register(models.User)
 class ItouUserAdmin(UserAdmin):
     add_form = ItouUserCreationForm
+    change_form_template = "admin/users/change_form.html"
     form = UserAdminForm
     list_display = (
         "pk",


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/ADMIN-DJANGO-avoir-le-bouton-D-tourner-dans-la-page-de-d-tail-de-l-utilisateur-60de1ebec2de4cbf92814f2e73957c74?pvs=4

### Pourquoi ?

Pour éviter de devoir revenir sur la vue liste en filtrant sur son utilisateur pour pouvoir le détourner.

![Screenshot 2023-06-29 at 16-24-22 Modification de utilisateur Les emplois de l'inclusion](https://github.com/betagouv/itou/assets/1089744/d1b4402c-7587-4dad-a38f-2ad18649e358)
