### PR TITLE
Recharger CreateProlongationForm.reason.help_text lors d’un changement

### DIFF
--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -25,29 +25,7 @@
                     {% if not preview %}
                         {# Edit mode. #}
                         {% include "approvals/includes/card.html" with common_approval=approval %}
-                        <div class="c-box my-4">
-                            <form id="mainForm" method="post" action="" class="js-prevent-multiple-submit">
-                                {% csrf_token %}
-
-                                {% bootstrap_form_errors form type="non_fields" %}
-
-                                {% bootstrap_field form.reason %}
-                                {% bootstrap_field form.end_at %}
-
-                                {% include "approvals/includes/declaration_upload_panel.html" %}
-
-                                <hr />
-
-                                {% buttons %}
-                                    <div class="text-right">
-                                        <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
-                                        {# Enable preview mode: preview=1. #}
-                                        <button type="submit" name="preview" value="1" class="btn btn-primary">Valider la déclaration</button>
-                                    </div>
-                                {% endbuttons %}
-
-                            </form>
-                        </div>
+                        <div class="c-box my-4">{% include "approvals/includes/prolongation_declaration_form.html" %}</div>
                     {% else %}
                         {# Preview mode: ask for confirmation before committing to DB. #}
 

--- a/itou/templates/approvals/includes/prolongation_declaration_form.html
+++ b/itou/templates/approvals/includes/prolongation_declaration_form.html
@@ -1,0 +1,21 @@
+{% load bootstrap4 %}
+<form id="mainForm" method="post" action="" class="js-prevent-multiple-submit">
+    {% csrf_token %}
+
+    {% bootstrap_form_errors form type="non_fields" %}
+
+    {% bootstrap_field form.reason %}
+    {% bootstrap_field form.end_at %}
+
+    {% include "approvals/includes/declaration_upload_panel.html" %}
+
+    <hr />
+
+    {% buttons %}
+        <div class="text-right">
+            <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
+            {# Enable preview mode: preview=1. #}
+            <button type="submit" name="preview" value="1" class="btn btn-primary">Valider la déclaration</button>
+        </div>
+    {% endbuttons %}
+</form>

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -127,9 +127,12 @@ class CreateProlongationForm(forms.ModelForm):
         self.fields["reason"].choices = ProlongationReason.for_siae(self.instance.declared_by_siae)
         self.fields["reason"].widget.attrs.update(
             {
-                "hx-post": reverse("approvals:toggle_upload_panel", kwargs={"approval_id": self.instance.approval_id}),
-                "hx-target": "#upload_panel",
-                "hx-select": "#upload_panel",
+                "hx-post": reverse(
+                    "approvals:prolongation_form_for_reason",
+                    kwargs={"approval_id": self.instance.approval_id},
+                ),
+                "hx-swap": "outerHTML",
+                "hx-target": "#mainForm",
             }
         )
 

--- a/itou/www/approvals_views/urls.py
+++ b/itou/www/approvals_views/urls.py
@@ -23,9 +23,9 @@ urlpatterns = [
         name="check_contact_details",
     ),
     path(
-        "declare_prolongation/<int:approval_id>/toggle_upload_panel",
-        views.ToggledUploadPanelView.as_view(),
-        name="toggle_upload_panel",
+        "declare_prolongation/<int:approval_id>/prolongation_form_for_reason",
+        views.UpdateFormForReasonView.as_view(),
+        name="prolongation_form_for_reason",
     ),
     path("prolongation/requests", views.prolongation_requests_list, name="prolongation_requests_list"),
     path(


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Prolongations-en-tant-qu-employeur-je-veux-comprendre-que-ma-prolongation-doit-se-faire-par-p-riod-1bfa9cc189414bccaec62abb49e62751**

### Pourquoi ?

Le `help_text` est calculé dynamiquement, mais n’est pas montré tant que le formulaire n’est pas rechargé. Voir le commit.