### PR TITLE
Remplacement du lien de disponibilité (désormais Updown)

### DIFF
--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -44,7 +44,7 @@
                             <a href="{{ ITOU_COMMUNITY_URL }}/doc/emplois/1829-2/" target="_blank" aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
                         </li>
                         <li>
-                            <a href="https://stats.uptimerobot.com/JYJ6XHq6xY" target="_blank" aria-label="Disponibilité (ouverture dans un nouvel onglet)">Disponibilité</a>
+                            <a href="https://updown.io/p/vjjst" target="_blank" aria-label="Disponibilité (ouverture dans un nouvel onglet)">Disponibilité</a>
                         </li>
                     </ul>
 	


### PR DESCRIPTION
Nous avons remplacé UptimeRobot par Updown mais nous avons oublié de le répercuter dans le site.