### PR TITLE
Ajouter un champ Approval.suspended_until

### DIFF
--- a/itou/approvals/migrations/0011_approval_suspended_until.py
+++ b/itou/approvals/migrations/0011_approval_suspended_until.py
@@ -1,0 +1,112 @@
+import time
+
+from django.db import migrations, models
+from django.utils import timezone
+
+from itou.utils.iterators import chunks
+
+
+def forwards(apps, schema_editor):
+    Approval = apps.get_model("approvals", "Approval")
+    apps.get_model("approvals", "Suspension")
+    approvals = []
+    for approval in Approval.objects.filter(suspension__end_at__gte=timezone.localdate()).annotate(
+        latest_suspension_end=models.Max("suspension__end_at")
+    ):
+        approval.suspended_until = approval.latest_suspension_end
+        approvals.append(approval)
+    for chunk in chunks(approvals, 1000):
+        Approval.objects.bulk_update(chunk, fields=["suspended_until"])
+        time.sleep(5)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("approvals", "0010_add_eligibility_diagnosis_constraint"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="approval",
+            name="suspended_until",
+            field=models.DateField(editable=False, null=True, verbose_name="suspendu jusqu’à"),
+        ),
+        migrations.RunSQL(
+            sql="""
+                CREATE FUNCTION update_approval_fields()
+                    RETURNS TRIGGER
+                    LANGUAGE plpgsql
+                    AS $$
+                    BEGIN
+                        --
+                        -- When a suspension is inserted/updated/deleted, the end date
+                        -- of its approval is automatically pushed back or forth.
+                        --
+                        -- See:
+                        -- https://www.postgresql.org/docs/14/triggers.html
+                        -- https://www.postgresql.org/docs/14/plpgsql-trigger.html#PLPGSQL-TRIGGER-AUDIT-EXAMPLE
+                        --
+                        IF (TG_OP = 'DELETE') THEN
+                            UPDATE approvals_approval
+                            SET (end_at, suspended_until) = (
+                                SELECT
+                                -- Push back approval end date.
+                                approvals_approval.end_at - (OLD.end_at - OLD.start_at),
+                                -- Denormalize the suspension end date.
+                                -- Note that suspensions cannot start in the future.
+                                MAX(approvals_suspension.end_at)
+                                FROM approvals_suspension
+                                WHERE approval_id=OLD.approval_id
+                            )
+                            WHERE id = OLD.approval_id;
+                        ELSIF (TG_OP = 'INSERT') THEN
+                            UPDATE approvals_approval
+                            SET (end_at, suspended_until) = (
+                                SELECT
+                                -- Push approval end date forward.
+                                approvals_approval.end_at + (NEW.end_at - NEW.start_at),
+                                MAX(approvals_suspension.end_at)
+                                FROM approvals_suspension
+                                WHERE approval_id=NEW.approval_id
+                            )
+                            WHERE id = NEW.approval_id;
+                        ELSIF (TG_OP = 'UPDATE') THEN
+                            -- At update time, the approval's end date is first reset before
+                            -- being pushed forward, e.g.:
+                            --     * step 1 "create new 90 days suspension":
+                            --         * extend approval: approval.end_date + 90 days
+                            --     * step 2 "edit 60 days instead of 90 days":
+                            --         * reset approval: approval.end_date - 90 days
+                            --         * extend approval: approval.end_date + 60 days
+                            UPDATE approvals_approval
+                            SET (end_at, suspended_until) = (
+                                SELECT
+                                approvals_approval.end_at - (OLD.end_at - OLD.start_at) + (NEW.end_at - NEW.start_at),
+                                MAX(approvals_suspension.end_at)
+                                FROM approvals_suspension
+                                WHERE approval_id=NEW.approval_id
+                            )
+                            WHERE id = NEW.approval_id;
+                        END IF;
+                        RETURN NULL;
+                    END;
+                $$;
+
+                CREATE OR REPLACE TRIGGER trigger_update_approval_end_at
+                AFTER INSERT OR UPDATE OR DELETE ON approvals_suspension
+                FOR EACH ROW
+                EXECUTE FUNCTION update_approval_fields();
+
+                ALTER TRIGGER trigger_update_approval_end_at
+                ON approvals_suspension
+                RENAME TO trigger_update_approval_fields;
+
+                DROP FUNCTION update_approval_end_at;
+            """,
+            reverse_sql="""
+                DROP TRIGGER IF EXISTS trigger_update_approval_fields ON approvals_suspension;
+                DROP FUNCTION IF EXISTS update_approval_fields();
+            """,
+        ),
+        migrations.RunPython(forwards, migrations.RunPython.noop, elidable=True),
+    ]

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -87,28 +87,20 @@ class CommonApprovalMixin(models.Model):
     def duration(self):
         return self.end_at - self.start_at
 
-    def _get_obj_remainder(self, obj):
-        """
-        Return the remaining time on an object with start_at and end_at dete fields
-        A.k.a an Approval, a Suspension or a Prolongation
-        """
-        return max(obj.end_at - timezone.localdate(), datetime.timedelta(0)) - max(
-            obj.start_at - timezone.localdate(), datetime.timedelta(0)
-        )
-
-    @cached_property
+    @property
     def remainder(self):
-        """
-        Return the remaining time of an Approval, we don't count future suspended periods.
-        """
-        result = self._get_obj_remainder(self)
-
-        if hasattr(self, "suspension_set"):
+        """Return the remaining time of an Approval."""
+        today = timezone.localdate()
+        zero = datetime.timedelta(0)
+        result = max(self.end_at - today, zero) - max(self.start_at - today, zero)
+        try:
+            suspended_until = self.suspended_until
+        except AttributeError:
             # PoleEmploiApprovals don't have suspensions
-            result -= sum(
-                (self._get_obj_remainder(suspension) for suspension in self.suspension_set.all()),
-                datetime.timedelta(0),
-            )
+            pass
+        else:
+            if suspended_until:
+                result -= max(suspended_until - today, zero)
         return result
 
     @property

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -255,6 +255,9 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
         "pour lui pendant la période de suspension."
     )
 
+    # This denormalized field is maintained by a TRIGGER, avoids querying the
+    # approvals.Suspension table to get the state of an Approval.
+    suspended_until = models.DateField(null=True, editable=False, verbose_name="suspendu jusqu’à")
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         verbose_name="demandeur d'emploi",

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -362,9 +362,9 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
 
     # Suspension.
 
-    @cached_property
+    @property
     def is_suspended(self):
-        return self.suspension_set.in_progress().exists()
+        return bool(self.suspended_until and self.suspended_until >= timezone.localdate())
 
     @cached_property
     def suspensions_by_start_date_asc(self):
@@ -387,7 +387,7 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     def last_old_suspension(self, exclude_pk=None):
         return self.suspensions_by_start_date_asc.exclude(pk=exclude_pk).old().last()
 
-    @cached_property
+    @property
     def can_be_suspended(self):
         return self.is_in_progress and not self.is_suspended
 
@@ -399,7 +399,7 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     def last_in_progress_suspension(self):
         return self.suspension_set.in_progress().order_by("start_at").last()
 
-    @cached_property
+    @property
     def can_be_unsuspended(self):
         if self.is_suspended:
             return self.last_in_progress_suspension.reason in Suspension.REASONS_ALLOWING_UNSUSPEND

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -389,7 +389,9 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
 
     @cached_property
     def last_in_progress_suspension(self):
-        return self.suspension_set.in_progress().order_by("start_at").last()
+        if self.is_suspended:
+            return self.suspension_set.in_progress().order_by("start_at").last()
+        return None
 
     @property
     def can_be_unsuspended(self):

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -474,7 +474,7 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
         upper_bound = self.end_at + relativedelta(months=self.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_END)
         return lower_bound <= now <= upper_bound
 
-    @cached_property
+    @property
     def can_be_prolonged(self):
         # Since it is possible to prolong even 3 months after the end of a PASS IAE,
         # it is possible that another one has been issued in the meantime. Thus we

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -124,7 +124,7 @@
                         </div>
                     </div>
                 </div>
-            {% elif item.has_suspension or item.has_prolongation %}
+            {% elif item.approval.suspended_until or item.has_prolongation %}
                 <div class="alert alert-warning" role="status">
                     <div class="row">
                         <div class="col-auto pr-0">

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -58,7 +58,7 @@ class ApprovalForm(forms.Form):
 
         status_filters_list = []
         now = timezone.localdate()
-        suspended_qs_filter = Q(suspension__start_at__lte=now, suspension__end_at__gte=now)
+        suspended_qs_filter = Q(suspended_until__isnull=False, suspended_until__gte=now)
         if data.get("status_valid"):
             status_filters_list.append(Q(start_at__lte=now, end_at__gte=now) & ~suspended_qs_filter)
         if data.get("status_suspended"):

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -549,8 +549,6 @@ class ApprovalModelTest(TestCase):
             start_at=datetime.date(2021, 11, 1),
             end_at=datetime.date(2021, 12, 1),
         )
-
-        del approval.remainder
         approval.refresh_from_db()
         prolonged_remainder = 122 + 4 + 5 + 30
         assert approval.remainder == datetime.timedelta(days=prolonged_remainder)
@@ -567,8 +565,6 @@ class ApprovalModelTest(TestCase):
             start_at=datetime.date(2022, 11, 1),
             end_at=datetime.date(2022, 12, 1),
         )
-        # Clear cache
-        del approval.remainder
         approval.refresh_from_db()
         # Substract to remainder the remaining suspension time
         assert approval.remainder == datetime.timedelta(days=(prolonged_remainder + 5 + 30 - 9))

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -354,6 +354,7 @@ class ApprovalModelTest(TestCase):
                 end_at=today + relativedelta(months=1),
                 reason=reason_to_refuse,
             )
+            approval.refresh_from_db()
             assert not approval.can_be_unsuspended
             suspension.delete()
             approval.delete()
@@ -366,7 +367,7 @@ class ApprovalModelTest(TestCase):
                 end_at=today + relativedelta(months=1),
                 reason=reason,
             )
-
+            approval.refresh_from_db()
             assert approval.can_be_unsuspended
             suspension.delete()
             approval.delete()
@@ -430,6 +431,7 @@ class ApprovalModelTest(TestCase):
                     start_at=suspension_start_date,
                     end_at=suspension_end_date,
                 )
+                approval.refresh_from_db()
                 approval.unsuspend(hiring_start_at=today)
                 suspension.refresh_from_db()
                 assert suspension.end_at == suspension_expected_end_date
@@ -459,6 +461,7 @@ class ApprovalModelTest(TestCase):
                     start_at=suspension_start_date,
                     end_at=suspension_end_date,
                 )
+                approval.refresh_from_db()
                 approval.unsuspend(hiring_start_at=today)
                 suspension.refresh_from_db()
                 assert suspension.end_at == suspension_end_date
@@ -472,6 +475,7 @@ class ApprovalModelTest(TestCase):
             end_at=today + relativedelta(months=2),
             reason=Suspension.Reason.BROKEN_CONTRACT.value,
         )
+        approval.refresh_from_db()
         approval.unsuspend(hiring_start_at=today)
         with pytest.raises(ObjectDoesNotExist):
             suspension.refresh_from_db()

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1193,6 +1193,7 @@ class SuspensionModelTest(TestCase):
 
 
 class SuspensionModelTestTrigger(TestCase):
+    @freeze_time("2023-04-26")
     def test_save(self):
         """
         Test `trigger_update_approval_end_at` with SQL INSERT.
@@ -1202,12 +1203,15 @@ class SuspensionModelTestTrigger(TestCase):
 
         approval = ApprovalFactory(start_at=start_at)
         initial_duration = approval.duration
+        assert approval.suspended_until is None
 
         suspension = SuspensionFactory(approval=approval, start_at=start_at)
 
         approval.refresh_from_db()
         assert approval.duration == initial_duration + suspension.duration
+        assert approval.suspended_until == datetime.date(2026, 4, 25)
 
+    @freeze_time("2023-04-26")
     def test_delete(self):
         """
         Test `trigger_update_approval_end_at` with SQL DELETE.
@@ -1217,16 +1221,20 @@ class SuspensionModelTestTrigger(TestCase):
 
         approval = ApprovalFactory(start_at=start_at)
         initial_duration = approval.duration
+        assert approval.suspended_until is None
 
         suspension = SuspensionFactory(approval=approval, start_at=start_at)
         approval.refresh_from_db()
         assert approval.duration == initial_duration + suspension.duration
+        assert approval.suspended_until == datetime.date(2026, 4, 25)
 
         suspension.delete()
 
         approval.refresh_from_db()
         assert approval.duration == initial_duration
+        assert approval.suspended_until is None
 
+    @freeze_time("2023-04-26")
     def test_save_and_edit(self):
         """
         Test `trigger_update_approval_end_at` with SQL UPDATE.
@@ -1237,11 +1245,13 @@ class SuspensionModelTestTrigger(TestCase):
 
         approval = ApprovalFactory(start_at=start_at)
         initial_duration = approval.duration
+        assert approval.suspended_until is None
 
         # New suspension.
         suspension = SuspensionFactory(approval=approval, start_at=start_at)
         suspension_duration_1 = suspension.duration
         approval.refresh_from_db()
+        assert approval.suspended_until == datetime.date(2026, 4, 25)
         approval_duration_2 = approval.duration
 
         # Edit suspension to be shorter.
@@ -1249,6 +1259,7 @@ class SuspensionModelTestTrigger(TestCase):
         suspension.save()
         suspension_duration_2 = suspension.duration
         approval.refresh_from_db()
+        assert approval.suspended_until == datetime.date(2026, 2, 25)
         approval_duration_3 = approval.duration
 
         # Check suspension duration.

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -393,6 +393,7 @@ class ApprovalModelTest(TestCase):
             end_at=today + relativedelta(months=2),
             reason=Suspension.Reason.BROKEN_CONTRACT.value,
         )
+        approval.refresh_from_db()
         assert suspension.pk == approval.last_in_progress_suspension.pk
 
     def test_last_in_progress_without_suspension_in_progress(self):

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -110,7 +110,6 @@ class TestApprovalDetailView:
             + 1  # job_seeker.approval
             + 1  # select all latest suspensions to check their end date
             + 1  # job_application.with_accepted_at annotation coming from next query
-            + 1  # approval.suspension active today
             + 1  # Suspension.can_be_handled_by_siae >> User.last_accepted_job_application
             + 1  # select latest approval for user (can_be_prolonged)
             + 1  # approval.remainder fetches approval suspensions to compute remaining days.
@@ -188,7 +187,6 @@ class TestApprovalDetailView:
             # get_context_data
             + 1  # select all latest suspensions to check their end date (with prefetch)
             + 1  # for every *active* suspension, check if there is an accepted job application after it
-            + 1  # approval.suspension_set.end_at >= today >= approval.suspension_set.start_at (.can_be_suspended)
             + 1  # job_application.with_accepted_at annotation coming from (.last_hire_was_made_by_siae)
             + 1  # siae infos (.last_hire_was_made_by_siae)
             + 1  # user approvals (.is_last_for_user)
@@ -298,9 +296,7 @@ class TestApprovalDetailView:
             start_at=timezone.localdate() - relativedelta(days=1),
             end_at=timezone.localdate() + relativedelta(days=1),
         )
-        # Clear cached property
-        del approval.can_be_suspended
-        del approval.is_suspended
+        approval.refresh_from_db()
         assert not approval.can_be_suspended_by_siae(siae)
         response = client.get(url)
         assertNotContains(response, reverse("approvals:suspend", kwargs={"approval_id": approval.id}))

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -320,8 +320,6 @@ class TestApprovalDetailView:
 
         approval.end_at = timezone.localdate() - relativedelta(months=4)
         approval.save()
-        # Clear cached property
-        del approval.can_be_prolonged
         assert not approval.can_be_prolonged
         response = client.get(url)
         assertNotContains(response, reverse("approvals:declare_prolongation", kwargs={"approval_id": approval.id}))

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -94,7 +94,6 @@ class TestApprovalsListView:
             + 1  # count (from paginator)
             + 1  # fetch siae membership (from context processor)
             + 1  # fetch approvals
-            + 2  # check if in progress suspensions exist for each approval (Approval.is_suspended)
             + 3  # savepoint, update session, release savepoint
         ):
             response = client.get(url)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Suite-journ-e-dev-Approval-suspended_until-6455d136d38146a192c9bfb04c09e1eb**

### Performances

Méthode : Best of 3, selon l’onglet SQL de la DjDT (arrondi à 5 ms)

#### SIAE
Utilisateur : Un utilisateur d’une grosse SIAE (2700 candidatures)

| Nom | Master | PR | URL |
|-----|--------|----|-----|
| Candidatures NEW & PROCESSING | 180 ms | 180 ms | http://localhost:8000/apply/siae/list?states=new&states=processing |
| Candidatures NEW & PROCESSING Eligibilité validée | 173 ms | 171 ms | http://localhost:8000/apply/siae/list?states=new&states=processing&eligibility_validated=on&start_date=&end_date= |
| Eligibilité validée, suspendu | 440 ms | 290 ms | http://localhost:8000/apply/siae/list?eligibility_validated=on&pass_iae_suspended=on&start_date=&end_date= |
| Eligibilité validée, actif | 420 ms | 275 ms | http://localhost:8000/apply/siae/list?eligibility_validated=on&pass_iae_active=on&start_date=&end_date= |
| Gérer les PASS IAE | 110 ms | 110 ms | http://localhost:8000/approvals/list |
| Gérer les PASS IAE suspendus | 360 ms | 105 ms | http://localhost:8000/approvals/list?status_suspended=on |
| Gérer les PASS IAE valides | 600 ms | 105 ms | http://localhost:8000/approvals/list?status_valid=on |
| Gérer les PASS IAE futurs | 110 ms | 105 ms | http://localhost:8000/approvals/list?status_future=on |
| Gérer les fiches salarié | 225 ms | 225 ms | http://localhost:8000/employee_record/list?status=NEW |

#### Prescripteur

Utilisateur : Un prescripteur ayant orienté beaucoup de candidats (1350 candidatures)

| Nom | Master | PR | URL |
|-----|--------|----|-----|
| Candidatures | 235 ms | 210 ms | http://localhost:8000/apply/prescriber/list |
| Candidatures avec éligibilité validée | 260 ms | 225 ms | http://localhost:8000/apply/prescriber/list?start_date=&end_date=&eligibility_validated=on |