### PR TITLE
Retirer du code non testé de EligibilityDiagnosis

### DIFF
--- a/itou/eligibility/models/iae.py
+++ b/itou/eligibility/models/iae.py
@@ -84,9 +84,6 @@ class EligibilityDiagnosisManager(models.Manager):
             last = query.by_author_kind_prescriber().last()
             if not last and for_siae:
                 last = query.authored_by_siae(for_siae).last()
-            if not last:
-                # Deals with cases from the past (when there was no restriction).
-                last = query.last()
 
         # Otherwise, search only in "non expired" diagnosis.
         else:


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Afficher-l-ligibilit-IAE-sur-la-liste-des-candidatures-2ae374e0d88d444d867fb1a05061463d**

### Pourquoi ?

Voir le message de commit.