### PR TITLE
FS : Ajout de `employee_records_status` pour extraire le statut de fiche salarié en masse

### DIFF
--- a/itou/employee_record/management/commands/employee_records_status.py
+++ b/itou/employee_record/management/commands/employee_records_status.py
@@ -1,0 +1,74 @@
+import argparse
+
+from django.core.management.base import BaseCommand
+
+from itou.approvals.enums import Origin
+from itou.approvals.models import Approval
+from itou.employee_record.constants import EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE
+from itou.employee_record.models import EmployeeRecord
+from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+
+        parser.add_argument(
+            "approvals_list_file",
+            type=argparse.FileType(mode="r"),
+        )
+        parser.add_argument("siret", type=str, nargs="+")
+        parser.add_argument("--wet-run", action="store_true")
+
+    def handle(self, *, approvals_list_file, siret, wet_run=False, **options):
+        approvals_number = []
+        for line in approvals_list_file:
+            approval_number = line.strip().replace(" ", "")
+            if not approval_number:
+                continue
+            approvals_number.append(approval_number)
+
+        self.stdout.write("PASS;SIRET;Information")
+        for approval_number in sorted(set(approvals_number)):
+            try:
+                employee_record = EmployeeRecord.objects.get(siret__in=siret, approval_number=approval_number)
+            except EmployeeRecord.DoesNotExist:
+                try:
+                    job_application = JobApplication.objects.select_related("to_siae").get(
+                        to_siae__siret__in=siret, approval__number=approval_number
+                    )
+                except JobApplication.DoesNotExist:
+                    siret_used = "+".join(siret)
+                    if not Approval.objects.filter(number=approval_number).exists():
+                        info = "PASS IAE inconnu"
+                    else:
+                        info = "Pas de candidature"
+                except JobApplication.MultipleObjectsReturned:
+                    info, siret_used = "Plusieurs candidatures", "+".join(siret)
+                else:
+                    siret_used = job_application.to_siae.siret
+                    if job_application.state != JobApplicationWorkflow.STATE_ACCEPTED:
+                        info = "La candidature n'est pas en état 'acceptée'"
+                    elif job_application.origin == Origin.AI_STOCK:
+                        info = "Import AI"
+                    elif not job_application.create_employee_record:
+                        info = "Création désactivée"
+                    elif (
+                        job_application.hiring_start_at
+                        and job_application.hiring_start_at < EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE.date()
+                    ):
+                        info = "Date de début du contrat avant l'interopérabilité"
+                    elif (
+                        JobApplication.objects.eligible_as_employee_record(job_application.to_siae)
+                        .filter(pk=job_application.pk)
+                        .exists()
+                    ):
+                        info = "En attente de création"
+                    else:
+                        info = "-"
+            except EmployeeRecord.MultipleObjectsReturned:
+                info, siret_used = "Plusieurs FS", "+".join(siret)
+            else:
+                info, siret_used = employee_record.get_status_display(), employee_record.siret
+
+            self.stdout.write(f"{approval_number};{siret_used};{info}")


### PR DESCRIPTION
### Pourquoi ?

Nous avons de plus en plus de demandes au support a propos de nombreuses fiches salariés n’apparaissent pas.
Dans la quasi-totalité des cas c'est suite à un changement de SIRET, l'ASP ne gérant pas cette opération de leur coté ils obligent les employeurs à renvoyer une fiche salarié pour tout leurs salariés...

### Comment <!-- optionnel -->

Création d'un script à utiliser par un tech afin d'extraire le statut de fiche salarié (semblable à ce qui est affiché dans l'admin des candidatures) pour une liste de PASS IAE et un/des SIRET.

Pour le moment pas de test associés car ça été fait (un peu) dans la précipitation, ça ne fait que lire la donnée et que c'est lancé manuellement par un tech.
