### PR TITLE
Stats : Ajout de nouvelles stats "Suivi du cofinancement de mon ACI" ouvertes à une liste blanche d'employeurs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -443,8 +443,9 @@ PILOTAGE_DASHBOARDS_WHITELIST = json.loads(
 # Only ACIs given by Convergence France may access some contracts
 ACI_CONVERGENCE_SIRET_WHITELIST = json.loads(os.getenv("ACI_CONVERGENCE_SIRET_WHITELIST", "[]"))
 
-# Specific stats are progressively being deployed to more and more departments and specific users.
-# Kept as a setting to not let User PKs in clear in the code.
+# Specific experimental stats are progressively being deployed to more and more users and/or siaes.
+# Kept as a setting to not let User/Siae PKs in clear in the code.
+STATS_SIAE_ASP_ID_WHITELIST = json.loads(os.getenv("STATS_SIAE_ASP_ID_WHITELIST", "[]"))
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_USER_PK_WHITELIST", "[]"))
 
 # Slack notifications sent by Metabase cronjobs.

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -5,6 +5,15 @@
         </div>
         <div class="px-3 px-lg-4 pt-3 pt-lg-4">
             <ul class="list-unstyled mb-lg-5">
+                {% if can_view_stats_siae_aci %}
+                    <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="{% url 'stats:stats_siae_aci' %}" class="btn-link btn-ico">
+                            <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
+                            <span>Voir le suivi du cofinancement de mon ACI</span>
+                        </a>
+                        <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
+                    </li>
+                {% endif %}
                 {% if can_view_stats_siae_etp %}
                     <!-- Stats temporarily suspended until we stabilize them
                         <li class="d-flex justify-content-between align-items-center mb-3">

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -749,9 +749,20 @@ class User(AbstractUser, AddressMixin):
             and current_org.convention is not None
         )
 
+    def can_view_stats_siae_aci(self, current_org):
+        """
+        Non official stats with very specific access rights.
+        """
+        return (
+            self.can_view_stats_siae(current_org)
+            and current_org.kind == SiaeKind.ACI
+            and current_org.convention is not None
+            and current_org.convention.asp_id in settings.STATS_SIAE_ASP_ID_WHITELIST
+        )
+
     def can_view_stats_siae_etp(self, current_org):
         """
-        Non official SIAE stats with very specific access rights.
+        Non official stats with very specific access rights.
         """
         return self.can_view_stats_siae(current_org) and self.pk in settings.STATS_SIAE_USER_PK_WHITELIST
 

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -4,7 +4,8 @@ import jwt
 from django.conf import settings
 
 
-ASP_SIAE_FILTER_KEY = "identifiant_de_la_structure"
+ASP_SIAE_FILTER_KEY_FLAVOR1 = "identifiant_de_la_structure"
+ASP_SIAE_FILTER_KEY_FLAVOR2 = "id_asp_de_la_siae"
 C1_SIAE_FILTER_KEY = "identifiant_de_la_structure_(c1)"
 IAE_NETWORK_FILTER_KEY = "id_r%C3%A9seau"
 DEPARTMENT_FILTER_KEY = "d%C3%A9partement"
@@ -24,6 +25,9 @@ METABASE_DASHBOARDS = {
     #
     # Employer stats.
     #
+    "stats_siae_aci": {
+        "dashboard_id": 327,
+    },
     "stats_siae_etp": {
         "dashboard_id": 128,
     },

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -163,6 +163,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_show_employee_records": can_show_employee_records,
         "can_view_stats_dashboard_widget": request.user.can_view_stats_dashboard_widget(current_org=current_org),
         "can_view_stats_siae": request.user.can_view_stats_siae(current_org=current_org),
+        "can_view_stats_siae_aci": request.user.can_view_stats_siae_aci(current_org=current_org),
         "can_view_stats_siae_etp": request.user.can_view_stats_siae_etp(current_org=current_org),
         "can_view_stats_cd": request.user.can_view_stats_cd(current_org=current_org),
         "can_view_stats_pe": request.user.can_view_stats_pe(current_org=current_org),

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path("", views.stats_public, name="stats_public"),
     path("pilotage/<int:dashboard_id>", views.stats_pilotage, name="stats_pilotage"),
     # Employer stats.
+    path("siae/aci", views.stats_siae_aci, name="stats_siae_aci"),
     path("siae/etp", views.stats_siae_etp, name="stats_siae_etp"),
     path("siae/hiring", views.stats_siae_hiring, name="stats_siae_hiring"),
     path("siae/auto_prescription", views.stats_siae_auto_prescription, name="stats_siae_auto_prescription"),

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -286,6 +286,8 @@ class DashboardViewTest(TestCase):
         # Unofficial stats are only accessible to specific whitelisted siaes.
         self.assertNotContains(response, "Voir les données de ma structure (extranet ASP)")
         self.assertNotContains(response, reverse("stats:stats_siae_etp"))
+        self.assertNotContains(response, "Voir le suivi du cofinancement de mon ACI")
+        self.assertNotContains(response, reverse("stats:stats_siae_aci"))
 
     def test_dashboard_ddets_log_institution_stats(self):
         membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DDETS_LOG)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Outil-ACI-Cr-er-une-liste-blanche-pour-mettre-disposition-ce-TB-priv-certaines-SIAE-a0e8210f55e84b72852ff5583be4d0a8**

### Pourquoi ?

Ces nouvelles stats sont prêtes à être mises à disposition de quelques ACI dans leur espace privé de telle manière qu’elles ne voient que les données qui les concernent. 

### Comment

- Nouvelle vue stats dédiée
- Nouvelle liste blanche par structure, similaire à la liste blanche déjà existante par utilisateur
- PR d'un nouveau secret https://github.com/betagouv/itou-secrets/pull/42 (👁️👁️👁️)
