### PR TITLE
Makefile: Déplacer checkmigrations et spectacular dans la règle quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,8 @@ jobs:
       run: |
         make venv
         echo ".venv/bin" >> $GITHUB_PATH
-    - name: ✨ Black, ruff & djlint
+    - name: ✨ Verify quality
       run: make quality
-    - name: 🚧 Check pending migrations
-      run: django-admin makemigrations --check --dry-run --noinput
-    - name: 👓 Check spectacular documentation
-      run: django-admin spectacular --validate --fail-on-warn --file /dev/null
     - name: 🤹 Django tests
       run: make test
       env:

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ quality: $(VIRTUAL_ENV)
 	ruff check $(LINTER_CHECKED_DIRS)
 	djlint --lint --check itou
 	find * -type f -name '*.sh' -exec shellcheck --external-sources {} +
+	python manage.py makemigrations --check --dry-run --noinput
+	python manage.py spectacular --validate --fail-on-warn --file /dev/null
 
 fix: $(VIRTUAL_ENV)
 	black $(LINTER_CHECKED_DIRS)


### PR DESCRIPTION
### Pourquoi ?

Harmoniser les tests locaux et la CI. Plus utiliser l’environnement `make`.