### PR TITLE
Rendre la fixture admin_client plus réaliste

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -395,9 +395,6 @@ class User(AbstractUser, AddressMixin):
         elif self.kind in UserKind:
             # Any other user kind isn't staff
             self.is_staff = False
-        elif self.is_staff:
-            # self.kind == "" : handle django admin_client pytest fixture
-            self.kind = UserKind.ITOU_STAFF
 
         self.validate_constraints()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from factory import Faker
 pytest.register_assert_rewrite("itou.utils.test")
 
 from itou.utils import faker_providers  # noqa: E402
+from tests.users.factories import ItouStaffFactory  # noqa: E402
 from tests.utils.htmx.test import HtmxClient  # noqa: E402
 from tests.utils.test import NoInlineClient  # noqa: E402
 
@@ -27,6 +28,13 @@ def pytest_collection_modifyitems(config, items):
         markers = {marker.name for marker in item.iter_markers()}
         if "no_django_db" not in markers and "django_db" not in markers:
             item.add_marker(pytest.mark.django_db)
+
+
+@pytest.fixture
+def admin_client():
+    client = NoInlineClient()
+    client.force_login(ItouStaffFactory(is_superuser=True))
+    return client
 
 
 @pytest.fixture


### PR DESCRIPTION
### Pourquoi ?

Ne pas gérer de cas impossible dans le code de production.