### PR TITLE
Retirer uWSGI des requirements Python

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -111,5 +111,4 @@ python-dotenv  # https://github.com/theskumar/python-dotenv
 
 # Production requirements
 # ------------------------------------------------------------------------------
-uwsgi==2.0.*  # https://github.com/unbit/uwsgi
 sentry-sdk  # https://github.com/getsentry/sentry-python

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -825,9 +825,6 @@ urllib3==1.26.16 \
     #   django-anymail
     #   requests
     #   sentry-sdk
-uwsgi==2.0.22 \
-    --hash=sha256:4cc4727258671ac5fa17ab422155e9aaef8a2008ebb86e4404b66deaae965db2
-    # via -r requirements/base.in
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1315,9 +1315,6 @@ urllib3==1.26.16 \
     #   django-anymail
     #   requests
     #   sentry-sdk
-uwsgi==2.0.22 \
-    --hash=sha256:4cc4727258671ac5fa17ab422155e9aaef8a2008ebb86e4404b66deaae965db2
-    # via -r requirements/test.txt
 virtualenv==20.24.0 \
     --hash=sha256:18d1b37fc75cc2670625702d76849a91ebd383768b4e91382a8d51be3246049e \
     --hash=sha256:e2a7cef9da880d693b933db7654367754f14e20650dc60e8ee7385571f8593a3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1172,9 +1172,6 @@ urllib3==1.26.16 \
     #   django-anymail
     #   requests
     #   sentry-sdk
-uwsgi==2.0.22 \
-    --hash=sha256:4cc4727258671ac5fa17ab422155e9aaef8a2008ebb86e4404b66deaae965db2
-    # via -r requirements/base.txt
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923


### PR DESCRIPTION
### Pourquoi ?

Clever fournit uWSGI, nous n’avons pas besoin de l’installer.