### PR TITLE
Utiliser le format français pour les dates dans les messages d’erreur

### DIFF
--- a/itou/utils/validators.py
+++ b/itou/utils/validators.py
@@ -4,7 +4,7 @@ import re
 import html5lib
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
-from django.core.validators import RegexValidator
+from django.core.validators import MinValueValidator, RegexValidator
 from django.utils import timezone
 
 
@@ -123,3 +123,13 @@ def validate_html(html):
         html5lib.HTMLParser(strict=True).parseFragment(html)
     except html5lib.html5parser.ParseError as exc:
         raise ValidationError("HTML invalide.") from exc
+
+
+class MinDateValidator(MinValueValidator):
+    def __call__(self, value):
+        try:
+            super().__call__(value)
+        except ValidationError as e:
+            params = e.params.copy()
+            params["limit_value"] = f"{params['limit_value']:%d/%m/%Y}"
+            raise ValidationError(e.message, code=e.code, params=params) from e

--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -2,7 +2,6 @@ from dateutil.relativedelta import relativedelta
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.validators import MinValueValidator
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 
@@ -14,6 +13,7 @@ from itou.siae_evaluations.models import (
     EvaluationCampaign,
 )
 from itou.utils.types import InclusiveDateRange
+from itou.utils.validators import MinDateValidator
 from itou.utils.widgets import DuetDatePickerWidget
 
 
@@ -176,7 +176,7 @@ class InstitutionEvaluatedSiaeNotifyStep3Form(forms.Form):
         if TEMPORARY_SUSPENSION in sanctions:
             self.fields["temporary_suspension_from"] = forms.DateField(
                 label="À partir du",
-                validators=[MinValueValidator(sanction_start_date)],
+                validators=[MinDateValidator(sanction_start_date)],
                 widget=DuetDatePickerWidget(
                     attrs={
                         "aria-label": f"{SANCTION_CHOICES[TEMPORARY_SUSPENSION]} à partir du",
@@ -187,7 +187,7 @@ class InstitutionEvaluatedSiaeNotifyStep3Form(forms.Form):
             )
             self.fields["temporary_suspension_to"] = forms.DateField(
                 label="Jusqu’au",
-                validators=[MinValueValidator(sanction_start_date)],
+                validators=[MinDateValidator(sanction_start_date)],
                 widget=DuetDatePickerWidget(
                     attrs={
                         "aria-label": f"{SANCTION_CHOICES[TEMPORARY_SUSPENSION]} jusqu’au",
@@ -199,7 +199,7 @@ class InstitutionEvaluatedSiaeNotifyStep3Form(forms.Form):
         if PERMANENT_SUSPENSION in sanctions:
             self.fields["permanent_suspension"] = forms.DateField(
                 label="À partir du",
-                validators=[MinValueValidator(sanction_start_date)],
+                validators=[MinDateValidator(sanction_start_date)],
                 widget=DuetDatePickerWidget(
                     attrs={
                         "aria-label": f"{SANCTION_CHOICES[PERMANENT_SUSPENSION]} à partir du",

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -2673,7 +2673,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
                                title=""
                                value="2022-11-20"></duet-date-picker>
               <div class="invalid-feedback">
-               Assurez-vous que cette valeur est supérieure ou égale à 2022-11-24.
+               Assurez-vous que cette valeur est supérieure ou égale à 24/11/2022.
               </div>
             </div>
             """,
@@ -2696,7 +2696,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
                                title=""
                                value="2022-11-20"></duet-date-picker>
               <div class="invalid-feedback">
-               Assurez-vous que cette valeur est supérieure ou égale à 2022-11-24.
+               Assurez-vous que cette valeur est supérieure ou égale à 24/11/2022.
               </div>
             </div>
             """,


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/format-date-en-anglais-dans-le-texte-d-erreur-dsl-pas-vu-au-1er-tour-c5e085ab35db4314882c31b475099ff1**

### Pourquoi ?

Clarté pour les utilisateurs.