### PR TITLE
Renouvellement des prolongations par périodes d’un an

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -951,7 +951,7 @@ class CommonProlongation(models.Model):
         },
         enums.ProlongationReason.PARTICULAR_DIFFICULTIES: {
             "duration": datetime.timedelta(days=3 * 365),
-            "label": "12 mois (365 jours), reconductibles dans la limite de 5 ans de parcours",
+            "label": "3 ans (1095 jours)",
         },
         enums.ProlongationReason.HEALTH_CONTEXT: {
             "duration": datetime.timedelta(days=365),

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -930,33 +930,32 @@ class CommonProlongation(models.Model):
     """
 
     # Max duration: 10 years but it depends on the `reason` field, see `get_max_end_at`.
-    # The addition of 0.25 day per year makes it possible to better manage leap years.
-    MAX_DURATION = datetime.timedelta(days=365.25 * 10)
+    MAX_DURATION = datetime.timedelta(days=10 * 365)
 
     MAX_CUMULATIVE_DURATION = {
         enums.ProlongationReason.SENIOR_CDI: {
-            "duration": datetime.timedelta(days=365.25 * 10),  # 10 years
-            "label": "10 ans",
+            "duration": MAX_DURATION,
+            "label": "10 ans (3650 jours)",
         },
         enums.ProlongationReason.COMPLETE_TRAINING: {
-            "duration": datetime.timedelta(days=365.25 * 2),  # 2 years
-            "label": "2 ans",
+            "duration": datetime.timedelta(days=2 * 365),
+            "label": "2 ans (730 jours)",
         },
         enums.ProlongationReason.RQTH: {
-            "duration": datetime.timedelta(days=365.25 * 3),  # 3 years
-            "label": "3 ans",
+            "duration": datetime.timedelta(days=3 * 365),
+            "label": "3 ans (1095 jours)",
         },
         enums.ProlongationReason.SENIOR: {
-            "duration": datetime.timedelta(days=365.25 * 5),  # 5 years
-            "label": "5 ans",
+            "duration": datetime.timedelta(days=5 * 365),
+            "label": "5 ans (1825 jours)",
         },
         enums.ProlongationReason.PARTICULAR_DIFFICULTIES: {
-            "duration": datetime.timedelta(days=365.25 * 3),  # 3 years
-            "label": "12 mois, reconductibles dans la limite de 5 ans de parcours",
+            "duration": datetime.timedelta(days=3 * 365),
+            "label": "12 mois (365 jours), reconductibles dans la limite de 5 ans de parcours",
         },
         enums.ProlongationReason.HEALTH_CONTEXT: {
-            "duration": datetime.timedelta(days=365),  # one year
-            "label": "12 mois",
+            "duration": datetime.timedelta(days=365),
+            "label": "12 mois (365 jours)",
         },
     }
 
@@ -1154,11 +1153,11 @@ class CommonProlongation(models.Model):
         """
         max_duration = Prolongation.MAX_DURATION
         if reason == enums.ProlongationReason.PARTICULAR_DIFFICULTIES.value:
-            # 12 months renewable up to 3 years for this reason
-            max_duration = relativedelta(months=12)
+            # A year, renewable up to 3 years for this reason
+            max_duration = datetime.timedelta(days=365)
         elif reason in Prolongation.MAX_CUMULATIVE_DURATION:
             max_duration = Prolongation.MAX_CUMULATIVE_DURATION[reason]["duration"]
-        return start_at + max_duration - relativedelta(days=1)
+        return start_at + max_duration - datetime.timedelta(days=1)
 
 
 class ProlongationRequest(CommonProlongation):

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1144,7 +1144,7 @@ class CommonProlongation(models.Model):
         if additional_duration:
             cumulative_duration += additional_duration
 
-        return cumulative_duration > self.MAX_CUMULATIVE_DURATION[self.reason]["duration"]
+        return cumulative_duration >= self.MAX_CUMULATIVE_DURATION[self.reason]["duration"]
 
     @staticmethod
     def get_max_end_at(start_at, reason=None):

--- a/itou/utils/validators.py
+++ b/itou/utils/validators.py
@@ -4,7 +4,7 @@ import re
 import html5lib
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
-from django.core.validators import RegexValidator
+from django.core.validators import MinValueValidator, RegexValidator
 from django.utils import timezone
 
 
@@ -123,3 +123,13 @@ def validate_html(html):
         html5lib.HTMLParser(strict=True).parseFragment(html)
     except html5lib.html5parser.ParseError as exc:
         raise ValidationError("HTML invalide.") from exc
+
+
+class MinDateValidator(MinValueValidator):
+    def __call__(self, value):
+        try:
+            super().__call__(value)
+        except ValidationError as e:
+            params = e.params.copy()
+            params["limit_value"] = f"{params['limit_value']:%d/%m/%Y}"
+            raise ValidationError(e.message, code=e.code, params=params) from e

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -172,6 +172,7 @@ class CreateProlongationForm(forms.ModelForm):
                     "approvals:prolongation_form_for_reason",
                     kwargs={"approval_id": self.instance.approval_id},
                 ),
+                "hx-params": "not end_at",  # Clear "end_at" when switching reason
                 "hx-swap": "outerHTML",
                 "hx-target": "#mainForm",
             }

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 
 from django import forms
 from django.core.exceptions import ValidationError
-from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db.models import Exists, OuterRef, Q
 from django.shortcuts import reverse
 from django.utils import timezone
@@ -17,6 +16,7 @@ from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import UserKind
 from itou.users.models import User
+from itou.utils.validators import MaxDateValidator, MinDateValidator
 from itou.utils.widgets import DuetDatePickerWidget
 
 
@@ -110,38 +110,38 @@ class CreateProlongationForm(forms.ModelForm):
             "max_duration": Prolongation.MAX_DURATION,
             "help_text": (
                 "Pour le CDI Inclusion, jusqu’à la retraite "
-                "(pour des raisons techniques, une durée de 10 ans est appliquée par défaut)."
+                "(pour des raisons techniques, une durée de 10 ans (3650 jours) est appliquée par défaut)."
             ),
         },
         ProlongationReason.COMPLETE_TRAINING: {
             "max_duration": timedelta(days=365),
             "help_text": format_html(
-                "12 mois maximum pour chaque demande.<br>"
+                "12 mois (365 jours) maximum pour chaque demande.<br> "
                 "Renouvellements possibles jusqu’à la fin de l’action de formation."
             ),
         },
         ProlongationReason.RQTH: {
             "max_duration": timedelta(days=365),
             "help_text": format_html(
-                "12 mois maximum pour chaque demande.<br>"
+                "12 mois (365 jours) maximum pour chaque demande.<br> "
                 "Renouvellements possibles dans la limite de 5 ans de parcours IAE "
-                "(2 ans de parcours initial + 3 ans)."
+                "(2 ans de parcours initial + 3 ans (1095 jours))."
             ),
         },
         ProlongationReason.SENIOR: {
             "max_duration": timedelta(days=365),
             "help_text": format_html(
-                "12 mois maximum pour chaque demande.<br>"
+                "12 mois (365 jours) maximum pour chaque demande.<br> "
                 "Renouvellements possibles dans la limite de 7 ans de parcours IAE "
-                "(2 ans de parcours initial + 5 ans)."
+                "(2 ans de parcours initial + 5 ans (1825 jours))."
             ),
         },
         ProlongationReason.PARTICULAR_DIFFICULTIES: {
             "max_duration": timedelta(days=365),
             "help_text": format_html(
-                "12 mois maximum pour chaque demande.<br>"
+                "12 mois (365 jours) maximum pour chaque demande.<br> "
                 "Renouvellements possibles dans la limite de 5 ans de parcours IAE "
-                "(2 ans de parcours initial + 3 ans)."
+                "(2 ans de parcours initial + 3 ans (1095 jours))."
             ),
         },
     }
@@ -199,9 +199,9 @@ class CreateProlongationForm(forms.ModelForm):
                 self.data = self.data.copy()
                 self.data["end_at"] = max_end_at
             end_at.widget.attrs["min"] = self.instance.start_at
-            end_at.validators.append(MinValueValidator(self.instance.start_at))
+            end_at.validators.append(MinDateValidator(self.instance.start_at))
             # Try switching reason with a date beyond the max_end_at of the new reason
-            end_at.validators.append(MaxValueValidator(max_end_at))
+            end_at.validators.append(MaxDateValidator(max_end_at))
 
 
 class CreateProlongationRequestForm(CreateProlongationForm):

--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -2,7 +2,6 @@ from dateutil.relativedelta import relativedelta
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.validators import MinValueValidator
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 
@@ -14,6 +13,7 @@ from itou.siae_evaluations.models import (
     EvaluationCampaign,
 )
 from itou.utils.types import InclusiveDateRange
+from itou.utils.validators import MinDateValidator
 from itou.utils.widgets import DuetDatePickerWidget
 
 
@@ -176,7 +176,7 @@ class InstitutionEvaluatedSiaeNotifyStep3Form(forms.Form):
         if TEMPORARY_SUSPENSION in sanctions:
             self.fields["temporary_suspension_from"] = forms.DateField(
                 label="À partir du",
-                validators=[MinValueValidator(sanction_start_date)],
+                validators=[MinDateValidator(sanction_start_date)],
                 widget=DuetDatePickerWidget(
                     attrs={
                         "aria-label": f"{SANCTION_CHOICES[TEMPORARY_SUSPENSION]} à partir du",
@@ -187,7 +187,7 @@ class InstitutionEvaluatedSiaeNotifyStep3Form(forms.Form):
             )
             self.fields["temporary_suspension_to"] = forms.DateField(
                 label="Jusqu’au",
-                validators=[MinValueValidator(sanction_start_date)],
+                validators=[MinDateValidator(sanction_start_date)],
                 widget=DuetDatePickerWidget(
                     attrs={
                         "aria-label": f"{SANCTION_CHOICES[TEMPORARY_SUSPENSION]} jusqu’au",
@@ -199,7 +199,7 @@ class InstitutionEvaluatedSiaeNotifyStep3Form(forms.Form):
         if PERMANENT_SUSPENSION in sanctions:
             self.fields["permanent_suspension"] = forms.DateField(
                 label="À partir du",
-                validators=[MinValueValidator(sanction_start_date)],
+                validators=[MinDateValidator(sanction_start_date)],
                 widget=DuetDatePickerWidget(
                     attrs={
                         "aria-label": f"{SANCTION_CHOICES[PERMANENT_SUSPENSION]} à partir du",

--- a/tests/approvals/__snapshots__/test_notifications.ambr
+++ b/tests/approvals/__snapshots__/test_notifications.ambr
@@ -15,7 +15,7 @@
   - Nom : Doe
   - Date de naissance : 01/01/2000
   - Début de la prolongation : 01/01/2000
-  - Fin de la prolongation : 30/12/2004
+  - Fin de la prolongation : 31/01/2000
   - Motif de prolongation : 50 ans et plus
   - Fiche bilan : https://None/None/f0r_5n4p5h07
   
@@ -69,7 +69,7 @@
   - Nom : Doe
   - Date de naissance : 01/01/2000
   - Début de la prolongation : 01/01/2000
-  - Fin de la prolongation : 30/12/2004
+  - Fin de la prolongation : 31/01/2000
   - Motif de prolongation : 50 ans et plus
   - Fiche bilan : https://None/None/f0r_5n4p5h07
   

--- a/tests/approvals/factories.py
+++ b/tests/approvals/factories.py
@@ -91,7 +91,7 @@ class BaseProlongationFactory(factory.django.DjangoModelFactory):
 
     approval = factory.SubFactory(ApprovalFactory)
     start_at = factory.Faker("date_between", start_date=factory.SelfAttribute("..approval.start_at"))
-    end_at = factory.LazyAttribute(lambda obj: Prolongation.get_max_end_at(obj.start_at, reason=obj.reason))
+    end_at = factory.LazyAttribute(lambda obj: obj.start_at + datetime.timedelta(days=30))
     reason = ProlongationReason.COMPLETE_TRAINING.value
     reason_explanation = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     declared_by = factory.LazyAttribute(lambda obj: obj.declared_by_siae.members.first())

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1558,8 +1558,10 @@ class ProlongationModelTest(TestCase):
             reason=ProlongationReason.COMPLETE_TRAINING.value,
         )
 
-        assert not prolongation.has_reached_max_cumulative_duration()
-        assert prolongation.has_reached_max_cumulative_duration(additional_duration=datetime.timedelta(days=1))
+        assert (
+            prolongation.has_reached_max_cumulative_duration(additional_duration=datetime.timedelta(days=-1)) is False
+        )
+        assert prolongation.has_reached_max_cumulative_duration() is True
 
     def test_has_reached_max_cumulative_duration_for_particular_difficulties(self):
         approval = ApprovalFactory()
@@ -1571,7 +1573,7 @@ class ProlongationModelTest(TestCase):
             reason=ProlongationReason.PARTICULAR_DIFFICULTIES.value,
         )
 
-        assert not prolongation1.has_reached_max_cumulative_duration()
+        assert prolongation1.has_reached_max_cumulative_duration() is False
 
         prolongation2 = ProlongationFactory(
             approval=approval,
@@ -1580,8 +1582,10 @@ class ProlongationModelTest(TestCase):
             reason=ProlongationReason.PARTICULAR_DIFFICULTIES.value,
         )
 
-        assert not prolongation2.has_reached_max_cumulative_duration()
-        assert prolongation2.has_reached_max_cumulative_duration(additional_duration=datetime.timedelta(days=1))
+        assert (
+            prolongation2.has_reached_max_cumulative_duration(additional_duration=datetime.timedelta(days=-1)) is False
+        )
+        assert prolongation2.has_reached_max_cumulative_duration() is True
 
 
 class ApprovalConcurrentModelTest(TransactionTestCase):

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1400,7 +1400,7 @@ class ProlongationModelTestTrigger(TestCase):
         approval_duration_2 = approval.duration
 
         # Edit prolongation to be shorter.
-        prolongation.end_at -= relativedelta(months=2)
+        prolongation.end_at -= relativedelta(days=2)
         prolongation.save()
         prolongation_duration_2 = prolongation.duration
         approval.refresh_from_db()

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1474,9 +1474,8 @@ class ProlongationModelTest(TestCase):
             (ProlongationReason.PARTICULAR_DIFFICULTIES, datetime.date(2024, 2, 1)),  # 1095 days (3 years).
             (ProlongationReason.HEALTH_CONTEXT, datetime.date(2022, 2, 1)),  # 365 days.
         ]:
-            # Cheap parametrize, to indicate what reason failed.
-            print(reason)
-            assert Prolongation.get_max_end_at(approval.pk, start_at, reason=reason) == expected_max_end_at
+            with self.subTest(reason):
+                assert Prolongation.get_max_end_at(approval.pk, start_at, reason=reason) == expected_max_end_at
 
     @freeze_time("2023-08-21")
     def test_year_after_year_prolongation(self):

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1467,7 +1467,7 @@ class ProlongationModelTest(TestCase):
         start_at = datetime.date(2021, 2, 1)
 
         reason = ProlongationReason.SENIOR_CDI
-        expected_max_end_at = datetime.date(2031, 1, 31)  # 10 years.
+        expected_max_end_at = datetime.date(2031, 1, 29)  # 10 years.
         max_end_at = Prolongation.get_max_end_at(start_at, reason=reason)
         assert max_end_at == expected_max_end_at
 
@@ -1482,7 +1482,7 @@ class ProlongationModelTest(TestCase):
         assert max_end_at == expected_max_end_at
 
         reason = ProlongationReason.SENIOR
-        expected_max_end_at = datetime.date(2026, 1, 31)  # 5 years.
+        expected_max_end_at = datetime.date(2026, 1, 30)  # 5 years.
         max_end_at = Prolongation.get_max_end_at(start_at, reason=reason)
         assert max_end_at == expected_max_end_at
 

--- a/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
@@ -5,13 +5,61 @@
 # name: ApprovalProlongationTest.test_check_multiple_prescriber_organization[prescriber is member of many organizations]
   '<div class="invalid-feedback">Ce champ est obligatoire.</div>'
 # ---
+# name: ApprovalProlongationTest.test_end_at_limits[COMPLETE_TRAINING]
+  '''
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois maximum pour chaque demande.Renouvellements possibles jusqu’à la fin de l’action de formation." value="2024-10-22"></duet-date-picker>
+      <small class="form-text text-muted">12 mois maximum pour chaque demande.<br/>Renouvellements possibles jusqu’à la fin de l’action de formation.</small>
+  
+  </div>
+  '''
+# ---
+# name: ApprovalProlongationTest.test_end_at_limits[PARTICULAR_DIFFICULTIES]
+  '''
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois maximum pour chaque demande.Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans)." value="2024-10-22"></duet-date-picker>
+      <small class="form-text text-muted">12 mois maximum pour chaque demande.<br/>Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans).</small>
+  
+  </div>
+  '''
+# ---
+# name: ApprovalProlongationTest.test_end_at_limits[RQTH]
+  '''
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois maximum pour chaque demande.Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans)." value="2024-10-22"></duet-date-picker>
+      <small class="form-text text-muted">12 mois maximum pour chaque demande.<br/>Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans).</small>
+  
+  </div>
+  '''
+# ---
+# name: ApprovalProlongationTest.test_end_at_limits[SENIOR]
+  '''
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois maximum pour chaque demande.Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans)." value="2024-10-22"></duet-date-picker>
+      <small class="form-text text-muted">12 mois maximum pour chaque demande.<br/>Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans).</small>
+  
+  </div>
+  '''
+# ---
+# name: ApprovalProlongationTest.test_end_at_limits[SENIOR_CDI]
+  '''
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2033-10-20" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans est appliquée par défaut)." value="2033-10-20"></duet-date-picker>
+      <small class="form-text text-muted">Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans est appliquée par défaut).</small>
+  
+  </div>
+  '''
+# ---
 # name: ApprovalProlongationTest.test_prolong_approval_view_no_end_at
   '''
-  <div class="form-group is-invalid form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="is-invalid" identifier="id_end_at" max="2033-10-21" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="Date jusqu'à laquelle le PASS IAE doit être prolongé (Durée maximum de 1 an renouvelable jusqu'à 5 ans).Au format JJ/MM/AAAA, par exemple 20/12/1978."></duet-date-picker>
+  <div class="form-group is-invalid form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="is-invalid" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois maximum pour chaque demande.Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans)."></duet-date-picker>
       <div class="invalid-feedback">Ce champ est obligatoire.</div>
   
   
-      <small class="form-text text-muted">Date jusqu'à laquelle le PASS IAE doit être prolongé <strong>(Durée maximum de 1 an renouvelable jusqu'à 5 ans)</strong>.<br/>Au format JJ/MM/AAAA, par exemple 20/12/1978.</small>
+      <small class="form-text text-muted">12 mois maximum pour chaque demande.<br/>Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans).</small>
+  
+  </div>
+  '''
+# ---
+# name: ApprovalProlongationTest.test_prolong_approval_view_prepopulates_SENIOR_CDI[value is set to max_end_at]
+  '''
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2033-10-20" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans est appliquée par défaut)." value="2033-10-20"></duet-date-picker>
+      <small class="form-text text-muted">Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans est appliquée par défaut).</small>
   
   </div>
   '''

--- a/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
@@ -7,59 +7,59 @@
 # ---
 # name: ApprovalProlongationTest.test_end_at_limits[COMPLETE_TRAINING]
   '''
-  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois maximum pour chaque demande.Renouvellements possibles jusqu’à la fin de l’action de formation." value="2024-10-22"></duet-date-picker>
-      <small class="form-text text-muted">12 mois maximum pour chaque demande.<br/>Renouvellements possibles jusqu’à la fin de l’action de formation.</small>
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois (365 jours) maximum pour chaque demande. Renouvellements possibles jusqu’à la fin de l’action de formation." value="2024-10-22"></duet-date-picker>
+      <small class="form-text text-muted">12 mois (365 jours) maximum pour chaque demande.<br/> Renouvellements possibles jusqu’à la fin de l’action de formation.</small>
   
   </div>
   '''
 # ---
 # name: ApprovalProlongationTest.test_end_at_limits[PARTICULAR_DIFFICULTIES]
   '''
-  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois maximum pour chaque demande.Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans)." value="2024-10-22"></duet-date-picker>
-      <small class="form-text text-muted">12 mois maximum pour chaque demande.<br/>Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans).</small>
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois (365 jours) maximum pour chaque demande. Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans (1095 jours))." value="2024-10-22"></duet-date-picker>
+      <small class="form-text text-muted">12 mois (365 jours) maximum pour chaque demande.<br/> Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans (1095 jours)).</small>
   
   </div>
   '''
 # ---
 # name: ApprovalProlongationTest.test_end_at_limits[RQTH]
   '''
-  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois maximum pour chaque demande.Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans)." value="2024-10-22"></duet-date-picker>
-      <small class="form-text text-muted">12 mois maximum pour chaque demande.<br/>Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans).</small>
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois (365 jours) maximum pour chaque demande. Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans (1095 jours))." value="2024-10-22"></duet-date-picker>
+      <small class="form-text text-muted">12 mois (365 jours) maximum pour chaque demande.<br/> Renouvellements possibles dans la limite de 5 ans de parcours IAE (2 ans de parcours initial + 3 ans (1095 jours)).</small>
   
   </div>
   '''
 # ---
 # name: ApprovalProlongationTest.test_end_at_limits[SENIOR]
   '''
-  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois maximum pour chaque demande.Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans)." value="2024-10-22"></duet-date-picker>
-      <small class="form-text text-muted">12 mois maximum pour chaque demande.<br/>Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans).</small>
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois (365 jours) maximum pour chaque demande. Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans (1825 jours))." value="2024-10-22"></duet-date-picker>
+      <small class="form-text text-muted">12 mois (365 jours) maximum pour chaque demande.<br/> Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans (1825 jours)).</small>
   
   </div>
   '''
 # ---
 # name: ApprovalProlongationTest.test_end_at_limits[SENIOR_CDI]
   '''
-  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2033-10-20" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans est appliquée par défaut)." value="2033-10-20"></duet-date-picker>
-      <small class="form-text text-muted">Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans est appliquée par défaut).</small>
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2033-10-20" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans (3650 jours) est appliquée par défaut)." value="2033-10-20"></duet-date-picker>
+      <small class="form-text text-muted">Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans (3650 jours) est appliquée par défaut).</small>
   
   </div>
   '''
 # ---
 # name: ApprovalProlongationTest.test_prolong_approval_view_no_end_at
   '''
-  <div class="form-group is-invalid form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="is-invalid" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois maximum pour chaque demande.Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans)."></duet-date-picker>
+  <div class="form-group is-invalid form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="is-invalid" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="12 mois (365 jours) maximum pour chaque demande. Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans (1825 jours))."></duet-date-picker>
       <div class="invalid-feedback">Ce champ est obligatoire.</div>
   
   
-      <small class="form-text text-muted">12 mois maximum pour chaque demande.<br/>Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans).</small>
+      <small class="form-text text-muted">12 mois (365 jours) maximum pour chaque demande.<br/> Renouvellements possibles dans la limite de 7 ans de parcours IAE (2 ans de parcours initial + 5 ans (1825 jours)).</small>
   
   </div>
   '''
 # ---
 # name: ApprovalProlongationTest.test_prolong_approval_view_prepopulates_SENIOR_CDI[value is set to max_end_at]
   '''
-  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2033-10-20" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans est appliquée par défaut)." value="2033-10-20"></duet-date-picker>
-      <small class="form-text text-muted">Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans est appliquée par défaut).</small>
+  <div class="form-group form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="" identifier="id_end_at" max="2033-10-20" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans (3650 jours) est appliquée par défaut)." value="2033-10-20"></duet-date-picker>
+      <small class="form-text text-muted">Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans (3650 jours) est appliquée par défaut).</small>
   
   </div>
   '''

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -55,9 +55,9 @@
   <div class="c-box mb-3 mb-lg-5">
                           <h2>Détail de la demande</h2>
                           <hr/>
-                          <h3>Date de fin de PASS IAE demandée : 30/12/2004</h3>
+                          <h3>Date de fin de PASS IAE demandée : 31/01/2000</h3>
                           <p>
-                              La prolongation est demandée pour une durée de 1825 jours.
+                              La prolongation est demandée pour une durée de 30 jours.
                           </p>
                           <h3>Motif sélectionné par l’employeur</h3>
                           <p>50 ans et plus</p>
@@ -120,7 +120,7 @@
       <div class="card-body">
           
               <div class="card-title">
-                  <h4>Prolongation du PASS IAE jusqu’au 30/12/2004</h4>
+                  <h4>Prolongation du PASS IAE jusqu’au 31/01/2000</h4>
               </div>
               <div class="card-text">
                   <p class="mb-2">
@@ -139,7 +139,7 @@
       <div class="card-body">
           
               <div class="card-title">
-                  <h4>Prolonger le PASS IAE jusqu’au 30/12/2004</h4>
+                  <h4>Prolonger le PASS IAE jusqu’au 31/01/2000</h4>
               </div>
               <div class="card-text">
                   <form method="post">

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -251,7 +251,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
                 response,
                 f"""
                 <div class="invalid-feedback">
-                    Assurez-vous que cette valeur est inférieure ou égale à {max_end_at.isoformat()}.
+                    Assurez-vous que cette valeur est inférieure ou égale à {max_end_at:%d/%m/%Y}.
                 </div>
                 """,
                 html=True,

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -8,7 +8,6 @@ from django.utils.http import urlencode
 from freezegun import freeze_time
 
 from itou.approvals.enums import ProlongationReason
-from itou.approvals.models import Prolongation
 from itou.siaes.enums import SiaeKind
 from itou.utils.storage.s3 import S3Upload
 from itou.utils.widgets import DuetDatePickerWidget
@@ -68,7 +67,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
 
         # Since December 1, 2021, health context reason can no longer be used
         reason = ProlongationReason.HEALTH_CONTEXT
-        end_at = Prolongation.get_max_end_at(self.approval.end_at, reason=reason)
+        end_at = self.approval.end_at + relativedelta(days=30)
         post_data = {
             "end_at": end_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
             "reason": reason,
@@ -82,7 +81,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
 
         # With valid reason
         reason = ProlongationReason.SENIOR
-        end_at = Prolongation.get_max_end_at(self.approval.end_at, reason=reason)
+        end_at = self.approval.end_at + relativedelta(days=30)
 
         post_data = {
             "end_at": end_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -197,7 +196,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
         assert response.context["preview"] is False
 
         reason = ProlongationReason.COMPLETE_TRAINING
-        end_at = Prolongation.get_max_end_at(self.approval.end_at, reason=reason)
+        end_at = self.approval.end_at + relativedelta(days=30)
 
         post_data = {
             "end_at": end_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -267,7 +266,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
         response = self.client.get(url)
 
         reason = ProlongationReason.RQTH
-        end_at = Prolongation.get_max_end_at(self.approval.end_at, reason=reason)
+        end_at = self.approval.end_at + relativedelta(days=30)
 
         post_data = {
             "end_at": end_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -298,7 +297,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
         response = self.client.get(url)
 
         reason = ProlongationReason.SENIOR
-        end_at = Prolongation.get_max_end_at(self.approval.end_at, reason=reason)
+        end_at = self.approval.end_at + relativedelta(days=30)
 
         post_data = {
             "end_at": end_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -333,7 +332,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
         self.client.get(url)
 
         reason = ProlongationReason.SENIOR
-        end_at = Prolongation.get_max_end_at(self.approval.end_at, reason=reason)
+        end_at = self.approval.end_at + relativedelta(days=30)
 
         post_data = {
             "end_at": end_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -360,7 +359,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
         self.client.get(url)
 
         reason = ProlongationReason.SENIOR
-        end_at = Prolongation.get_max_end_at(self.approval.end_at, reason=reason)
+        end_at = self.approval.end_at + relativedelta(days=30)
 
         post_data = {
             "end_at": end_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -389,7 +388,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
         self.client.get(url)
 
         reason = ProlongationReason.SENIOR
-        end_at = Prolongation.get_max_end_at(self.approval.end_at, reason=reason)
+        end_at = self.approval.end_at + relativedelta(days=30)
 
         post_data = {
             "end_at": end_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -413,7 +412,7 @@ class ApprovalProlongationTest(S3AccessingTestCase):
         response = self.client.get(url)
 
         reason = ProlongationReason.SENIOR
-        end_at = Prolongation.get_max_end_at(self.approval.end_at, reason=reason)
+        end_at = self.approval.end_at + relativedelta(days=30)
 
         post_data = {
             "end_at": end_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -2673,7 +2673,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
                                title=""
                                value="2022-11-20"></duet-date-picker>
               <div class="invalid-feedback">
-               Assurez-vous que cette valeur est supérieure ou égale à 2022-11-24.
+               Assurez-vous que cette valeur est supérieure ou égale à 24/11/2022.
               </div>
             </div>
             """,
@@ -2696,7 +2696,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
                                title=""
                                value="2022-11-20"></duet-date-picker>
               <div class="invalid-feedback">
-               Assurez-vous que cette valeur est supérieure ou égale à 2022-11-24.
+               Assurez-vous que cette valeur est supérieure ou égale à 24/11/2022.
               </div>
             </div>
             """,


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Prolongations-en-tant-qu-employeur-je-veux-comprendre-que-ma-prolongation-doit-se-faire-par-p-riod-1bfa9cc189414bccaec62abb49e62751**

### Pourquoi ?

Beaucoup de demandes de prolongation (pour motifs RQTH ou + de 50 ans + AI/ACI difficultés particulières) sont déposées pour 2, 3, 4 voire 5 ans d’un coup alors que le réglementaire indique “par prolongations successives de 12 mois”

Le support doit reprendre toutes ces demandes à la main pour aller modifier la demande de prolongation = perte de temps.