### PR TITLE
Metabase : Ajouter une colonne candidatures.parcours_de_création (reprise de stock AI)

### DIFF
--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -45,6 +45,7 @@ elif [[ "$1" == "--monthly" ]]; then
     django-admin populate_metabase_emplois --mode=insee_codes |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=insee_codes_vs_post_codes |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=departments |& tee -a "$OUTPUT_LOG"
+    django-admin populate_metabase_emplois --mode=enums |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=final_tables |& tee -a "$OUTPUT_LOG"
     django-admin send_slack_message ":white_check_mark: succès mise à jour de données peu fréquentes C1 -> Metabase"
 else

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -312,6 +312,8 @@ class Command(BaseCommand):
             .only(
                 "pk",
                 "created_at",
+                "hiring_start_at",
+                "origin",
                 "sender_kind",
                 "sender_siae__kind",
                 "sender_prescriber_organization__kind",

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -107,6 +107,7 @@ class Command(BaseCommand):
             "insee_codes": self.populate_insee_codes,
             "insee_codes_vs_post_codes": self.populate_insee_codes_vs_post_codes,
             "departments": self.populate_departments,
+            "enums": self.populate_enums,
             "final_tables": self.build_final_tables,
             "data_inconsistencies": self.report_data_inconsistencies,
         }
@@ -446,6 +447,16 @@ class Command(BaseCommand):
 
             rows.append(row)
 
+        df = get_df_from_rows(rows)
+        store_df(df=df, table_name=table_name)
+
+    def populate_enums(self):
+        # TODO(vperron,dejafait): This works as long as we don't have several table creations in the same call.
+        # If we someday want to create several tables, we will probably need to disable autocommit in our helper
+        # functions and make it manually at the end.
+        table_name = "c1_ref_origine_candidature"
+        self.stdout.write(f"Preparing content for {table_name} table...")
+        rows = [OrderedDict(code=str(item), label=item.label) for item in Origin]
         df = get_df_from_rows(rows)
         store_df(df=df, table_name=table_name)
 

--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -161,6 +161,15 @@ TABLE.add_columns(
             "fn": get_job_application_detailed_origin,
         },
         {
+            "name": "parcours_de_création",
+            "type": "varchar",
+            "comment": (
+                "Parcours de création de la candidature "
+                "(Normale, reprise de stock AI, import agrément PE, action support...)"
+            ),
+            "fn": lambda o: o.get_origin_display(),
+        },
+        {
             "name": "délai_prise_en_compte",
             "type": "interval",
             "comment": (
@@ -218,7 +227,7 @@ TABLE.add_columns(
             "name": "nom_complet_structure",
             "type": "varchar",
             "comment": "Nom complet de la structure destinaire de la candidature",
-            "fn": lambda o: f"{o.to_siae.kind} - ID {o.to_siae.id} - {o.to_siae.display_name}",
+            "fn": lambda o: f"{o.to_siae.kind} - ID {o.to_siae_id} - {o.to_siae.display_name}",
         },
     ]
 )

--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -167,7 +167,7 @@ TABLE.add_columns(
                 "Parcours de création de la candidature "
                 "(Normale, reprise de stock AI, import agrément PE, action support...)"
             ),
-            "fn": lambda o: o.get_origin_display(),
+            "fn": lambda o: o.origin,
         },
         {
             "name": "délai_prise_en_compte",


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Ajouter-une-colonne-candidatures-parcours_de_cr-ation-reprise-de-stock-AI-7726c410cb52499c88d4a5b2742be9f1**

### Pourquoi ?

Suite aux améliorations réalisées par Antoine on peut désormais savoir quel parcours de création à suivi une candidature (Normale, reprise de stock AI, import agrément PE, action support).

Il faut désormais créer une colonne `candidatures.parcours_de_création` afin que les merveilleux data analyst du C2 puissent l’exploiter, en particulier en ce qui concerne la fiabilisation des reprises de stock AI.


