### PR TITLE
[Fix] Cron - transfer_employee_records : Utiliser `--wet-run` pour la PROD

### DIFF
--- a/clevercloud/download_employee_records.sh
+++ b/clevercloud/download_employee_records.sh
@@ -17,9 +17,9 @@ fi
 # $APP_HOME is set by default by clever cloud.
 cd "$APP_HOME" || exit
 
-# Download employee records 
-django-admin transfer_employee_records --download
+# Download employee records
+django-admin transfer_employee_records --download --wet-run
 
-# Download update notifications 
+# Download update notifications
 django-admin transfer_employee_records_updates --download --wet-run
 


### PR DESCRIPTION
### Pourquoi ?

Changement de la logique de `--dry-run` à `--wet-run` dans 91ad4396ec07390d7cf83e332c62f74f3354948a qui n'a pas été répercuté dans le script shell utilisé sur la PROD...
