### PR TITLE
Parcours de candidature: la session est maintenant optionelle

### DIFF
--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -387,8 +387,9 @@ class ApplyAsJobSeekerTest(S3AccessingTestCase):
         # With a session namespace
         self.client.get(reverse("apply:start", kwargs={"siae_pk": siae.pk}))  # Init the session
         response = self.client.get(reverse("apply:check_nir_for_sender", kwargs={"siae_pk": siae.pk}))
-        assert response.status_code == 302
-        assert response.url == reverse("apply:start", kwargs={"siae_pk": siae.pk})
+        self.assertRedirects(
+            response, reverse("apply:start", kwargs={"siae_pk": siae.pk}), fetch_redirect_response=False
+        )
 
 
 class ApplyAsAuthorizedPrescriberTest(S3AccessingTestCase):
@@ -1265,8 +1266,9 @@ class ApplyAsPrescriberTest(S3AccessingTestCase):
         # With a session namespace
         self.client.get(reverse("apply:start", kwargs={"siae_pk": siae.pk}))  # Use that view to init the session
         response = self.client.get(reverse("apply:check_nir_for_job_seeker", kwargs={"siae_pk": siae.pk}))
-        assert response.status_code == 302
-        assert response.url == reverse("apply:start", kwargs={"siae_pk": siae.pk})
+        self.assertRedirects(
+            response, reverse("apply:start", kwargs={"siae_pk": siae.pk}), fetch_redirect_response=False
+        )
 
 
 class ApplyAsPrescriberNirExceptionsTest(S3AccessingTestCase):


### PR DESCRIPTION
### Pourquoi ?

La seule utilisation de la session est pour `selected_jobs`, afin d'avoir un poste présélectionné pour la candidature.
En cas de session manquante, l'utilisateur peut tout à fait recocher la case et cela permet d'éviter les erreurs de session manquante aux utilisateurs.

