### PR TITLE
Retrait d’un garde inutile de CreateProlongationForm

### DIFF
--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -143,7 +143,7 @@ class CreateProlongationForm(forms.ModelForm):
         self.fields["end_at"].label = f'Du {self.instance.start_at.strftime("%d/%m/%Y")} au'
 
         end_at_extra_help_text = ""
-        if self.data and (reason := self.data.get("reason")):
+        if reason := self.data.get("reason"):
             try:
                 max_duration = Prolongation.MAX_CUMULATIVE_DURATION[reason]
             except KeyError:


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Prolongations-en-tant-qu-employeur-je-veux-comprendre-que-ma-prolongation-doit-se-faire-par-p-riod-1bfa9cc189414bccaec62abb49e62751**