### PR TITLE
Stats : Ajout de deux nouveaux TB pour les CD sur liste blanche de quelques départements

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -446,6 +446,7 @@ ACI_CONVERGENCE_SIRET_WHITELIST = json.loads(os.getenv("ACI_CONVERGENCE_SIRET_WH
 # Kept as a setting to not let User/Siae PKs in clear in the code.
 STATS_SIAE_ASP_ID_WHITELIST = json.loads(os.getenv("STATS_SIAE_ASP_ID_WHITELIST", "[]"))
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_USER_PK_WHITELIST", "[]"))
+STATS_CD_DEPARTMENT_WHITELIST = ["13", "37", "38", "41", "45", "49"]
 
 # Slack notifications sent by Metabase cronjobs.
 SLACK_CRON_WEBHOOK_URL = os.getenv("SLACK_CRON_WEBHOOK_URL")

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -47,14 +47,20 @@
                     </li>
                 {% endif %}
                 {% if can_view_stats_cd %}
-                    <!-- Stats temporarily suspended until we stabilize them
-                        <li class="d-flex justify-content-between align-items-center mb-3">
-                            <a href="{% url 'stats:stats_cd' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
-                                <span>Voir les données IAE de mon département</span>
-                            </a>
-                        </li>
-                    -->
+                    <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="{% url 'stats:stats_cd_hiring' %}" class="btn-link btn-ico">
+                            <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
+                            <span>Voir les données facilitation de l'embauche</span>
+                        </a>
+                        <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
+                    </li>
+                    <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="{% url 'stats:stats_cd_brsa' %}" class="btn-link btn-ico">
+                            <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
+                            <span>Suivre les prescriptions des accompagnateurs des publics bRSA</span>
+                        </a>
+                        <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
+                    </li>
                 {% endif %}
                 {% if can_view_stats_pe %}
                     <li class="d-flex justify-content-between align-items-center mb-3">

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -787,6 +787,7 @@ class User(AbstractUser, AddressMixin):
             and current_org.is_authorized
             and current_org.authorization_status == PrescriberAuthorizationStatus.VALIDATED
             and not current_org.is_brsa
+            and current_org.department in settings.STATS_CD_DEPARTMENT_WHITELIST
         )
 
     def can_view_stats_pe(self, current_org):

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -45,8 +45,11 @@ METABASE_DASHBOARDS = {
     #
     # Prescriber stats - CD.
     #
-    "stats_cd": {
-        "dashboard_id": 118,
+    "stats_cd_hiring": {
+        "dashboard_id": 346,
+    },
+    "stats_cd_brsa": {
+        "dashboard_id": 330,
     },
     #
     # Prescriber stats - PE.

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -19,8 +19,10 @@ urlpatterns = [
         views.stats_siae_follow_siae_evaluation,
         name="stats_siae_follow_siae_evaluation",
     ),
-    # Prescriber stats.
-    path("cd", views.stats_cd, name="stats_cd"),
+    # Prescriber stats - CD.
+    path("cd/hiring", views.stats_cd_hiring, name="stats_cd_hiring"),
+    path("cd/brsa", views.stats_cd_brsa, name="stats_cd_brsa"),
+    # Prescriber stats - PE.
     path("pe/delay/main", views.stats_pe_delay_main, name="stats_pe_delay_main"),
     path("pe/delay/raw", views.stats_pe_delay_raw, name="stats_pe_delay_raw"),
     path("pe/conversion/main", views.stats_pe_conversion_main, name="stats_pe_conversion_main"),

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -243,8 +243,7 @@ def stats_siae_follow_siae_evaluation(request):
     return render_stats_siae(request=request, page_title="Suivi du contrôle a posteriori")
 
 
-@login_required
-def stats_cd(request):
+def render_stats_cd(request, page_title):
     """
     CD ("Conseil Départemental") stats shown to relevant members.
     They can only view data for their own departement.
@@ -255,11 +254,21 @@ def stats_cd(request):
     department = current_org.department
     params = get_params_for_departement(department)
     context = {
-        "page_title": f"Données de mon département : {DEPARTMENTS[department]}",
+        "page_title": f"{page_title} de mon département : {DEPARTMENTS[department]}",
         "department": department,
         "matomo_custom_url_suffix": format_region_and_department_for_matomo(department),
     }
     return render_stats(request=request, context=context, params=params)
+
+
+@login_required
+def stats_cd_hiring(request):
+    return render_stats_cd(request=request, page_title="Facilitation des embauches en IAE")
+
+
+@login_required
+def stats_cd_brsa(request):
+    return render_stats_cd(request=request, page_title="Suivi des prescriptions des accompagnateurs des publics bRSA")
 
 
 def render_stats_pe(request, page_title, extra_params=None):

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -713,10 +713,19 @@ class ModelTest(TestCase):
         user3 = siae3.members.get()
         assert user3.can_view_stats_siae(current_org=siae3)
 
+    @override_settings(STATS_CD_DEPARTMENT_WHITELIST=["93"])
     def test_can_view_stats_cd(self):
         """
         CD as in "Conseil Départemental".
         """
+        # Department outside of the whitelist cannot access.
+        org = PrescriberOrganizationWithMembershipFactory(
+            authorized=True, kind=PrescriberOrganizationKind.DEPT, department="01"
+        )
+        user = org.members.get()
+        assert not user.can_view_stats_cd(current_org=org)
+        assert not user.can_view_stats_dashboard_widget(current_org=org)
+
         # Admin prescriber of authorized CD can access.
         org = PrescriberOrganizationWithMembershipFactory(
             authorized=True, kind=PrescriberOrganizationKind.DEPT, department="93"
@@ -737,13 +746,20 @@ class ModelTest(TestCase):
         assert user.can_view_stats_dashboard_widget(current_org=org)
 
         # Non authorized organization does not give access.
-        org = PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganizationKind.DEPT)
+        org = PrescriberOrganizationWithMembershipFactory(
+            kind=PrescriberOrganizationKind.DEPT,
+            department="93",
+        )
         user = org.members.get()
         assert not user.can_view_stats_cd(current_org=org)
         assert not user.can_view_stats_dashboard_widget(current_org=org)
 
         # Non CD organization does not give access.
-        org = PrescriberOrganizationWithMembershipFactory(authorized=True, kind=PrescriberOrganizationKind.CHRS)
+        org = PrescriberOrganizationWithMembershipFactory(
+            authorized=True,
+            kind=PrescriberOrganizationKind.CHRS,
+            department="93",
+        )
         user = org.members.get()
         assert not user.can_view_stats_cd(current_org=org)
         assert not user.can_view_stats_dashboard_widget(current_org=org)


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Cr-er-liste-blanche-et-publier-les-TB345-et-TB330-sur-c1-pour-les-CD-phase-de-test-aupr-s-d-un-gro-0ecae07747d8434bae347e620c96acfc**

### Pourquoi ?

Cela fait un moment que les CD n'ont plus aucune stats spécifiques à eux (le TB 118 était désactivé). Ici on teste deux nouveaux TB à leur destination.

### Notes

L'intégration est testée OK depuis mon local dev, mais il reste un souci côté Metabase à résoudre par les analistos avant MEP, les filtres du 330 n'ont pas l'effet filtrant attendu. Cf https://itou-inclusion.slack.com/archives/C04SAGUGJFJ/p1692107278924309?thread_ts=1691560994.578509&cid=C04SAGUGJFJ


<img width="911" alt="image" src="https://github.com/betagouv/itou/assets/10533583/771eae21-a721-49c7-af8c-02add44e56ec">
