### PR TITLE
Préciser le JS qui cache le champchamp password de l’admin

### DIFF
--- a/itou/static/js/admin.js
+++ b/itou/static/js/admin.js
@@ -24,6 +24,10 @@
       }
     }
   });
-  // Remove bootstrap CSS elements not needed for admin
-  document.querySelectorAll(".input-group-append").forEach(elt => { elt.remove(); });
+  // Remove toggle password button from the admin.
+    document.querySelectorAll(".input-group-append").forEach(elt => {
+    if ("password" in elt.children.item(0).dataset) {
+      elt.remove();
+    }
+  });
 }());


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=1fd7b3e4df2a46898bd1cdaf8a6f647c&pm=c**

### Pourquoi ?

https://github.com/betagouv/itou/pull/2790#discussion_r1272191364