### PR TITLE
job_applications: Add the job seeker title in exports

### DIFF
--- a/itou/job_applications/export.py
+++ b/itou/job_applications/export.py
@@ -1,8 +1,10 @@
 from itou.job_applications.enums import SenderKind
+from itou.users.enums import Title
 from itou.utils.export import to_streaming_response
 
 
 JOB_APPLICATION_CSV_HEADERS = [
+    "Civilité candidat",
     "Nom candidat",
     "Prénom candidat",
     "Email candidat",
@@ -78,6 +80,17 @@ def _get_readable_sender_kind(job_application):
     return kind
 
 
+def _resolve_title(title, nir):
+    if title:
+        return title
+    if nir:
+        return {
+            "1": Title.M,
+            "2": Title.MME,
+        }[nir[0]]
+    return ""
+
+
 def _serialize_job_application(job_application):
     job_seeker = job_application.job_seeker
     siae = job_application.to_siae
@@ -92,6 +105,7 @@ def _serialize_job_application(job_application):
         approval_end_date = approval.end_at
 
     return [
+        _resolve_title(job_seeker.title, job_seeker.nir),
         job_seeker.last_name,
         job_seeker.first_name,
         job_seeker.email,


### PR DESCRIPTION

**[Carte Notion](https://www.notion.so/plateforme-inclusion/Ajouter-la-civilit-du-candidat-dans-le-fichier-des-exports-de-candidatures-bf07f5590fda4b6b913e0b8c08579ecf)**

### Pourquoi ?
Permettre de partager cette info en particulier à RDVI qui en a besoin et les traite manuellement pour l'instant.

Sans promesse que la donnée soit dispo, mais on donne ce qu'on a : titre déclaré et si dispo, info depuis le NIR (dans cet ordre).

### Comment
- 781 480 candidats
- 322 048 (41%) ont ET un titre, et un NIR renseigné (obligatoire depuis un certain temps)
- 221 089 ont un NIR mais pas de civilité
-  54 952 ont une civilité mais pas de NIR
- 183 391 (23%) n'ont ni NIR, ni civilité 

Dans 76% des cas nous aurons donc une civilité à proposer.

En outre, le titre déclaré et celui proposé par le NIR est différent dans 1705 cas sur 322 048 (soit 0.5% des cas)



