### PR TITLE
Correction de la date de début des prolongations

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1105,10 +1105,11 @@ class CommonProlongation(models.Model):
             raise ValidationError("Cet utilisateur n'est pas un prescripteur habilité.")
 
         # Avoid blocking updates in admin by limiting this check to only new instances.
-        if not self.pk and self.start_at != self.approval.end_at:
+        expected_start = self.approval.end_at + datetime.timedelta(days=1)
+        if not self.pk and self.start_at != expected_start:
             raise ValidationError(
-                "La date de début doit être la même que la date de fin du PASS IAE "
-                f"« {self.approval.end_at.strftime('%d/%m/%Y')} »."
+                "La date de début doit suivre immédiatement la date de fin du PASS IAE "
+                f"« {expected_start.strftime('%d/%m/%Y')} »."
             )
 
         if self.has_reached_max_cumulative_duration(additional_duration=self.duration):

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django import forms
 from django.core.exceptions import ValidationError
 from django.db.models import Exists, OuterRef, Q
@@ -120,7 +122,8 @@ class CreateProlongationForm(forms.ModelForm):
             self.instance.approval = approval
             self.instance.declared_by_siae = siae
             # `start_at` should begin just after the approval. It cannot be set by the user.
-            self.instance.start_at = self.instance.approval.end_at
+            # Approval.end_at is inclusive.
+            self.instance.start_at = self.instance.approval.end_at + timedelta(days=1)
             self.instance.end_at = None
 
         # Customize "reason" field

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1461,7 +1461,7 @@ class ProlongationModelTest(TestCase):
 
         with pytest.raises(ValidationError) as error:
             prolongation.clean()
-        assert "La date de début doit être la même que la date de fin du PASS IAE" in error.value.message
+        assert "La date de début doit suivre immédiatement la date de fin du PASS IAE" in error.value.message
 
     def test_clean_with_no_end_at(self):
         """


### PR DESCRIPTION
### Pourquoi ?

`Approval.end_at` est inclusive, la prolongation demarre le jour suivant.