### PR TITLE
Ressucitation du debugging interactif en local dev dans le cas de Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       - "${DJANGO_PORT_ON_DOCKER_HOST:-8000}:8000"
     # Make interactive debugging possible.
     # Source: https://stackoverflow.com/questions/36249744/interactive-shell-using-docker-compose
+    # Run the usual `make run` (`docker-compose up`) and then in a second terminal run `docker attach itou_django`.
+    # You should now be able to access the usual interactive debugger on that second terminal.
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,10 @@ services:
     restart: always
     ports:
       - "${DJANGO_PORT_ON_DOCKER_HOST:-8000}:8000"
+    # Make interactive debugging possible.
+    # Source: https://stackoverflow.com/questions/36249744/interactive-shell-using-docker-compose
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
 
 volumes:
   postgres_data:


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/C0412CTV63D/p1691682102369149**

### Pourquoi ?

Le debugging interactif (`import ipdb; ipdb.set_trace()`) ne fonctionne plus avec Docker depuis... un certain temps.


