### PR TITLE
BOOST: remplacer "e-mail" par "adresse e-mail" où nécessaire

### DIFF
--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -90,7 +90,7 @@ class SiaeResource(resources.ModelResource):
     last_name = Field(attribute="created_by__last_name", column_name="Nom")
     first_name = Field(attribute="created_by__first_name", column_name="Prénom")
     phone = Field(attribute="created_by__phone", column_name="Téléphone")
-    email = Field(attribute="created_by__email", column_name="E-mail")
+    email = Field(attribute="created_by__email", column_name="Adresse e-mail")
     created_at = Field(attribute="created_at", column_name="Date de création")
 
     class Meta:

--- a/itou/templates/apply/includes/job_application_sender_info.html
+++ b/itou/templates/apply/includes/job_application_sender_info.html
@@ -13,7 +13,7 @@
     </li>
 
     <li>
-        E-mail : <a href="mailto:{{ job_application.sender.email }}">{{ job_application.sender.email }}</a>
+        Adresse e-mail : <a href="mailto:{{ job_application.sender.email }}">{{ job_application.sender.email }}</a>
     </li>
 
     {% if job_application.sender_prescriber_organization %}

--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -22,7 +22,7 @@
             Date de naissance : <b>{{ job_seeker.birthdate|date:"d/m/Y" }}</b>
         </li>
         <li>
-            E-mail : <a href="mailto:{{ job_seeker.email }}">{{ job_seeker.email }}</a>
+            Adresse e-mail : <a href="mailto:{{ job_seeker.email }}">{{ job_seeker.email }}</a>
         </li>
 
         <li>

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -70,7 +70,7 @@
                                         <tr>
                                             <th scope="col">Prénom</th>
                                             <th scope="col">Nom</th>
-                                            <th scope="col">E-mail</th>
+                                            <th scope="col">Adresse e-mail</th>
                                             <th scope="col">Envoyée le</th>
                                         </tr>
                                     </thead>

--- a/itou/templates/invitations_views/email/accepted_notif_establishment_sender_body.txt
+++ b/itou/templates/invitations_views/email/accepted_notif_establishment_sender_body.txt
@@ -7,6 +7,6 @@ Détails
 -------------------
 - Prénom : {{ first_name }}
 - Nom : {{ last_name }}
-- E-mail : {{ email }}
+- Adresse e-mail : {{ email }}
 
 {% endblock %}

--- a/itou/templates/prescribers/card.html
+++ b/itou/templates/prescribers/card.html
@@ -30,7 +30,7 @@
 
                     {% if user.is_authenticated and prescriber_org.email %}
                         <p>
-                            <i class="ri-mail-line mr-1" aria-label="E-mail"></i>
+                            <i class="ri-mail-line mr-1" aria-label="Adresse e-mail"></i>
                             <a href="mailto:{{ prescriber_org.email }}">{{ prescriber_org.email }}</a>
                         </p>
                     {% endif %}

--- a/itou/templates/static/accessibility.html
+++ b/itou/templates/static/accessibility.html
@@ -101,7 +101,7 @@
                     </p>
                     <ul>
                         <li>
-                            E-mail : <a href="mailto:{{ ITOU_EMAIL_CONTACT }}">{{ ITOU_EMAIL_CONTACT }}</a>
+                            Adresse e-mail : <a href="mailto:{{ ITOU_EMAIL_CONTACT }}">{{ ITOU_EMAIL_CONTACT }}</a>
                         </li>
                         <li>
                             Adresse :

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -38,7 +38,7 @@ class UserExistsForm(forms.Form):
         self.user = None
 
     email = forms.EmailField(
-        label="E-mail personnel du candidat",
+        label="Adresse e-mail du candidat",
         widget=forms.EmailInput(attrs={"autocomplete": "off", "placeholder": "julie@example.com"}),
     )
 

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -164,7 +164,7 @@ class CreateProlongationRequestForm(CreateProlongationForm):
     report_file_path = forms.CharField(required=False, disabled=True, widget=forms.HiddenInput())
     uploaded_file_name = forms.CharField(required=False, disabled=True, widget=forms.HiddenInput())
     email = forms.EmailField(
-        label="E-mail du prescripteur habilité sollicité pour cette prolongation",
+        label="Adresse e-mail du prescripteur habilité sollicité pour cette prolongation",
         help_text=(
             "Attention : l'adresse e-mail doit correspondre à un compte utilisateur de type prescripteur habilité"
         ),
@@ -218,7 +218,7 @@ class CreateProlongationRequestForm(CreateProlongationForm):
         # Customize "email" and "prescriber_organization" fields
         if self.data.get("reason") not in Prolongation.REASONS_NOT_NEED_PRESCRIBER_OPINION:
             self.fields["email"].required = True
-        self.fields["email"].widget.attrs.update({"placeholder": "E-mail du prescripteur habilité"})
+        self.fields["email"].widget.attrs.update({"placeholder": "Adresse e-mail du prescripteur habilité"})
         self.fields["prescriber_organization"].widget.attrs.update(
             {
                 "hx-post": reverse(

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -225,7 +225,7 @@ class FacilitatorSearchForm(CheckAlreadyExistsForm):
 # ------------------------------------------------------------------------------------------
 class PrescriberRequestInvitationForm(FullnameFormMixin):
     email = forms.EmailField(
-        label="E-mail",
+        label="Adresse e-mail",
         required=True,
         widget=forms.TextInput(
             attrs={
@@ -331,7 +331,7 @@ class PrescriberPoleEmploiSafirCodeForm(forms.Form):
 
 class PrescriberCheckPEemail(forms.Form):
     email = forms.EmailField(
-        label="E-mail",
+        label="Adresse e-mail",
         required=True,
         widget=forms.TextInput(
             attrs={


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/Harmoniser-le-wording-e-mail-Adresse-e-mail-partout-dans-l-interface-boost-effc21ea11464650beef2138fb8664c8

### Pourquoi ?

Faire le distingo entre l'objet e-mail et l'adresse e-mail

### Comment 

`ripgrep` mais pas tout le temps



