### PR TITLE
Mise en commun du code JS et HTML pour la copie presse-papier

### DIFF
--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -704,7 +704,7 @@ class SiaeJobDescription(models.Model):
     def get_absolute_url(self):
         if self.is_external:
             return self.source_url
-        return reverse("siaes_views:job_description_card", kwargs={"job_description_id": self.pk})
+        return get_absolute_url(reverse("siaes_views:job_description_card", kwargs={"job_description_id": self.pk}))
 
 
 class SiaeConvention(models.Model):

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -56,4 +56,11 @@ htmx.onLoad((target) => {
     // null value removes the attribute altogether instead of having aria-disabled="false"
     $('a.btn', this).attr("aria-disabled", $(selector).length !== 0 || null)
   })
+
+  /**
+   * JS to copy some text from the DOM into the clipboard.
+   */
+  $(".js-copy-to-clipboard", target).on("click", function(event) {
+    navigator.clipboard.writeText(event.currentTarget.dataset.copyToClipboard)
+  })
 });

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -61,6 +61,11 @@ htmx.onLoad((target) => {
    * JS to copy some text from the DOM into the clipboard.
    */
   $(".js-copy-to-clipboard", target).on("click", function(event) {
-    navigator.clipboard.writeText(event.currentTarget.dataset.copyToClipboard)
+    navigator.clipboard.writeText(event.currentTarget.dataset.copyToClipboard).then(function () {
+      $(event.currentTarget).tooltip('show')
+    })
+  })
+  $(".js-copy-to-clipboard", target).on("blur", function (event) {
+    $(event.currentTarget).tooltip('hide')
   })
 });

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -50,7 +50,7 @@ htmx.onLoad((target) => {
     * Typically useful when forms are available and you don't want the user
     * to be confused in which button to use or to forget to validate the editing form.
   **/
-  $('[data-disable-btn-if]').each(function() {
+  $('[data-disable-btn-if]', target).each(function() {
     const selector = this.getAttribute("data-disable-btn-if")
     $('.btn', this).toggleClass("disabled", $(selector).length !== 0)
     // null value removes the attribute altogether instead of having aria-disabled="false"

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -52,10 +52,7 @@
                             <p>
                                 <i class="ri-mail-line"></i>
                                 <a class="btn-link mr-3" href="mailto:{{ prolongation_request.contact_email }}">{{ prolongation_request.contact_email }}</a>
-                                <button class="btn btn-secondary btn-ico" data-copy-to-clipboard="{{ prolongation_request.contact_email }}" id="copy-to-clipboard">
-                                    <i class="ri-file-copy-line ri-lg font-weight-normal"></i>
-                                    <span>Copier</span>
-                                </button>
+                                {% include 'includes/copy_to_clipboard.html' with content=prolongation_request.contact_email css_classes="btn-secondary" %}
                             </p>
                             <p>
                                 <i class="ri-phone-line"></i>
@@ -85,14 +82,4 @@
             </div>
         </div>
     </section>
-{% endblock %}
-
-{% block script %}
-    {{ block.super }}
-    <script nonce="{{ CSP_NONCE }}">
-        // TODO: Refactor that behavior into utils
-        document.getElementById('copy-to-clipboard').addEventListener("click", function select(event) {
-            navigator.clipboard.writeText(event.currentTarget.dataset.copyToClipboard);
-        });
-    </script>
 {% endblock %}

--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -48,12 +48,10 @@
                                         <div class="form-row align-items-center">
                                             <div class="form-group mb-0 col-8">
                                                 Votre token d'API est :
-                                                <span id="token">{{ token.key }}</span>
+                                                <span>{{ token.key }}</span>
                                             </div>
                                             <div class="form-group mb-0 col-4 text-right">
-                                                <button class="btn btn-primary" id="copy-token">
-                                                    <i class="ri-file-copy-line mr-2 ri-lg"></i>Copier le token
-                                                </button>
+                                                {% include 'includes/copy_to_clipboard.html' with content=token.key text="Copier le token" css_classes="btn-primary" %}
                                             </div>
                                         </div>
                                     </div>
@@ -65,12 +63,4 @@
             </div>
         </div>
     </section>
-
-    <script nonce="{{ CSP_NONCE }}">
-        var copyToken = document.getElementById('copy-token')
-        copyToken.addEventListener("click", function select(event) {
-            var token = document.getElementById('token');
-            navigator.clipboard.writeText(token.innerText);
-        });
-    </script>
 {% endblock %}

--- a/itou/templates/includes/copy_to_clipboard.html
+++ b/itou/templates/includes/copy_to_clipboard.html
@@ -1,4 +1,4 @@
-<button class="js-copy-to-clipboard btn btn-ico {{ css_classes }}" data-copy-to-clipboard="{{ content }}">
+<button class="js-copy-to-clipboard btn btn-ico {{ css_classes }}" data-copy-to-clipboard="{{ content }}" data-toggle="tooltip" data-placement="top" data-trigger="manual" data-original-title="Copié !">
     <i class="ri-file-copy-line ri-lg font-weight-normal"></i>
     <span>{{ text|default:"Copier" }}</span>
 </button>

--- a/itou/templates/includes/copy_to_clipboard.html
+++ b/itou/templates/includes/copy_to_clipboard.html
@@ -1,0 +1,4 @@
+<button class="js-copy-to-clipboard btn btn-ico {{ css_classes }}" data-copy-to-clipboard="{{ content }}">
+    <i class="ri-file-copy-line ri-lg font-weight-normal"></i>
+    <span>{{ text|default:"Copier" }}</span>
+</button>

--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -30,15 +30,7 @@
                         </td>
                         <td>{{ invitation.sent_at|date:"d F Y à H:i" }}</td>
                         <td>
-                            <p>
-                                <a data-toggle="collapse" href="#share-invitation-link-{{ forloop.counter }}" role="button" aria-expanded="false">
-                                    Afficher le lien
-                                </a>
-                            </p>
-                            <div class="collapse form-group invitation-link" id="share-invitation-link-{{ forloop.counter }}">
-                                <p>Cliquez sur le lien ci-dessous pour le copier:</p>
-                                <input type="text" class="form-control" readonly="readonly" value="{{ invitation.acceptance_link }}">
-                            </div>
+                            {% include 'includes/copy_to_clipboard.html' with content=invitation.acceptance_link css_classes="btn-outline-primary btn-sm" %}
                         </td>
                     </tr>
                 {% endfor %}
@@ -46,15 +38,3 @@
         </table>
     </div>
 </div>
-
-
-<script nonce="{{ CSP_NONCE }}">
-    var links = document.getElementsByClassName('invitation-link')
-    for (var i = 0, j = links.length; i < j; i++) {
-        links[i].addEventListener("click", function select(event) {
-            var input = event.target.querySelector('input');
-            input.select();
-            navigator.clipboard.writeText(input.value);
-        });
-    }
-</script>

--- a/itou/templates/siaes/job_description_card.html
+++ b/itou/templates/siaes/job_description_card.html
@@ -40,7 +40,7 @@
                                         <a href="#job_description_link" class="btn btn-sm btn-outline-primary" data-toggle="collapse" aria-label="Partager cette fiche métier">Partager cette fiche métier</a>
                                         <div class="collapse pt-2" id="job_description_link">
                                             <p class="small mb-1">Cliquez sur le lien ci-dessous pour le copier:</p>
-                                            <input type="text" class="form-control form-control-sm" value="{{ request.scheme }}://{{ request.get_host }}{{ job.get_absolute_url }}">
+                                            <input type="text" class="form-control form-control-sm" value="{{ job.get_absolute_url }}">
                                         </div>
                                     </div>
                                     {% if job.is_active and not siae.block_job_applications %}

--- a/itou/templates/siaes/job_description_card.html
+++ b/itou/templates/siaes/job_description_card.html
@@ -37,11 +37,7 @@
                             {% else %}
                                 <div class="row mb-4">
                                     <div class="col">
-                                        <a href="#job_description_link" class="btn btn-sm btn-outline-primary" data-toggle="collapse" aria-label="Partager cette fiche métier">Partager cette fiche métier</a>
-                                        <div class="collapse pt-2" id="job_description_link">
-                                            <p class="small mb-1">Cliquez sur le lien ci-dessous pour le copier:</p>
-                                            <input type="text" class="form-control form-control-sm" value="{{ job.get_absolute_url }}">
-                                        </div>
+                                        {% include 'includes/copy_to_clipboard.html' with content=job.get_absolute_url text="Copier le lien de cette fiche métier" css_classes="btn-outline-primary btn-sm" %}
                                     </div>
                                     {% if job.is_active and not siae.block_job_applications %}
                                         <div class="col-auto text-right">
@@ -75,15 +71,4 @@
             </div>
         </div>
     </section>
-{% endblock %}
-
-{% block script %}
-    {{ block.super }}
-    <script nonce="{{ CSP_NONCE }}">
-        document.getElementById('job_description_link').addEventListener("click", function select(event) {
-            var input = event.target;
-            input.select();
-            navigator.clipboard.writeText(input.value);
-        });
-    </script>
 {% endblock %}

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -81,10 +81,11 @@
                               <p>
                                   <i class="ri-mail-line"></i>
                                   <a class="btn-link mr-3" href="mailto:email@example.com">email@example.com</a>
-                                  <button class="btn btn-secondary btn-ico" data-copy-to-clipboard="email@example.com" id="copy-to-clipboard">
-                                      <i class="ri-file-copy-line ri-lg font-weight-normal"></i>
-                                      <span>Copier</span>
-                                  </button>
+                                  <button class="js-copy-to-clipboard btn btn-ico btn-secondary" data-copy-to-clipboard="email@example.com">
+      <i class="ri-file-copy-line ri-lg font-weight-normal"></i>
+      <span>Copier</span>
+  </button>
+  
                               </p>
                               <p>
                                   <i class="ri-phone-line"></i>

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -81,7 +81,7 @@
                               <p>
                                   <i class="ri-mail-line"></i>
                                   <a class="btn-link mr-3" href="mailto:email@example.com">email@example.com</a>
-                                  <button class="js-copy-to-clipboard btn btn-ico btn-secondary" data-copy-to-clipboard="email@example.com">
+                                  <button class="js-copy-to-clipboard btn btn-ico btn-secondary" data-copy-to-clipboard="email@example.com" data-original-title="Copié !" data-placement="top" data-toggle="tooltip" data-trigger="manual">
       <i class="ri-file-copy-line ri-lg font-weight-normal"></i>
       <span>Copier</span>
   </button>

--- a/tests/www/siaes_views/test_views.py
+++ b/tests/www/siaes_views/test_views.py
@@ -134,7 +134,7 @@ class CardViewTest(TestCase):
                       data-matomo-action="clic"
                       data-matomo-category="candidature"
                       data-matomo-option="clic-metiers"
-                      href="/siae/job_description/{job_description.pk}/card?back_url=/siae/{siae.pk}/card">
+                      href="{job_description.get_absolute_url()}?back_url=/siae/{siae.pk}/card">
                     Plaquiste
                    </a>
                   </div>
@@ -234,7 +234,7 @@ class CardViewTest(TestCase):
                       data-matomo-action="clic"
                       data-matomo-category="candidature"
                       data-matomo-option="clic-metiers"
-                      href="/siae/job_description/{job_description.pk}/card?back_url=/siae/{siae.pk}/card">
+                      href="{job_description.get_absolute_url()}?back_url=/siae/{siae.pk}/card">
                     Plaquiste
                    </a>
                   </div>
@@ -359,7 +359,7 @@ class CardViewTest(TestCase):
                       data-matomo-action="clic"
                       data-matomo-category="candidature"
                       data-matomo-option="clic-metiers"
-                      href="/siae/job_description/{active_job_description.pk}/card?back_url=/siae/{siae.pk}/card">
+                      href="{active_job_description.get_absolute_url()}?back_url=/siae/{siae.pk}/card">
                     Plaquiste
                    </a>
                   </div>
@@ -388,7 +388,7 @@ class CardViewTest(TestCase):
                       data-matomo-action="clic"
                       data-matomo-category="candidature"
                       data-matomo-option="clic-metiers"
-                      href="/siae/job_description/{other_job_description.pk}/card?back_url=/siae/{siae.pk}/card">
+                      href="{other_job_description.get_absolute_url()}?back_url=/siae/{siae.pk}/card">
                     Peintre
                    </a>
                   </div>
@@ -507,7 +507,7 @@ class CardViewTest(TestCase):
                       data-matomo-action="clic"
                       data-matomo-category="candidature"
                       data-matomo-option="clic-metiers"
-                      href="/siae/job_description/{job_description.pk}/card?back_url=/siae/{siae.pk}/card">
+                      href="{job_description.get_absolute_url()}?back_url=/siae/{siae.pk}/card">
                     Plaquiste
                    </a>
                   </div>


### PR DESCRIPTION
### Pourquoi ?

Simplifier la réutilisation et la maintenance.
Uniformiser le comportement, code et UI ([fil slack UX](https://itou-inclusion.slack.com/archives/CQ6C3LSAH/p1692622507238619)).

Le thème contient aussi un moyen de copier dans le presse-papier mais ce n'est actuellement pas utilisé et demande un balisage particulier donc à voir ce qu'on veux en faire.

### Captures d'écran <!-- optionnel -->

1. Lien fiche métier (Avant/Après)
![copy_job_link_old](https://github.com/betagouv/itou/assets/20045330/069c58f0-29b5-4a4b-91b2-4a8ae9fa8ce8)
![copy_job_link_new](https://github.com/betagouv/itou/assets/20045330/73acdebe-727e-4a64-af85-63d91d5c6a03)

2. Invitation (Avant/Après)
![copy_invitation_link_old](https://github.com/betagouv/itou/assets/20045330/dcc65869-3881-48d2-95bb-e6d1e2f163a6)
![copy_invitation_link_new](https://github.com/betagouv/itou/assets/20045330/944603ea-5268-45e7-ab4d-fde0e91be139)

3. Token API (pas de changement UI)
![copy_api_token](https://github.com/betagouv/itou/assets/20045330/659bfd71-5f04-41de-8ce4-859bb1596aa3)

4. Demande de prolongation (pas de changement UI)
![copy_prolongation_request_email](https://github.com/betagouv/itou/assets/20045330/8e6507eb-bcbe-4ff2-837c-0a85fc45c763)

5. Tooltip
![tooltip](https://github.com/betagouv/itou/assets/20045330/4b5cb26d-5eb0-4967-8338-fc54b65857f4)
