### PR TITLE
Améliorations et corrections pour certaines `approvals.factories`

### DIFF
--- a/tests/approvals/factories.py
+++ b/tests/approvals/factories.py
@@ -56,7 +56,7 @@ class SuspensionFactory(factory.django.DjangoModelFactory):
         model = Suspension
 
     approval = factory.SubFactory(ApprovalFactory)
-    start_at = factory.SelfAttribute("approval.start_at")
+    start_at = factory.Faker("date_between", start_date=factory.SelfAttribute("..approval.start_at"))
     end_at = factory.LazyAttribute(lambda obj: Suspension.get_max_end_at(obj.start_at))
     siae = factory.SubFactory(SiaeFactory)
 
@@ -68,7 +68,7 @@ class ProlongationFactory(factory.django.DjangoModelFactory):
         model = Prolongation
 
     approval = factory.SubFactory(ApprovalFactory)
-    start_at = factory.SelfAttribute("approval.start_at")
+    start_at = factory.Faker("date_between", start_date=factory.SelfAttribute("..approval.start_at"))
     end_at = factory.LazyAttribute(lambda obj: Prolongation.get_max_end_at(obj.start_at, reason=obj.reason))
     reason = ProlongationReason.COMPLETE_TRAINING.value
     reason_explanation = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."

--- a/tests/approvals/factories.py
+++ b/tests/approvals/factories.py
@@ -56,7 +56,7 @@ class SuspensionFactory(factory.django.DjangoModelFactory):
         model = Suspension
 
     approval = factory.SubFactory(ApprovalFactory)
-    start_at = factory.LazyAttribute(lambda obj: obj.approval.start_at)
+    start_at = factory.SelfAttribute("approval.start_at")
     end_at = factory.LazyAttribute(lambda obj: Suspension.get_max_end_at(obj.start_at))
     siae = factory.SubFactory(SiaeFactory)
 
@@ -68,13 +68,13 @@ class ProlongationFactory(factory.django.DjangoModelFactory):
         model = Prolongation
 
     approval = factory.SubFactory(ApprovalFactory)
-    start_at = factory.LazyAttribute(lambda obj: obj.approval.start_at)
+    start_at = factory.SelfAttribute("approval.start_at")
     end_at = factory.LazyAttribute(lambda obj: Prolongation.get_max_end_at(obj.start_at, reason=obj.reason))
     reason = ProlongationReason.COMPLETE_TRAINING.value
     reason_explanation = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     declared_by = factory.LazyAttribute(lambda obj: obj.declared_by_siae.members.first())
     declared_by_siae = factory.SubFactory(SiaeFactory, with_membership=True)
-    created_by = factory.LazyAttribute(lambda obj: obj.declared_by)
+    created_by = factory.SelfAttribute("declared_by")
 
     @factory.post_generation
     def set_validated_by(self, create, extracted, **kwargs):
@@ -96,7 +96,7 @@ class PoleEmploiApprovalFactory(factory.django.DjangoModelFactory):
     pe_structure_code = factory.fuzzy.FuzzyText(length=5, chars=string.digits)
     pole_emploi_id = factory.fuzzy.FuzzyText(length=8, chars=string.digits)
     number = factory.fuzzy.FuzzyText(length=12, chars=string.digits)
-    birth_name = factory.LazyAttribute(lambda obj: obj.last_name)
+    birth_name = factory.SelfAttribute("last_name")
     birthdate = factory.fuzzy.FuzzyDate(datetime.date(1968, 1, 1), datetime.date(2000, 1, 1))
     start_at = factory.LazyFunction(datetime.date.today)
     end_at = factory.LazyAttribute(lambda obj: obj.start_at + relativedelta(years=2) - relativedelta(days=1))

--- a/tests/approvals/factories.py
+++ b/tests/approvals/factories.py
@@ -1,7 +1,6 @@
 import datetime
 import string
 
-import factory
 import factory.fuzzy
 from dateutil.relativedelta import relativedelta
 from faker import Faker
@@ -11,9 +10,8 @@ from itou.approvals.models import Approval, PoleEmploiApproval, Prolongation, Su
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.siaes.enums import SiaeKind
 from tests.eligibility.factories import EligibilityDiagnosisFactory
-from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from tests.siaes.factories import SiaeFactory
-from tests.users.factories import JobSeekerFactory
+from tests.users.factories import JobSeekerFactory, PrescriberFactory
 
 
 fake = Faker("fr_FR")
@@ -74,19 +72,8 @@ class ProlongationFactory(factory.django.DjangoModelFactory):
     reason_explanation = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     declared_by = factory.LazyAttribute(lambda obj: obj.declared_by_siae.members.first())
     declared_by_siae = factory.SubFactory(SiaeFactory, with_membership=True)
+    validated_by = factory.SubFactory(PrescriberFactory, membership__organization__authorized=True)
     created_by = factory.SelfAttribute("declared_by")
-
-    @factory.post_generation
-    def set_validated_by(self, create, extracted, **kwargs):
-        if not create:
-            return
-        # Ignore setting validated_by:
-        # ProlongationFactory(set_validated_by=False)
-        if extracted is False:
-            return
-
-        authorized_prescriber_org = PrescriberOrganizationWithMembershipFactory(authorized=True)
-        self.validated_by = authorized_prescriber_org.members.first()
 
 
 class PoleEmploiApprovalFactory(factory.django.DjangoModelFactory):

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1474,7 +1474,6 @@ class ProlongationModelTest(TestCase):
         """
 
         approval = ApprovalFactory()
-        siae = SiaeFactory(with_membership=True)
 
         start_at = approval.end_at - relativedelta(days=2)
         end_at = start_at + relativedelta(months=1)
@@ -1482,7 +1481,13 @@ class ProlongationModelTest(TestCase):
         # We need an object without `pk` to test `clean()`, so we use `build`
         # which provides a local object without saving it to the database.
         prolongation = ProlongationFactory.build(
-            start_at=start_at, end_at=end_at, approval=approval, declared_by_siae=siae
+            start_at=start_at,
+            end_at=end_at,
+            approval=approval,
+            # Force unneeded dependant fields to None as we are using .build()
+            declared_by=None,
+            declared_by_siae=None,
+            validated_by=None,
         )
 
         with pytest.raises(ValidationError) as error:

--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -142,7 +142,7 @@ class JobApplicationSentBySiaeFactory(JobApplicationFactory):
     sender_kind = SenderKind.SIAE_STAFF
     # Currently an Siae can only postulate for itself,
     # this is the default behavior here.
-    sender_siae = factory.LazyAttribute(lambda obj: obj.to_siae)
+    sender_siae = factory.SelfAttribute("to_siae")
     sender = factory.LazyAttribute(lambda obj: obj.to_siae.members.first())
 
 

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -3,7 +3,6 @@ import functools
 import random
 import string
 
-import factory
 import factory.fuzzy
 from allauth.account import models as allauth_models
 from django.contrib.auth.hashers import make_password
@@ -69,6 +68,16 @@ class ItouStaffFactory(UserFactory):
 class PrescriberFactory(UserFactory):
     kind = UserKind.PRESCRIBER
     identity_provider = IdentityProvider.INCLUSION_CONNECT
+
+    @factory.post_generation
+    def membership(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted or kwargs:
+            from tests.prescribers.factories import PrescriberMembershipFactory
+
+            PrescriberMembershipFactory(user=self, **kwargs)
 
 
 class SiaeStaffFactory(UserFactory):

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -223,7 +223,7 @@ class TestApprovalDetailView:
         ## Display prolongations
         default_kwargs = {
             "declared_by": PrescriberFactory(first_name="Milady", last_name="de Winter", email="milady@dewinter.com"),
-            "set_validated_by": False,
+            "validated_by": None,
             "approval": approval,
         }
         # Valid


### PR DESCRIPTION
### Pourquoi ?

Utiliser les fonctionnalités natives de _factory_boy_ et essayer de coller au maximum à sa philosophie pour éviter des déconvenues.
