### PR TITLE
Parcours de vérification de profil : correction du titre sur la dernière étape

### DIFF
--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html
@@ -2,7 +2,14 @@
 {% load bootstrap4 %}
 {% load format_filters %}
 
-{% block title %}Création du compte candidat {{ block.super }}{% endblock %}
+{% block title %}
+    {% if update_job_seeker %}
+        Modification
+    {% else %}
+        Création
+    {% endif %}
+    du compte candidat {{ block.super }}
+{% endblock %}
 
 {% block content %}
     <section class="s-section-twocolumns s-section">
@@ -10,7 +17,14 @@
             <div class="row">
                 <div class="col-12 col-lg-4 order-md-2 pl-lg-5 d-none d-lg-block mb-6"></div>
                 <div class="col-12 col-lg-8 order-md-1 pr-lg-5">
-                    <h1 class="my-5">Création du compte candidat</h1>
+                    <h1 class="my-5">
+                        {% if update_job_seeker %}
+                            Modification
+                        {% else %}
+                            Création
+                        {% endif %}
+                        du compte candidat
+                    </h1>
                     <div class="c-stepper my-5">
                         <div class="progress text-emploi-light mb-2">
                             <div class="progress-bar progress-bar-{{ progress }} bg-emploi" role="progressbar" aria-valuenow="{{ progress }}" aria-valuemin="0" aria-valuemax="100">

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -1904,6 +1904,7 @@ class UpdateJobSeekerViewTestCase(TestCase):
         self.assertNotContains(response, self.INFO_MODIFIABLE_PAR_CANDIDAT_UNIQUEMENT)
 
         NEW_FIRST_NAME = "New first name"
+        PROCESS_TITLE = "Modification du compte candidat"
 
         post_data = {
             "title": "M",
@@ -1927,10 +1928,12 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # If you go back to step 1, new data is shown
         response = self.client.get(self.step_1_url)
+        self.assertContains(response, PROCESS_TITLE, html=True)
         self.assertContains(response, NEW_FIRST_NAME)
 
         # STEP 2
         response = self.client.get(self.step_2_url)
+        self.assertContains(response, PROCESS_TITLE, html=True)
         self.assertContains(response, self.job_seeker.phone)
         self.assertNotContains(response, self.INFO_MODIFIABLE_PAR_CANDIDAT_UNIQUEMENT)
 
@@ -1958,6 +1961,7 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # STEP 3
         response = self.client.get(self.step_3_url)
+        self.assertContains(response, PROCESS_TITLE, html=True)
         self.assertContains(response, "Niveau de formation")
 
         post_data = {
@@ -1997,6 +2001,7 @@ class UpdateJobSeekerViewTestCase(TestCase):
 
         # Step END
         response = self.client.get(self.step_end_url)
+        self.assertContains(response, PROCESS_TITLE, html=True)
         self.assertContains(response, NEW_FIRST_NAME)
         self.assertContains(response, NEW_ADDRESS_LINE)
         self.assertContains(response, "Formation de niveau BAC")


### PR DESCRIPTION
### Pourquoi ?

Pour bien indiquer qu'on modifie un candidat et non qu'on en crée un.

