### PR TITLE
Parcours de candidature GEIQ: sauvegarde du niveau de qualification

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -566,6 +566,7 @@ class AcceptForm(forms.ModelForm):
             "contract_type_details",
             "nb_hours_per_week",
             "hiring_start_at",
+            "qualification_level",
             "qualification_type",
             "planned_training_hours",
             "hiring_end_at",

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -291,6 +291,8 @@ class JobApplicationAcceptFormWithGEIQFieldsTest(TestCase):
         assert job_application.contract_type == post_data["contract_type"]
         assert job_application.contract_type_details == post_data["contract_type_details"]
         assert job_application.nb_hours_per_week == post_data["nb_hours_per_week"]
+        assert job_application.qualification_level == post_data["qualification_level"]
+        assert job_application.qualification_type == post_data["qualification_type"]
         assert not job_application.inverted_vae_contract
 
     def test_geiq_inverted_vae_fields(self):


### PR DESCRIPTION
### Pourquoi ?

Petit oubli dans le `Meta` du form.

