### PR TITLE
BOOST - retirer des mentions spécifique à l'IAE dans le formulaire d'embauche

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -530,7 +530,8 @@ class AcceptForm(forms.ModelForm):
                         "hx-target": "#geiq_contract_type_and_options_block",
                     },
                 )
-            else:
+
+            if job_application.to_siae.kind in SIAE_WITH_CONVENTION_KINDS:
                 # Add specific details to help texts for IAE
                 self.fields["hiring_start_at"].help_text += (
                     " La date est modifiable jusqu'à la veille de la date saisie. En cas de premier PASS IAE pour "


### PR DESCRIPTION
**Carte Notion : **

(https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=39dd6f8b478f44bfad2aa9ea41d0fdfa&pm=c)

### Pourquoi ?

Mentions non applicables aux structures ne faisant pas partie de l'IAE (EA, EATT, OPCS, GEIQ). 
