### PR TITLE
Retrait de Suspension.start_in_future

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -806,10 +806,6 @@ class Suspension(models.Model):
         if self.end_at < self.start_at:
             raise ValidationError({"end_at": "La date de fin doit être postérieure à la date de début."})
 
-        # A suspension cannot be in the future.
-        if self.start_in_future:
-            raise ValidationError({"start_at": "La suspension ne peut pas commencer dans le futur."})
-
         # A suspension cannot exceed max duration.
         max_end_at = self.get_max_end_at(self.start_at)
         if self.end_at > max_end_at:
@@ -863,10 +859,6 @@ class Suspension(models.Model):
     @property
     def is_in_progress(self):
         return self.start_at <= timezone.now().date() <= self.end_at
-
-    @property
-    def start_in_future(self):
-        return self.start_at > timezone.now().date()
 
     @property
     def start_in_approval_boundaries(self):

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1104,12 +1104,6 @@ class SuspensionModelTest(TestCase):
         suspension = SuspensionFactory(start_at=start_at, end_at=end_at)
         assert suspension.duration == expected_duration
 
-    def test_start_in_future(self):
-        start_at = timezone.localdate() + relativedelta(days=10)
-        # Build provides a local object without saving it to the database.
-        suspension = SuspensionFactory.build(start_at=start_at, approval__eligibility_diagnosis=None)
-        assert suspension.start_in_future
-
     def test_start_in_approval_boundaries(self):
         start_at = timezone.localdate()
         end_at = start_at + relativedelta(days=10)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Suite-journ-e-dev-Approval-suspended_until-6455d136d38146a192c9bfb04c09e1eb**

### Pourquoi ?

Inutile depuis 57403698c6e27a219711f5f16a02e4df324f19e2.