### PR TITLE
Les bilans de prolongation ne sont disponibles que pour les AI

### DIFF
--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -429,6 +429,14 @@ class Siae(AddressMixin, OrganizationAbstract):
         # No need to check if convention is active (done by middleware)
         return self.kind in self.ASP_EMPLOYEE_RECORD_KINDS
 
+    @property
+    def can_upload_prolongation_report(self):
+        """
+        Is this SIAE allowed to use / upload a prolongation report file ?
+        (temporary: limited to AI only)
+        """
+        return self.kind == SiaeKind.AI
+
     def convention_can_be_accessed_by(self, user):
         """
         Decides whether the user can show the siae convention or not.

--- a/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
+++ b/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
@@ -19,7 +19,7 @@ L'employeur souhaite vous apporter des explications supplémentaires par télép
 - Début de la prolongation : {{ prolongation.start_at|date:"d/m/Y" }}
 - Fin de la prolongation : {{ prolongation.end_at|date:"d/m/Y" }}
 - Motif de prolongation : {{ prolongation.get_reason_display }}
-- Fiche bilan : {{ prolongation.report_file.link }}
+{% if prolongation.report_file %}- Fiche bilan : {{ prolongation.report_file.link }}{% endif %}
 
 Pour valider ou refuser cette prolongation, merci de nous transférer ce message à l'adresse suivante : {{ itou_email_prolongation }}
 

--- a/itou/templates/approvals/includes/declaration_upload_panel.html
+++ b/itou/templates/approvals/includes/declaration_upload_panel.html
@@ -2,56 +2,57 @@
 {% load bootstrap4 %}
 <div id="upload_panel">
     {% if unfold_details %}
-        <hr/>
-        <span class="badge badge-base badge-pill badge-important my-3">Nouveau</span>
+        {% if can_upload_prolongation_report %}
+            <hr/>
+            <span class="badge badge-base badge-pill badge-important my-3">Nouveau</span>
 
-        <div id="file_upload_part">
-            <h4>Bilan à renseigner : le motif selectionné nécessite l'accord d'un prescripteur habilité</h4>
-            <p>
-                Vous devez présenter un bilan de la situation du salarié au regard de l'emploi, des actions d'accompagnement et de formation conduites pendant la durée initiale du parcours et des actions envisagées pour la poursuite de ce parcours.
-            </p>
-            <p>
-                Un modèle au format excel (modele_bilan_prolongation_PASS_IAE.xlsx) pour réaliser ce bilan permettra au prescripteur habilité d’avoir une meilleure connaissance du contexte de la prolongation.
-                Vous devez désormais télécharger, compléter et téléverser ce modèle pour enregistrer une demande de prolongation.
-            </p>
-            <a href="{% static 'templates/modele_bilan_prolongation_PASS_IAE.xlsx' %}" class="btn btn-ico btn-primary my-4" download="modele_bilan_prolongation_PASS_IAE.xlsx">
-                <i class="ri-download-2-line" aria-hidden="true"></i>
-                <span>Télécharger le modèle</span>
-            </a>
+            <div id="file_upload_part">
+                <h4>Bilan à renseigner : le motif selectionné nécessite l'accord d'un prescripteur habilité</h4>
+                <p>
+                    Vous devez présenter un bilan de la situation du salarié au regard de l'emploi, des actions d'accompagnement et de formation conduites pendant la durée initiale du parcours et des actions envisagées pour la poursuite de ce parcours.
+                </p>
+                <p>
+                    Un modèle au format excel (modele_bilan_prolongation_PASS_IAE.xlsx) pour réaliser ce bilan permettra au prescripteur habilité d’avoir une meilleure connaissance du contexte de la prolongation.
+                    Vous devez désormais télécharger, compléter et téléverser ce modèle pour enregistrer une demande de prolongation.
+                </p>
+                <a href="{% static 'templates/modele_bilan_prolongation_PASS_IAE.xlsx' %}" class="btn btn-ico btn-primary my-4" download="modele_bilan_prolongation_PASS_IAE.xlsx">
+                    <i class="ri-download-2-line" aria-hidden="true"></i>
+                    <span>Télécharger le modèle</span>
+                </a>
 
-            {% bootstrap_field form.report_file_path %}
-            {% bootstrap_field form.uploaded_file_name %}
+                {% bootstrap_field form.report_file_path %}
+                {% bootstrap_field form.uploaded_file_name %}
 
-            <h4>Téléverser le modèle complété</h4>
+                <h4>Téléverser le modèle complété</h4>
 
-            <div class="form-group">
-                {% if form.report_file_path %}
-                    <p>
-                        Bilan ajouté : <strong><span id="uploaded_file_name_display">{{ form.uploaded_file_name.value|default:"Aucun" }}</span></strong>
-                    </p>
-                {% endif %}
-                <div class="js-display-if-javascript-enabled d-block">
-                    <div id="report_file_form" class="dropzone dz-clickable text-center">
-                        <div class="dz-message">
-                            <p class="mb-1 text-nuance-06">
-                                <i class="ri-upload-cloud-2-line ri-2x"></i>
-                            </p>
-                            <p class="mb-2">
-                                Glisser votre fichier de bilan ici ou <strong>rechercher</strong> dans vos fichiers
-                            </p>
-                            <a href="" class="js-prevent-default btn-link btn-sm btn-ico mb-2">
-                                <i class="ri-folder-line ri-xl"></i>
-                                <span>Rechercher dans vos fichiers</span>
-                            </a>
-                            <p class="small text-nuance-06">Taille maximale : {{ s3_upload.config.max_file_size }} Mo</p>
+                <div class="form-group">
+                    {% if form.report_file_path %}
+                        <p>
+                            Bilan ajouté : <strong><span id="uploaded_file_name_display">{{ form.uploaded_file_name.value|default:"Aucun" }}</span></strong>
+                        </p>
+                    {% endif %}
+                    <div class="js-display-if-javascript-enabled d-block">
+                        <div id="report_file_form" class="dropzone dz-clickable text-center">
+                            <div class="dz-message">
+                                <p class="mb-1 text-nuance-06">
+                                    <i class="ri-upload-cloud-2-line ri-2x"></i>
+                                </p>
+                                <p class="mb-2">
+                                    Glisser votre fichier de bilan ici ou <strong>rechercher</strong> dans vos fichiers
+                                </p>
+                                <a href="" class="js-prevent-default btn-link btn-sm btn-ico mb-2">
+                                    <i class="ri-folder-line ri-xl"></i>
+                                    <span>Rechercher dans vos fichiers</span>
+                                </a>
+                                <p class="small text-nuance-06">Taille maximale : {{ s3_upload.config.max_file_size }} Mo</p>
+                            </div>
                         </div>
+                        <p class="small text-muted">Type de fichier : Excel / XLSX</p>
                     </div>
-                    <p class="small text-muted">Type de fichier : Excel / XLSX</p>
                 </div>
             </div>
-        </div>
- 
-        <hr/>
+            <hr/>
+        {% endif %}
  
         <div>
             {# HTMX: confirm prescriber organization if many #}

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -193,6 +193,8 @@ class DeclareProlongationForm(forms.ModelForm):
             }
         )
 
+        self.fields["report_file_path"].disabled = not self.siae.can_upload_prolongation_report
+
         # Dynamic : checking prescriber email
         if kwargs.get("data"):
             if email := kwargs.get("data", {}).get("email"):
@@ -248,8 +250,13 @@ class DeclareProlongationForm(forms.ModelForm):
             if not self.cleaned_data.get("contact_phone"):
                 self.add_error("contact_phone", "Veuillez saisir un numéro de téléphone de contact")
 
-        # Prolongation report is only mandatory for these reasons:
-        if self.cleaned_data.get("reason") in PROLONGATION_REPORT_FILE_REASONS:
+        # Prolongation report :
+        # - is only mandatory for these reasons
+        # - is temporarily limited to AI kind
+        if (
+            self.cleaned_data.get("reason") in PROLONGATION_REPORT_FILE_REASONS
+            and self.siae.can_upload_prolongation_report
+        ):
             if not self.cleaned_data.get("report_file_path") or not self.cleaned_data.get("uploaded_file_name"):
                 # No visible field for this form field
                 raise ValidationError("Vous devez fournir un fichier de bilan renseigné")


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/Limiter-l-affichage-du-bilan-Excel-prolongation-uniquement-aux-AI-c7c73577a3ae4a83bf470fc2131e63a3

### Pourquoi ?

Changement d'avis coté DGEFP, à priori temporaire

### Comment ?

Le téléversement du fichier bilan et sa mention dans l'e-mail récapitulatif sont désormais réservés aux AI pour les bonnes raisons de prolongation.