### PR TITLE
BOOST: enlever les boutons disgracieux sur les champs de mot passe dans l'admin

### DIFF
--- a/itou/static/js/admin.js
+++ b/itou/static/js/admin.js
@@ -24,4 +24,6 @@
       }
     }
   });
+  // Remove bootstrap CSS elements not needed for admin
+  document.querySelectorAll(".input-group-append").forEach(elt => { elt.remove(); });
 }());


### PR DESCRIPTION

**Carte Notion : **

https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=1fd7b3e4df2a46898bd1cdaf8a6f647c&pm=c

### Pourquoi ?

Tout est dans le titre : c'est pas beau.

### Comment 

Le fichier template du widget par défaut des champs de mots de passe a été modifié pour le site principal avec un ajout de bouton (pour cacher ou montrer le mot de passe).

Ce n'est pas utile (ni fonctionnel) sur l'admin, puisque pas de bootstrap disponible.


