### PR TITLE
Quelques corrections et un réusinage pour le formulaire de prolongation des PASS IAE

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -362,6 +362,7 @@ class ProlongationAdmin(admin.ModelAdmin):
         "declared_by",
         "declared_by_siae",
         "validated_by",
+        "prescriber_organization",
         "created_by",
         "updated_by",
     )

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -215,8 +215,6 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
         prolongation = form.save(commit=False)
         prolongation.created_by = request.user
         prolongation.declared_by = request.user
-        prolongation.declared_by_siae = form.siae
-        prolongation.validated_by = form.validated_by
 
         if request.POST.get("preview"):
             preview = True
@@ -313,6 +311,7 @@ class DeclareProlongationHTMXFragmentView(TemplateView):
 
 class CheckPrescriberEmailView(DeclareProlongationHTMXFragmentView):
     template_name = "approvals/includes/declaration_prescriber_email.html"
+    clear_errors = ("prescriber_organization",)
 
 
 class CheckContactDetailsView(DeclareProlongationHTMXFragmentView):

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -218,8 +218,6 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
         prolongation.declared_by_siae = form.siae
         prolongation.validated_by = form.validated_by
 
-        if request.POST.get("edit"):
-            preview = False
         if request.POST.get("preview"):
             preview = True
         elif request.POST.get("save"):

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -328,6 +328,7 @@ class ToggledUploadPanelView(DeclareProlongationHTMXFragmentView):
         context = super().get_context_data(**kwargs)
         context |= {
             "unfold_details": self.form.data.get("reason") in PROLONGATION_REPORT_FILE_REASONS,
+            "can_upload_prolongation_report": self.siae.can_upload_prolongation_report,
         }
         return context
 

--- a/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
@@ -3,5 +3,5 @@
   '<div class="invalid-feedback">Ce prescripteur n\'a pas de compte sur les emplois de l\'inclusion. Merci de renseigner l\'e-mail d\'un conseiller inscrit sur le service.</div>'
 # ---
 # name: ApprovalProlongationTest.test_check_multiple_prescriber_organization[prescriber is member of many organizations]
-  '<div class="invalid-feedback">Le prescripteur selectionné fait partie de plusieurs organisations. Veuillez en sélectionner une.</div>'
+  '<div class="invalid-feedback">Ce champ est obligatoire.</div>'
 # ---

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -360,7 +360,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
         }
         response = self.client.post(url, data=post_data)
 
-        error_msg = parse_response_to_soup(response, selector="div#check_prescriber_email .invalid-feedback")
+        error_msg = parse_response_to_soup(response, selector="input#id_email + .invalid-feedback")
         assert str(error_msg) == self.snapshot(name="unknown authorized prescriber")
 
     def test_prolongation_without_report_file(self):


### PR DESCRIPTION
### Pourquoi ?

- Utiliser au maximum ce que Django nous propose (`required`, `initial`, `errors_messages`, _widgets_, etc) et ainsi réduire le code _custom_.
- N'avoir au maximum que 2 endroits (classe et `__init__`) qui modifie le comportement du champs au lieu de 3 (classe, `__init__` et `Meta`).
- Ne garder que ce qui est dynamique dans les méthodes, le reste est mis dans la classe.
- Faciliter le découpage en 2 formulaires pour #2727.