### PR TITLE
Suppression d’une vérification doublon sur Prolongation.end_at

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1072,7 +1072,8 @@ class CommonProlongation(models.Model):
 
     def clean(self):
         if not self.end_at:
-            raise ValidationError({"end_at": "La date de fin de prolongation est obligatoire."})
+            # Model.clean() is called by ModelForm.clean(), even if the form is invalid.
+            return
 
         # Min duration == 1 day.
         if self.end_at <= self.start_at:

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -100,7 +100,6 @@ class CreateProlongationForm(forms.ModelForm):
         widget=forms.RadioSelect(),
     )
     end_at = forms.DateField(
-        required=False,  # Checked by model clean(), avoid double validation message
         initial=None,
         widget=DuetDatePickerWidget(),
     )

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -99,10 +99,7 @@ class CreateProlongationForm(forms.ModelForm):
         initial=None,  # Uncheck radio buttons.
         widget=forms.RadioSelect(),
     )
-    end_at = forms.DateField(
-        initial=None,
-        widget=DuetDatePickerWidget(),
-    )
+    end_at = forms.DateField(widget=DuetDatePickerWidget())
 
     class Meta:
         model = Prolongation

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1463,22 +1463,6 @@ class ProlongationModelTest(TestCase):
             prolongation.clean()
         assert "La date de début doit être la même que la date de fin du PASS IAE" in error.value.message
 
-    def test_clean_with_no_end_at(self):
-        """
-        Checking `end_at` emptyness is now in clean model method, and not in forms anymore
-        to ensure single validation message (and more robust / cleaner btw).
-        """
-        approval = ApprovalFactory()
-        siae = SiaeFactory(with_membership=True)
-        start_at = approval.end_at - relativedelta(days=2)
-
-        # build: no need to save the prolongation
-        prolongation = ProlongationFactory.build(
-            start_at=start_at, end_at=None, approval=approval, declared_by_siae=siae
-        )
-        with pytest.raises(ValidationError, match="La date de fin de prolongation est obligatoire."):
-            prolongation.clean()
-
     def test_get_max_end_at(self):
         start_at = datetime.date(2021, 2, 1)
 

--- a/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
@@ -5,3 +5,14 @@
 # name: ApprovalProlongationTest.test_check_multiple_prescriber_organization[prescriber is member of many organizations]
   '<div class="invalid-feedback">Ce champ est obligatoire.</div>'
 # ---
+# name: ApprovalProlongationTest.test_prolong_approval_view_no_end_at
+  '''
+  <div class="form-group is-invalid form-group-required"><label for="id_end_at">Du 23/10/2023 au</label><duet-date-picker class="is-invalid" identifier="id_end_at" max="2033-10-21" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" title="Date jusqu'à laquelle le PASS IAE doit être prolongé (Durée maximum de 1 an renouvelable jusqu'à 5 ans).Au format JJ/MM/AAAA, par exemple 20/12/1978."></duet-date-picker>
+      <div class="invalid-feedback">Ce champ est obligatoire.</div>
+  
+  
+      <small class="form-text text-muted">Date jusqu'à laquelle le PASS IAE doit être prolongé <strong>(Durée maximum de 1 an renouvelable jusqu'à 5 ans)</strong>.<br/>Au format JJ/MM/AAAA, par exemple 20/12/1978.</small>
+  
+  </div>
+  '''
+# ---

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -135,6 +135,20 @@ class ApprovalProlongationTest(S3AccessingTestCase):
         )
         self.assertNotContains(response, self.MAX_DURATION_TEXT)
 
+    def test_prolong_approval_view_no_end_at(self):
+        self.client.force_login(self.siae_user)
+        response = self.client.post(
+            reverse("approvals:declare_prolongation", kwargs={"approval_id": self.approval.pk}),
+            {
+                # end_at is missing.
+                "reason": ProlongationReason.SENIOR,
+                "email": self.prescriber.email,
+            },
+        )
+        soup = parse_response_to_soup(response)
+        [end_at_field] = soup.select("[name=end_at]")
+        assert str(end_at_field.parent) == self.snapshot()
+
     @freeze_time()
     def test_htmx_on_reason(self):
         self.client.force_login(self.siae_user)


### PR DESCRIPTION
### Pourquoi ?

`prolongation.end_at` n’est pas _nullable_.