### PR TITLE
Améliorer la cohérence SSO / User.kind

### DIFF
--- a/itou/openid_connect/france_connect/models.py
+++ b/itou/openid_connect/france_connect/models.py
@@ -21,6 +21,7 @@ class FranceConnectUserData(OIDConnectUserData):
     city: str | None = None
     kind: str = UserKind.JOB_SEEKER
     identity_provider: IdentityProvider = IdentityProvider.FRANCE_CONNECT
+    login_allowed_user_kinds = [UserKind.JOB_SEEKER]
 
     @staticmethod
     def user_info_mapping_dict(user_info: dict):

--- a/itou/openid_connect/inclusion_connect/models.py
+++ b/itou/openid_connect/inclusion_connect/models.py
@@ -18,9 +18,11 @@ class InclusionConnectState(OIDConnectState):
 class InclusionConnectPrescriberData(OIDConnectUserData):
     kind: str = UserKind.PRESCRIBER
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
+    login_allowed_user_kinds = [UserKind.PRESCRIBER, UserKind.SIAE_STAFF]
 
 
 @dataclasses.dataclass
 class InclusionConnectSiaeStaffData(OIDConnectUserData):
     kind: str = UserKind.SIAE_STAFF
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
+    login_allowed_user_kinds = [UserKind.PRESCRIBER, UserKind.SIAE_STAFF]

--- a/itou/openid_connect/models.py
+++ b/itou/openid_connect/models.py
@@ -5,7 +5,7 @@ from django.core import signing
 from django.db import models
 from django.utils import crypto, timezone
 
-from itou.users.enums import IdentityProvider
+from itou.users.enums import IdentityProvider, UserKind
 from itou.users.models import User
 
 from .constants import OIDC_STATE_CLEANUP, OIDC_STATE_EXPIRATION
@@ -95,6 +95,7 @@ class OIDConnectUserData:
     username: str
     identity_provider: IdentityProvider
     kind: str
+    login_allowed_user_kinds = [UserKind]
 
     def create_or_update_user(self, is_login=False):
         """
@@ -135,7 +136,7 @@ class OIDConnectUserData:
                 # This happens when the user tried to update its email with one already used by another account.
                 raise MultipleUsersFoundException([user, other_user])
 
-        if user.kind != user_data_dict["kind"] and not is_login:
+        if user.kind not in self.login_allowed_user_kinds or (user.kind != user_data_dict["kind"] and not is_login):
             raise InvalidKindException(user)
 
         if not created:

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -377,6 +377,19 @@ class User(AbstractUser, AddressMixin):
         if self.birth_country and self.birth_country.code != self.INSEE_CODE_FRANCE and self.birth_place:
             raise ValidationError(self.ERROR_BIRTH_COMMUNE_WITH_FOREIGN_COUNTRY)
 
+    def validate_identity_provider(self):
+        if self.identity_provider == IdentityProvider.FRANCE_CONNECT and self.kind != UserKind.JOB_SEEKER:
+            raise ValidationError("France connect n'est utilisable que par un candidat.")
+
+        if self.identity_provider == IdentityProvider.PE_CONNECT and self.kind != UserKind.JOB_SEEKER:
+            raise ValidationError("PE connect n'est utilisable que par un candidat.")
+
+        if self.identity_provider == IdentityProvider.INCLUSION_CONNECT and self.kind not in [
+            UserKind.PRESCRIBER,
+            UserKind.SIAE_STAFF,
+        ]:
+            raise ValidationError("Inclusion connect n'est utilisable que par un presctipeur ou employeur.")
+
     def save(self, *args, **kwargs):
         must_create_profile = self._state.adding
 
@@ -397,6 +410,7 @@ class User(AbstractUser, AddressMixin):
             self.is_staff = False
 
         self.validate_constraints()
+        self.validate_identity_provider()
 
         super().save(*args, **kwargs)
 

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -234,7 +234,7 @@ class FranceConnectTest(TestCase):
         we use it but we do not update it
         """
         fc_user_data = FranceConnectUserData.from_user_info(FC_USERINFO)
-        JobSeekerFactory(email=fc_user_data.email, identity_provider=IdentityProvider.INCLUSION_CONNECT)
+        JobSeekerFactory(email=fc_user_data.email, identity_provider=IdentityProvider.PE_CONNECT)
         user, created = fc_user_data.create_or_update_user()
         assert not created
         assert user.last_name != FC_USERINFO["family_name"]

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -28,7 +28,7 @@ def test_add_user(client):
 
 
 def test_no_email_sent(client):
-    user = JobSeekerFactory(identity_provider=IdentityProvider.INCLUSION_CONNECT)
+    user = JobSeekerFactory(identity_provider=IdentityProvider.FRANCE_CONNECT)
 
     # Typical admin user.
     admin_user = ItouStaffFactory(is_superuser=True)
@@ -66,7 +66,7 @@ def test_no_email_sent(client):
     assert user_refreshed.last_name == user.last_name
     assert user_refreshed.date_joined == now
     assert user_refreshed.last_checked_at == now
-    assert user_refreshed.identity_provider == IdentityProvider.INCLUSION_CONNECT
+    assert user_refreshed.identity_provider == IdentityProvider.FRANCE_CONNECT
 
 
 def test_hijack_button(client):

--- a/tests/www/login/tests.py
+++ b/tests/www/login/tests.py
@@ -53,7 +53,7 @@ class ItouLoginFormTest(TestCase):
         We should block him upstream but this means hard work (overriding default Allauth views),
         too long for this quite uncommon use case.
         """
-        user = PrescriberFactory(identity_provider=users_enums.IdentityProvider.FRANCE_CONNECT)
+        user = JobSeekerFactory(identity_provider=users_enums.IdentityProvider.FRANCE_CONNECT)
         form_data = {
             "login": user.email,
             "password": DEFAULT_PASSWORD,


### PR DESCRIPTION
**Carte Notion : **  https://www.notion.so/plateforme-inclusion/Emp-cher-les-candidats-d-utiliser-Inclusion-Connect-84a3ac9e883a42118c3e2535dd8b97e9?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Pour éviter des cas de candidats migrant à inclusion connect parce que le prescripteur leur a donné leur email. 

