### PR TITLE
populate_metabase_matomo: Retirer un argument inutilisé

### DIFF
--- a/clevercloud/crons/populate_metabase_matomo.sh
+++ b/clevercloud/crons/populate_metabase_matomo.sh
@@ -15,7 +15,6 @@ mkdir -p $OUTPUT_PATH
 OUTPUT_LOG="$OUTPUT_PATH/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
 
 django-admin send_slack_message ":rocket: Démarrage de la mise à jour des données Matomo"
-django-admin populate_metabase_matomo --mode=public --wet-run |& tee -a "$OUTPUT_LOG"
-django-admin populate_metabase_matomo --mode=private --wet-run |& tee -a "$OUTPUT_LOG"
+django-admin populate_metabase_matomo --wet-run |& tee -a "$OUTPUT_LOG"
 django-admin populate_metabase_emplois --mode final_tables |& tee -a "$OUTPUT_LOG"
 django-admin send_slack_message  ":white_check_mark: Mise à jour des données Matomo terminée"


### PR DESCRIPTION
### Pourquoi ?
Cela fait planter la commande.

### Comment
En le corrigeant tout bêtement.



