### PR TITLE
ASP imports: fix EA/EATT XLS import

### DIFF
--- a/itou/siaes/management/commands/import_ea_eatt.py
+++ b/itou/siaes/management/commands/import_ea_eatt.py
@@ -70,6 +70,11 @@ def get_ea_eatt_df():
     df = df.replace({np.nan: None})
 
     df = df[df.kind != "Entreprise Adaptée en Milieu Pénitentiaire"]
+
+    # note (fv): apparently, EA / EATT XLS source file can also contain the following field value
+    # (which is the same as the line above, on a business POV)
+    df = df[df.kind != "Entreprise Adaptée en Etablissement Pénitentiaire"]
+
     df["kind"] = df.kind.apply(convert_kind)
 
     # Drop rows without siret.


### PR DESCRIPTION
XLS import file for EA / EATT can contain fields with a new value that must be ignored : _"Entreprise Adaptée en Etablissement Pénitentiaire"_
