### PR TITLE
Amélioration du test contre la XSS

### DIFF
--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -1,4 +1,4 @@
 # serializer version: 1
 # name: ProcessTransferJobApplicationTest.test_job_application_transfer_redirection[job application transfer message]
-  '<p>La candidature de <b>John Doe</b> a bien été transférée à la SIAE <b>Acme inc.</b>, 112 rue de la Croix-Nivert, 75015 Paris.</p><p>Pour la consulter, rendez-vous sur son tableau de bord en changeant de structure.</p>'
+  '<p>La candidature de <b>&lt;&gt;html escaped&lt;&gt; Doe</b> a bien été transférée à la SIAE <b>Acme inc.</b>, 112 rue de la Croix-Nivert, 75015 Paris.</p><p>Pour la consulter, rendez-vous sur son tableau de bord en changeant de structure.</p>'
 # ---

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -1481,6 +1481,7 @@ class ProcessTransferJobApplicationTest(TestCase):
             to_siae=siae,
             state=JobApplicationWorkflow.STATE_PROCESSING,
             job_seeker__for_snapshot=True,
+            job_seeker__first_name="<>html escaped<>",
         )
         transfer_url = reverse("apply:transfer", kwargs={"job_application_id": job_application.pk})
 


### PR DESCRIPTION
### Pourquoi ?

Le test ne couvrait pas contre une régression, puisque les données de l’utilisateur n’avaient pas besoin d’être échappées.