### PR TITLE
CheckConstraint que les Suspensions ne démarrent pas dans le futur

### DIFF
--- a/itou/approvals/migrations/0009_suspension_cannot_start_in_the_future.py
+++ b/itou/approvals/migrations/0009_suspension_cannot_start_in_the_future.py
@@ -1,0 +1,23 @@
+import django.db.models.functions.datetime
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("approvals", "0008_poleemploiapproval_nir_idx"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="suspension",
+            constraint=models.CheckConstraint(
+                check=models.Q(
+                    (
+                        "start_at__lte",
+                        django.db.models.functions.datetime.TruncDate(django.db.models.functions.datetime.Now()),
+                    )
+                ),
+                name="suspension_cannot_start_in_the_future",
+            ),
+        ),
+    ]

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MinLengthValidator
 from django.db import models
 from django.db.models import Case, Count, Q, When
-from django.db.models.functions import TruncDate
+from django.db.models.functions import Now, TruncDate
 from django.utils import timezone
 from django.utils.functional import cached_property
 from unidecode import unidecode
@@ -784,6 +784,10 @@ class Suspension(models.Model):
                     ),
                     ("approval", RangeOperators.EQUAL),
                 ),
+            ),
+            models.CheckConstraint(
+                check=Q(start_at__lte=TruncDate(Now())),
+                name="%(class)s_cannot_start_in_the_future",
             ),
         ]
 


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Suite-journ-e-dev-Approval-suspended_until-6455d136d38146a192c9bfb04c09e1eb**

### Pourquoi ?

Vérifier et documenter cette contrainte.