### PR TITLE
Ajout d’une notification lors du passage en phase 2 & 3 bis

### DIFF
--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -38,6 +38,17 @@ class CampaignEmailFactory:
         body = "siae_evaluations/email/to_institution_siaes_transition_to_adversarial_stage_body.txt"
         return get_email_message(self.recipients, context, subject, body)
 
+    def submission_frozen(self):
+        subject = "siae_evaluations/email/to_institution_siaes_submission_frozen_subject.txt"
+        body = "siae_evaluations/email/to_institution_siaes_submission_frozen_body.txt"
+        return get_email_message(self.recipients, {}, subject, body)
+
+    def submission_frozen_reminder(self):
+        context = {"campaign": self.evaluation_campaign.institution.name}
+        subject = "siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_subject.txt"
+        body = "siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_body.txt"
+        return get_email_message(self.recipients, context, subject, body)
+
     def close(self):
         context = {
             "evaluated_siaes_list_url": get_absolute_url(

--- a/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
+++ b/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
@@ -1,10 +1,12 @@
+import datetime
+
 from dateutil.relativedelta import relativedelta
 from django.core.management import BaseCommand
-from django.db.models import Exists, F, OuterRef, Q
+from django.db.models import Exists, F, Max, OuterRef, Q
 from django.utils import timezone
 
-from itou.siae_evaluations.emails import SIAEEmailFactory
-from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria, EvaluationCampaign
+from itou.siae_evaluations.emails import CampaignEmailFactory, SIAEEmailFactory
+from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria, EvaluatedSiae, EvaluationCampaign
 from itou.utils.emails import send_email_messages
 
 
@@ -59,3 +61,36 @@ class Command(BaseCommand):
                 self.stdout.write(
                     f"Emailed second reminders to {len(emails)} SIAE which did not submit proofs to {campaign}."
                 )
+
+        # When SIAE submissions are frozen, notify institutions:
+        # - on the day submissions are frozen, and
+        # - 7 days after submissions have been frozen.
+        siae_subq = EvaluatedSiae.objects.filter(evaluation_campaign_id=OuterRef("pk"))
+        submissions_frozen = ~Exists(siae_subq.filter(submission_freezed_at=None))
+        has_siae_to_control = Exists(
+            siae_subq.filter(
+                Q(reviewed_at=None, evaluation_campaign__calendar__adversarial_stage_start__gt=today)
+                | Q(final_reviewed_at=None, evaluation_campaign__calendar__adversarial_stage_start__lte=today)
+            )
+        )
+        for campaign in campaigns.filter(
+            Q(submission_freeze_notified_at=None)
+            | Q(submission_freeze_notified_at__date__lte=today - relativedelta(days=7)),
+            submissions_frozen,
+            has_siae_to_control,
+        ):
+            action = None
+            if campaign.submission_freeze_notified_at is None:
+                send_email_messages([CampaignEmailFactory(campaign).submission_frozen()])
+                action = "Instructed"
+            else:
+                submission_frozen_at = EvaluatedSiae.objects.filter(evaluation_campaign=campaign).aggregate(
+                    Max("submission_freezed_at")
+                )["submission_freezed_at__max"]
+                if submission_frozen_at - campaign.submission_freeze_notified_at <= datetime.timedelta(days=7):
+                    send_email_messages([CampaignEmailFactory(campaign).submission_frozen_reminder()])
+                    action = "Reminded"
+            if action:
+                self.stdout.write(f"{action} “{campaign.institution}” to control SIAE during the submission freeze.")
+                campaign.submission_freeze_notified_at = timezone.now()
+                campaign.save(update_fields=["submission_freeze_notified_at"])

--- a/itou/siae_evaluations/migrations/0010_evaluationcampaign_submission_freeze_notified_at.py
+++ b/itou/siae_evaluations/migrations/0010_evaluationcampaign_submission_freeze_notified_at.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("siae_evaluations", "0009_calendar_adversarial_stage_start"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evaluationcampaign",
+            name="submission_freeze_notified_at",
+            field=models.DateTimeField(
+                editable=False,
+                help_text="Date de dernière notification des DDETS après blocage des soumissions SIAE",
+                null=True,
+                verbose_name="notification des DDETS après blocage des soumissions SIAE",
+            ),
+        ),
+    ]

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -155,6 +155,15 @@ class EvaluationCampaign(models.Model):
         verbose_name="Date de notification du contrôle aux Siaes", blank=True, null=True
     )
     ended_at = models.DateTimeField(verbose_name="Date de clôture de la campagne", blank=True, null=True)
+    # When SIAE submissions are frozen, notify institutions:
+    # - on the day submissions are frozen, and
+    # - 7 days after submissions have been frozen.
+    submission_freeze_notified_at = models.DateTimeField(
+        verbose_name="notification des DDETS après blocage des soumissions SIAE",
+        help_text="Date de dernière notification des DDETS après blocage des soumissions SIAE",
+        null=True,
+        editable=False,
+    )
 
     # dates of the evaluated period
     # to do later : add coherence controls between campaign.
@@ -342,6 +351,8 @@ class EvaluationCampaign(models.Model):
         EvaluatedSiae.objects.filter(evaluation_campaign=self, submission_freezed_at__isnull=False).update(
             submission_freezed_at=None
         )
+        self.submission_freeze_notified_at = None
+        self.save(update_fields=["submission_freeze_notified_at"])
 
     def close(self):
         now = timezone.now()

--- a/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_body.txt
@@ -1,0 +1,14 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+La phase de transmission des justificatifs par les SIAE est désormais terminée. Les DDETS disposent d’un délai supplémentaire* pour étudier les justificatifs et valider le contrôle de chaque SIAE.
+
+* Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel des emplois de l’inclusion.
+
+Pour chaque SIAE contrôlée vous devez :
+- accepter ou refuser l’intégralité des justificatifs soumis
+- et valider le contrôle (sans cette validation le résultat ne sera pas enregistré)
+
+Cordialement,
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_body.txt
@@ -1,0 +1,16 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+Une ou plusieurs SIAE qui ont transmis leurs justificatifs n’ont pas encore été contrôlée(s) par vos services.
+
+En tant que membre de l’organisation {{ campaign.institution.name }}, nous vous invitons à finaliser ce contrôle. Sans réponse de votre part avant la fin de cette phase*, le résultat du contrôle des SIAE non contrôlées sera par défaut positif.
+
+* Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel des emplois de l’inclusion.
+
+Nous vous rappelons que pour chaque SIAE contrôlée vous devez :
+- accepter ou refuser l’intégralité des justificatifs soumis
+- et valider le contrôle (sans cette validation le résultat ne sera pas enregistré)
+
+Cordialement,
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+[Contrôle a posteriori] Rappel : Contrôle des justificatifs à finaliser
+{% endblock %}

--- a/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+[Contrôle a posteriori] Contrôle des justificatifs à réaliser avant la clôture de phase
+{% endblock %}

--- a/tests/siae_evaluations/__snapshots__/test_management_commands.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_management_commands.ambr
@@ -1,0 +1,23 @@
+# serializer version: 1
+# name: TestManagementCommand.test_institution_submission_freeze_reminder
+  '''
+  Bonjour,
+  
+  Une ou plusieurs SIAE qui ont transmis leurs justificatifs n’ont pas encore été contrôlée(s) par vos services.
+  
+  En tant que membre de l’organisation , nous vous invitons à finaliser ce contrôle. Sans réponse de votre part avant la fin de cette phase*, le résultat du contrôle des SIAE non contrôlées sera par défaut positif.
+  
+  * Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel des emplois de l’inclusion.
+  
+  Nous vous rappelons que pour chaque SIAE contrôlée vous devez :
+  - accepter ou refuser l’intégralité des justificatifs soumis
+  - et valider le contrôle (sans cette validation le résultat ne sera pas enregistré)
+  
+  Cordialement,
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---

--- a/tests/siae_evaluations/factories.py
+++ b/tests/siae_evaluations/factories.py
@@ -72,12 +72,12 @@ class EvaluatedJobApplicationFactory(factory.django.DjangoModelFactory):
                 "tests.siae_evaluations.factories.EvaluatedAdministrativeCriteriaFactory",
                 factory_related_name="evaluated_job_application",
                 uploaded_at=factory.LazyAttribute(
-                    lambda siae: siae.factory_parent.evaluated_siae.evaluation_campaign.ended_at
-                    - relativedelta(days=10)
+                    lambda siae: siae.factory_parent.evaluated_siae.evaluation_campaign.evaluations_asked_at
+                    + relativedelta(days=10)
                 ),
                 submitted_at=factory.LazyAttribute(
-                    lambda siae: siae.factory_parent.evaluated_siae.evaluation_campaign.ended_at
-                    - relativedelta(days=5)
+                    lambda siae: siae.factory_parent.evaluated_siae.evaluation_campaign.evaluations_asked_at
+                    + relativedelta(days=15)
                 ),
             )
         )


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Notification-e-mail-pour-annoncer-l-Ouverture-de-la-phase-2-bis-et-3-bis-uniquement-pour-les-ddet-e5fb9c1a204d4d67bd582b16834955b6**
**Carte Notion : https://www.notion.so/plateforme-inclusion/Notification-e-mail-Rappel-8-jours-apr-s-le-lancement-d-une-phase-bis-2-ou-3-uniquement-pour-les-a821c688aff24140a2ff484ef188f5bf**

### Pourquoi ?

Informer les DDETS que leur contrôle est attendu par les SIAE.