### PR TITLE
BOOST : retrait d'une mention obsolète sur le formulaire de suspension

### DIFF
--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -366,7 +366,6 @@ class SuspensionForm(forms.ModelForm):
                 f"Renseignez une date de fin à {Suspension.MAX_DURATION_MONTHS} mois "
                 "si le contrat de travail est terminé ou rompu."
             ),
-            "reason_explanation": "Obligatoire seulement en cas de force majeure.",
         }
 
     def clean_start_at(self):


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=d0715164c06741279f40cea896652fe1&p=05244c8409ad4769aa788e3b45ab34cc&pm=c

### Pourquoi ?

Cette mention fait référence aux motifs de suspension de la circulaire DGEFP de 2006 et n’est désormais plus en vigueur.

