### PR TITLE
Éligibilité GEIQ: utilisation des paramètres d'URL plutôt que la session

### DIFF
--- a/itou/templates/apply/process_geiq_eligibility.html
+++ b/itou/templates/apply/process_geiq_eligibility.html
@@ -53,7 +53,7 @@
                         <div class="row">
                             <div class="col-7">
                                 <div id="form_errors"></div>
-                                <form action="{% url "apply:geiq_eligibility_criteria" job_application_id=job_application.pk %}" method="post" hx-target="#geiq_form">
+                                <form action="{{ geiq_criteria_form_url }}" method="post" hx-target="#geiq_form">
                                     {% csrf_token %}
                                     <div id="geiq_form">
                                         <hr>


### PR DESCRIPTION
### Pourquoi ?

Évite l'utilisation de la session (qui peut être perturbant avec plusieurs onglets) et cela facilitera la réutilisation de ces vues pour le parcours de déclaration d'embauche (sans objet candidature disponible).
