### PR TITLE
Ne pas recompter les candidatures dans l’admin

### DIFF
--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -55,6 +55,7 @@ class ManualApprovalDeliveryRequiredFilter(admin.SimpleListFilter):
 class JobApplicationAdmin(admin.ModelAdmin):
     form = JobApplicationAdminForm
     list_display = ("pk", "job_seeker", "state", "sender_kind", "created_at")
+    show_full_result_count = False
     raw_id_fields = (
         "job_seeker",
         "eligibility_diagnosis",


### PR DESCRIPTION
### Pourquoi ?

Le compte engendre une requête SQL en doublon :
`SELECT COUNT(*) AS "__count" FROM "job_applications_jobapplication"`

Avec 1.5M d’entrée dans la table, éviter cette requête dupliqué a un impact sur les performances.
- avant ce commit, 3 requêtes, 300 ms
- après ce commit, 2 requêtes, 160 ms