### PR TITLE
Réécrire Approval.can_be_deleted

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -333,14 +333,12 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
         """
         return f"{self.number[:5]} {self.number[5:7]} {self.number[7:]}"
 
-    @cached_property
     def can_be_deleted(self):
-        state_accepted = self.jobapplication_set.model.state.STATE_ACCEPTED
-
-        job_applications = self.jobapplication_set
-        if job_applications.count() != 1:
+        JobApplication = self.jobapplication_set.model
+        try:
+            return self.jobapplication_set.get().state == JobApplication.state.STATE_ACCEPTED
+        except (JobApplication.DoesNotExist, JobApplication.MultipleObjectsReturned):
             return False
-        return self.jobapplication_set.get().state == state_accepted
 
     @cached_property
     def is_last_for_user(self):

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -1024,7 +1024,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         if not self.can_be_cancelled:
             raise xwf_models.AbortTransition("Cette candidature n'a pu être annulée.")
 
-        if self.approval and self.approval.can_be_deleted:
+        if self.approval and self.approval.can_be_deleted():
             self.approval.delete()
             self.approval = None
 

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -101,21 +101,19 @@ class CommonApprovalQuerySetTest(TestCase):
         approval = ApprovalFactory(start_at=start_at, end_at=end_at)
         assert Approval.objects.filter(id=approval.id).valid().exists()
 
-    def test_can_be_deleted(self):
+    def test_can_be_delete_no_app(self):
+        approval = ApprovalFactory()
+        assert not approval.can_be_deleted
+
+    def test_can_be_deleted_one_app(self):
         job_app = JobApplicationFactory(with_approval=True)
         approval = job_app.approval
         assert approval.can_be_deleted
 
-        # An approval exists without a Job Application
-        approval = ApprovalFactory()
-        assert not approval.can_be_deleted
-
-        job_app.state = JobApplicationWorkflow.STATE_REFUSED
-        job_app.save()
-        assert not approval.can_be_deleted
-
+    def test_can_be_deleted_multiple_apps(self):
+        job_app = JobApplicationFactory(with_approval=True)
         JobApplicationFactory(with_approval=True, job_seeker=job_app.job_seeker, approval=job_app.approval)
-        assert not approval.can_be_deleted
+        assert not job_app.approval.can_be_deleted
 
     def test_starts_date_filters_for_approval_model(self):
         start_at = timezone.localdate() - relativedelta(years=1)

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -103,17 +103,17 @@ class CommonApprovalQuerySetTest(TestCase):
 
     def test_can_be_delete_no_app(self):
         approval = ApprovalFactory()
-        assert not approval.can_be_deleted
+        assert not approval.can_be_deleted()
 
     def test_can_be_deleted_one_app(self):
         job_app = JobApplicationFactory(with_approval=True)
         approval = job_app.approval
-        assert approval.can_be_deleted
+        assert approval.can_be_deleted()
 
     def test_can_be_deleted_multiple_apps(self):
         job_app = JobApplicationFactory(with_approval=True)
         JobApplicationFactory(with_approval=True, job_seeker=job_app.job_seeker, approval=job_app.approval)
-        assert not job_app.approval.can_be_deleted
+        assert not job_app.approval.can_be_deleted()
 
     def test_starts_date_filters_for_approval_model(self):
         start_at = timezone.localdate() - relativedelta(years=1)


### PR DESCRIPTION
### Pourquoi ?

Moins de requêtes, moins de mémoire utilisée, plus de clarté.