### PR TITLE
admin: change display name of some apps

### DIFF
--- a/itou/prescribers/apps.py
+++ b/itou/prescribers/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class PrescribersAppConfig(AppConfig):
+    name = "itou.prescribers"
+    verbose_name = "Prescripteurs"

--- a/itou/users/apps.py
+++ b/itou/users/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class UsersAppConfig(AppConfig):
+    name = "itou.users"
+    verbose_name = "Utilisateurs"


### PR DESCRIPTION
But not all of them!
Do not change all models / app : some users are heavily relying on the current display order (by force of habit or convenience). 
Display order can be changed with a custom ordering field in the app (should the need arise).
