### PR TITLE
Parcours de candidature: utilisation du bloc content_title

### DIFF
--- a/itou/templates/apply/submit_base_two_columns.html
+++ b/itou/templates/apply/submit_base_two_columns.html
@@ -3,13 +3,15 @@
 
 {% block title %}Postuler {{ block.super }}{% endblock %}
 
+{% block content_title %}
+    <h1>{% include 'apply/includes/_submit_title.html' %}</h1>
+{% endblock %}
+
 {% block content %}
     <section class="s-section-twocolumns s-section">
         <div class="container">
             <div class="row">
                 <div class="col-12 col-lg-6 order-md-1 pr-lg-5 mt-4">
-                    <h1>{% include 'apply/includes/_submit_title.html' %}</h1>
-
                     <div class="card c-card c-card--emploi mb-3 mb-lg-5">
                         <div class="card-body">
                             <p>


### PR DESCRIPTION
### Pourquoi ?

Cela facilitera la mise en place du bandeau d'information prévu dans le parcours de Déclaration d'embauche.

Avant:
![Screenshot 2023-08-08 at 15-59-52 Les emplois de l'inclusion](https://github.com/betagouv/itou/assets/1089744/51ad1efc-71c2-4009-a2d2-34a337c24ed9)

Après:
![Screenshot 2023-08-08 at 15-59-39 Les emplois de l'inclusion](https://github.com/betagouv/itou/assets/1089744/d2ea12a7-afe8-4a45-8fde-7767e8538fa5)
