### PR TITLE
Définir un mot de passe inutilisable pour les utilisateurs créés par des tiers

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -911,12 +911,7 @@ class User(AbstractUser, AddressMixin):
         username = cls.generate_unique_username()
         fields["kind"] = UserKind.JOB_SEEKER
         fields["created_by"] = proxy_user
-        user = cls.objects.create_user(
-            username,
-            email=fields.pop("email"),
-            password=cls.objects.make_random_password(),
-            **fields,
-        )
+        user = cls.objects.create_user(username, email=fields.pop("email"), **fields)
         return user
 
     @classmethod


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Django-4-2-d30d5bfb62b24ca495c0d87ac19669f3**

### Pourquoi ?

Au lieu de définir un mot de passe pour un utilisateur qui ne sait même pas qu’il dispose d’un compte sur la plateforme, on peut l’empêcher de se connecter.