### PR TITLE
Retourner sur l'admin quand on relâche un utilisateur détourné.

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -13,7 +13,7 @@ register_converter(SiretConverter, "siret")
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("hijack/", include("hijack.urls")),
+    path("hijack/", include("itou.utils.hijack.urls")),
     # --------------------------------------------------------------------------------------
     # allauth URLs. Order is important because some URLs are overriden.
     # --------------------------------------------------------------------------------------

--- a/itou/utils/hijack/urls.py
+++ b/itou/utils/hijack/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from . import views
+
+
+app_name = "hijack"
+urlpatterns = [
+    path("acquire/", views.AcquireUserView.as_view(), name="acquire"),
+    path("release/", views.ReleaseUserView.as_view(), name="release"),
+]

--- a/itou/utils/hijack/views.py
+++ b/itou/utils/hijack/views.py
@@ -1,0 +1,22 @@
+from hijack import views
+
+
+HIJACK_KEY = "hijack_previous_url"
+
+
+class AcquireUserView(views.AcquireUserView):
+    def post(self, request, *args, **kwargs):
+        previous_url = self.request.META.get("HTTP_REFERER")
+        res = super().post(request, *args, **kwargs)
+        if previous_url:
+            self.request.session[HIJACK_KEY] = previous_url
+        return res
+
+
+class ReleaseUserView(views.ReleaseUserView):
+    def post(self, request, *args, **kwargs):
+        self.previous_url = self.request.session.get(HIJACK_KEY)
+        return super().post(request, *args, **kwargs)
+
+    def get_success_url(self):
+        return self.previous_url or super().get_success_url()

--- a/tests/utils/perms/tests.py
+++ b/tests/utils/perms/tests.py
@@ -100,6 +100,21 @@ class UserHijackPermTestCase(TestCase):
         assert response["Location"] == "/bar/"
         assert cm.records[0].message == f"admin={hijacker} has ended impersonation of user={hijacked}"
 
+    def test_release_redirects_to_admin(self):
+        hijacked = JobSeekerFactory()
+        hijacker = ItouStaffFactory(is_superuser=True)
+        self.client.force_login(hijacker)
+
+        initial_url = reverse("admin:users_user_changelist")
+
+        response = self.client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk}, HTTP_REFERER=initial_url)
+        assert response.status_code == 302
+        assert response["Location"] == "/accounts/profile/"
+
+        response = self.client.post(reverse("hijack:release"), {"user_pk": hijacked.pk})
+        assert response.status_code == 302
+        assert response["Location"] == "/admin/users/user/"
+
 
 @pytest.mark.parametrize(
     "user_factory,identity_provider,is_redirected",


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Revenir-sur-l-admin-lorsqu-on-rel-che-un-utilisateur-d60f2474dd354a81ac258fce4a2b4f63?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Pour simplifier la vie du support.
