### PR TITLE
Metabase : Ajout de l'ID de PASS IAE

### DIFF
--- a/itou/metabase/tables/approvals.py
+++ b/itou/metabase/tables/approvals.py
@@ -5,11 +5,21 @@ from django.conf import settings
 
 from itou.approvals.enums import Origin
 from itou.approvals.models import Approval, PoleEmploiApproval
-from itou.metabase.tables.utils import MetabaseTable, get_department_and_region_columns, get_hiring_siae, hash_content
+from itou.metabase.tables.utils import (
+    MetabaseTable,
+    get_column_from_field,
+    get_department_and_region_columns,
+    get_hiring_siae,
+    hash_content,
+)
 from itou.prescribers.models import PrescriberOrganization
 
 
 POLE_EMPLOI_APPROVAL_MINIMUM_START_DATE = datetime(2018, 1, 1)
+
+
+def get_field(name):
+    return Approval._meta.get_field(name)
 
 
 @functools.cache
@@ -67,6 +77,7 @@ def get_approval_type(approval):
 TABLE = MetabaseTable(name="pass_agréments")
 TABLE.add_columns(
     [
+        get_column_from_field(get_field("id"), name="id"),
         {"name": "type", "type": "varchar", "comment": "Type", "fn": get_approval_type},
         {"name": "date_début", "type": "date", "comment": "Date de début", "fn": lambda o: o.start_at},
         {"name": "date_fin", "type": "date", "comment": "Date de fin", "fn": lambda o: o.end_at},

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -432,6 +432,7 @@ def test_populate_approvals():
         rows = cursor.fetchall()
         assert rows == [
             (
+                approval.pk,
                 "PASS IAE (XXXXX)",
                 datetime.date(2023, 2, 2),
                 datetime.date(2025, 2, 1),
@@ -450,6 +451,7 @@ def test_populate_approvals():
                 datetime.date(2023, 2, 1),
             ),
             (
+                pe_approval.pk,
                 "Agrément PE",
                 datetime.date(2023, 2, 2),
                 datetime.date(2025, 2, 1),


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/Ajouter-la-colonne-ID-pass-agr-ment-sur-la-table-pass-agr-ments-puis-ajouter-une-colonne-injection_-47b196f5d93644c08dd6ebc4f75d8a77**

### Pourquoi ?

Pour permettre à nos analystes de croiser la table des demandes de prolongation avec celle des PASS IAE.

C'est essentiellement un oubli de ma part.