### PR TITLE
BOOST: CAP - décalage de la partie "données" dans la notification de sanction

### DIFF
--- a/itou/templates/siae_evaluations/institution_evaluated_siae_notify_step2.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_notify_step2.html
@@ -56,8 +56,8 @@
                                 </form>
                             </div>
                         </div>
-                        {% include "siae_evaluations/includes/evaluation_data.html" %}
                     </div>
+                    {% include "siae_evaluations/includes/evaluation_data.html" %}
                 </div>
             </div>
         </section>


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=b325b680bd5d48dcb49a8f0848110199&pm=c

### Pourquoi ?

La partie "Données" doit être positionnée à droite de l'écran 

### Comment 

Dans le bon `div`.

### Captures d'écran

![image](https://github.com/betagouv/itou/assets/147232/e0baed90-900b-4a92-b057-739ddf18861e)
