### PR TITLE
Bloquer les candidatures dans des SIAEs sans membre actif

### DIFF
--- a/itou/templates/siaes/card.html
+++ b/itou/templates/siaes/card.html
@@ -47,8 +47,10 @@
                 </div>
                 <div class="col-12 col-lg-4 order-1 order-lg-2 d-flex flex-column">
                     <h2 class="sr-only">Actions rapides</h2>
-                    <div class="c-box mb-3 mb-lg-5">
-                        {% if not siae.block_job_applications %}
+                    <div class="c-box mb-3 mb-lg-5{% if not siae.has_active_members %} bg-emploi-lightest border-info{% endif %}">
+                        {% if not siae.has_active_members %}
+                            <p class="mb-0">Cet employeur n'est pas inscrit, vous ne pouvez pas déposer de candidatures en ligne.</p>
+                        {% elif not siae.block_job_applications %}
                             <a class="btn btn-primary btn-block btn-ico justify-content-center" href="{% url 'apply:start' siae_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                                 <i class="ri-draft-line"></i>
                                 <span>Postuler</span>
@@ -141,7 +143,7 @@
                                 </ul>
                             </div>
                         {% endif %}
-                        {% if not siae.block_job_applications %}
+                        {% if not siae.block_job_applications and siae.has_active_members %}
                             <div class="d-flex justify-content-end mt-3">
                                 <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" href="{% url 'apply:start' siae_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                                     <i class="ri-draft-line"></i>

--- a/itou/templates/siaes/includes/_card_siae.html
+++ b/itou/templates/siaes/includes/_card_siae.html
@@ -45,7 +45,11 @@
         </p>
     </div>
     <div class="card-body">
-        {% if siae.block_job_applications %}
+        {% if not siae.has_active_members %}
+            <p class="mb-0">
+                <i>Cet employeur n'est actuellement pas inscrit sur le site des emplois de l’inclusion, vous ne pouvez pas déposer de candidature en ligne</i>
+            </p>
+        {% elif siae.block_job_applications %}
             <p class="mb-0">
                 <i>Cet employeur ne traite plus de nouvelles candidatures pour le moment</i>
             </p>

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -83,7 +83,7 @@ class ApplyStepBaseView(LoginRequiredMixin, TemplateView):
         self.apply_session = None
 
     def setup(self, request, *args, **kwargs):
-        self.siae = get_object_or_404(Siae, pk=kwargs["siae_pk"])
+        self.siae = get_object_or_404(Siae.objects.with_has_active_members(), pk=kwargs["siae_pk"])
         self.apply_session = SessionNamespace(request.session, f"job_application-{self.siae.pk}")
         super().setup(request, *args, **kwargs)
 
@@ -94,6 +94,12 @@ class ApplyStepBaseView(LoginRequiredMixin, TemplateView):
             UserKind.SIAE_STAFF,
         ]:
             raise PermissionDenied("Vous n'êtes pas autorisé à déposer de candidature.")
+
+        if not self.siae.has_active_members:
+            raise PermissionDenied(
+                "Cet employeur n'est pas inscrit, vous ne pouvez pas déposer de candidatures en ligne."
+            )
+
         return super().dispatch(request, *args, **kwargs)
 
     def get_back_url(self):

--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -384,7 +384,7 @@ def select_financial_annex(request, template_name="siaes/select_financial_annex.
 
 
 def card(request, siae_id, template_name="siaes/card.html"):
-    siae = get_object_or_404(Siae, pk=siae_id)
+    siae = get_object_or_404(Siae.objects.with_has_active_members(), pk=siae_id)
     jobs_descriptions = SiaeJobDescription.objects.filter(siae=siae).select_related("appellation", "location")
     back_url = get_safe_url(request, "back_url")
     active_jobs_descriptions = []

--- a/tests/siaes/factories.py
+++ b/tests/siaes/factories.py
@@ -111,6 +111,8 @@ class SiaeFactory(factory.django.DjangoModelFactory):
                     user__for_snapshot=True,
                 ),
             ),
+            email="contact@acmeinc.com",
+            phone="0612345678",
         )
 
     # Don't start a SIRET with 0.

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -40,8 +40,24 @@ from tests.utils.test import TestCase, assertMessages
 
 
 class ApplyTest(TestCase):
+    def test_siae_with_no_members(self):
+        siae = SiaeFactory()
+        user = JobSeekerFactory()
+        self.client.force_login(user)
+        url = reverse("apply:start", kwargs={"siae_pk": siae.pk})
+        response = self.client.get(url)
+        assert response.status_code == 403
+        assertContains(
+            response,
+            '<p class="mb-0">'
+            "Cet employeur n&#x27;est pas inscrit, vous ne pouvez pas déposer de candidatures en ligne."
+            "</p>",
+            status_code=403,
+            count=1,
+        )
+
     def test_anonymous_access(self):
-        siae = SiaeFactory(with_jobs=True)
+        siae = SiaeFactory(with_jobs=True, with_membership=True)
         for viewname in (
             "apply:start",
             "apply:pending_authorization_for_sender",

--- a/tests/www/siaes_views/__snapshots__/test_views.ambr
+++ b/tests/www/siaes_views/__snapshots__/test_views.ambr
@@ -1,0 +1,141 @@
+# serializer version: 1
+# name: CardViewTest.test_card_no_active_members
+  '''
+  <main class="s-main bg-gray-400" id="main" role="main">
+              <div aria-atomic="true" aria-live="polite" class="toast-placement-wrapper">
+  
+  </div>
+              <div class="container container-messages">
+                  
+  
+                      
+  
+  
+  
+                      
+                      <div class="alert alert-secondary alert-old-browser" role="status">
+                          <p class="mb-0">
+                              La version de votre navigateur n'est plus supportée. Veuillez utiliser une version plus récente pour améliorer votre expérience sur notre site.
+                          </p>
+                      </div>
+                  
+              </div>
+  
+              <div class="container container-breadcrumb">
+                  
+              </div>
+  
+              
+              
+                  <section class="s-title-01">
+                      <div class="s-title-01__container container">
+                          <div class="s-title-01__row row">
+                              <div class="s-title-01__col col-12">
+                                  
+      <h1>Acme inc.</h1>
+      <h2 class="h5">Entreprise d'insertion</h2>
+  
+                              </div>
+                          </div>
+                      </div>
+                  </section>
+              
+  
+              
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-lg-8 order-2 order-lg-1 mt-3 mt-lg-0 d-none d-lg-block">
+                      <div class="c-box h-100 d-flex align-items-center justify-content-center">
+                          
+  
+                          
+  
+                          
+                              <div class="text-center">
+                                  <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-siae-card-no-result.svg"/>
+                                  <p class="mb-0 mt-3">
+                                      <strong>Oups ! Aucune information en vue !</strong>
+                                  </p>
+                                  <p>
+                                      <i>La structure n’a pas encore renseigné son activité
+                                          <br class="d-none d-lg-inline"/>
+                                      et l’accompagnement proposé.</i>
+                                  </p>
+                              </div>
+                          
+                      </div>
+                  </div>
+                  <div class="col-12 col-lg-4 order-1 order-lg-2 d-flex flex-column">
+                      <h2 class="sr-only">Actions rapides</h2>
+                      <div class="c-box mb-3 mb-lg-5 bg-emploi-lightest border-info">
+                          
+                              <p class="mb-0">Cet employeur n'est pas inscrit, vous ne pouvez pas déposer de candidatures en ligne.</p>
+                          
+                          
+                      </div>
+                      <div class="c-box flex-grow-1">
+                          <h2 class="h3">Coordonnées</h2>
+                          <ul class="list-unstyled mb-0">
+                              <li class="my-2">
+                                  <div class="d-flex align-items-start">
+                                      <i class="ri-map-pin-2-line ri-xl mr-2"></i>
+                                      <address class="font-weight-bold m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
+                                  </div>
+                              </li>
+                              
+                                  <li class="my-2">
+                                      <i class="ri-mail-line ri-xl mr-2"></i>
+                                      <a aria-label="Contact par mail" class="font-weight-bold" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
+                                  </li>
+                              
+  
+                              
+                                  <li class="my-2">
+                                      <i class="ri-phone-line ri-xl mr-2"></i>
+                                      <a aria-label="Contact téléphonique" class="font-weight-bold" href="tel:0612345678">06 12 34 56 78</a>
+                                  </li>
+                              
+  
+                              
+                          </ul>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+      <section class="s-tabs-01 mt-0 pt-0" id="metiers">
+          <div class="s-tabs-01__container container">
+              <div class="s-tabs-01__row row">
+                  <div class="s-tabs-01__col col-12">
+                      <h2 class="sr-only" id="metiers-title">Métiers de la structure</h2>
+                      <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" role="tablist">
+                          <li class="nav-item" role="presentation">
+                              <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
+                                  Recrutement en cours <span class="badge badge-sm badge-primary badge-pill text-white ml-2">0</span>
+                              </a>
+                          </li>
+                          
+                          <li class="nav-item-dropdown dropdown" role="presentation">
+                              <a aria-expanded="false" class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="sTabs01DropdownMoreLink" role="button"><i class="ri-more-line"></i></a>
+                              <div aria-labelledby="sTabs01DropdownMoreLink" class="dropdown-menu dropdown-menu-right"></div>
+                          </li>
+                      </ul>
+                      <div class="tab-content">
+                          <div aria-labelledby="recrutements-en-cours-tab" class="tab-pane fade active show" id="recrutements-en-cours" role="tabpanel">
+                              
+                                  <p>Pour le moment, il n’y a aucun recrutement en cours dans cette structure.</p>
+                              
+                          </div>
+                          
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+          </main>
+  '''
+# ---


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Bloquer-la-possibilit-de-postuler-sur-les-structures-qui-n-ont-pas-de-membres-539eddfa645c4b25bd592633436288c2?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Des candidats postulent à des postes dans des entreprise n’ayant pas de membre et ces candidatures restent lettre morte si aucun employeur ne s’inscrit sur la structure