### PR TITLE
Tableau de bord: vérification des sanctions au niveau de la vue

### DIFF
--- a/itou/templates/dashboard/includes/siae_employees_card.html
+++ b/itou/templates/dashboard/includes/siae_employees_card.html
@@ -11,21 +11,22 @@
                 We will have to discuss this matter further with AVE, but it has been
                 decided that it probably did not make much sense initially.
                 {% endcomment %}
-                {% with suspension=current_siae.get_active_suspension_text_with_dates %}
-                    <li class="d-flex justify-content-between align-items-center mb-3">
-                        {% if suspension %}
-                            <span class="btn-link btn-ico" data-toggle="tooltip" data-placement="top" title="Vous ne pouvez pas déclarer d'embauche suite aux mesures prises dans le cadre du contrôle a posteriori. {{ suspension }}">
-                                <i class="ri-user-follow-line ri-lg font-weight-normal disabled"></i>
-                                <span class="disabled">Déclarer une embauche</span>
-                            </span>
-                        {% else %}
-                            <a href="{% url 'apply:start' siae_pk=current_siae.pk %}" class="btn-link btn-ico">
-                                <i class="ri-user-follow-line ri-lg font-weight-normal"></i>
-                                <span>Déclarer une embauche</span>
-                            </a>
-                        {% endif %}
-                    </li>
-                {% endwith %}
+                <li class="d-flex justify-content-between align-items-center mb-3">
+                    {% if siae_suspension_text_with_dates %}
+                        <span class="btn-link btn-ico"
+                              data-toggle="tooltip"
+                              data-placement="top"
+                              title="Vous ne pouvez pas déclarer d'embauche suite aux mesures prises dans le cadre du contrôle a posteriori. {{ siae_suspension_text_with_dates }}">
+                            <i class="ri-user-follow-line ri-lg font-weight-normal disabled"></i>
+                            <span class="disabled">Déclarer une embauche</span>
+                        </span>
+                    {% else %}
+                        <a href="{% url 'apply:start' siae_pk=current_siae.pk %}" class="btn-link btn-ico">
+                            <i class="ri-user-follow-line ri-lg font-weight-normal"></i>
+                            <span>Déclarer une embauche</span>
+                        </a>
+                    {% endif %}
+                </li>
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'approvals:list' %}" data-matomo-category="salaries" data-matomo-action="clic" data-matomo-option="gestion-des-salaries-et-pass-iae" class="matomo-event btn-link btn-ico">
                         <i class="ri-contacts-book-line ri-lg font-weight-normal"></i>

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -54,6 +54,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
     active_campaigns = []
     closed_campaigns = []
     evaluated_siae_notifications = EvaluatedSiae.objects.none()
+    siae_suspension_text_with_dates = None
 
     # `current_org` can be a Siae, a PrescriberOrganization or an Institution.
     current_org = None
@@ -101,6 +102,9 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         num_rejected_employee_records = (
             EmployeeRecord.objects.for_siae(current_org).filter(status=Status.REJECTED).count()
         )
+        if current_org.is_subject_to_eligibility_rules:
+            # Otherwise they cannot be suspended
+            siae_suspension_text_with_dates = current_org.get_active_suspension_text_with_dates()
 
     if request.user.is_prescriber:
         try:
@@ -173,6 +177,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "active_campaigns": active_campaigns,
         "closed_campaigns": closed_campaigns,
         "evaluated_siae_notifications": evaluated_siae_notifications,
+        "siae_suspension_text_with_dates": siae_suspension_text_with_dates,
         "precriber_kind_pe": PrescriberOrganizationKind.PE,
         "precriber_kind_dept": PrescriberOrganizationKind.DEPT,
         "show_dora_banner": (


### PR DESCRIPTION
### Pourquoi ?

Dans le cadre du parcours de déclaration d'embauche, on aura bientôt 2 liens ("Enregistrer une candidature" & "Déclarer une embauche"), qui seront tous les deux désactivés en cas de sanction.
Il faudra soit une `cached_property` soit une variable dans le contexte, je pars sur la seconde option.