### PR TITLE
Permettre la configuration du début de la phase contradictoire

### DIFF
--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -152,7 +152,7 @@ class SIAEEmailFactory:
             kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
         )
         context = {
-            "adversarial_stage_start": self.evaluated_siae.evaluation_campaign.adversarial_stage_start_date,
+            "adversarial_stage_start": self.evaluated_siae.evaluation_campaign.calendar.adversarial_stage_start,
             "evaluation_campaign": self.evaluated_siae.evaluation_campaign,
             "siae": self.evaluated_siae.siae,
             "evaluated_job_app_list_url": get_absolute_url(job_app_list_url),

--- a/itou/siae_evaluations/fixtures.py
+++ b/itou/siae_evaluations/fixtures.py
@@ -55,6 +55,7 @@ def load_data():
     now = timezone.now()
     evaluated_period_start_at = now - relativedelta(months=3)
     evaluated_period_end_at = now - relativedelta(months=1)
+    adversarial_stage_start = now.date() + relativedelta(weeks=6)
     datetime_within_period_range = evaluated_period_end_at - relativedelta(weeks=2)
 
     created_job_applications_pks = []
@@ -130,7 +131,7 @@ def load_data():
     job_applications = JobApplication.objects.filter(pk__in=created_job_applications_pks)
 
     with override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"), transaction.atomic():
-        create_campaigns_and_calendar(evaluated_period_start_at, evaluated_period_end_at)
+        create_campaigns_and_calendar(evaluated_period_start_at, evaluated_period_end_at, adversarial_stage_start)
         evaluation_campaign = EvaluationCampaign.objects.get(institution=institution)
 
         # eligible_job_applications must return a queryset, not a list.

--- a/itou/siae_evaluations/migrations/0009_calendar_adversarial_stage_start.py
+++ b/itou/siae_evaluations/migrations/0009_calendar_adversarial_stage_start.py
@@ -1,0 +1,28 @@
+import datetime
+
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    Calendar = apps.get_model("siae_evaluations", "Calendar")
+    Calendar.objects.update(adversarial_stage_start=datetime.date(2023, 9, 1))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("siae_evaluations", "0008_add_calendar_pk_and_content_20230602"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="calendar",
+            name="adversarial_stage_start",
+            field=models.DateField(null=True, verbose_name="Début de la phase contradictoire"),
+        ),
+        migrations.RunPython(forwards, migrations.RunPython.noop, elidable=True),
+        migrations.AlterField(
+            model_name="calendar",
+            name="adversarial_stage_start",
+            field=models.DateField(verbose_name="Début de la phase contradictoire"),
+        ),
+    ]

--- a/tests/siae_evaluations/factories.py
+++ b/tests/siae_evaluations/factories.py
@@ -23,6 +23,7 @@ class CalendarFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Calendar
 
+    adversarial_stage_start = factory.LazyFunction(lambda: timezone.localdate() + relativedelta(weeks=6))
     html = "<span>I'm valid HTML</span>"
 
 
@@ -30,13 +31,11 @@ class EvaluationCampaignFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.EvaluationCampaign
 
-    class Params:
-        with_calendar = factory.Trait(calendar=factory.SubFactory(CalendarFactory))
-
     name = factory.fuzzy.FuzzyText(length=10)
     institution = factory.SubFactory(InstitutionFactory, department="14")
     evaluated_period_start_at = factory.LazyAttribute(before_ended_at(months=3))
     evaluated_period_end_at = factory.LazyAttribute(before_ended_at(months=1))
+    calendar = factory.SubFactory(CalendarFactory)
 
 
 class EvaluatedSiaeFactory(factory.django.DjangoModelFactory):

--- a/tests/siae_evaluations/test_management_commands.py
+++ b/tests/siae_evaluations/test_management_commands.py
@@ -315,6 +315,7 @@ class TestManagementCommand:
     def test_second_notification_for_siaes_without_proofs(self, capsys, mailoutbox):
         campaign = EvaluationCampaignFactory(
             evaluations_asked_at=timezone.now() - relativedelta(weeks=6, days=30),
+            calendar__adversarial_stage_start=timezone.localdate() - relativedelta(days=30),
             evaluated_period_start_at=datetime.date(2022, 1, 1),
             evaluated_period_end_at=datetime.date(2022, 9, 30),
             institution__name="DDETS 01",

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -265,19 +265,24 @@ class EvaluationCampaignManagerTest(TestCase):
     def test_create_campaigns_and_calendar(self):
         evaluated_period_start_at = timezone.now() - relativedelta(months=2)
         evaluated_period_end_at = timezone.now() - relativedelta(months=1)
+        adversarial_stage_start = timezone.localdate() + relativedelta(months=1)
 
         # not DDETS IAE
         for kind in [k for k in InstitutionKind if k != InstitutionKind.DDETS_IAE]:
             with self.subTest(kind=kind):
                 InstitutionFactory(kind=kind)
-                assert 0 == create_campaigns_and_calendar(evaluated_period_start_at, evaluated_period_end_at)
+                assert 0 == create_campaigns_and_calendar(
+                    evaluated_period_start_at, evaluated_period_end_at, adversarial_stage_start
+                )
                 assert 0 == EvaluationCampaign.objects.all().count()
                 assert 1 == Calendar.objects.all().count()
                 assert len(mail.outbox) == 0
 
         # institution DDETS IAE
         InstitutionWith2MembershipFactory.create_batch(2, kind=InstitutionKind.DDETS_IAE)
-        assert 2 == create_campaigns_and_calendar(evaluated_period_start_at, evaluated_period_end_at)
+        assert 2 == create_campaigns_and_calendar(
+            evaluated_period_start_at, evaluated_period_end_at, adversarial_stage_start
+        )
         assert 2 == EvaluationCampaign.objects.all().count()
         assert 1 == Calendar.objects.all().count()
 
@@ -291,10 +296,12 @@ class EvaluationCampaignManagerTest(TestCase):
     def test_create_campaigns_and_calendar_on_specific_DDETS_IAE(self):
         evaluated_period_start_at = timezone.now() - relativedelta(months=2)
         evaluated_period_end_at = timezone.now() - relativedelta(months=1)
+        adversarial_stage_start = timezone.localdate() + relativedelta(months=1)
         institution_ids = InstitutionWith2MembershipFactory.create_batch(2, kind=InstitutionKind.DDETS_IAE)
         assert 1 == create_campaigns_and_calendar(
             evaluated_period_start_at,
             evaluated_period_end_at,
+            adversarial_stage_start,
             institution_ids=[institution_ids[0].pk],
         )
         assert 1 == EvaluationCampaign.objects.all().count()

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -4083,9 +4083,7 @@ class InstitutionCalendarViewTest(TestCase):
                 </tbody>
             </table>
         """
-        evaluation_campaign = EvaluationCampaignFactory(
-            institution=self.institution, with_calendar=True, calendar__html=calendar_html
-        )
+        evaluation_campaign = EvaluationCampaignFactory(institution=self.institution, calendar__html=calendar_html)
         calendar_url = reverse("siae_evaluations_views:campaign_calendar", args=[evaluation_campaign.pk])
 
         self.client.force_login(self.user)


### PR DESCRIPTION
**Doit être en prod avant le 24 juillet 2023**

### Pourquoi ?

Le calendrier type de la DGEFP n’est pas respecté pour cette campagne. Il stipule que la phase contradictoire commence 6 semaines après le début de la phase amiable.
Pour cette campagne de contrôles qui a débuté le 12 juin, ça tombe le 24 juillet. À cause de la période juillet-août, il a été décidé de reprendre le contrôle a posteriori au 1er septembre 2023, mais le code n’a pas été modifié.

En l’état, la phase contradictoire démarrerait donc le 24 juillet 2023 et non le 1er septembre.