### PR TITLE
Makefile : Réparation des commandes `make django_admin`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,13 @@ fix: $(VENV_REQUIREMENT)
 # Django.
 # =============================================================================
 
-.PHONY: django_admin populate_db populate_db_with_cities populate_db_minimal graph_models_itou
+.PHONY: mgmt_cmd populate_db populate_db_with_cities populate_db_minimal graph_models_itou
 
-# make django_admin
-# make django_admin COMMAND=dbshell
-# make django_admin COMMAND=createsuperuser
-# make --silent django_admin COMMAND="dumpdata siaes.Siae --indent=3" > itou/fixtures/django/02_siaes.json
-django_admin:
+# make mgmt_cmd
+# make mgmt_cmd COMMAND=dbshell
+# make mgmt_cmd COMMAND=createsuperuser
+# make --silent mgmt_cmd COMMAND="dumpdata siaes.Siae --indent=3" > itou/fixtures/django/02_siaes.json
+mgmt_cmd:
 	$(EXEC_CMD) python manage.py $(COMMAND)
 
 # After migrate

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ fix: $(VENV_REQUIREMENT)
 # make django_admin COMMAND=createsuperuser
 # make --silent django_admin COMMAND="dumpdata siaes.Siae --indent=3" > itou/fixtures/django/02_siaes.json
 django_admin:
-	$(EXEC_CMD) django-admin $(COMMAND)
+	$(EXEC_CMD) python manage.py $(COMMAND)
 
 # After migrate
 ifeq ($(USE_VENV),1)

--- a/itou/siaes/management/commands/move_siae_data.py
+++ b/itou/siaes/management/commands/move_siae_data.py
@@ -32,8 +32,8 @@ HELP_TEXT = """
     does everything.
 
     Examples of use in local dev:
-    $ make django_admin COMMAND="move_siae_data --from 3243 --to 9612"
-    $ make django_admin COMMAND="move_siae_data --from 3243 --to 9612 --only-job-applications"
+    $ make mgmt_cmd COMMAND="move_siae_data --from 3243 --to 9612"
+    $ make mgmt_cmd COMMAND="move_siae_data --from 3243 --to 9612 --only-job-applications"
 
     And in production:
     $ cd && cd app_* && django-admin move_siae_data --from 3243 --to 9612 --wet-run

--- a/scripts/import-latest-db-backup.sh
+++ b/scripts/import-latest-db-backup.sh
@@ -28,5 +28,5 @@ cat << EOF
 
 Import is over. Now you need to:
  - restart your container: make run
- - make django_admin COMMAND=set_fake_passwords
+ - make mgmt_cmd COMMAND=set_fake_passwords
 EOF


### PR DESCRIPTION
### Pourquoi ?

Les commandes `make django_admin` cassent toutes chez moi sur `django.core.exceptions.ImproperlyConfigured: Requested setting DATABASES, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.`.

Si le problème est juste chez moi, ignorer cette PR (je pars en congés et revient le 7 août de toute façon donc pas d'urgence).

Si le problème est chez plus de monde, le fix de cette PR est un début qui a fonctionné au moins pour moi, après quelques autres essais.
