### PR TITLE
HTML : Ne plus spécifier `type="submit"` pour les `<button>`

### DIFF
--- a/itou/static/js/s3_upload.js
+++ b/itou/static/js/s3_upload.js
@@ -27,9 +27,6 @@ window.s3UploadInit = function s3UploadInit({
   // When a file is added to the drop zone, send a POST request to this URL.
   const formUrl = formValues["url"];
 
-  // Submit button to be disabled during file processing
-  const submitButton = $("button[type='submit']");
-
   // S3 form params sent when a new file is added to the drop zone.
   const formParams = formValues["fields"];
 
@@ -79,6 +76,8 @@ window.s3UploadInit = function s3UploadInit({
   });
 
   const dropzone = existingDropzone ? existingDropzone : new Dropzone(dropzoneSelector, dropzoneConfig);
+  // Submit button to be disabled during file processing
+  const submitButton = $(":submit", $(myDropzoneElement).parents("form"));
 
   // Events
   dropzone.on("addedfile", function (file) {

--- a/itou/templates/account/email_confirm.html
+++ b/itou/templates/account/email_confirm.html
@@ -33,7 +33,7 @@
                             {% if request.GET.next %}<input type="hidden" name="next" value="{{ request.GET.next }}">{% endif %}
 
                             {% buttons %}
-                                <button type="submit" class="btn btn-primary">Confirmer</button>
+                                <button class="btn btn-primary">Confirmer</button>
                             {% endbuttons %}
 
                         </form>

--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -69,7 +69,7 @@
                             </fieldset>
                             <div class="form-row justify-content-end">
                                 <div class="form-group col-12 col-lg-auto">
-                                    {% bootstrap_button "Se connecter" button_type="submit" button_class="btn btn-block btn-primary" %}
+                                    {% bootstrap_button "Se connecter" button_class="btn btn-block btn-primary" %}
                                 </div>
                             </div>
                         </form>

--- a/itou/templates/account/login_job_seeker.html
+++ b/itou/templates/account/login_job_seeker.html
@@ -68,7 +68,7 @@
                             </fieldset>
                             <div class="form-row justify-content-end">
                                 <div class="form-group col-12 col-lg-auto">
-                                    {% bootstrap_button "Se connecter" button_type="submit" button_class="btn btn-primary btn-block" %}
+                                    {% bootstrap_button "Se connecter" button_class="btn btn-primary btn-block" %}
                                 </div>
                             </div>
                         </form>

--- a/itou/templates/account/logout.html
+++ b/itou/templates/account/logout.html
@@ -22,7 +22,7 @@
                             {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
 
                             {% buttons %}
-                                <button type="submit" class="btn btn-primary">Se déconnecter</button>
+                                <button class="btn btn-primary">Se déconnecter</button>
                             {% endbuttons %}
 
                         </form>

--- a/itou/templates/account/password_change.html
+++ b/itou/templates/account/password_change.html
@@ -27,7 +27,7 @@
 
                             {% buttons %}
                                 <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
-                                <button type="submit" class="btn btn-primary">Modifier le mot de passe</button>
+                                <button class="btn btn-primary">Modifier le mot de passe</button>
                             {% endbuttons %}
 
                         </form>

--- a/itou/templates/account/password_reset.html
+++ b/itou/templates/account/password_reset.html
@@ -27,7 +27,7 @@
                         {% bootstrap_form form alert_error_type="all" %}
 
                         {% buttons %}
-                            <button type="submit" class="btn btn-primary">Réinitialiser votre mot de passe</button>
+                            <button class="btn btn-primary">Réinitialiser votre mot de passe</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/account/password_reset_from_key.html
+++ b/itou/templates/account/password_reset_from_key.html
@@ -40,7 +40,7 @@
                                 {% bootstrap_field form.password2 %}
 
                                 {% buttons %}
-                                    <button type="submit" class="btn btn-primary">Modifier le mot de passe</button>
+                                    <button class="btn btn-primary">Modifier le mot de passe</button>
                                 {% endbuttons %}
 
                             </form>

--- a/itou/templates/apply/edit_contract_start_date.html
+++ b/itou/templates/apply/edit_contract_start_date.html
@@ -29,7 +29,7 @@
                                         <a class="btn btn-outline-primary" href="{{ prev_url }}" aria-label="Annuler la modification de la date de contrat">Annuler</a>
                                     </div>
                                     <div class="form-group mb-0 col-6 col-lg-auto">
-                                        <button type="submit" class="btn btn-block btn-primary" aria-label="Enregistrer la modification de la date de contrat">
+                                        <button class="btn btn-block btn-primary" aria-label="Enregistrer la modification de la date de contrat">
                                             Enregistrer
                                         </button>
                                     </div>

--- a/itou/templates/apply/includes/geiq/check_geiq_eligibility_form.html
+++ b/itou/templates/apply/includes/geiq/check_geiq_eligibility_form.html
@@ -32,7 +32,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-sm btn-outline-primary" data-dismiss="modal">Retour</button>
-                <button type="submit" class="btn btn-sm btn-primary">Confirmer</button>
+                <button class="btn btn-sm btn-primary">Confirmer</button>
             </div>
         </div>
     </div>

--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -33,7 +33,7 @@
         <hr>
         <h2>Embauche</h2>
         {% bootstrap_form_errors form_accept type="non_fields" %}
- 
+
         {# reloadable contract type and options for GEIQ #}
         {% if job_application.to_siae.kind == SiaeKind.GEIQ %}
             {% include "apply/includes/geiq/geiq_contract_type_and_options.html" %}
@@ -56,7 +56,7 @@
                     <a class="btn btn-block btn-outline-primary" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Retour</a>
                 </div>
                 <div class="form-group mb-0 col-6 col-lg-auto">
-                    <button type="submit" class="btn btn-ico btn-block btn-primary" aria-label="Valider l’embauche de {{ job_application.job_seeker.get_full_name|title|mask_unless:can_view_personal_information }}">
+                    <button class="btn btn-ico btn-block btn-primary" aria-label="Valider l’embauche de {{ job_application.job_seeker.get_full_name|title|mask_unless:can_view_personal_information }}">
                         <i class="ri-check-line ri-xl"></i>
                         <span>Valider l’embauche</span>
                     </button>

--- a/itou/templates/apply/includes/job_application_prior_action.html
+++ b/itou/templates/apply/includes/job_application_prior_action.html
@@ -43,7 +43,7 @@
                                 {% csrf_token %}
                                 <div class="text-right">
                                     <button class="btn btn-outline-primary btn-sm" data-dismiss="modal" aria-label="Annuler">Annuler</button>
-                                    <button type="submit" class="btn btn-danger btn-sm" aria-label="Supprimer">Supprimer</button>
+                                    <button class="btn btn-danger btn-sm" aria-label="Supprimer">Supprimer</button>
                                 </div>
                             </form>
                         </div>

--- a/itou/templates/apply/includes/job_application_prior_action_form.html
+++ b/itou/templates/apply/includes/job_application_prior_action_form.html
@@ -15,9 +15,7 @@
             {% bootstrap_form_errors form type='non_fields' %}
             <div class="text-right">
                 <button class="btn btn-secondary btn-sm" hx-get="{{ form_url }}">Annuler</button>
-                <button type="submit" class="btn btn-primary btn-sm editing-prior-action">
-                    Enregistrer l'action préalable à l'embauche
-                </button>
+                <button class="btn btn-primary btn-sm editing-prior-action">Enregistrer l'action préalable à l'embauche</button>
             </div>
         {% endif %}
     </form>

--- a/itou/templates/apply/includes/state_transition_siae.html
+++ b/itou/templates/apply/includes/state_transition_siae.html
@@ -8,7 +8,7 @@
             {% csrf_token %}
             {% buttons %}
                 <p class="text-right">
-                    <button type="submit" class="btn btn-primary">J'étudie cette candidature</button>
+                    <button class="btn btn-primary">J'étudie cette candidature</button>
                 </p>
             {% endbuttons %}
         </form>
@@ -60,7 +60,7 @@
                 {% if job_application.inverted_vae_contract %}associé à une VAE inversée{% endif %}
             </p>
         {% endif %}
- 
+
         <ul>
             <li>Début : {{ job_application.hiring_start_at|date:"d F Y" }}</li>
             <li>Fin : {{ job_application.hiring_end_at|date:"d F Y"|default:"Non renseigné" }}</li>

--- a/itou/templates/apply/includes/transfer_job_application.html
+++ b/itou/templates/apply/includes/transfer_job_application.html
@@ -50,7 +50,7 @@
                                     {% csrf_token %}
                                     <input type="hidden" name="target_siae_id" value="{{ siae.pk }}" />
                                     <input type="hidden" name="back_url" value="{{ back_url }}" />
-                                    <button type="submit" class="btn btn-primary">Confirmer</button>
+                                    <button class="btn btn-primary">Confirmer</button>
                                 </form>
                             </div>
                         </div>

--- a/itou/templates/apply/list_for_job_seeker.html
+++ b/itou/templates/apply/list_for_job_seeker.html
@@ -22,7 +22,7 @@
                                     {% include "apply/includes/job_applications_filters/statut.html" %}
                                     <hr>
                                     {% include "apply/includes/job_applications_filters/dates.html" %}
-                                    <button id="js-job-applications-filters-apply-button" type="submit" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
+                                    <button id="js-job-applications-filters-apply-button" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
                                         Appliquer
                                     </button>
                                 </div>

--- a/itou/templates/apply/list_for_prescriber.html
+++ b/itou/templates/apply/list_for_prescriber.html
@@ -40,7 +40,7 @@
                                     {% include "apply/includes/job_applications_filters/criteria.html" %}
                                     <hr>
                                     {% include "apply/includes/job_applications_filters/departments.html" %}
-                                    <button id="js-job-applications-filters-apply-button" type="submit" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
+                                    <button id="js-job-applications-filters-apply-button" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
                                         Appliquer
                                     </button>
                                 </div>

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -48,7 +48,7 @@
                                     {% include "apply/includes/job_applications_filters/selected_jobs.html" %}
                                     <hr>
                                     {% include "apply/includes/job_applications_filters/sender.html" %}
-                                    <button id="js-job-applications-filters-apply-button" type="submit" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
+                                    <button id="js-job-applications-filters-apply-button" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
                                         Appliquer
                                     </button>
                                 </div>

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -27,7 +27,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-outline-primary" data-dismiss="modal">Retour</button>
-                    <button type="submit" class="btn btn-primary" hx-post={{ request.path }} hx-vals='{"confirmed": "True"}' hx-include="#acceptForm">Confirmer
+                    <button class="btn btn-primary" hx-post={{ request.path }} hx-vals='{"confirmed": "True"}' hx-include="#acceptForm">Confirmer
                     </button>
                 </div>
             </div>

--- a/itou/templates/apply/process_cancel.html
+++ b/itou/templates/apply/process_cancel.html
@@ -32,7 +32,7 @@
                     <a class="btn btn-outline-primary btn-block" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Retour</a>
                 </div>
                 <div class="form-group mb-0 col-6 col-lg-auto">
-                    <button type="submit" class="btn btn-danger btn-block">Confirmer l'annulation de l'embauche</button>
+                    <button class="btn btn-danger btn-block">Confirmer l'annulation de l'embauche</button>
                 </div>
             </div>
         {% endbuttons %}

--- a/itou/templates/apply/process_postpone.html
+++ b/itou/templates/apply/process_postpone.html
@@ -17,7 +17,7 @@
                         <a class="btn btn-outline-primary btn-block" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Annuler</a>
                     </div>
                     <div class="form-group mb-0 col-6 col-lg-auto">
-                        <button type="submit" class="btn btn-block btn-success" aria-label="Mettre la candidature de {{ job_application.job_seeker.get_full_name|title|mask_unless:can_view_personal_information }} en liste d'attente">
+                        <button class="btn btn-block btn-success" aria-label="Mettre la candidature de {{ job_application.job_seeker.get_full_name|title|mask_unless:can_view_personal_information }} en liste d'attente">
                             Mettre en liste d'attente
                         </button>
                     </div>

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -49,7 +49,7 @@
                         <a class="btn btn-outline-primary btn-block" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Annuler</a>
                     </div>
                     <div class="form-group mb-0 col-6 col-lg-auto">
-                        <button type="submit" class="btn btn-block btn-danger">Confirmer le refus</button>
+                        <button class="btn btn-block btn-danger">Confirmer le refus</button>
                     </div>
                 </div>
             {% endbuttons %}

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -134,7 +134,7 @@
                                     {% endif %}
                                     {% block form_submit_button %}
                                         <div class="form-group mb-0 col-6 col-lg-auto">
-                                            <button type="submit" class="btn btn-primary btn-block" aria-label="Passer à l'étape suivante">Suivant</button>
+                                            <button class="btn btn-primary btn-block" aria-label="Passer à l'étape suivante">Suivant</button>
                                         </div>
                                     {% endblock %}
                                 </div>

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -89,7 +89,7 @@
                                     {% buttons %}
                                         <div class="text-right">
                                             <button type="reset" class="btn btn-link" data-swap-element=".c-form">Annuler</button>
-                                            <button type="submit" class="btn btn-primary">Enregistrer</button>
+                                            <button class="btn btn-primary">Enregistrer</button>
                                         </div>
                                     {% endbuttons %}
                                 </form>

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -249,8 +249,8 @@
 
 {% block form_submit_button %}
     {% if request.user.is_siae_staff %}
-        <button type="submit" class="btn btn-primary">Enregistrer</button>
+        <button class="btn btn-primary">Enregistrer</button>
     {% else %}
-        <button type="submit" class="btn btn-primary">Envoyer la candidature</button>
+        <button class="btn btn-primary">Envoyer la candidature</button>
     {% endif %}
 {% endblock %}

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
@@ -42,7 +42,7 @@
                     <div class="modal-footer">
                         <div class="row">
                             {# Go to the next step. #}
-                            <button type="submit" name="confirm" value="1" class="btn btn-sm btn-link">Poursuivre la création du compte</button>
+                            <button name="confirm" value="1" class="btn btn-sm btn-link">Poursuivre la création du compte</button>
                             {# Reload this page with a new form. #}
                             <a href="{{ back_url }}" class="btn btn-sm btn-primary">Modifier l'email du candidat</a>
                         </div>

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
@@ -71,7 +71,7 @@
                             {% buttons %}
                                 <div class="text-right">
                                     {% if back_url %}<a class="btn btn-link" href="{{ back_url }}">Retour</a>{% endif %}
-                                    <button type="submit" class="btn btn-primary">Suivant</button>
+                                    <button class="btn btn-primary">Suivant</button>
                                 </div>
                             {% endbuttons %}
                         </form>

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html
@@ -136,7 +136,7 @@
                             {% buttons %}
                                 <div class="text-right">
                                     <a class="btn btn-link" href="{{ back_url }}" aria-label="Retourner à l'étape précédente">Retour</a>
-                                    <button type="submit" class="btn btn-primary">Valider les informations</button>
+                                    <button class="btn btn-primary">Valider les informations</button>
                                 </div>
                             {% endbuttons %}
                         </form>

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -22,7 +22,7 @@
                         <div class="col">
                             <p class="mb-0">
                                 Vous possédez un numéro de sécurité sociale temporaire ?
-                                <button type="submit" name="skip" value="1" class="btn btn-link p-0 matomo-event" data-matomo-category="nir-temporaire" data-matomo-action="etape-suivante" data-matomo-option="candidature">
+                                <button name="skip" value="1" class="btn btn-link p-0 matomo-event" data-matomo-category="nir-temporaire" data-matomo-action="etape-suivante" data-matomo-option="candidature">
                                     Cliquez ici pour accéder à l'étape suivante.
                                 </button>
                             </p>
@@ -61,7 +61,7 @@
                         <a class="btn btn-link btn-block" aria-label="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
                     </div>
                     <div class="form-group mb-0 col-6 col-lg-auto">
-                        <button type="submit" name="preview" value="1" class="btn btn-primary btn-block">Suivant</button>
+                        <button name="preview" value="1" class="btn btn-primary btn-block">Suivant</button>
                     </div>
                 </div>
             {% endbuttons %}
@@ -88,9 +88,9 @@
                         <div class="modal-footer">
                             {% buttons %}
                                 {# Reload this page with a new form. #}
-                                <button type="submit" name="cancel" value="1" class="btn btn-sm btn-secondary">Ce n'est pas mon candidat</button>
+                                <button name="cancel" value="1" class="btn btn-sm btn-secondary">Ce n'est pas mon candidat</button>
                                 {# Go to the next step. #}
-                                <button type="submit" name="confirm" value="1" class="btn btn-sm btn-primary">Continuer</button>
+                                <button name="confirm" value="1" class="btn btn-sm btn-primary">Continuer</button>
                             {% endbuttons %}
                         </div>
                     </div>

--- a/itou/templates/apply/submit_step_check_prev_applications.html
+++ b/itou/templates/apply/submit_step_check_prev_applications.html
@@ -26,7 +26,7 @@
                     <a class="btn btn-outline-primary btn-block" href="{% url 'home:hp' %}">Annuler</a>
                 </div>
                 <div class="form-group mb-0 col-6 col-lg-auto">
-                    <button type="submit" class="btn btn-primary btn-block">Postuler à nouveau</button>
+                    <button class="btn btn-primary btn-block">Postuler à nouveau</button>
                 </div>
             </div>
         {% endbuttons %}

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -46,7 +46,7 @@
                     </div>
                     <div class="form-group mb-0 col-6 col-lg-auto">
                         {# Reload this page and show a modal containing more information about the job seeker. #}
-                        <button type="submit" name="preview" value="1" class="btn btn-primary btn-block" aria-label="Passer à l'étape suivante">
+                        <button name="preview" value="1" class="btn btn-primary btn-block" aria-label="Passer à l'étape suivante">
                             Suivant
                         </button>
                     </div>
@@ -83,9 +83,9 @@
                         <div class="modal-footer">
                             {% buttons %}
                                 {# Reload this page with a new form. #}
-                                <button type="submit" name="cancel" value="1" class="btn btn-sm btn-secondary">Ce n'est pas mon candidat</button>
+                                <button name="cancel" value="1" class="btn btn-sm btn-secondary">Ce n'est pas mon candidat</button>
                                 {# Go to the next step. #}
-                                <button type="submit" name="confirm" value="1" class="btn btn-sm btn-primary">Continuer</button>
+                                <button name="confirm" value="1" class="btn btn-sm btn-primary">Continuer</button>
                             {% endbuttons %}
                         </div>
                     </div>

--- a/itou/templates/apply/submit_step_job_seeker_check_info.html
+++ b/itou/templates/apply/submit_step_job_seeker_check_info.html
@@ -15,7 +15,7 @@
             <hr>
             <div class="form-row align-items-center justify-content-end">
                 <div class="form-group mb-0 col-12 col-lg-auto">
-                    <button type="submit" class="btn btn-primary btn-block">Continuer</button>
+                    <button class="btn btn-primary btn-block">Continuer</button>
                 </div>
             </div>
         {% endbuttons %}

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -67,9 +67,9 @@
                                 </p>
                                 {% buttons %}
                                     {# Allow the user to modify the prolongation: edit=1. #}
-                                    <button type="submit" name="edit" value="1" class="btn btn-secondary">Annuler</button>
+                                    <button name="edit" value="1" class="btn btn-secondary">Annuler</button>
                                     {# Create a prolongation: save=1. #}
-                                    <button type="submit" name="save" value="1" class="btn btn-primary">Confirmer la déclaration</button>
+                                    <button name="save" value="1" class="btn btn-primary">Confirmer la déclaration</button>
                                 {% endbuttons %}
                             </div>
                         </form>

--- a/itou/templates/approvals/includes/prolongation_declaration_form.html
+++ b/itou/templates/approvals/includes/prolongation_declaration_form.html
@@ -15,7 +15,7 @@
         <div class="text-right">
             <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
             {# Enable preview mode: preview=1. #}
-            <button type="submit" name="preview" value="1" class="btn btn-primary">Valider la déclaration</button>
+            <button name="preview" value="1" class="btn btn-primary">Valider la déclaration</button>
         </div>
     {% endbuttons %}
 </form>

--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -25,7 +25,7 @@
                                     {% include "approvals/includes/approvals_filters/users.html" %}
                                     <hr>
                                     {% include "approvals/includes/approvals_filters/status.html" %}
-                                    <button id="js-job-applications-filters-apply-button" type="submit" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
+                                    <button id="js-job-applications-filters-apply-button" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
                                         Appliquer
                                     </button>
                                 </div>

--- a/itou/templates/approvals/pe_approval_search.html
+++ b/itou/templates/approvals/pe_approval_search.html
@@ -33,7 +33,7 @@
                         {% bootstrap_form form alert_error_type="all" %}
 
                         {% buttons %}
-                            <button type="submit" class="btn btn-primary">Rechercher</button>
+                            <button class="btn btn-primary">Rechercher</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/approvals/pe_approval_search_user.html
+++ b/itou/templates/approvals/pe_approval_search_user.html
@@ -23,7 +23,7 @@
                         <div>{% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}</div>
 
                         {% buttons %}
-                            <button type="submit" class="btn btn-primary">Continuer</button>
+                            <button class="btn btn-primary">Continuer</button>
                         {% endbuttons %}
                     </form>
                 </div>

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -54,7 +54,7 @@
                                 {% buttons %}
                                     <a class="btn btn-outline-primary" href="{{ back_url }}" aria-label="Retour à l'étape précédente">Retour</a>
                                     {# Enable preview mode: preview=1. #}
-                                    <button type="submit" name="preview" value="1" class="btn btn-primary" aria-label="Valider la suspension du PASS IAE de {{ approval.user.get_full_name }}">
+                                    <button name="preview" value="1" class="btn btn-primary" aria-label="Valider la suspension du PASS IAE de {{ approval.user.get_full_name }}">
                                         Valider la suspension
                                     </button>
                                 {% endbuttons %}
@@ -97,11 +97,11 @@
                                     </p>
                                     {% buttons %}
                                         {# Allow the user to modify the suspension: edit=1. #}
-                                        <button type="submit" name="edit" value="1" class="btn btn-secondary" aria-label="Annuler la suspension du PASS IAE de {{ approval.user.get_full_name }}">
+                                        <button name="edit" value="1" class="btn btn-secondary" aria-label="Annuler la suspension du PASS IAE de {{ approval.user.get_full_name }}">
                                             Annuler
                                         </button>
                                         {# Create a suspension: save=1. #}
-                                        <button type="submit" name="save" value="1" class="btn btn-primary" aria-label="Confirmer la suspension du PASS IAE de {{ approval.user.get_full_name }}">
+                                        <button name="save" value="1" class="btn btn-primary" aria-label="Confirmer la suspension du PASS IAE de {{ approval.user.get_full_name }}">
                                             Confirmer la suspension
                                         </button>
                                     {% endbuttons %}

--- a/itou/templates/approvals/suspension_delete.html
+++ b/itou/templates/approvals/suspension_delete.html
@@ -37,7 +37,7 @@
 
                         {% buttons %}
                             <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
-                            <button type="submit" class="btn btn-danger">Confirmer l'annulation de la suspension</button>
+                            <button class="btn btn-danger">Confirmer l'annulation de la suspension</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/approvals/suspension_update.html
+++ b/itou/templates/approvals/suspension_update.html
@@ -26,7 +26,7 @@
 
                         {% buttons %}
                             <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
-                            <button type="submit" class="btn btn-primary">Valider</button>
+                            <button class="btn btn-primary">Valider</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/dashboard/edit_user_email.html
+++ b/itou/templates/dashboard/edit_user_email.html
@@ -26,7 +26,7 @@
                             {% bootstrap_form form alert_error_type="all" %}
 
                             <div class="text-right">
-                                <button type="submit" class="btn btn-primary">Enregistrer</button>
+                                <button class="btn btn-primary">Enregistrer</button>
                             </div>
                         </form>
                     </div>

--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -63,7 +63,7 @@
                                         {% buttons %}
                                             <div class="text-right mb-4">
                                                 <a class="btn btn-link" href="{{ prev_url }}">Annuler</a>
-                                                <button type="submit" class="btn btn-primary">Enregistrer et quitter</button>
+                                                <button class="btn btn-primary">Enregistrer et quitter</button>
                                             </div>
                                         {% endbuttons %}
                                     </form>

--- a/itou/templates/dashboard/edit_user_notifications.html
+++ b/itou/templates/dashboard/edit_user_notifications.html
@@ -24,7 +24,7 @@
 
                             {% buttons %}
                                 <a class="btn btn-outline-primary" href="{{ back_url }}">Annuler</a>
-                                <button type="submit" class="btn btn-primary">Enregistrer</button>
+                                <button class="btn btn-primary">Enregistrer</button>
                             {% endbuttons %}
 
                         </form>

--- a/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
+++ b/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
@@ -31,7 +31,7 @@
     {% buttons %}
         <div class="text-right mb-4">
             <a class="btn btn-link" href="{{ prev_url }}">Annuler</a>
-            <button type="submit" class="btn btn-primary">{{ submit_label }}</button>
+            <button class="btn btn-primary">{{ submit_label }}</button>
         </div>
     {% endbuttons %}
 

--- a/itou/templates/eligibility/includes/form.html
+++ b/itou/templates/eligibility/includes/form.html
@@ -45,7 +45,7 @@
                 </div>
             {% endif %}
             <div class="form-group mb-0 col-6 col-lg-auto">
-                <button type="submit" class="btn btn-primary btn-block">Valider</button>
+                <button class="btn btn-primary btn-block">Valider</button>
             </div>
         </div>
     {% endbuttons %}

--- a/itou/templates/employee_record/disable.html
+++ b/itou/templates/employee_record/disable.html
@@ -48,7 +48,7 @@
                         <input type="hidden" name="confirm" value="true">
                         {% buttons %}
                             <a class="btn btn-outline-primary" href="{% url "employee_record_views:list" %}?status={{ employee_record.status }}">Retour à la liste</a>
-                            <button type="submit" class="btn btn-danger">Confirmer la désactivation</button>
+                            <button class="btn btn-danger">Confirmer la désactivation</button>
                         {% endbuttons %}
                     </form>
                 </div>

--- a/itou/templates/employee_record/includes/create_step_1.html
+++ b/itou/templates/employee_record/includes/create_step_1.html
@@ -37,7 +37,7 @@
                                 </a>
                             </div>
                             <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
-                                <button type="submit" class="btn btn-block btn-ico btn-primary" aria-label="Passer à l'étape suivante">
+                                <button class="btn btn-block btn-ico btn-primary" aria-label="Passer à l'étape suivante">
                                     <span>Étape suivante</span>
                                     <i class="ri-arrow-right-line ri-lg"></i>
                                 </button>

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -86,7 +86,7 @@
                 </fieldset>
                 <div class="form-row">
                     <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                        <button type="submit" class="btn btn-outline-primary">Valider cette adresse</button>
+                        <button class="btn btn-outline-primary">Valider cette adresse</button>
                     </div>
                 </div>
                 <div class="row">

--- a/itou/templates/employee_record/includes/create_step_3.html
+++ b/itou/templates/employee_record/includes/create_step_3.html
@@ -80,7 +80,7 @@
                                 </a>
                             </div>
                             <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
-                                <button type="submit" class="btn btn-block btn-ico btn-primary" aria-label="Passer à l'étape suivante">
+                                <button class="btn btn-block btn-ico btn-primary" aria-label="Passer à l'étape suivante">
                                     <span>Étape suivante</span>
                                     <i class="ri-arrow-right-line ri-lg"></i>
                                 </button>

--- a/itou/templates/employee_record/includes/create_step_4.html
+++ b/itou/templates/employee_record/includes/create_step_4.html
@@ -24,7 +24,7 @@
                                 </a>
                             </div>
                             <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
-                                <button type="submit" class="btn btn-block btn-ico btn-primary" aria-label="Passer à l'étape suivante">
+                                <button class="btn btn-block btn-ico btn-primary" aria-label="Passer à l'étape suivante">
                                     <span>Étape suivante</span>
                                     <i class="ri-arrow-right-line ri-lg"></i>
                                 </button>

--- a/itou/templates/employee_record/includes/create_step_5.html
+++ b/itou/templates/employee_record/includes/create_step_5.html
@@ -35,7 +35,7 @@
                                 </a>
                             </div>
                             <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
-                                <button type="submit" class="btn btn-block btn-ico btn-primary">
+                                <button class="btn btn-block btn-ico btn-primary">
                                     <span>Valider la fiche salarié</span>
                                     <i class="ri-arrow-right-line ri-lg"></i>
                                 </button>

--- a/itou/templates/employee_record/reactivate.html
+++ b/itou/templates/employee_record/reactivate.html
@@ -48,7 +48,7 @@
                         <input type="hidden" name="confirm" value="true">
                         {% buttons %}
                             <a class="btn btn-outline-primary" href="{% url "employee_record_views:list" %}?status={{ employee_record.status }}">Retour à la liste</a>
-                            <button type="submit" class="btn btn-danger">Confirmer la réactivation</button>
+                            <button class="btn btn-danger">Confirmer la réactivation</button>
                         {% endbuttons %}
                     </form>
                 </div>

--- a/itou/templates/hijack/notification.html
+++ b/itou/templates/hijack/notification.html
@@ -13,7 +13,7 @@
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ request.path }}">
             <button id="hide-btn" class="djhj-button" type="button">{% trans 'hide' %}</button>
-            <button class="djhj-button" type="submit">{% trans 'release' %}</button>
+            <button class="djhj-button">{% trans 'release' %}</button>
         </form>
     </div>
 </div>

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -49,7 +49,7 @@
                                             </a>
                                         </div>
                                         <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                            <button type="submit" class="btn btn-ico btn-block btn-primary">
+                                            <button class="btn btn-ico btn-block btn-primary">
                                                 <i class="ri-send-plane-line ri-lg"></i>
                                                 <span>Envoyer</span>
                                             </button>

--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -35,7 +35,7 @@
                             {% for s in user_siaes %}
                                 {% if s.pk != current_siae.pk %}
                                     <li>
-                                        <button class="dropdown-item font-weight-bold" type="submit" name="siae_id" value="{{ s.pk }}">
+                                        <button class="dropdown-item font-weight-bold" name="siae_id" value="{{ s.pk }}">
                                             <span class="badge badge-pill badge-xs badge-primary mr-1">{{ s.kind }}</span>
                                             {{ s.display_name|truncatechars:50 }}
                                         </button>
@@ -59,7 +59,7 @@
                             {% for po in user_prescriberorganizations %}
                                 {% if po.pk != current_prescriber_organization.pk %}
                                     <li>
-                                        <button class="dropdown-item font-weight-bold" type="submit" name="prescriber_organization_id" value="{{ po.pk }}">
+                                        <button class="dropdown-item font-weight-bold" name="prescriber_organization_id" value="{{ po.pk }}">
                                             <span class="badge badge-pill badge-xs badge-primary mr-1">{{ po.kind }}</span>
                                             {{ po.display_name|truncatechars:50 }}
                                         </button>
@@ -84,7 +84,7 @@
                             {% for i in user_institutions %}
                                 {% if i.pk != current_institution.pk %}
                                     <li>
-                                        <button class="dropdown-item font-weight-bold" type="submit" name="institution_id" value="{{ i.pk }}">
+                                        <button class="dropdown-item font-weight-bold" name="institution_id" value="{{ i.pk }}">
                                             <span class="badge badge-xs badge-pill badge-primary mr-1">{{ i.kind }}</span>
                                             {{ i.display_name|truncatechars:50 }}
                                         </button>

--- a/itou/templates/prescribers/edit_organization.html
+++ b/itou/templates/prescribers/edit_organization.html
@@ -31,7 +31,7 @@
 
                         {% buttons %}
                             <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
-                            <button type="submit" class="btn btn-primary">Enregistrer</button>
+                            <button class="btn btn-primary">Enregistrer</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/search/includes/prescribers_search_form.html
+++ b/itou/templates/search/includes/prescribers_search_form.html
@@ -21,6 +21,6 @@
         </div>
     </div>
     <div class="col-12 col-md-3 col-lg-2 mb-2 pl-md-3">
-        <button type="submit" class="btn btn-primary form-control js-search-button" aria-label="Rechercher">Rechercher</button>
+        <button class="btn btn-primary form-control js-search-button" aria-label="Rechercher">Rechercher</button>
     </div>
 </div>

--- a/itou/templates/search/includes/siaes_search_form.html
+++ b/itou/templates/search/includes/siaes_search_form.html
@@ -22,6 +22,6 @@
         </div>
     </div>
     <div class="col-12 col-md-3 col-lg-2 mb-2 pl-md-3">
-        <button type="submit" class="btn btn-primary btn-block js-search-button" aria-label="Rechercher">Rechercher</button>
+        <button class="btn btn-primary btn-block js-search-button" aria-label="Rechercher">Rechercher</button>
     </div>
 </div>

--- a/itou/templates/siae_evaluations/includes/criteria_form.html
+++ b/itou/templates/siae_evaluations/includes/criteria_form.html
@@ -30,6 +30,6 @@
     {% endif %}
 
     {% buttons %}
-        <button type="submit" class="btn btn-primary float-right">Enregistrer ce(s) critère(s)</button>
+        <button class="btn btn-primary float-right">Enregistrer ce(s) critère(s)</button>
     {% endbuttons %}
 </form>

--- a/itou/templates/siae_evaluations/institution_evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_job_application.html
@@ -37,8 +37,7 @@
 
                                                     {% bootstrap_form form alert_error_type="all" %}
                                                     {% with evaluated_job_application_state=evaluated_job_application.compute_state %}
-                                                        <button type="submit"
-                                                                class="btn {% if evaluated_job_application_state == 'ACCEPTED' or evaluated_job_application_state == 'REFUSED' or evaluated_job_application_state == 'REFUSED_2' %}btn-primary {% else %}btn-outline-primary {% endif %}float-right">
+                                                        <button class="btn {% if evaluated_job_application_state == 'ACCEPTED' or evaluated_job_application_state == 'REFUSED' or evaluated_job_application_state == 'REFUSED_2' %}btn-primary {% else %}btn-outline-primary {% endif %}float-right">
                                                             Enregistrer le commentaire et retourner à la liste des auto-prescriptions
                                                         </button>
                                                     {% endwith %}

--- a/itou/templates/siae_evaluations/samples_selection.html
+++ b/itou/templates/siae_evaluations/samples_selection.html
@@ -86,7 +86,7 @@
                                     </div>
 
                                     {% buttons %}
-                                        <button type="submit" class="btn btn-primary float-right">Valider</button>
+                                        <button class="btn btn-primary float-right">Valider</button>
                                     {% endbuttons %}
                                 </form>
                             {% endif %}

--- a/itou/templates/siae_evaluations/siae_upload_doc.html
+++ b/itou/templates/siae_evaluations/siae_upload_doc.html
@@ -65,7 +65,7 @@
                                             </div>
                                         </div>
 
-                                        <button type="submit" class="btn btn-primary float-right">
+                                        <button class="btn btn-primary float-right">
                                             {% if evaluated_administrative_criteria.proof_url %}
                                                 Enregistrer le nouveau justificatif
                                             {% else %}

--- a/itou/templates/siaes/create_siae.html
+++ b/itou/templates/siaes/create_siae.html
@@ -53,7 +53,7 @@
                             {% buttons %}
                                 <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
 
-                                <button type="submit" class="btn btn-primary">Enregistrer</button>
+                                <button class="btn btn-primary">Enregistrer</button>
                             {% endbuttons %}
                         </form>
                     </div>

--- a/itou/templates/siaes/edit_job_description.html
+++ b/itou/templates/siaes/edit_job_description.html
@@ -62,7 +62,7 @@
                             {% buttons %}
                                 <div class="pt-3 text-right">
                                     <a class="btn btn-outline-primary" href="{% url "siaes_views:job_description_list" %}" aria-label="Retour à la liste des métiers">Retour</a>
-                                    <button type="submit" class="btn btn-primary" aria-label="Passer à l'étape suivante">Suivant</button>
+                                    <button class="btn btn-primary" aria-label="Passer à l'étape suivante">Suivant</button>
                                 </div>
                             {% endbuttons %}
                         </form>

--- a/itou/templates/siaes/edit_job_description_details.html
+++ b/itou/templates/siaes/edit_job_description_details.html
@@ -82,7 +82,7 @@
                             {% buttons %}
                                 <div class="pt-3 text-right">
                                     <a class="btn btn-outline-primary" href="{% url "siaes_views:edit_job_description" %}" aria-label="Retour à la page précédente">Retour</a>
-                                    <button type="submit" class="btn btn-primary" aria-label="Passer à l'étape suivante">Suivant</button>
+                                    <button class="btn btn-primary" aria-label="Passer à l'étape suivante">Suivant</button>
                                 </div>
                             {% endbuttons %}
                         </form>

--- a/itou/templates/siaes/edit_job_description_preview.html
+++ b/itou/templates/siaes/edit_job_description_preview.html
@@ -48,7 +48,7 @@
                             {% buttons %}
                                 <div class="text-right">
                                     <a class="btn btn-outline-primary" aria-label="Retour à la page précédente" href="{% url "siaes_views:edit_job_description_details" %}">Retour</a>
-                                    <button type="submit" class="btn btn-primary" aria-label="Publier la fiche de poste">Publier la fiche de poste</button>
+                                    <button class="btn btn-primary" aria-label="Publier la fiche de poste">Publier la fiche de poste</button>
                                 </div>
                             {% endbuttons %}
                         </form>

--- a/itou/templates/siaes/edit_siae.html
+++ b/itou/templates/siaes/edit_siae.html
@@ -73,9 +73,7 @@
                                     <a class="btn btn-link" aria-label="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
                                 </div>
                                 <div class="col-6 col-lg-auto">
-                                    <button type="submit" aria-label="Vers l'étape suivante du formulaire" class="btn float-right btn-primary">
-                                        Suivant
-                                    </button>
+                                    <button aria-label="Vers l'étape suivante du formulaire" class="btn float-right btn-primary">Suivant</button>
                                 </div>
                             </div>
                         </form>

--- a/itou/templates/siaes/edit_siae_description.html
+++ b/itou/templates/siaes/edit_siae_description.html
@@ -81,9 +81,7 @@
                                     <a class="btn btn-link" aria-label="Retourner à l'édition des coordonnées" href="{{ prev_url }}">Retour</a>
                                 </div>
                                 <div class="col-6 col-lg-auto">
-                                    <button type="submit"  aria-label="Vers l'étape suivante du formulaire"  class="btn float-right btn-primary">
-                                        Suivant
-                                    </button>
+                                    <button aria-label="Vers l'étape suivante du formulaire"  class="btn float-right btn-primary">Suivant</button>
                                 </div>
                             </div>
 

--- a/itou/templates/siaes/edit_siae_preview.html
+++ b/itou/templates/siaes/edit_siae_preview.html
@@ -112,7 +112,7 @@
                                     <a class="btn btn-link" aria-label="Retourner à l'édition de la description" href="{{ prev_url }}">Retour</a>
                                 </div>
                                 <div class="col-6 col-lg-auto">
-                                    <button type="submit" aria-label="Publier le formulaire" class="btn btn-primary float-right">Publier</button>
+                                    <button aria-label="Publier le formulaire" class="btn btn-primary float-right">Publier</button>
                                 </div>
                             </div>
                         </form>

--- a/itou/templates/siaes/job_description_list.html
+++ b/itou/templates/siaes/job_description_list.html
@@ -113,7 +113,7 @@
                                                                         {% csrf_token %}
                                                                         <input type="hidden" name="job_description_id" value="{{ job_description.id }}" />
                                                                         <button class="btn btn-outline-primary btn-sm" data-dismiss="modal" aria-label="Annuler">Annuler</button>
-                                                                        <button type="submit" class="btn btn-primary btn-sm" aria-label="Supprimer">Supprimer</button>
+                                                                        <button class="btn btn-primary btn-sm" aria-label="Supprimer">Supprimer</button>
                                                                     </form>
                                                                 </div>
                                                             </div>

--- a/itou/templates/siaes/select_financial_annex.html
+++ b/itou/templates/siaes/select_financial_annex.html
@@ -22,7 +22,7 @@
                         {% bootstrap_field select_form.financial_annexes %}
 
                         {% buttons %}
-                            <button type="submit" class="btn btn-primary">Continuer</button>
+                            <button class="btn btn-primary">Continuer</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/signup/facilitator_search.html
+++ b/itou/templates/signup/facilitator_search.html
@@ -45,9 +45,7 @@
                                 <a class="btn btn-link" aria-label="Retourner à l'édition des coordonnées" href="{{ prev_url }}">Retour</a>
                             </div>
                             <div class="col-6 col-lg-auto">
-                                <button type="submit"  aria-label="Rechercher une entreprise par SIRET"  class="btn float-right btn-primary">
-                                    Suivant
-                                </button>
+                                <button aria-label="Rechercher une entreprise par SIRET"  class="btn float-right btn-primary">Suivant</button>
                             </div>
                         </div>
 

--- a/itou/templates/signup/includes/submit_rgpd.html
+++ b/itou/templates/signup/includes/submit_rgpd.html
@@ -20,5 +20,5 @@
     </p>
 </div>
 {% buttons %}
-    <button type="submit" class="btn btn-primary">Inscription</button>
+    <button class="btn btn-primary">Inscription</button>
 {% endbuttons %}

--- a/itou/templates/signup/job_seeker_nir.html
+++ b/itou/templates/signup/job_seeker_nir.html
@@ -29,14 +29,14 @@
                             {% if form.errors %}
                                 <div class="alert alert-info">
                                     Vous possédez un numéro de sécurité sociale temporaire ?
-                                    <button type="submit" name="skip" value="1" class="btn btn-link p-0 matomo-event" data-matomo-category="nir-temporaire" data-matomo-action="etape-suivante" data-matomo-option="inscription">
+                                    <button name="skip" value="1" class="btn btn-link p-0 matomo-event" data-matomo-category="nir-temporaire" data-matomo-action="etape-suivante" data-matomo-option="inscription">
                                         Cliquez ici pour accéder à l'étape suivante.
                                     </button>
                                 </div>
                             {% endif %}
 
                             {% buttons %}
-                                <button type="submit" class="btn btn-primary">Suivant</button>
+                                <button class="btn btn-primary">Suivant</button>
                             {% endbuttons %}
 
                         </form>

--- a/itou/templates/signup/job_seeker_situation.html
+++ b/itou/templates/signup/job_seeker_situation.html
@@ -25,7 +25,7 @@
                             {% bootstrap_form form alert_error_type="all" %}
 
                             {% buttons %}
-                                <button type="submit" class="btn btn-primary">Continuer</button>
+                                <button class="btn btn-primary">Continuer</button>
                             {% endbuttons %}
 
                         </form>

--- a/itou/templates/signup/prescriber_check_already_exists.html
+++ b/itou/templates/signup/prescriber_check_already_exists.html
@@ -27,7 +27,7 @@
                         {% bootstrap_form form alert_error_type="all" %}
 
                         {% buttons %}
-                            <button type="submit" class="btn btn-primary">Rechercher</button>
+                            <button class="btn btn-primary">Rechercher</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/signup/prescriber_check_pe_email.html
+++ b/itou/templates/signup/prescriber_check_pe_email.html
@@ -29,7 +29,7 @@
 
                         {% buttons %}
                             <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            <button type="submit" class="btn btn-primary">Continuer</button>
+                            <button class="btn btn-primary">Continuer</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -35,7 +35,7 @@
 
                         {% buttons %}
                             <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            <button type="submit" class="btn btn-primary">Continuer</button>
+                            <button class="btn btn-primary">Continuer</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/signup/prescriber_choose_org.html
+++ b/itou/templates/signup/prescriber_choose_org.html
@@ -28,7 +28,7 @@
 
                         {% buttons %}
                             <a class="btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            <button type="submit" class="btn btn-primary">Continuer</button>
+                            <button class="btn btn-primary">Continuer</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/signup/prescriber_confirm_authorization.html
+++ b/itou/templates/signup/prescriber_confirm_authorization.html
@@ -26,7 +26,7 @@
 
                         {% buttons %}
                             <a class="btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            <button type="submit" class="btn btn-primary">Continuer</button>
+                            <button class="btn btn-primary">Continuer</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/signup/prescriber_is_pole_emploi.html
+++ b/itou/templates/signup/prescriber_is_pole_emploi.html
@@ -23,7 +23,7 @@
                         {% bootstrap_form form alert_error_type="all" %}
 
                         {% buttons %}
-                            <button type="submit" class="btn btn-primary">Continuer</button>
+                            <button class="btn btn-primary">Continuer</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/signup/prescriber_pole_emploi_safir_code.html
+++ b/itou/templates/signup/prescriber_pole_emploi_safir_code.html
@@ -24,7 +24,7 @@
 
                         {% buttons %}
                             <a class="btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            <button type="submit" class="btn btn-primary">Continuer</button>
+                            <button class="btn btn-primary">Continuer</button>
                         {% endbuttons %}
 
                     </form>

--- a/itou/templates/signup/prescriber_request_invitation.html
+++ b/itou/templates/signup/prescriber_request_invitation.html
@@ -29,7 +29,7 @@
 
                         {% buttons %}
                             <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            <button type="submit" class="btn btn-primary">Valider la demande</button>
+                            <button class="btn btn-primary">Valider la demande</button>
                         {% endbuttons %}
                     </form>
                 </div>

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -23,7 +23,7 @@
 
                         <div class="text-right">
                             {% buttons %}
-                                <button type="submit" class="btn btn-primary">Rechercher</button>
+                                <button class="btn btn-primary">Rechercher</button>
                             {% endbuttons %}
                         </div>
 
@@ -107,7 +107,7 @@
                                 </p>
                                 <div class="text-right">
                                     {% buttons %}
-                                        <button type="submit" class="btn btn-primary">Envoyer ma demande de validation</button>
+                                        <button class="btn btn-primary">Envoyer ma demande de validation</button>
                                     {% endbuttons %}
                                 </div>
                             </form>

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -2344,10 +2344,7 @@ def test_detect_existing_job_seeker(client):
     )
     assertContains(
         response,
-        (
-            '<button type="submit" name="confirm" value="1" class="btn btn-sm btn-link">'
-            "Poursuivre la création du compte</button>"
-        ),
+        '<button name="confirm" value="1" class="btn btn-sm btn-link">' "Poursuivre la création du compte</button>",
         html=True,
     )
     check_email_url = reverse(

--- a/tests/www/prescribers_views/__snapshots__/test_edit.ambr
+++ b/tests/www/prescribers_views/__snapshots__/test_edit.ambr
@@ -243,7 +243,7 @@
   
                           <div class="form-group">
                               <a class="btn btn-outline-primary" href="/dashboard/">Annuler</a>
-                              <button class="btn btn-primary" type="submit">Enregistrer</button>
+                              <button class="btn btn-primary">Enregistrer</button>
                           </div>
   
                       </form>

--- a/tests/www/signup/test_job_seeker.py
+++ b/tests/www/signup/test_job_seeker.py
@@ -184,7 +184,7 @@ class JobSeekerSignupTest(TestCase):
         url = reverse("signup:job_seeker")
         response = self.client.get(url)
         assert response.status_code == 200
-        self.assertContains(response, '<button type="submit" class="btn btn-primary">Inscription</button>', html=True)
+        self.assertContains(response, '<button class="btn btn-primary">Inscription</button>', html=True)
 
         address_line_1 = "Test adresse"
         address_line_2 = "Test adresse complémentaire"


### PR DESCRIPTION
### Pourquoi ?

Changement peu important mais rapide à faire et ça permet de réduire le nombre d'attributs donc normalement d'améliorer la lisibilité :).