### PR TITLE
Parcours de candidature: vérification des permissions des utilisateurs

### DIFF
--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -500,7 +500,8 @@ def archive(request, job_application_id):
 
 @login_required
 def transfer(request, job_application_id):
-    job_application = get_object_or_404(JobApplication.objects, pk=job_application_id)
+    queryset = JobApplication.objects.siae_member_required(request.user)
+    job_application = get_object_or_404(queryset, pk=job_application_id)
     target_siae = get_object_or_404(Siae.objects, pk=request.POST.get("target_siae_id"))
     back_url = request.POST.get("back_url", reverse("apply:list_for_siae"))
 
@@ -572,8 +573,9 @@ def eligibility(request, job_application_id, template_name="apply/process_eligib
 
 @login_required
 def geiq_eligibility(request, job_application_id, template_name="apply/process_geiq_eligibility.html"):
+    queryset = JobApplication.objects.siae_member_required(request.user)
     # Check GEIQ eligibility during job application process
-    job_application = get_object_or_404(JobApplication, pk=job_application_id)
+    job_application = get_object_or_404(queryset, pk=job_application_id)
     back_url = request.GET.get("back_url") or reverse(
         "apply:details_for_siae", kwargs={"job_application_id": job_application.pk}
     )
@@ -619,7 +621,8 @@ def geiq_eligibility_criteria(
 ):
     """Dynamic GEIQ eligibility criteria form (HTMX)"""
 
-    job_application = get_object_or_404(JobApplication, pk=job_application_id)
+    queryset = JobApplication.objects.siae_member_required(request.user)
+    job_application = get_object_or_404(queryset, pk=job_application_id)
     diagnosis = GEIQEligibilityDiagnosis.objects.valid_diagnoses_for(
         job_application.job_seeker, job_application.to_siae
     ).first()

--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -289,3 +289,21 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
 
         self.assertTemplateUsed(response, "apply/includes/known_criteria.html")
         self.assertContains(response, "Résident en ZRR")
+
+    def test_jobseeker_cannot_create_geiq_diagnosis(self):
+        job_application = JobApplicationFactory(job_seeker=self.job_seeker, to_siae=self.geiq)
+        self.client.force_login(self.job_seeker)
+        # Needed to setup session
+        response = self.client.get(
+            reverse("apply:geiq_eligibility", kwargs={"job_application_id": job_application.pk})
+        )
+        assert response.status_code == 404
+        response = self.client.post(
+            reverse("apply:geiq_eligibility_criteria", kwargs={"job_application_id": job_application.pk}),
+            data={
+                "jeune_26_ans": "on",
+                "sortant_ase": "on",
+            },
+        )
+        assert not self.job_seeker.geiq_eligibility_diagnoses.exists()
+        assert response.status_code == 404


### PR DESCRIPTION
### Pourquoi ?

Avec des requêtes manuelles un candidat pouvait se créer un diagnostic GEIQ

