### PR TITLE
Optimisation de requêtes entre le middleware & le context processor

### DIFF
--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -1,6 +1,3 @@
-from django.core.exceptions import PermissionDenied
-from django.urls import reverse
-
 from itou.users.enums import IdentityProvider
 from itou.utils import constants as global_constants
 
@@ -24,8 +21,6 @@ def get_current_organization_and_perms(request):
 
         if siae_pk:
             extra_context, extra_matomo_context = get_context_siae(request.user, siae_pk)
-            if "current_siae" not in extra_context and request.path != reverse("account_logout"):
-                raise PermissionDenied
 
         if prescriber_org_pk:
             extra_context, extra_matomo_context = get_context_prescriber(request.user, prescriber_org_pk)

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -2,10 +2,6 @@ from itou.users.enums import IdentityProvider
 from itou.utils import constants as global_constants
 
 
-def join_keys_str(collection):
-    return ";".join(str(o.pk) for o in collection)
-
-
 def sort_organizations(collection):
     return sorted(collection, key=lambda o: (o.kind, o.display_name))
 

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -3,7 +3,7 @@ from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils import safestring
+from django.utils.html import format_html
 
 from itou.users.enums import IdentityProvider, UserKind
 from itou.utils import constants as global_constants
@@ -109,7 +109,7 @@ class ItouCurrentOrganizationMiddleware:
                     # SIAE user has no active SIAE and thus must not be able to access any page,
                     # thus we force a logout with a few exceptions (cf skip_middleware_conditions)
                     if not active_memberships:
-                        message = (
+                        message = format_html(
                             "Nous sommes désolés, votre compte n'est "
                             "actuellement rattaché à aucune structure.<br>"
                             "Nous espérons cependant avoir l'occasion de vous accueillir de "
@@ -124,7 +124,6 @@ class ItouCurrentOrganizationMiddleware:
                             "avoir l'occasion de vous accueillir de "
                             "nouveau."
                         )
-                    message = safestring.mark_safe(message)
                     messages.warning(request, message)
                     return redirect("account_logout")
 
@@ -154,13 +153,12 @@ class ItouCurrentOrganizationMiddleware:
                     global_constants.ITOU_SESSION_CURRENT_INSTITUTION_KEY,
                 )
                 if not request.current_organization and request.path != reverse("account_logout"):
-                    message = (
+                    message = format_html(
                         "Nous sommes désolés, votre compte n'est "
                         "actuellement rattaché à aucune structure.<br>"
                         "Nous espérons cependant avoir l'occasion de vous accueillir de "
                         "nouveau."
                     )
-                    message = safestring.mark_safe(message)
                     messages.warning(request, message)
                     return redirect("account_logout")
 

--- a/itou/utils/perms/prescriber.py
+++ b/itou/utils/perms/prescriber.py
@@ -20,7 +20,7 @@ def get_all_available_job_applications_as_prescriber(request):
     """
     from itou.job_applications.models import JobApplication
 
-    if request.user.is_prescriber_with_org:
+    if request.current_organization and request.user.is_prescriber:  # Set by middleware for prescriber users
         prescriber_organization = get_current_org_or_404(request)
         # Show all applications organization-wide + applications sent by the
         # current user for backward compatibility (in the past, a user could

--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -22,12 +22,16 @@ class Message(NamedTuple):
 LEVEL_TO_NAME = {intlevel: name for name, intlevel in DEFAULT_LEVELS.items()}
 
 
-def assertMessages(response: HttpResponse, expected_messages: list[Message]):
-    request_messages = get_messages(response.wsgi_request)
+def assertMessagesFromRequest(request, expected_messages: list[Message]):
+    request_messages = get_messages(request)
     for message, (expected_level, expected_msg) in zip(request_messages, expected_messages, strict=True):
         msg_levelname = LEVEL_TO_NAME.get(message.level, message.level)
         expected_levelname = LEVEL_TO_NAME.get(expected_level, expected_level)
         assert (msg_levelname, message.message) == (expected_levelname, expected_msg)
+
+
+def assertMessages(response: HttpResponse, expected_messages: list[Message]):
+    assertMessagesFromRequest(response.wsgi_request, expected_messages)
 
 
 def pprint_html(response, **selectors):

--- a/tests/www/apply/test_list.py
+++ b/tests/www/apply/test_list.py
@@ -870,10 +870,11 @@ def test_list_for_unauthorized_prescriber_view(client):
         + 1  # get list of senders (distinct sender_id)
         + 1  # get list of job seekers (distinct job_seeker_id)
         + 1  # get list of administrative criteria
-        + 3  # get list of job application + prefetch of job descriptions + prefetch of approvals
-        + 1  # get list of siaes (distinct)
+        + 2  # get list of job application + prefetch of job descriptions
+        + 1  # get list of siaes (distinct to_siae_id)
         + 3  # count, list & prefetch of job application
-        + 1  # check user membership again
+        + 1  # get job seekers approvals
+        + 1  # check user authorized membership (can_edit_personal_information)
         + 3  # update session
     ):
         response = client.get(url)

--- a/tests/www/apply/test_list.py
+++ b/tests/www/apply/test_list.py
@@ -237,7 +237,6 @@ class ProcessListSiaeTest(ProcessListTest):
             + 1  # manually prefetch administrative_criteria
             #
             # Render template:
-            + 1  # context processor: user siae membership
             # 9 job applications (1 per state in JobApplicationWorkflow + 1 sent by prescriber)
             # 22 requests, maggie has a diagnosis made by a prescriber in this test
             + 1  # jobapp1: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
@@ -866,7 +865,7 @@ def test_list_for_unauthorized_prescriber_view(client):
         BASE_NUM_QUERIES
         + 1  # fetch django session
         + 1  # fetch user
-        + 1  # check for membeship
+        + 1  # fetch user memberships
         + 1  # get list of senders (distinct sender_id)
         + 1  # get list of job seekers (distinct job_seeker_id)
         + 1  # get list of administrative criteria

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -115,7 +115,7 @@ class TestApprovalDetailView:
             + 1  # select latest approval for user (can_be_prolonged)
             + 1  # approval.remainder fetches approval suspensions to compute remaining days.
             + 1  # release savepoint before the template rendering
-            + 1  # template: job_application.get_eligibility_diagnosis => Siae.is_subject_to_eligibility_rules
+            + 1  # siae membership (context processor)
             + 1  # template: approval.pending_prolongation_request fetch the current pending prolongation request
             + 1  # template: approval.suspensions_for_status_card lists approval suspensions
             + 1  # template: approval prolongations list.

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -115,7 +115,6 @@ class TestApprovalDetailView:
             + 1  # select latest approval for user (can_be_prolonged)
             + 1  # approval.remainder fetches approval suspensions to compute remaining days.
             + 1  # release savepoint before the template rendering
-            + 1  # siae membership (context processor)
             + 1  # template: approval.pending_prolongation_request fetch the current pending prolongation request
             + 1  # template: approval.suspensions_for_status_card lists approval suspensions
             + 1  # template: approval prolongations list.

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -87,12 +87,10 @@ class TestApprovalsListView:
             BASE_NUM_QUERIES
             + 1  # fetch django session
             + 1  # fetch user
-            + 1  # fetch siae membership
-            + 1  # fetch siae infos
+            + 2  # fetch siae memberships & its active/grace_period (middleware)
             + 1  # fetch SIAE (get_current_siae_or_404)
             + 1  # fetch job seekers (ApprovalForm._get_choices_for_job_seekers)
             + 1  # count (from paginator)
-            + 1  # fetch siae membership (from context processor)
             + 1  # fetch approvals
             + 2  # check if in progress suspensions exist for each approval (Approval.is_suspended)
             + 3  # savepoint, update session, release savepoint

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -32,11 +32,8 @@ def test_list_view(snapshot, client):
         BASE_NUM_QUERIES
         + 1  # fetch django session
         + 1  # fetch user
-        + 1  # check user is in member of the organization
-        + 1  # fetch organization membership
+        + 1  # check user memberships
         + 1  # fetch organization infos
-        + 1  # fetch user's current organization
-        + 1  # fetch organization info and membership (from context processor)
         + 1  # fetch prolongation requests rows
         + 3  # savepoint, update session, release savepoint
     )

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -102,7 +102,7 @@ class DashboardViewTest(TestCase):
         last_url = response.redirect_chain[-1][0]
         assert last_url == reverse("account_logout")
 
-        expected_message = "votre compte n'est malheureusement plus actif"
+        expected_message = "votre compte n&#x27;est malheureusement plus actif"
         self.assertContains(response, expected_message)
 
     def test_dashboard_eiti(self):

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -613,11 +613,10 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         with self.assertNumQueries(
             BASE_NUM_QUERIES
             + 1  # django session
-            + 1  # fetch user
-            + 3  # fetch institution membership & institution x 2 !should be fixed!
+            + 2  # fetch user & its memberships (middleware)
+            + 1  # fetch institution membership
             + 1  # fetch evaluation campaign
             + 3  # fetch evaluated_siae and its prefetch_related eval_job_app & eval_admin_crit
-            + 1  # one again institution membership
             + 3  # savepoint, update session, release savepoint
         ):
             response = self.client.get(url)
@@ -1712,10 +1711,10 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         with self.assertNumQueries(
             BASE_NUM_QUERIES
             + 1  # django session
-            + 1  # fetch user
-            + 3  # fetch institution membership & institution x 2 !should be fixed!
-            + 6  # fetch evaluated_siae and its prefetch_related
-            + 1  # one again institution membership
+            + 2  # fetch user & its memberships (middleware)
+            + 1  # fetch institution membership
+            + 3  # fetch evaluated_siae, evaluated_jobapp & criteria
+            + 3  # fetch jobapplication, approvals & users
             + 3  # savepoint, update session, release savepoint
         ):
             response = self.client.get(url)
@@ -1967,10 +1966,10 @@ class InstitutionEvaluatedSiaeNotifyViewAccessTestMixin:
         with self.assertNumQueries(
             BASE_NUM_QUERIES
             + 1  # Load session
-            + 4  # Check user, membership, institution & institution membership (!)
+            + 2  # Check user & its memberships
+            + 1  # Laod institution infos
             + 1  # Load evaluated siae infos
             + 1  # Load evaluated job applications
-            + 1  # Check institution membership again
             + 3  # Load evaluated siae infos + job application + criteria for previous campaigns
             + 3  # Update session
         ):
@@ -3624,10 +3623,10 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         with self.assertNumQueries(
             BASE_NUM_QUERIES
             + 1  # django session
-            + 1  # fetch user
-            + 3  # fetch institution membership & institution x 2 !should be fixed!
-            + 5  # fetch evaluated_siae and its prefetch_related (evalcriteria, admincriteria, jobapp, approval)
-            + 2  # user & institution membership (again)
+            + 2  # fetch user & its memberships (middleware)
+            + 1  # fetch institution membership
+            + 3  # fetch evaluated_jobapp & criteria
+            + 3  # jobapp, approvals & users
             + 2  # evaljobapp & its evalcriteria
             + 3  # savepoint, update session, release savepoint
         ):

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -96,7 +96,6 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
             + 2  # fetch siae membership and siae infos
             + 1  # fetch evaluated siae
             + 2  # fetch evaluatedjobapplication and its prefetched evaluatedadministrativecriteria
-            + 1  # weird fetch siae membership
             # NOTE(vperron): the prefetch is necessary to check the SUBMITTABLE state of the evaluated siae
             # We do those requests "two times" but at least it's now accurate information, and we get
             # the EvaluatedJobApplication list another way so that we can select_related on them.

--- a/tests/www/siaes_views/test_job_description_views.py
+++ b/tests/www/siaes_views/test_job_description_views.py
@@ -496,10 +496,9 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             BASE_NUM_QUERIES
             + 1  # fetch django session
             + 1  # fetch user
-            + 1  # check user is active
+            + 1  # fetch user memberships
             + 1  # fetch siaes_siaejobdescription
             + 1  # fetch siaes infos
-            + 1  # fetch prescribers_prescribermembership/organization
             + 1  # fetch jobappelation
             + 1  # fetch other job infos
         ):


### PR DESCRIPTION
### Pourquoi ?

Le middleware et le context processor regardent à peu près les mêmes infos: autant stocker les infos sur la requête et éviter de les récupérer deux fois.

Globalement on passe pour les vues avec rendu de template:
- pour les SIAE: de 2 à 4 requêtes à toujours 2 requêtes
- pour les prescripteurs: de 2 à 4 requêtes à toujours 1 requête
- pour les inspecteurs: de 1 à 3 requêtes à toujours 1 requête

Et pour les vues sans rendu de template:
- pour les SIAE: de 1 à 3 requêtes à toujours 2 requêtes
- pour les prescripteurs: de 1 à 3 requêtes à toujours 1 requête
- pour les inspecteurs: de 0 à 2 requêtes à toujours 1 requête