### PR TITLE
Gérer les identifiants dans la recherche admin et les pages de changement

### DIFF
--- a/itou/static/js/admin.js
+++ b/itou/static/js/admin.js
@@ -1,0 +1,27 @@
+(function () {
+  document.addEventListener("DOMContentLoaded", function (event) {
+    function handlePaste(event) {
+      const pasted = event.clipboardData.getData("text");
+      const cleaned = pasted.replaceAll(" ", "");
+      if (/[0-9]{9,}/.test(cleaned)) {
+        event.preventDefault();
+        const field = event.target
+        field.value = field.value.substring(0, field.selectionStart)
+            + cleaned
+            + field.value.substring(field.selectionEnd);
+      }
+    }
+
+    for (const id of [
+      "searchbar",
+      "id_nir",
+      "id_number", // PASS IAE
+      "id_siret",
+    ]) {
+      const element = document.getElementById(id);
+      if (element) {
+        element.addEventListener("paste", handlePaste);
+      }
+    }
+  });
+}());

--- a/itou/templates/admin/base_site.html
+++ b/itou/templates/admin/base_site.html
@@ -1,4 +1,5 @@
 {% extends "admin/base.html" %}
+{% load static %}
 
 {% block title %}{{ title }} | Les emplois de l'inclusion{% endblock %}
 
@@ -79,4 +80,5 @@
             outline-style: auto;
         }
     </style>
+    <script src="{% static "js/admin.js" %}" defer></script>
 {% endblock %}


### PR DESCRIPTION
### Pourquoi ?

Les SIRET, NIR et numéro de PASS IAE ont une signification particulière, et les espaces séparateurs devraient être ignorés. Le support passe pas mal de temps à les gérer manuellement.