### PR TITLE
Docker : MAJ de Debian et quelques améliorations au passage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     build:
       context: .
       dockerfile: ./docker/dev/postgres/Dockerfile
+      args:
+        PG_MAJOR: 14
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - postgres_data_backups:/backups
@@ -48,6 +50,11 @@ services:
     build:
       context: .
       dockerfile: ./docker/dev/django/Dockerfile
+      args:
+        APP_USER: app
+        APP_DIR: /app
+        PYTHON_VERSION: 3.11
+        PG_MAJOR: 14
     volumes:
       # Mount the current directory into `/app` inside the running container.
       - .:/app

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,5 +1,11 @@
+ARG PYTHON_VERSION
+
 # Debian Buster slim variant.
-FROM python:3.11-slim-buster
+FROM python:$PYTHON_VERSION-slim-buster
+
+ARG APP_USER
+ARG APP_DIR
+ARG PG_MAJOR
 
 # Inspiration
 # https://github.com/azavea/docker-django/blob/1ef366/Dockerfile-slim.template
@@ -11,12 +17,10 @@ ENV PYTHONUNBUFFERED=1
 # https://www.andreagrandi.it/2018/10/16/using-ipdb-with-python-37-breakpoint/
 ENV PYTHONBREAKPOINT=ipdb.set_trace
 
-ENV APP_DIR="/app"
-
 # Add new user to run the whole thing as non-root.
 RUN set -ex \
-    && addgroup app \
-    && adduser --ingroup app --home $APP_DIR --disabled-password app;
+    && addgroup $APP_USER \
+    && adduser --ingroup $APP_USER --home $APP_DIR --disabled-password $APP_USER;
 
 RUN set -ex; \
     if ! command -v gpg > /dev/null; then \
@@ -41,8 +45,6 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME"; \
     apt-key list;
 
-ENV PG_MAJOR="14"
-
 # Add PostgreSQL's repository. It contains the most recent stable release.
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list
 
@@ -65,11 +67,11 @@ RUN pip install --upgrade pip \
     && pip install psycopg[binary] --no-binary psycopg[binary] \
     && rm -rf /requirements
 
-COPY --chown=app:app ./docker/dev/django/entrypoint.sh /entrypoint.sh
+COPY --chown=$APP_USER:$APP_USER ./docker/dev/django/entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
-USER app
+USER $APP_USER
 
 WORKDIR $APP_DIR
 

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -25,7 +25,6 @@ RUN set -ex \
 RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-      gnupg \
       curl \
       lsb-release \
     ; \
@@ -33,10 +32,10 @@ RUN set -ex; \
 
 
 # Add the PostgreSQL key to verify their Debian packages.
-RUN curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc --output /etc/apt/keyrings/postgresql.asc --create-dirs
 
 # Add PostgreSQL's repository. It contains the most recent stable release.
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_VERSION
 
-# Debian Buster slim variant.
-FROM python:$PYTHON_VERSION-slim-buster
+# https://hub.docker.com/_/python
+FROM python:$PYTHON_VERSION-slim
 
 ARG APP_USER
 ARG APP_DIR

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -35,7 +35,6 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     libpq-dev \
     gdal-bin \
-    gettext \
     git \
     postgresql-client-$PG_MAJOR \
     jq \

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -17,11 +17,7 @@ ENV PYTHONUNBUFFERED=1
 # https://www.andreagrandi.it/2018/10/16/using-ipdb-with-python-37-breakpoint/
 ENV PYTHONBREAKPOINT=ipdb.set_trace
 
-# Add new user to run the whole thing as non-root.
-RUN set -ex \
-    && addgroup $APP_USER \
-    && adduser --ingroup $APP_USER --home $APP_DIR --disabled-password $APP_USER;
-
+# Install tools to setup the PostgreSQL reposity
 RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
@@ -29,14 +25,12 @@ RUN set -ex; \
       lsb-release \
     ; \
     rm -rf /var/lib/apt/lists/*;
-
-
 # Add the PostgreSQL key to verify their Debian packages.
 RUN curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc --output /etc/apt/keyrings/postgresql.asc --create-dirs
-
 # Add PostgreSQL's repository. It contains the most recent stable release.
 RUN echo "deb [signed-by=/etc/apt/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
+# Install system dependancies
 RUN apt-get update && apt-get install -y \
     build-essential \
     libpq-dev \
@@ -48,7 +42,7 @@ RUN apt-get update && apt-get install -y \
     moreutils \
     --no-install-recommends
 
-# Requirements are installed here to ensure they will be cached.
+# Install python dependancies
 COPY ./requirements /requirements
 RUN pip install --upgrade pip \
     && pip install --no-cache-dir -r /requirements/dev.txt \
@@ -56,10 +50,15 @@ RUN pip install --upgrade pip \
     && pip install psycopg[binary] --no-binary psycopg[binary] \
     && rm -rf /requirements
 
+# Add new user to run the whole thing as non-root.
+RUN set -ex \
+    && addgroup $APP_USER \
+    && adduser --ingroup $APP_USER --home $APP_DIR --disabled-password $APP_USER;
+
+# Setup the entrypoint
 COPY --chown=$APP_USER:$APP_USER --chmod=755 ./docker/dev/django/entrypoint.sh /entrypoint.sh
-
-USER $APP_USER
-
-WORKDIR $APP_DIR
-
 ENTRYPOINT ["/entrypoint.sh"]
+
+# Don't use root as default user
+USER $APP_USER
+WORKDIR $APP_DIR

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -23,30 +23,20 @@ RUN set -ex \
     && adduser --ingroup $APP_USER --home $APP_DIR --disabled-password $APP_USER;
 
 RUN set -ex; \
-    if ! command -v gpg > /dev/null; then \
-        apt-get update; \
-        apt-get install -y --no-install-recommends \
-            gnupg \
-            dirmngr \
-        ; \
-        rm -rf /var/lib/apt/lists/*; \
-    fi
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      gnupg \
+      curl \
+      lsb-release \
+    ; \
+    rm -rf /var/lib/apt/lists/*;
 
-# Add the PostgreSQL PGP key to verify their Debian packages.
-RUN set -ex; \
-# pub   4096R/ACCC4CF8 2011-10-13 [expires: 2019-07-02]
-#       Key fingerprint = B97B 0AFC AA1A 47F0 44F2  44A0 7FCC 7D46 ACCC 4CF8
-# uid                  PostgreSQL Debian Repository
-    key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
-    export GNUPGHOME="$(mktemp -d)"; \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-    gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
-    command -v gpgconf > /dev/null && gpgconf --kill all; \
-    rm -rf "$GNUPGHOME"; \
-    apt-key list;
+
+# Add the PostgreSQL key to verify their Debian packages.
+RUN curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 # Add PostgreSQL's repository. It contains the most recent stable release.
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,7 +1,6 @@
 # Debian Buster slim variant.
 FROM python:3.11-slim-buster
 
-ENV DOCKER_DEFAULT_PLATFORM=linux/amd64
 # Inspiration
 # https://github.com/azavea/docker-django/blob/1ef366/Dockerfile-slim.template
 # https://github.com/docker-library/postgres/blob/9d8e24/11/Dockerfile

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -57,9 +57,7 @@ RUN pip install --upgrade pip \
     && pip install psycopg[binary] --no-binary psycopg[binary] \
     && rm -rf /requirements
 
-COPY --chown=$APP_USER:$APP_USER ./docker/dev/django/entrypoint.sh /entrypoint.sh
-
-RUN chmod +x /entrypoint.sh
+COPY --chown=$APP_USER:$APP_USER --chmod=755 ./docker/dev/django/entrypoint.sh /entrypoint.sh
 
 USER $APP_USER
 

--- a/docker/dev/postgres/Dockerfile
+++ b/docker/dev/postgres/Dockerfile
@@ -1,5 +1,7 @@
+ARG PG_MAJOR
+
 # https://registry.hub.docker.com/r/postgis/postgis
-FROM postgis/postgis:14-master
+FROM postgis/postgis:$PG_MAJOR-master
 
 COPY ./docker/dev/postgres/maintenance /tmp/maintenance
 


### PR DESCRIPTION
### Pourquoi ?

Debian buster ne sera bientôt plus du tout maintenu : https://www.debian.org/releases/buster/.

Je n'ai pas eu de problème particulier de mon coté mais a tester pour ceux qui utilisent MacOS ;).