### PR TITLE
Afficher l’éligibilité IAE dans la liste des candidatures SIAE

### DIFF
--- a/itou/templates/apply/includes/list_card_body_siae.html
+++ b/itou/templates/apply/includes/list_card_body_siae.html
@@ -17,6 +17,29 @@
                 </span>
             {% endif %}
 
+            {% if siae.is_subject_to_eligibility_rules %}
+                {% with approval=job_application.job_seeker.latest_common_approval %}
+                    {% if approval %}
+                        <span class="badge badge-xs badge-pill{% if approval.state == 'EXPIRED' %} badge-emploi-light{% else %} badge-success-lighter{% endif %} text-primary">
+                            <i class="{% if approval.state == 'EXPIRED' %}ri-close-circle-line{% elif approval.state == 'SUSPENDED' %}ri-pause-circle-line{% else %}ri-checkbox-circle-line{% endif %}"></i>
+                            PASS IAE {{ approval.get_state_display|lower }}
+                        </span>
+                    {% else %}
+                        {% if job_application.eligibility_diagnosis_by_siae_required %}
+                            <span class="badge badge-xs badge-pill badge-accent-02-lighter text-primary">
+                                <i class="ri-error-warning-line"></i>
+                                Éligibilité à l’IAE à valider
+                            </span>
+                        {% else %}
+                            <span class="badge badge-xs badge-pill badge-success-light text-primary">
+                                <i class="ri-check-line"></i>
+                                Éligible à l’IAE
+                            </span>
+                        {% endif %}
+                    {% endif %}
+
+                {% endwith %}
+            {% endif %}
         </div>
         {% if job_application.preloaded_administrative_criteria %}
             <div class="col-12 col-lg-7 mb-3 mb-lg-0">

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -573,6 +573,19 @@
               </h3>
               
   
+              
+                  
+                      
+                          
+                              <span class="badge badge-xs badge-pill badge-success-light text-primary">
+                                  <i class="ri-check-line"></i>
+                                  Éligible à l’IAE
+                              </span>
+                          
+                      
+  
+                  
+              
           </div>
           
       </div>
@@ -662,6 +675,19 @@
               </h3>
               
   
+              
+                  
+                      
+                          
+                              <span class="badge badge-xs badge-pill badge-success-light text-primary">
+                                  <i class="ri-check-line"></i>
+                                  Éligible à l’IAE
+                              </span>
+                          
+                      
+  
+                  
+              
           </div>
           
       </div>
@@ -725,6 +751,19 @@
               </h3>
               
   
+              
+                  
+                      
+                          
+                              <span class="badge badge-xs badge-pill badge-success-light text-primary">
+                                  <i class="ri-check-line"></i>
+                                  Éligible à l’IAE
+                              </span>
+                          
+                      
+  
+                  
+              
           </div>
           
       </div>

--- a/tests/www/apply/test_list.py
+++ b/tests/www/apply/test_list.py
@@ -241,38 +241,31 @@ class ProcessListSiaeTest(ProcessListTest):
             # 9 job applications (1 per state in JobApplicationWorkflow + 1 sent by prescriber)
             # 22 requests, maggie has a diagnosis made by a prescriber in this test
             + 1  # jobapp1: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp1: select last valid diagnosis made by prescriber (exists)
+            + 1  # jobapp1: select last valid diagnosis made by prescriber or SIAE (prescriber)
             # 24 requests
             + 1  # jobapp2: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp2: select last valid diagnosis made by prescriber (does not exist)
-            + 1  # jobapp2: select last valid diagnosis made by siae (exists)
-            # 27 requests
+            + 1  # jobapp2: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            # 26 requests
             + 1  # jobapp3: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp3: select last valid diagnosis made by prescriber (does not exist)
-            + 1  # jobapp3: select last valid diagnosis made by siae (exists)
-            # 30 requests
+            + 1  # jobapp3: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            # 28 requests
             + 1  # jobapp4: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp4: select last valid diagnosis made by prescriber (does not exist)
-            + 1  # jobapp4: select last valid diagnosis made by siae (exists)
-            # 33 requests
+            + 1  # jobapp4: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            # 30 requests
             + 1  # jobapp5: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp5: select last valid diagnosis made by prescriber (does not exist)
-            + 1  # jobapp5: select last valid diagnosis made by siae (exists)
-            # 36 requests
+            + 1  # jobapp5: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            # 32 requests
             + 1  # jobapp6: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp6: select last valid diagnosis made by prescriber (does not exist)
-            + 1  # jobapp6: select last valid diagnosis made by siae (exists)
-            # 39 requests
+            + 1  # jobapp6: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            # 34 requests
             + 1  # jobapp7: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp7: select last valid diagnosis made by prescriber (does not exist)
-            + 1  # jobapp7: select last valid diagnosis made by siae (exists)
-            # 42 requests
+            + 1  # jobapp7: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            # 36 requests
             + 1  # jobapp8: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp8: select last valid diagnosis made by prescriber (does not exist)
-            + 1  # jobapp8: select last valid diagnosis made by siae (exists)
-            # 45 requests, maggie has a diagnosis made by a prescriber in this test
+            + 1  # jobapp8: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            # 38 requests, maggie has a diagnosis made by a prescriber in this test
             + 1  # jobapp9: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp9: select last valid diagnosis made by prescriber (exists)
+            + 1  # jobapp8: select last valid diagnosis made by prescriber or SIAE (prescriber)
             + 3  # update session
         ):
             response = self.client.get(self.siae_base_url)

--- a/tests/www/apply/test_list.py
+++ b/tests/www/apply/test_list.py
@@ -238,6 +238,41 @@ class ProcessListSiaeTest(ProcessListTest):
             #
             # Render template:
             + 1  # context processor: user siae membership
+            # 9 job applications (1 per state in JobApplicationWorkflow + 1 sent by prescriber)
+            # 22 requests, maggie has a diagnosis made by a prescriber in this test
+            + 1  # jobapp1: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
+            + 1  # jobapp1: select last valid diagnosis made by prescriber (exists)
+            # 24 requests
+            + 1  # jobapp2: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
+            + 1  # jobapp2: select last valid diagnosis made by prescriber (does not exist)
+            + 1  # jobapp2: select last valid diagnosis made by siae (exists)
+            # 27 requests
+            + 1  # jobapp3: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
+            + 1  # jobapp3: select last valid diagnosis made by prescriber (does not exist)
+            + 1  # jobapp3: select last valid diagnosis made by siae (exists)
+            # 30 requests
+            + 1  # jobapp4: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
+            + 1  # jobapp4: select last valid diagnosis made by prescriber (does not exist)
+            + 1  # jobapp4: select last valid diagnosis made by siae (exists)
+            # 33 requests
+            + 1  # jobapp5: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
+            + 1  # jobapp5: select last valid diagnosis made by prescriber (does not exist)
+            + 1  # jobapp5: select last valid diagnosis made by siae (exists)
+            # 36 requests
+            + 1  # jobapp6: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
+            + 1  # jobapp6: select last valid diagnosis made by prescriber (does not exist)
+            + 1  # jobapp6: select last valid diagnosis made by siae (exists)
+            # 39 requests
+            + 1  # jobapp7: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
+            + 1  # jobapp7: select last valid diagnosis made by prescriber (does not exist)
+            + 1  # jobapp7: select last valid diagnosis made by siae (exists)
+            # 42 requests
+            + 1  # jobapp8: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
+            + 1  # jobapp8: select last valid diagnosis made by prescriber (does not exist)
+            + 1  # jobapp8: select last valid diagnosis made by siae (exists)
+            # 45 requests, maggie has a diagnosis made by a prescriber in this test
+            + 1  # jobapp9: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
+            + 1  # jobapp9: select last valid diagnosis made by prescriber (exists)
             + 3  # update session
         ):
             response = self.client.get(self.siae_base_url)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Afficher-l-ligibilit-IAE-sur-la-liste-des-candidatures-2ae374e0d88d444d867fb1a05061463d**

### Pourquoi ?

Faciliter la vie des SIAE.

### Comment <!-- optionnel -->

Le badge avait été retiré pour des raisons de performances. Depuis la recherche d’agréments Pôle emploi a été accélérée (bc31fd390bc0830893aead76e664593640fea372 et 8b154ca66d2acffbc418e5b0b0ed7399878a9cf7).
Avec le second commit, la recherche du dernier diagnostic valide a également été accélérée.

La vue passe plus de temps à construire les filtres (2s sur les 3 nécessaires au rendu pour une SIAE avec beaucoup de candidatures). Les requêtes SQL prennent au total 200ms en local, ce qui reste raisonnable.

Il reste un 1+N pour chercher le dernier diagnostic d’éligibilité. Comme ce n’est pas une mince affaire, ce sera priorisé avec https://www.notion.so/plateforme-inclusion/Perfs-diagnostique-ligibilit-8160be31dc364c6f88c437bd5e345313. En attendant, espérons que le système soit suffisamment rapide malgré la 1+N.