### PR TITLE
Xfernandez/fix attribute errors

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -960,7 +960,7 @@ class ApplicationResumeView(ApplicationBaseView):
         )
         self.s3_upload = S3Upload(kind="resume")
 
-    def dispatch(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         # Prevent multiple rapid clicks on the submit button to create multiple job applications.
         job_application = (
             self.job_seeker.job_applications.filter(to_siae=self.siae).created_in_past(seconds=10).first()
@@ -971,10 +971,6 @@ class ApplicationResumeView(ApplicationBaseView):
                     "apply:application_end", kwargs={"siae_pk": self.siae.pk, "application_pk": job_application.pk}
                 )
             )
-
-        return super().dispatch(request, *args, **kwargs)
-
-    def post(self, request, *args, **kwargs):
         if self.form.is_valid():
             # Fill the job application with the required information
             job_application = self.form.save(commit=False)

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -47,10 +47,28 @@ fake = faker.Faker(locale="fr_FR")
 class ApplyTest(TestCase):
     def test_anonymous_access(self):
         siae = SiaeFactory(with_jobs=True)
+        for viewname in (
+            "apply:start",
+            "apply:pending_authorization_for_sender",
+            "apply:check_nir_for_sender",
+            "apply:check_nir_for_job_seeker",
+        ):
+            url = reverse(viewname, kwargs={"siae_pk": siae.pk})
+            response = self.client.get(url)
+            self.assertRedirects(response, reverse("account_login") + f"?next={url}")
+
         job_seeker = JobSeekerFactory()
-        url = reverse("apply:step_check_job_seeker_info", kwargs={"siae_pk": siae.pk, "job_seeker_pk": job_seeker.pk})
-        response = self.client.get(url)
-        self.assertRedirects(response, reverse("account_login") + f"?next={url}")
+        for viewname in (
+            "apply:step_check_job_seeker_info",
+            "apply:step_check_prev_applications",
+            "apply:application_jobs",
+            "apply:application_eligibility",
+            "apply:application_geiq_eligibility",
+            "apply:application_resume",
+        ):
+            url = reverse(viewname, kwargs={"siae_pk": siae.pk, "job_seeker_pk": job_seeker.pk})
+            response = self.client.get(url)
+            self.assertRedirects(response, reverse("account_login") + f"?next={url}")
 
     def test_we_raise_a_permission_denied_on_missing_session(self):
         user = JobSeekerFactory()


### PR DESCRIPTION
### Pourquoi ?

Conséquence de #2718. Ce qui était avant géré par l'absence de session doit maintenant être géré à la main.

J'ai hésité à `raise PermissionDenied()` dans le `setup()` de `ApplyStepBaseView` mais rediriger vers la page de login avec le bon next est tout de même plus sympathique pour les utilisateurs que renvoyer une 403...

