### PR TITLE
[Zendesk] Ajout d'une constante pour référencer la plateforme d'aide aux DDETS et suppression d'un lien

### DIFF
--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -24,10 +24,6 @@ class CampaignEmailFactory:
         context = {
             "evaluated_period_start_at": self.evaluation_campaign.evaluated_period_start_at,
             "evaluated_period_end_at": self.evaluation_campaign.evaluated_period_end_at,
-            "ddets_evaluation_handbook_url": urllib.parse.urljoin(
-                global_constants.DDETS_HELP_CENTER_URL,
-                "/categories/14785701360401-Contrôle-à-posteriori",
-            ),
         }
         subject = "siae_evaluations/email/to_institution_selected_siae_subject.txt"
         body = "siae_evaluations/email/to_institution_selected_siae_body.txt"

--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -139,7 +139,7 @@ class SIAEEmailFactory:
             "siae": self.evaluated_siae.siae,
             "auto_prescription_url": get_absolute_url(auto_prescription_url),
             "siae_evaluation_handbook_url": urllib.parse.urljoin(
-                global_constants.ITOU_DOCS_URL,
+                global_constants.ITOU_COMMUNITY_URL,
                 "/doc/emplois/controle-a-posteriori-pour-les-siae/",
             ),
         }

--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -25,8 +25,8 @@ class CampaignEmailFactory:
             "evaluated_period_start_at": self.evaluation_campaign.evaluated_period_start_at,
             "evaluated_period_end_at": self.evaluation_campaign.evaluated_period_end_at,
             "ddets_evaluation_handbook_url": urllib.parse.urljoin(
-                global_constants.ITOU_DOCS_URL,
-                "/doc/emplois/mode-demploi-sur-le-controle-a-posteriori-pour-les-ddets/",
+                global_constants.DDETS_HELP_CENTER_URL,
+                "/categories/14785701360401-Contrôle-à-posteriori",
             ),
         }
         subject = "siae_evaluations/email/to_institution_selected_siae_subject.txt"

--- a/itou/templates/siae_evaluations/email/to_institution_selected_siae_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_selected_siae_body.txt
@@ -26,9 +26,6 @@ Vous pouvez consulter les justificatifs pour chaque salarié, les accepter ou le
 3- Valider le contrôle
 Après avoir traité toutes les justificatifs d’une SIAE, vous pouvez finaliser le contrôle en cliquant sur le bouton “Valider”. La SIAE sera automatiquement notifiée.
 
-
-Vous trouverez plus d’informations dans ce mode d’emploi : {{ ddets_evaluation_handbook_url }}
-
 Cordialement,
 
 {% endblock %}

--- a/itou/utils/constants.py
+++ b/itou/utils/constants.py
@@ -1,6 +1,6 @@
 ITOU_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/aide/emplois"
 ITOU_COMMUNITY_URL = "https://communaute.inclusion.beta.gouv.fr"
-ITOU_DOCS_URL = "https://documentation.inclusion.beta.gouv.fr"
+DDETS_HELP_CENTER_URL = "https://plateforme-inclusion-ddets-dreets.zendesk.com/hc/fr"
 ITOU_EMAIL_PROLONGATION = "prolongation@inclusion.beta.gouv.fr"
 PILOTAGE_ASSISTANCE_URL = "https://communaute.inclusion.beta.gouv.fr/aide/pilotage"
 PILOTAGE_SITE_URL = "https://pilotage.inclusion.beta.gouv.fr"

--- a/tests/siae_evaluations/__snapshots__/test_models.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_models.ambr
@@ -163,7 +163,7 @@
   
   Accès direct à votre liste d’auto-prescriptions : http://localhost:8000/siae_evaluation/siae_job_applications_list/1002/
   
-  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://documentation.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
+  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://communaute.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
   
   Cordialement,
   
@@ -185,7 +185,7 @@
   
   Accès direct à votre liste d’auto-prescriptions : http://localhost:8000/siae_evaluation/siae_job_applications_list/1001/
   
-  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://documentation.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
+  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://communaute.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
   
   Cordialement,
   
@@ -301,7 +301,7 @@
   
   Accès direct à votre liste d’auto-prescriptions : http://localhost:8000/siae_evaluation/siae_job_applications_list/1000/
   
-  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://documentation.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
+  En cas de besoin, vous pouvez consulter ce mode d’emploi : https://communaute.inclusion.beta.gouv.fr/doc/emplois/controle-a-posteriori-pour-les-siae/
   
   Cordialement,
   


### PR DESCRIPTION
### Pourquoi ?

Le nom de domaine est différent de celui utilisé pour les emplois (`aide.emplois`).
ATTENTION : ce centre d'aide n'a pas encore été publié, c'est pourquoi nous avons décidé avec Sarah de supprimer le seul lien public en attendant.