### PR TITLE
Parcours de candidature: faciliter la réutilisation d'un formulaire sans candidature

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -970,8 +970,6 @@ class PrescriberFilterJobApplicationsForm(SiaePrescriberFilterJobApplicationsFor
 class CheckJobSeekerGEIQEligibilityForm(forms.Form):
     choice = forms.BooleanField(required=False, widget=forms.RadioSelect(choices=((True, "Oui"), (False, "Non"))))
 
-    def __init__(self, job_application, *args, **kwargs):
+    def __init__(self, hx_post_url, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["choice"].widget.attrs.update(
-            {"hx-post": reverse("apply:geiq_eligibility", kwargs={"job_application_id": job_application.pk})}
-        )
+        self.fields["choice"].widget.attrs.update({"hx-post": hx_post_url})

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -580,7 +580,7 @@ def geiq_eligibility(request, job_application_id, template_name="apply/process_g
         "apply:details_for_siae", kwargs={"job_application_id": job_application.pk}
     )
     next_url = request.GET.get("next_url")
-    form = CheckJobSeekerGEIQEligibilityForm(job_application, data=request.POST or None)
+    form = CheckJobSeekerGEIQEligibilityForm(hx_post_url=request.path, data=request.POST or None)
 
     if request.method == "POST" and form.is_valid() and request.htmx:
         if form.cleaned_data["choice"]:


### PR DESCRIPTION
### Pourquoi ?

Pour le parcours de déclaration d'embauche, on souhaite réutiliser au maximum les vues existantes, mais sans candidature.

