### PR TITLE
Retirer la mention qui fait référence à l’acceptation automatique dans l’email de notif des prolongations

### DIFF
--- a/itou/approvals/notifications.py
+++ b/itou/approvals/notifications.py
@@ -1,4 +1,3 @@
-from dateutil.relativedelta import relativedelta
 from django.db.models import F
 
 from itou.common_apps.notifications.base_class import BaseNotification
@@ -42,7 +41,6 @@ class ProlongationRequestCreatedReminder(BaseNotification):
         )
         context = {
             "prolongation_request": self.prolongation_request,
-            "auto_grant_date": self.prolongation_request.created_at.date() + relativedelta(days=30),
         }
         subject = "approvals/email/prolongation_request/created_reminder_subject.txt"
         body = "approvals/email/prolongation_request/created_reminder_body.txt"

--- a/itou/templates/approvals/email/prolongation_request/created_reminder_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/created_reminder_body.txt
@@ -3,7 +3,6 @@
 Bonjour,
 
 Une demande de prolongation du PASS IAE a été transmise à un membre de votre organisation, cette demande est toujours en attente de réponse. Si des démarches sont en cours, veuillez ne pas tenir compte de ce message.
-Si aucune réponse n’est apportée avant le {{ auto_grant_date|date:"d/m/Y" }}, la demande sera acceptée automatiquement.
 
 Rappel du message initial :
 

--- a/tests/approvals/__snapshots__/test_notifications.ambr
+++ b/tests/approvals/__snapshots__/test_notifications.ambr
@@ -52,7 +52,6 @@
   Bonjour,
   
   Une demande de prolongation du PASS IAE a été transmise à un membre de votre organisation, cette demande est toujours en attente de réponse. Si des démarches sont en cours, veuillez ne pas tenir compte de ce message.
-  Si aucune réponse n’est apportée avant le 31/01/2000, la demande sera acceptée automatiquement.
   
   Rappel du message initial :
   


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Retirer-la-mention-qui-fait-r-f-rence-l-acceptation-automatique-dans-l-email-de-notif-des-prolonga-3616e4ea7c0a4544b2d893427d013e38