### PR TITLE
BOOST : le label du champ "reason" apparait en anglais dans le formulaire 

### DIFF
--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -94,6 +94,7 @@ class CreateProlongationForm(forms.ModelForm):
     """Declare a prolongation. Used when the reason doesn't need to be validated by a prescriber."""
 
     reason = forms.ChoiceField(
+        label="Motif",
         choices=ProlongationReason.choices,
         initial=None,  # Uncheck radio buttons.
         widget=forms.RadioSelect(),


### PR DESCRIPTION
### Carte Notion

https://www.notion.so/plateforme-inclusion/Mot-anglais-qui-s-est-gliss-dans-le-formulaire-de-prolongation-fe4ad23e9e594a829c790b5b37b2f234

### Pourquoi ?

On est contre les anglicismes

