### PR TITLE
Envoi des e-mails de prolongation avec l'adresse adéquate

### DIFF
--- a/itou/approvals/notifications.py
+++ b/itou/approvals/notifications.py
@@ -1,4 +1,5 @@
 from itou.common_apps.notifications.base_class import BaseNotification
+from itou.utils import constants as base_constants
 from itou.utils.emails import get_email_message
 
 
@@ -18,4 +19,4 @@ class NewProlongationToAuthorizedPrescriberNotification(BaseNotification):
         context = {"prolongation": self.prolongation}
         subject = "approvals/email/new_prolongation_for_prescriber_subject.txt"
         body = "approvals/email/new_prolongation_for_prescriber_body.txt"
-        return get_email_message(to, context, subject, body)
+        return get_email_message(to, context, subject, body, from_email=base_constants.ITOU_EMAIL_PROLONGATION)

--- a/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
+++ b/itou/templates/approvals/email/new_prolongation_for_prescriber_body.txt
@@ -6,7 +6,7 @@ Bonjour,
 {{ prolongation.declared_by.get_full_name|title }} de la structure {{ prolongation.declared_by_siae.display_name }} a besoin de votre accord pour prolonger un PASS IAE.
 
 {% if prolongation.require_phone_interview %}
-L'employeur souhaite vous apporter des explications supplémentaires par téléphone. vous trouverez ci-dessous ses coordonnées pour le contacter : 
+L'employeur souhaite vous apporter des explications supplémentaires par téléphone. vous trouverez ci-dessous ses coordonnées pour le contacter :
 
 - Email de l’employeur: {{ prolongation.contact_email }}
 - Numéro de téléphone de l’employeur : {{ prolongation.contact_phone }}
@@ -21,17 +21,17 @@ L'employeur souhaite vous apporter des explications supplémentaires par télép
 - Motif de prolongation : {{ prolongation.get_reason_display }}
 {% if prolongation.report_file %}- Fiche bilan : {{ prolongation.report_file.link }}{% endif %}
 
-Pour valider ou refuser cette prolongation, merci de nous transférer ce message à l'adresse suivante : {{ itou_email_prolongation }}
+Pour valider ou refuser cette prolongation, merci de répondre à cet e-mail.
 
-Précisions en cas de refus : 
+Précisions en cas de refus :
 
 Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
 
 * Motifs de refus et actions associées :
 
-1/ L’IAE ne correspond plus aux besoins / à la situation de la personne : 
+1/ L’IAE ne correspond plus aux besoins / à la situation de la personne :
 
-Actions possibles : 
+Actions possibles :
 - Accompagnement à la recherche d’emploi hors IAE et mobilisation de l’offre de services disponible au sein de votre structure ou celle d’un partenaire
 - Orientation vers un partenaire de l’accompagnement social/professionnel
 

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -23,7 +23,6 @@ def get_email_text_template(template, context):
     context.update(
         {
             "itou_help_center_url": global_constants.ITOU_HELP_CENTER_URL,
-            "itou_email_prolongation": global_constants.ITOU_EMAIL_PROLONGATION,
             "itou_environment": settings.ITOU_ENVIRONMENT,
             "itou_fqdn": settings.ITOU_FQDN,
             "itou_protocol": settings.ITOU_PROTOCOL,

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -26,7 +26,6 @@ def expose_settings(request):
         "BASE_TEMPLATE": base_template,
         "ITOU_HELP_CENTER_URL": help_center_url,
         "ITOU_EMAIL_CONTACT": settings.ITOU_EMAIL_CONTACT,
-        "ITOU_EMAIL_PROLONGATION": global_constants.ITOU_EMAIL_PROLONGATION,
         "ITOU_ENVIRONMENT": settings.ITOU_ENVIRONMENT,
         "ITOU_FQDN": settings.ITOU_FQDN,
         "ITOU_PILOTAGE_URL": global_constants.PILOTAGE_SITE_URL,

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1614,6 +1614,9 @@ class ProlongationNotificationsTest(TestCase):
 
         email = NewProlongationToAuthorizedPrescriberNotification(prolongation).email
 
+        # From
+        assert email.from_email == global_constants.ITOU_EMAIL_PROLONGATION
+
         # To.
         assert prolongation.validated_by.email in email.to
         assert len(email.to) == 1
@@ -1630,7 +1633,6 @@ class ProlongationNotificationsTest(TestCase):
         assert title(prolongation.approval.user.first_name) in email.body
         assert title(prolongation.approval.user.last_name) in email.body
         assert prolongation.approval.user.birthdate.strftime("%d/%m/%Y") in email.body
-        assert global_constants.ITOU_EMAIL_PROLONGATION in email.body
 
 
 class ApprovalConcurrentModelTest(TransactionTestCase):


### PR DESCRIPTION
[Carte Notion](https://www.notion.so/plateforme-inclusion/Envoi-des-e-mails-de-prolongation-avec-l-adresse-ad-quate-dfd061ab4abc44b5afd9f5e06f0b9548?pvs=4)

### Pourquoi ?

Zendesk considère les e-mails transférés comme étant du SPAM. De plus, il est plus confortable pour l'utilisateur de répondre à un courriel que de le transférer.
