### PR TITLE
Utilisation de `@admin.display` partout et uniformisation du format de date pour certaines f-string

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -55,7 +55,7 @@ class JobApplicationInline(admin.StackedInline):
     # there is no direct relation between approvals and employee records
     # (YET...)
     @staticmethod
-    @admin.display(description="Fiches salariés")
+    @admin.display(description="fiches salariés")
     def employee_record_status(obj):
         if obj.employee_record.exists():
             return mark_safe(
@@ -238,11 +238,9 @@ class ApprovalAdmin(admin.ModelAdmin):
 
         super().save_model(request, obj, form, change)
 
+    @admin.display(boolean=True, description="en cours de validité")
     def is_valid(self, obj):
         return obj.is_valid()
-
-    is_valid.boolean = True
-    is_valid.short_description = "En cours de validité"
 
     def manually_add_approval(self, request, job_application_id):
         """
@@ -271,14 +269,13 @@ class ApprovalAdmin(admin.ModelAdmin):
         ]
         return additional_urls + super().get_urls()
 
+    @admin.display(description="date de naissance")
     def birthdate(self, obj):
         """
         User birthdate as custom value in display
 
         """
         return obj.user.birthdate
-
-    birthdate.short_description = "Date de naissance"
 
 
 class IsInProgressFilter(admin.SimpleListFilter):
@@ -337,11 +334,9 @@ class SuspensionAdmin(admin.ModelAdmin):
     )
     inlines = (PkSupportRemarkInline,)
 
+    @admin.display(boolean=True, description="en cours")
     def is_in_progress(self, obj):
         return obj.is_in_progress
-
-    is_in_progress.boolean = True
-    is_in_progress.short_description = "En cours"
 
     def save_model(self, request, obj, form, change):
         if not change:
@@ -384,16 +379,13 @@ class ProlongationCommonAdmin(admin.ModelAdmin):
     def get_list_display(self, request):
         return self.list_display + ("created_at",)  # Put the audit fields after the one added in subclasses
 
+    @admin.display(boolean=True, description="en cours")
     def is_in_progress(self, obj):
         return obj.is_in_progress
 
-    is_in_progress.boolean = True
-    is_in_progress.short_description = "En cours"
-
+    @admin.display(description="lien du fichier bilan")
     def report_file_link(self, obj):
         return mark_safe(f"<a href='{obj.report_file.link}'>{obj.report_file.key}</a>")
-
-    report_file_link.short_description = "Lien du fichier bilan"
 
     def get_queryset(self, request):
         # Speed up the list display view by fetching related objects.
@@ -452,8 +444,6 @@ class PoleEmploiApprovalAdmin(admin.ModelAdmin):
     list_filter = (IsValidFilter,)
     date_hierarchy = "birthdate"
 
+    @admin.display(boolean=True, description="en cours de validité")
     def is_valid(self, obj):
         return obj.is_valid()
-
-    is_valid.boolean = True
-    is_valid.short_description = "En cours de validité"

--- a/itou/asp/models.py
+++ b/itou/asp/models.py
@@ -414,7 +414,7 @@ class Commune(PrettyPrintMixin, AbstractPeriod):
         except Commune.DoesNotExist as ex:
             raise CommuneUnknownInPeriodError(
                 f"Période inconnue dans le référentiel ASP pour le code INSEE {insee_code} "
-                f"en date du {point_in_time:%d-%m-%Y}"
+                f"en date du {point_in_time:%d/%m/%Y}"
             ) from ex
 
     @cached_property

--- a/itou/cities/admin.py
+++ b/itou/cities/admin.py
@@ -17,7 +17,7 @@ class CityAdmin(ItouGISMixin, admin.ModelAdmin):
 
     fields = ("name", "department", "post_codes", "code_insee", "zrr", "coords", "edition_mode")
 
-    @admin.display(description="Commune en ZRR")
+    @admin.display(description="commune en ZRR")
     def zrr(self, obj):
         # DO NOT USE THIS DYNAMIC FIELD IN 'list_display'
         try:

--- a/itou/common_apps/organizations/admin.py
+++ b/itou/common_apps/organizations/admin.py
@@ -27,10 +27,9 @@ class HasMembersFilter(admin.SimpleListFilter):
 
 
 class OrganizationAdmin(admin.ModelAdmin):
+    @admin.display(ordering="_member_count")
     def member_count(self, obj):
         return obj._member_count
-
-    member_count.admin_order_field = "_member_count"
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)

--- a/itou/eligibility/admin.py
+++ b/itou/eligibility/admin.py
@@ -77,11 +77,9 @@ class AbstractEligibilityDiagnosisAdmin(admin.ModelAdmin):
         "author_kind",
     )
 
+    @admin.display(boolean=True, description="en cours de validité")
     def is_valid(self, obj):
         return obj.is_valid
-
-    is_valid.boolean = True
-    is_valid.short_description = "En cours de validité"
 
 
 @admin.register(models.EligibilityDiagnosis)
@@ -107,6 +105,7 @@ class EligibilityDiagnosisAdmin(AbstractEligibilityDiagnosisAdmin):
             "is_considered_valid",
         )
 
+    @admin.display(boolean=True, description="valide ou PASS IAE en cours")
     def is_considered_valid(self, obj):
         """
         This uses a property of the model and is intended to be used on the
@@ -114,17 +113,12 @@ class EligibilityDiagnosisAdmin(AbstractEligibilityDiagnosisAdmin):
         """
         return obj.is_considered_valid
 
-    is_considered_valid.boolean = True
-    is_considered_valid.short_description = "Valide ou PASS IAE en cours"
-
+    @admin.display(boolean=True, description="PASS IAE en cours")
     def has_approval(self, obj):
         """
         This uses an annotated attribute and is intended to be used on the list view.
         """
         return obj._has_approval
-
-    has_approval.boolean = True
-    has_approval.short_description = "PASS IAE en cours"
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
@@ -151,16 +145,13 @@ class GEIQEligibilityDiagnosisAdmin(AbstractEligibilityDiagnosisAdmin):
             "allowance_amount",
         )
 
+    @admin.display(boolean=True, description="éligibilité GEIQ confirmée")
     def has_eligibility(self, obj):
         return obj.eligibility_confirmed
 
-    has_eligibility.boolean = True
-    has_eligibility.short_description = "Eligibilité GEIQ confirmée"
-
+    @admin.display(description="montant de l'aide")
     def allowance_amount(self, obj):
         return f"{obj.allowance_amount} EUR"
-
-    allowance_amount.short_description = "Montant de l'aide"
 
 
 class AbstractAdministrativeCriteriaAdmin(admin.ModelAdmin):

--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -138,26 +138,25 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
         ),
     )
 
+    @admin.display(description="salarié")
     def job_seeker_link(self, obj):
         if job_seeker := obj.job_application.job_seeker:
             return get_admin_view_link(job_seeker, content=job_seeker)
 
         return "-"
 
+    @admin.display(description="profil du salarié")
     def job_seeker_profile_link(self, obj):
         job_seeker_profile = obj.job_application.job_seeker.jobseeker_profile
         return get_admin_view_link(job_seeker_profile, content=f"Profil salarié ID:{job_seeker_profile.pk}")
 
+    @admin.display(description="type de traitement")
     def asp_processing_type(self, obj):
         if obj.processed_as_duplicate:
             return "Intégrée par les emplois suite à une erreur 3436 (doublon PASS IAE/SIRET)"
         if obj.asp_processing_code == obj.ASP_PROCESSING_SUCCESS_CODE:
             return "Intégrée par l'ASP"
         return "-"
-
-    asp_processing_type.short_description = "Type de traitement"
-    job_seeker_link.short_description = "Salarié"
-    job_seeker_profile_link.short_description = "Profil du salarié"
 
 
 @admin.register(models.EmployeeRecordUpdateNotification)

--- a/itou/invitations/admin.py
+++ b/itou/invitations/admin.py
@@ -32,15 +32,13 @@ class BaseInvitationAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("sender")
 
+    @admin.display(boolean=True, description="en cours de validité")
     def is_valid(self, obj):
         return not obj.has_expired
 
+    @admin.display(description="lien")
     def acceptance_link(self, obj):
         return obj.acceptance_link
-
-    is_valid.boolean = True
-    is_valid.short_description = "En cours de validité"
-    acceptance_link.short_description = "Lien"
 
 
 @admin.register(SiaeStaffInvitation)

--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -26,10 +26,9 @@ class EvaluatedSiaesInline(admin.TabularInline):
     def state(self, obj):
         return obj.state
 
+    @admin.display(description="lien vers les Siaes évaluées")
     def id_link(self, obj):
         return get_admin_view_link(obj, content=mark_safe(f"Lien vers la Siae évaluée <strong>{obj}</strong>"))
-
-    id_link.short_description = "Lien vers les Siaes évaluées"
 
 
 class EvaluatedJobApplicationsInline(admin.TabularInline):
@@ -46,10 +45,9 @@ class EvaluatedJobApplicationsInline(admin.TabularInline):
     def state(self, obj):
         return obj.state
 
+    @admin.display(description="lien vers les candidatures évaluées")
     def id_link(self, obj):
         return get_admin_view_link(obj, content=mark_safe(f"Lien vers la candidature évaluée <strong>{obj}</strong>"))
-
-    id_link.short_description = "Lien vers les candidatures évaluées"
 
     def approval(self, obj):
         if obj.job_application.approval:
@@ -68,12 +66,11 @@ class EvaluatedAdministrativeCriteriaInline(admin.TabularInline):
     readonly_fields = ("id_link", "uploaded_at", "submitted_at", "review_state")
     extra = 0
 
+    @admin.display(description="lien vers les critères administratifs évalués")
     def id_link(self, obj):
         return get_admin_view_link(
             obj, content=mark_safe(f"Lien vers le critère administratif <strong>{obj}</strong>")
         )
-
-    id_link.short_description = "Lien vers les critères administratifs évalués"
 
 
 def _evaluated_siae_serializer(queryset):
@@ -306,11 +303,11 @@ class SanctionsAdmin(admin.ModelAdmin):
         "no_sanction_reason",
     ]
 
-    @admin.display(description="Campagne", ordering="evaluated_siae__evaluation_campaign")
+    @admin.display(description="campagne", ordering="evaluated_siae__evaluation_campaign")
     def evaluation_campaign(self, obj):
         return obj.evaluated_siae.evaluation_campaign.name
 
-    @admin.display(description="Institution", ordering="evaluated_siae__evaluation_campaign__institution")
+    @admin.display(description="institution", ordering="evaluated_siae__evaluation_campaign__institution")
     def institution(self, obj):
         return obj.evaluated_siae.evaluation_campaign.institution
 

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -40,10 +40,9 @@ class JobsInline(admin.TabularInline):
         "jobdescription_id_link",
     )
 
+    @admin.display(description="lien vers la fiche de poste")
     def jobdescription_id_link(self, obj):
         return get_admin_view_link(obj, content=mark_safe(f"<strong>Fiche de poste ID: {obj.id}</strong>"))
-
-    jobdescription_id_link.short_description = "Lien vers la fiche de poste"
 
 
 class FinancialAnnexesInline(admin.TabularInline):
@@ -54,11 +53,9 @@ class FinancialAnnexesInline(admin.TabularInline):
 
     ordering = ("-number",)
 
+    @admin.display(boolean=True, description="active")
     def is_active(self, obj):
         return obj.is_active
-
-    is_active.boolean = True
-    is_active.short_description = "Active"
 
     def has_change_permission(self, request, obj=None):
         return False

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -153,7 +153,7 @@ class SentJobApplicationInline(JobApplicationInline):
     verbose_name = "candidature envoyée"
     verbose_name_plural = "candidatures envoyées"
 
-    @admin.display(description="Candidat")
+    @admin.display(description="candidat")
     def job_seeker_link(self, obj):
         return get_admin_view_link(obj.job_seeker, content=obj.job_seeker.get_full_name())
 
@@ -181,11 +181,9 @@ class EligibilityDiagnosisInline(admin.TabularInline):
     def pk_link(self, obj):
         return get_admin_view_link(obj)
 
+    @admin.display(boolean=True, description="en cours de validité")
     def is_valid(self, obj):
         return obj.is_valid
-
-    is_valid.boolean = True
-    is_valid.short_description = "En cours de validité"
 
 
 class GEIQEligibilityDiagnosisInline(EligibilityDiagnosisInline):
@@ -211,15 +209,13 @@ class ApprovalInline(admin.TabularInline):
     def has_add_permission(self, request, obj=None):
         return False
 
-    @admin.display(description="Numéro")
+    @admin.display(description="numéro")
     def pk_link(self, obj):
         return get_admin_view_link(obj, content=obj.number)
 
+    @admin.display(boolean=True, description="en cours de validité")
     def is_valid(self, obj):
         return obj.is_valid()
-
-    is_valid.boolean = True
-    is_valid.short_description = "En cours de validité"
 
 
 class CreatedByProxyFilter(admin.SimpleListFilter):
@@ -319,25 +315,20 @@ class ItouUserAdmin(UserAdmin):
         ),
     )
 
+    @admin.display(boolean=True, description="email validé", ordering="_has_verified_email")
     def has_verified_email(self, obj):
         """
         Quickly identify unverified email that could be the result of a typo.
         """
         return obj._has_verified_email
 
-    has_verified_email.boolean = True
-    has_verified_email.admin_order_field = "_has_verified_email"
-    has_verified_email.short_description = "Email validé"
-
+    @admin.display(boolean=True, description="créé par un tiers")
     def is_created_by_a_proxy(self, obj):
         # Use the "hidden" field with an `_id` suffix to avoid hitting the database for each row.
         # https://docs.djangoproject.com/en/dev/ref/models/fields/#database-representation
         return bool(obj.created_by_id)
 
-    is_created_by_a_proxy.boolean = True
-    is_created_by_a_proxy.short_description = "créé par un tiers"
-
-    @admin.display(description="Adresse en QPV")
+    @admin.display(description="adresse en QPV")
     def address_in_qpv(self, obj):
         # DO NOT PUT THIS FIELD IN 'list_display' : dynamically computed, only for detail page
         if not obj.coords:
@@ -539,36 +530,29 @@ class JobSeekerProfileAdmin(admin.ModelAdmin):
 
     inlines = (PkSupportRemarkInline,)
 
+    @admin.display(description="date de naissance")
     def birthdate(self, obj):
         return obj.user.birthdate
 
-    birthdate.short_description = "Date de naissance"
-
+    @admin.display(description="NIR")
     def nir(self, obj):
         return obj.user.nir or "-"
 
-    nir.short_description = "NIR"
-
+    @admin.display(description="nom complet")
     def username(self, obj):
         return f"{obj.user.first_name} {obj.user.last_name}"
 
-    username.short_description = "Nom complet"
-
+    @admin.display(description="identifiant Pôle emploi")
     def pole_emploi_id(self, obj):
         return obj.user.pole_emploi_id or "-"
 
-    pole_emploi_id.short_description = "Identifiant Pôle emploi"
-
+    @admin.display(boolean=True, description="profil certifié par Pôle emploi")
     def is_pe_certified(self, obj):
         return obj.pe_obfuscated_nir is not None
 
-    is_pe_certified.short_description = "Profil certifié par Pôle emploi"
-    is_pe_certified.boolean = True
-
+    @admin.display(description="utilisateur")
     def user_link(self, obj):
         return get_admin_view_link(obj.user, content=f"🔗 {obj.user.email}")
-
-    user_link.short_description = "Utilisateur"
 
 
 class EmailAddressWithRemarkAdmin(EmailAddressAdmin):

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -139,7 +139,7 @@ class NewEmployeeRecordStep1Form(forms.ModelForm):
                 self.cleaned_data["birth_place"] = Commune.by_insee_code_and_period(commune_code, birth_date)
             except CommuneUnknownInPeriodError as ex:
                 raise forms.ValidationError(
-                    f"Le code INSEE {commune_code} n'est pas référencé en date du {birth_date:%d-%m-%Y}"
+                    f"Le code INSEE {commune_code} n'est pas référencé en date du {birth_date:%d/%m/%Y}"
                 ) from ex
 
     class Meta:


### PR DESCRIPTION
### Pourquoi ?

`@admin.display` est bien plus propre que l'ancienne méthode.