### PR TITLE
Indexer PoleEmploiApproval.nir

### DIFF
--- a/itou/approvals/migrations/0008_poleemploiapproval_nir_idx.py
+++ b/itou/approvals/migrations/0008_poleemploiapproval_nir_idx.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("approvals", "0007_prolongation_report_file"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="poleemploiapproval",
+            index=models.Index(fields=["nir"], name="nir_idx"),
+        ),
+    ]

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1368,7 +1368,10 @@ class PoleEmploiApproval(PENotificationMixin, CommonApprovalMixin):
         verbose_name = "Agrément Pôle emploi"
         verbose_name_plural = "Agréments Pôle emploi"
         ordering = ["-start_at"]
-        indexes = [models.Index(fields=["pole_emploi_id", "birthdate"], name="pe_id_and_birthdate_idx")]
+        indexes = [
+            models.Index(fields=["nir"], name="nir_idx"),
+            models.Index(fields=["pole_emploi_id", "birthdate"], name="pe_id_and_birthdate_idx"),
+        ]
 
     def __str__(self):
         return self.number


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Afficher-l-ligibilit-IAE-sur-la-liste-des-candidatures-2ae374e0d88d444d867fb1a05061463d**

### Pourquoi ?

Approximativement une accélération de 25x de `PoleEmploiApprovalQuerySet.find_for()`.