### PR TITLE
Correction de quelques typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,12 +105,12 @@
 ### Ajouté
 
 - API : Possibilité de créer son token d’accès
-- Fiches salariés : Ajout du filtre par nom du candidat à la liste des fiches salarié
+- Fiches salarié : Ajout du filtre par nom du candidat à la liste des fiches salarié
 - GEIQ : Ajout d'actions préalables à l'embauche
 
 ### Modifié
 
-- Fiches salariés : Précision du message d’erreur lors de la création quand lorsqu’une fiche archivée existe
+- Fiches salarié : Précision du message d’erreur lors de la création quand lorsqu’une fiche archivée existe
 - Liste des candidatures : Légère correction en cas de multiples diagnostiques d’éligibilité
 - Liste des candidatures : Refonte et affichage de la localisation des postes pour les employeurs
 - Liste des métiers d’une SIAE : Afficher le nombre de métiers
@@ -177,18 +177,18 @@
 ### Ajouté
 
 - Automatisation : Mise à jour des villes
-- Fiches salariés : ajout d'un bandeau d'information pour les SIAEs ayant une convention active sans annexe financière
-- Fiches salariés : ajout des informations d'horodatage ASP
+- Fiches salarié : ajout d'un bandeau d'information pour les SIAEs ayant une convention active sans annexe financière
+- Fiches salarié : ajout des informations d'horodatage ASP
 - Parcours d'embauche : Possibilité de renseigner le numéro de sécurité sociale ou la raison de son absence
 - UI : Ajout d'un bandeau de promotion de DORA dans le tableau de bord
 
 ### Modifié
 
 - Admin : cacher les boutons de validation/refus des habilitations au support externe
-- Admin : plus de granularité sur certains messages des PASS IAE et des fiches salariés
+- Admin : plus de granularité sur certains messages des PASS IAE et des fiches salarié
 - Contrôle a posteriori : Exclusion des SIAE dont le controle est terminé du rappel en phase contradictoire
 - Contrôle a posteriori : Notifier les DDETS quand les SIAE attendent les sanctions
-- Fiches salariés : Correction pour le message d'information d'actualisation
+- Fiches salarié : Correction pour le message d'information d'actualisation
 - Matomo : améliorations de stabilisation
 - Metabase : améliorations et corrections diverses
 - Recherche de postes : suppression du badge du nombre de postes ouverts si le recrutement est fermé
@@ -298,7 +298,7 @@
 - Candidatures : ajout du motif de refus "dupliqué"
 - Contrôle a posteriori : Ajout du parcours de sanctions
 - Contrôle a posteriori : Mode lecture seule pour les campagnes terminées
-- Fiches salariés : Transmission de la date de fin pour les PASS IAE sans fiches salariés
+- Fiches salarié : Transmission de la date de fin pour les PASS IAE sans fiches salarié
 - Technique : ajout de HTMX
 
 ### Modifié
@@ -322,11 +322,11 @@
 - Contrôle a posteriori : Nouvelle option pour se retirer de la campagne
 - Contrôle a posteriori : Autorise la modification des justificatifs pendant la revue de la phase contradictoire
 - Contrôle a posteriori : Mode lecture seule pour les campagnes terminées
-- Fiches salariés : Transmission de la date de fin pour les PASS IAE sans fiches salariés
+- Fiches salarié : Transmission de la date de fin pour les PASS IAE sans fiches salarié
 - API : Exposition d'un lien vers la page de la structure sur les emplois pour l'API data.inclusion
 
 ### Modifié
-- Fiches salariés : La géolocalisation est réalisée à l'étape 2 au lieu de l'étape 1 du parcours
+- Fiches salarié : La géolocalisation est réalisée à l'étape 2 au lieu de l'étape 1 du parcours
 - Correction du formatage du NIR lors du dépôt de candidature
 - UI : Ajustement du bandeau Dora dans le tableau de bord
 - Inscription : Gestion de l'erreur en cas de changement d'email sur France Connect qui rentre en conflit sur les emplois
@@ -475,7 +475,7 @@
 ## [47] - 2022-07-29
 
 ### Ajouté
-- Affichage (puis suppression une semaine plus tard) d'un message informatif concernant l'indisponibilité des fiches salariés.
+- Affichage (puis suppression une semaine plus tard) d'un message informatif concernant l'indisponibilité des fiches salarié.
 - Ajout d'un message d'alerte lors d'une suspension pour indiquer la possibilité qu'elle soit levée.
 - Ajout d'une option de « preflight » pour les _management commands_ des fiches salarié.
 - Ajout du lien vers le formulaire de suspension pour les prescripteurs habilités.
@@ -560,7 +560,7 @@
 - Contrôle a posteriori : laisser le formulaire de saisie du commentaire modifiable après la revue par les DDETS
 - Controle a posteriori : afficher la date du Pass IAE
 - Controle a posteriori : email d'information aux siaes de la campagne 2021 partie 2
-- Gérer mes fiches salariés : rendre visible les fiches à l'état 'nouvelle'
+- Gérer mes fiches salarié : rendre visible les fiches à l'état 'nouvelle'
 - Correctif pour débloquer les prescripteurs n'ayant pas la possibilité de mettre à jour le NIR
 - En tant qu’employeur je veux valider l’embauche d’un candidat dans le tableau de bord de la bonne structure. Ajout d'une modale de confirmation contenant la carte de la structure lors de l’embauche.
 - Contextualiser les contrats proposés lors de l’enregistrement d’une fiche de poste
@@ -587,7 +587,7 @@
 - Nouvelle interface pour les résultats de recherche employeurs
 - Contrôle a posteriori, Pack SIAE : Rattrapage des SIAE ayant réalisé entre 2 et 9 autoprescriptions
 - Plus de mention du PASS IAE dans les emails reçus par les employeurs non soumis aux règles d’éligibilité IAE
-- Mise à jour des scripts de transfert des fiches salariés
+- Mise à jour des scripts de transfert des fiches salarié
 - Mise à jour du theme itou vers la v0.3.9
 - Pilotage : Parmi les fiches de poste en difficulté de recrutement, calculer le nombre de fiches de poste n'ayant jamais reçu de candidatures
 - Pilotage : Ajout d'informations afin d'avoir des filtres à l'échelle locale
@@ -961,9 +961,9 @@ Technique:
 ### Ajouté
 
 - Nouveau motif de refus de candidature : « Candidature pas assez renseignée ».
-- Ajout du champ `create_employee_record` sur `Approval` (PASS IAE) afin d'empêcher la création automatique de fiches salariés. Non visible dans l'admin Django.
+- Ajout du champ `create_employee_record` sur `Approval` (PASS IAE) afin d'empêcher la création automatique de fiches salarié. Non visible dans l'admin Django.
 - Nouvelle page de statistiques chargée dans une iframe.
-- Ajout des champs e-mail et téléphone dans l'API fiches salariés.
+- Ajout des champs e-mail et téléphone dans l'API fiches salarié.
 
 ### Modifié
 
@@ -972,8 +972,8 @@ Technique:
 - Réparation : les employeurs peuvent ajouter deux métiers identiques à leur SIAE.
 - Réactivation du script d'import des EA dans celui qui est lancé hebdomadairement par Supportix.
 - Les durées maximales des prolongations (différentes selon le motif) ont été modifiées.
-- Corrections d'erreurs diverses liées aux fiches salariés.
-- Pendant l'enregistrement des fiches salariés, la sélection d'une annexe financière est désormais optionnelle.
+- Corrections d'erreurs diverses liées aux fiches salarié.
+- Pendant l'enregistrement des fiches salarié, la sélection d'une annexe financière est désormais optionnelle.
 - Mise à jour de l'URL du portail assistance : il pointe désormais vers la Communauté.
 - Prise en compte du NIR dans le script de déduplication des candidats.
 - Gestion plus propre des logs des doublons avec export en CSV pour faciliter la vie de Supportix.
@@ -1070,7 +1070,7 @@ Technique:
     - Simplification des paramètres de `user.can_view_stats_*`
     - Restriction des stats DDETS aux 4 départements d'expérimentation
 - Correctif pour `make test` qui ne permettait plus de spécifier la série spécifique de tests à réaliser
-- Affichage d’un texte à destination des SIAE concernant les fiches salariés
+- Affichage d’un texte à destination des SIAE concernant les fiches salarié
 - Affichage d’un texte pour préciser la fonction de l’import prolongation/suspension
 
 ### Supprimé
@@ -1278,7 +1278,7 @@ Technique:
 ### Modifié
 
  - Mise à jour vers Django 3.2.5
- - Écrans fiches salariés
+ - Écrans fiches salarié
  - Tri des résultats de recherche employeur par score (et non plus de manière aléatoire)
  - Les demandeurs d'emploi ne doivent pas pouvoir changer leur adresse mail dans la modification de leur profil
  - Correctif pour pouvoir modifier une prolongation dans l'admin

--- a/itou/api/applicants_api/views.py
+++ b/itou/api/applicants_api/views.py
@@ -22,7 +22,7 @@ class ApplicantsView(generics.ListAPIView):
 
     Pour l'obtention d'un jeton, veuillez utiliser **les identifiants d'un compte administrateur de la structure.**
 
-    Voir le endpoint `token-auth` pour obtenir un jeton.
+    Voir l'entrée d'API `token-auth` pour obtenir un jeton.
 
     Ce compte ne doit être *uniquement membre* de la structure dont on souhaite récupérer la liste de candidats.
 

--- a/itou/api/data_inclusion_api/views.py
+++ b/itou/api/data_inclusion_api/views.py
@@ -55,7 +55,7 @@ class DataInclusionStructureView(generics.ListAPIView):
         }
 
         # * ordered by ascending creation date : if any instances are added during the querying
-        # of the endpoint, they will appeared in the last page.
+        # of the endpoint, they will appear in the last page.
         # * ordered by pk : given that some instances share the same creation date, it ensures
         # repeatable order between page evaluation
         return qs_by_structure_type_str[valid_type_str].order_by("created_at", "pk")

--- a/itou/api/employee_record_api/viewsets.py
+++ b/itou/api/employee_record_api/viewsets.py
@@ -78,7 +78,7 @@ class EmployeeRecordViewSet(AbstractEmployeeRecordViewSet):
     - utilisables en paramètres de requête (query string),
     - chainables : il est possible de préciser un ou plusieurs de ces paramètres pour affiner la recherche.
 
-    Sans paramètre fourni, la liste de résultats contient les fiches salariés en l'état
+    Sans paramètre fourni, la liste de résultats contient les fiches salarié en l'état
 
     - `PROCESSED` (integrées par l'ASP).
 

--- a/itou/api/employee_record_api/viewsets.py
+++ b/itou/api/employee_record_api/viewsets.py
@@ -33,7 +33,7 @@ class AbstractEmployeeRecordViewSet(viewsets.ReadOnlyModelViewSet):
 
     # Possible authentication frameworks:
     # - token auth: for external access / real world use case
-    # - session auth: for dev context and browseable API
+    # - session auth: for dev context and browsable API
     authentication_classes = [TokenAuthentication, SessionAuthentication]
 
     # Additional / custom permission classes:
@@ -80,7 +80,7 @@ class EmployeeRecordViewSet(AbstractEmployeeRecordViewSet):
 
     Sans paramètre fourni, la liste de résultats contient les fiches salarié en l'état
 
-    - `PROCESSED` (integrées par l'ASP).
+    - `PROCESSED` (intégrées par l'ASP).
 
     ## `status` : par statut des fiches salarié
     Ce paramètre est un tableau permettant de filtrer les fiches retournées par leur statut
@@ -105,9 +105,9 @@ class EmployeeRecordViewSet(AbstractEmployeeRecordViewSet):
 
     """
 
-    # Above doc section is in french for Swagger / OAS auto doc generation
+    # Above doc section is in French for Swagger / OAS auto doc generation
 
-    # If no queryset class parameter is given (f.i. overidding)
+    # If no queryset class parameter is given (f.i. overriding)
     # a `basename` parameter must be set on the router (see local `urls.py` file)
     # See: https://www.django-rest-framework.org/api-guide/routers/
 

--- a/itou/api/siae_api/viewsets.py
+++ b/itou/api/siae_api/viewsets.py
@@ -44,7 +44,7 @@ class SiaeViewSet(viewsets.ReadOnlyModelViewSet):
     La plateforme renvoie une liste de SIAE à proximité d’une ville (déterminée par son code INSEE)
     et dans un rayon de recherche en kilomètres autour du centre de cette ville.
 
-    Les coordonnées des centre villes sont issus de [https://geo.api.gouv.fr](https://geo.api.gouv.fr/)
+    Les coordonnées des centres-villes sont issus de [https://geo.api.gouv.fr](https://geo.api.gouv.fr/)
 
 
     Chaque SIAE est accompagnée d’un certain nombre de métadonnées :

--- a/itou/api/urls.py
+++ b/itou/api/urls.py
@@ -17,7 +17,7 @@ from .token_auth.views import ObtainAuthToken
 # https://docs.djangoproject.com/en/dev/topics/http/urls/#url-namespaces-and-included-urlconfs
 app_name = "itou.api"
 
-# Using DRF router with viewsets means automatic definition of utl patterns
+# Using DRF router with viewsets means automatic definition of URL patterns
 router = routers.DefaultRouter()
 router.register(r"employee-records", EmployeeRecordViewSet, basename="employee-records")
 router.register(
@@ -30,7 +30,7 @@ router.register(r"siaes", SiaeViewSet, basename="siaes")
 urlpatterns = [
     # TokenAuthentication endpoint to get token from login/password.
     path("token-auth/", ObtainAuthToken.as_view(), name="token-auth"),
-    # Needed for Browseable API (dev)
+    # Needed for Browsable API (dev)
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     # OpenAPI
     # See: https://www.django-rest-framework.org/topics/documenting-your-api/

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -66,7 +66,7 @@ class JobApplicationInline(admin.StackedInline):
             )
 
         if not obj.to_siae.can_use_employee_record:
-            return "La SIAE n'utilise pas les fiches salariés"
+            return "La SIAE n'utilise pas les fiches salarié"
 
         if not obj.create_employee_record:
             return "Création désactivée"

--- a/itou/approvals/tests/tests.py
+++ b/itou/approvals/tests/tests.py
@@ -1021,7 +1021,7 @@ class CustomApprovalAdminViewsTest(TestCase):
                 job_application = JobApplicationFactory(with_approval=True, to_siae__kind=kind)
                 msg = JobApplicationInline.employee_record_status(job_application)
                 if not job_application.to_siae.can_use_employee_record:
-                    assert msg == "La SIAE n'utilise pas les fiches salariés"
+                    assert msg == "La SIAE n'utilise pas les fiches salarié"
                 else:
                     assert msg == "En attente de création"
 

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -100,7 +100,7 @@
                                         <strong>Une action de votre part est nécessaire</strong>
                                     </p>
                                     <p class="mb-0">
-                                        Attention, nous avons détecté une ou plusieurs fiches salariés qui nécessitent une régularisation manuelle de votre part.
+                                        Attention, nous avons détecté une ou plusieurs fiches salarié qui nécessitent une régularisation manuelle de votre part.
                                     </p>
                                 </div>
                             </div>
@@ -118,7 +118,7 @@
                     <aside class="c-aside-filters">
                         <button class="c-aside-filters__btn__collapse" data-toggle="collapse" data-target="#status-filter-form" aria-expanded="false" aria-controls="status-filter-form">
                             <i class="ri-filter-line"></i>
-                            <span>Filtres des fiches salariés</span>
+                            <span>Filtres des fiches salarié</span>
                         </button>
                         <div class="c-aside-filters__card rounded-lg" id="status-filter-form">
                             <form method="get">

--- a/itou/www/employee_record_views/tests/test_list.py
+++ b/itou/www/employee_record_views/tests/test_list.py
@@ -113,7 +113,7 @@ class ListEmployeeRecordsTest(TestCase):
         response = self.client.get(self.url + "?status=NEW")
 
         self.assertContains(response, "Une action de votre part est nécessaire")
-        self.assertContains(response, "Attention, nous avons détecté une ou plusieurs fiches salariés")
+        self.assertContains(response, "Attention, nous avons détecté une ou plusieurs fiches salarié")
         self.assertContains(
             response, "Une mise à jour manuelle est nécessaire même si ce salarié a déjà quitté la structure."
         )
@@ -129,7 +129,7 @@ class ListEmployeeRecordsTest(TestCase):
         response = self.client.get(self.url + "?status=NEW")
 
         self.assertContains(response, "Une action de votre part est nécessaire")
-        self.assertContains(response, "Attention, nous avons détecté une ou plusieurs fiches salariés")
+        self.assertContains(response, "Attention, nous avons détecté une ou plusieurs fiches salarié")
         self.assertContains(
             response, "Une mise à jour manuelle est nécessaire même si ce salarié a déjà quitté la structure."
         )
@@ -155,7 +155,7 @@ class ListEmployeeRecordsTest(TestCase):
 
         self.assertContains(response, format_filters.format_approval_number(self.job_application.approval.number))
         self.assertContains(response, "Une action de votre part est nécessaire")
-        self.assertContains(response, "Attention, nous avons détecté une ou plusieurs fiches salariés")
+        self.assertContains(response, "Attention, nous avons détecté une ou plusieurs fiches salarié")
         self.assertContains(response, "demander la régularisation du numéro de sécurité sociale")
         self.assertContains(response, f'href="https://tally.so/r/wzxQlg?jobapplication={ self.job_application.pk }"')
         self.assertNotContains(response, "Mettre à jour")
@@ -172,7 +172,7 @@ class ListEmployeeRecordsTest(TestCase):
 
         self.assertContains(response, format_filters.format_approval_number(self.job_application.approval.number))
         self.assertContains(response, "Une action de votre part est nécessaire")
-        self.assertContains(response, "Attention, nous avons détecté une ou plusieurs fiches salariés")
+        self.assertContains(response, "Attention, nous avons détecté une ou plusieurs fiches salarié")
         self.assertContains(response, "demander la régularisation du numéro de sécurité sociale")
         self.assertContains(response, f'href="https://tally.so/r/wzxQlg?employeerecord={ new_er.pk }"')
         self.assertNotContains(response, "Désactiver la fiche salarié")


### PR DESCRIPTION
### Pourquoi ?

1. Uniformisation du nommage "fiches salarié"
2. Corrections de typo pour les pages API qui vont bientôt être utilisé pour les GEIQ