### PR TITLE
Update menu "besoin d'aide"

### DIFF
--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -35,10 +35,10 @@
                 </div>
 
                 <div class="s-footer-quick__col col-12 col-md-6 col-lg-auto">
-                    <strong>Documentation</strong>
+                    <strong>Besoin d'aide ?</strong>
                     <ul>
                         <li>
-                            <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)">Besoin d'aide ?</a>
+                            <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)">Documentation</a>
                         </li>
                         <li>
                             <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733403281937--Comprendre-l-IAE" target="_blank" aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">Qui peut bénéficier des contrats d'IAE&nbsp;?</a>

--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -1,8 +1,26 @@
 {% load redirection_fields %}
 
 <ul>
-    <li>
-        <a href="{{ ITOU_HELP_CENTER_URL }}" class="btn btn-link {% if is_mobile %}mh-auto p-0{% endif %}" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)">Besoin d'aide ?</a>
+    <li class="dropdown">
+        <button type="button"
+                class="btn btn-link dropdown-toggle {% if is_mobile %}mh-auto p-0{% endif %}"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-controls="helpDropdown{% if is_mobile %}Mobile{% endif %}"
+                aria-expanded="false">Besoin d'aide ?</button>
+        <div class="dropdown-menu" id="helpDropdown{% if is_mobile %}Mobile{% endif %}">
+            <ul class="list-unstyled">
+                <li>
+                    <a href="{{ ITOU_HELP_CENTER_URL }}" class="dropdown-item has-external-link" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)">Documentation</a>
+                </li>
+                <li>
+                    <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733403281937--Comprendre-l-IAE"
+                       class="dropdown-item has-external-link"
+                       target="_blank"
+                       aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
+                </li>
+            </ul>
+        </div>
     </li>
     {% if user.is_authenticated %}
         {% if user.is_siae_staff and user_siaes|length > 1 %}


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/C1-Dropdown-besoin-d-aide-74e9f80717ec4e2686c50a3a26c6bf46?pvs=4

### Pourquoi ?

Transformation du bouton "besoin d’aide ?" du header menu en dropdown
Harmonisation du menu footer au passage

