### PR TITLE
Limiter le nombre de destinataire pour l'email de relance pour la demande de prolongation

### DIFF
--- a/itou/approvals/notifications.py
+++ b/itou/approvals/notifications.py
@@ -1,4 +1,5 @@
 from dateutil.relativedelta import relativedelta
+from django.db.models import F
 
 from itou.common_apps.notifications.base_class import BaseNotification
 from itou.prescribers.models import PrescriberMembership
@@ -35,6 +36,8 @@ class ProlongationRequestCreatedReminder(BaseNotification):
             PrescriberMembership.objects.active()
             .filter(organization=self.prolongation_request.prescriber_organization)
             .exclude(user=self.prolongation_request.validated_by)
+            # Limit to the last 10 active colleagues, it should cover the ones dedicated to the IAE and some more.
+            .order_by(F("user__last_login").desc(nulls_last=True), "-joined_at", "-pk")[:10]
             .values_list("user__email", flat=True)
         )
         context = {

--- a/tests/approvals/test_notifications.py
+++ b/tests/approvals/test_notifications.py
@@ -1,3 +1,7 @@
+import datetime
+
+import factory
+
 from itou.approvals import notifications
 
 from ..users.factories import PrescriberFactory
@@ -24,6 +28,23 @@ def test_prolongation_request_created_reminder(snapshot):
     assert set(email.cc) == {member.email for member in other_prescribers}
     assert email.subject == snapshot(name="subject")
     assert email.body == snapshot(name="body")
+
+
+def test_prolongation_request_created_reminder_carbon_copy_list_limit():
+    prolongation_request = ProlongationRequestFactory(for_snapshot=True)
+    # We limit to the 10 most recent active users, so the first one created should not make the cut
+    [_, *prescribers_to_be_cc] = PrescriberFactory.create_batch(
+        11,
+        membership__organization=prolongation_request.prescriber_organization,
+        last_login=factory.Sequence(lambda n: datetime.datetime(2000, 1, n % 31, tzinfo=datetime.UTC)),
+    )
+    PrescriberFactory(
+        membership__organization=prolongation_request.prescriber_organization,
+        last_login=None,
+    )
+    email = notifications.ProlongationRequestCreatedReminder(prolongation_request).email
+
+    assert set(email.cc) == {member.email for member in prescribers_to_be_cc}
 
 
 def test_prolongation_request_granted_employer(snapshot):


### PR DESCRIPTION
### Pourquoi ?

Mailjet limite à 50 destinataires, certaine agence PE ont plus de 50 agents inscrits donc l'envoi de l'email de rappel échouais.

### Comment

Vu qu'il n'est pas vraiment nécessaire d'envoyer le rappel à autant de personne on limite désormais au 10 utilisateurs qui se sont connecté le plus récemment, cela devrais cibler les personnes qui sont dédiés à l'IAE mais aussi ceux qui interviennent ponctuellement dessus.