### PR TITLE
BOOST - Retirer le texte qui parle d’IAE dans l’écran d’inscription des candidats

### DIFF
--- a/itou/templates/signup/job_seeker_situation.html
+++ b/itou/templates/signup/job_seeker_situation.html
@@ -34,7 +34,6 @@
                 <div class="col-12 order-md-1 pr-lg-5 col-lg-6 bg-emploi-lightest">
                     <!-- Hide left column on small devices. -->
                     <div class="d-none d-md-block py-md-5 py-lg-7 text-center">
-                        <p class="display-1 ff-extra-01 mb-5">Votre éligibilité à l'IAE dépend de votre situation</p>
                         <img class="img-fluid img-fitcover w-50 w-md-auto" src="{% static 'img/job_seeker_signup_situation.svg' %}" alt="">
                     </div>
                 </div>


### PR DESCRIPTION
**Carte Notion : **

(https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=73b2807b839d4d4aae362d48144cc9d7&pm=c)

### Pourquoi ?

Plus nécessaire (point UI)

