### PR TITLE
PASS IAE : modification de la période ou les prolongations sont possibles

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -242,8 +242,7 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     ASP_ITOU_PREFIX = settings.ASP_ITOU_PREFIX
 
     # The period of time during which it is possible to prolong a PASS IAE.
-    IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_START = 12
-    IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_END = 3
+    IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_BEFORE_END = 7
 
     # Error messages.
     ERROR_PASS_IAE_SUSPENDED_FOR_USER = (
@@ -473,9 +472,8 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     @property
     def is_open_to_prolongation(self):
         now = timezone.localdate()
-        lower_bound = self.start_at + relativedelta(months=self.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_START)
-        upper_bound = self.end_at + relativedelta(months=self.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_END)
-        return lower_bound <= now <= upper_bound
+        lower_bound = self.end_at - relativedelta(months=self.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_BEFORE_END)
+        return lower_bound <= now <= self.end_at
 
     @cached_property
     def can_be_prolonged(self):

--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -1,11 +1,9 @@
 import django.db.transaction as transaction
-from dateutil.relativedelta import relativedelta
 from django.core.management.base import BaseCommand
 from django.db.models import F, Max
 from django.db.models.functions import Greatest
 from django.utils import timezone
 
-from itou.approvals.models import Approval
 from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordUpdateNotification
 
@@ -135,10 +133,7 @@ class Command(BaseCommand):
     @transaction.atomic()
     def _check_missed_notifications(self, dry_run):
         self.stdout.write("* Checking missing employee records notifications:")
-
-        prolongation_cutoff = timezone.now() - relativedelta(
-            months=Approval.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_END,
-        )
+        prolongation_cutoff = timezone.now()
         employee_record_with_missing_notification = (
             EmployeeRecord.objects.annotate(
                 last_employee_record_snapshot=Greatest(

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -136,9 +136,7 @@ class EmployeeRecordQuerySet(models.QuerySet):
         return self.filter(asp_batch_file=filename, asp_batch_line_number=line_number)
 
     def archivable(self):
-        prolongation_cutoff = timezone.now() - relativedelta(
-            months=Approval.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_END,
-        )
+        prolongation_cutoff = timezone.now()
         return (
             self.annotate(
                 approval_is_valid=Exists(Approval.objects.filter(number=OuterRef("approval_number")).valid())

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -280,26 +280,26 @@ class ApprovalModelTest(TestCase):
 
     @freeze_time("2022-11-17")
     def test_is_open_to_prolongation(self):
-        # Ensure that "now" is "before" the period open to prolongations (12 months after approval start)
+        # Ensure that "now" is "before" the period open to prolongations (7 months before approval end)
         approval = ApprovalFactory(
-            start_at=datetime.date(2021, 11, 18),
-            end_at=datetime.date(2023, 11, 17),
+            start_at=datetime.date(2021, 6, 17),
+            end_at=datetime.date(2023, 6, 18),
         )
         assert not approval.is_open_to_prolongation
 
         # Ensure "now" is in the period open to prolongations.
         approval = ApprovalFactory(
-            start_at=datetime.date(2021, 11, 17),
-            end_at=datetime.date(2023, 11, 16),
+            start_at=datetime.date(2021, 6, 16),
+            end_at=datetime.date(2023, 6, 15),
         )
         assert approval.is_open_to_prolongation
 
-        # until 3 month after the end date, users are allowed to prolong it up to 3 months after the end.
+        # users are not allowed to make a prolongation 3 months after the approval end anymore.
         approval = ApprovalFactory(
             start_at=datetime.date(2020, 8, 18),
             end_at=datetime.date(2022, 8, 17),
         )
-        assert approval.is_open_to_prolongation
+        assert not approval.is_open_to_prolongation
 
         # Ensure "now" is "after" the period open to prolongations.
         approval = ApprovalFactory(


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/En-tant-que-SIAE-je-veux-pouvoir-prolonger-un-PASS-IAE-7-mois-avant-la-fin-210-jours-de-reliquat-re-a6684dd5dfc34e1dbfd80f87b5b3802a

### Pourquoi ?

Changement demandé par la DGEFP

### Comment 

- une prolongation est possible 7 mois avant la fin du PASS IAE (210 jours de reliquat)
- un seul commit : retour en arrière facilité (demande métier)
