### PR TITLE
Demandes de prolongation : Filtre "À traiter" et navigation

### DIFF
--- a/itou/templates/approvals/prolongation_requests/list.html
+++ b/itou/templates/approvals/prolongation_requests/list.html
@@ -10,17 +10,17 @@
 {% endblock %}
 
 {% block content %}
-    <section class="s-section">
+    <section class="s-section" hx-select=".s-section" hx-target=".s-section" hx-swap="outerHTML show:window:top">
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12">
                     <div class="c-box">
                         <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between">
-                            <h3 class="mb-0">{{ prolongation_requests|length }} résultat{{ prolongation_requests|pluralizefr }}</h3>
+                            <h3 class="mb-0">{{ pager.paginator.count }} résultat{{ pager.paginator.count|pluralizefr }}</h3>
                         </div>
                         <div class="d-flex flex-column flex-md-row mt-3 mt-md-4">
                             <h4 class="mr-4">Filtres :</h4>
-                            <form action="{% url "approvals:prolongation_requests_list" %}" hx-boost="true" hx-trigger="change" hx-select=".s-section" hx-target=".s-section" hx-swap="outerHTML show:window:top">
+                            <form action="{% url "approvals:prolongation_requests_list" %}" hx-boost="true" hx-trigger="change">
                                 {{ form.only_pending }}
                                 {{ form.only_pending.label_tag }}
                             </form>
@@ -41,7 +41,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {% for prolongation_request in prolongation_requests %}
+                                    {% for prolongation_request in pager %}
                                         <tr>
                                             <th scope="row">{{ forloop.counter }}</th>
                                             <td class="font-weight-bold">{{ prolongation_request.approval.user.get_full_name|title }}</td>
@@ -63,6 +63,8 @@
                                 </tbody>
                             </table>
                         </div>
+
+                        {% include "includes/pagination.html" with page=pager boost=true %}
                     </div>
                 </div>
             </div>

--- a/itou/templates/approvals/prolongation_requests/list.html
+++ b/itou/templates/approvals/prolongation_requests/list.html
@@ -16,7 +16,14 @@
                 <div class="col-12">
                     <div class="c-box">
                         <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between">
-                            <h3 class="h4 mb-0">{{ prolongation_requests|length }} résultat{{ prolongation_requests|pluralizefr }}</h3>
+                            <h3 class="mb-0">{{ prolongation_requests|length }} résultat{{ prolongation_requests|pluralizefr }}</h3>
+                        </div>
+                        <div class="d-flex flex-column flex-md-row mt-3 mt-md-4">
+                            <h4 class="mr-4">Filtres :</h4>
+                            <form action="{% url "approvals:prolongation_requests_list" %}" hx-boost="true" hx-trigger="change" hx-select=".s-section" hx-target=".s-section" hx-swap="outerHTML show:window:top">
+                                {{ form.only_pending }}
+                                {{ form.only_pending.label_tag }}
+                            </form>
                         </div>
 
                         <div class="table-responsive-lg mt-3 mt-md-4">
@@ -56,7 +63,6 @@
                                 </tbody>
                             </table>
                         </div>
-
                     </div>
                 </div>
             </div>

--- a/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
@@ -7,7 +7,7 @@
         <div class="px-3 px-lg-4">
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
-                    <a href="{% url 'approvals:prolongation_requests_list' %}" class="btn-link btn-ico">
+                    <a href="{% url 'approvals:prolongation_requests_list' %}?only_pending=on" class="btn-link btn-ico">
                         <i class="ri-list-check-3 ri-lg font-weight-normal"></i>
                         <span>Gérer mes prolongations de PASS IAE</span>
                     </a>

--- a/itou/templates/includes/pagination.html
+++ b/itou/templates/includes/pagination.html
@@ -7,7 +7,7 @@
 {% endcomment %}
 {% if page.display_pager %}
     {% with request.get_full_path as url %}
-        <nav role="navigation" aria-label="Pagination">
+        <nav role="navigation" aria-label="Pagination" {% if boost %}hx-boost="{{ boost }}"{% endif %}>
             {# Pagination is not responsive by default https://github.com/twbs/bootstrap/issues/23504 #}
             <ul class="pagination flex-wrap justify-content-center">
                 {# First page. #}

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -344,6 +344,14 @@ class CreateProlongationRequestForm(CreateProlongationForm):
         ]
 
 
+class ProlongationRequestFilterForm(forms.Form):
+    only_pending = forms.BooleanField(
+        label="Voir uniquement les demandes à traiter",
+        label_suffix="",
+        required=False,
+    )
+
+
 class SuspensionForm(forms.ModelForm):
     """
     Create or edit a suspension.

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -19,7 +19,7 @@ from itou.job_applications.enums import Origin, SenderKind
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.users.models import User
 from itou.utils import constants as global_constants
-from itou.utils.pagination import ItouPaginator
+from itou.utils.pagination import ItouPaginator, pager
 from itou.utils.perms.prescriber import get_current_org_or_404
 from itou.utils.perms.siae import get_current_siae_or_404
 from itou.utils.storage.s3 import S3Upload
@@ -344,7 +344,7 @@ def prolongation_requests_list(request, template_name="approvals/prolongation_re
 
     context = {
         "form": form,
-        "prolongation_requests": queryset,
+        "pager": pager(queryset, request.GET.get("page"), items_per_page=10),
     }
     return render(request, template_name, context)
 

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -3,7 +3,14 @@
   '''
   <div class="c-box">
                           <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between">
-                              <h3 class="h4 mb-0">1 résultat</h3>
+                              <h3 class="mb-0">1 résultat</h3>
+                          </div>
+                          <div class="d-flex flex-column flex-md-row mt-3 mt-md-4">
+                              <h4 class="mr-4">Filtres :</h4>
+                              <form action="/approvals/prolongation/requests" hx-boost="true" hx-select=".s-section" hx-swap="outerHTML show:window:top" hx-target=".s-section" hx-trigger="change">
+                                  <input id="id_only_pending" name="only_pending" type="checkbox"/>
+                                  <label for="id_only_pending">Voir uniquement les demandes à traiter</label>
+                              </form>
                           </div>
   
                           <div class="table-responsive-lg mt-3 mt-md-4">
@@ -46,7 +53,6 @@
                                   </tbody>
                               </table>
                           </div>
-  
                       </div>
   '''
 # ---

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -7,7 +7,7 @@
                           </div>
                           <div class="d-flex flex-column flex-md-row mt-3 mt-md-4">
                               <h4 class="mr-4">Filtres :</h4>
-                              <form action="/approvals/prolongation/requests" hx-boost="true" hx-select=".s-section" hx-swap="outerHTML show:window:top" hx-target=".s-section" hx-trigger="change">
+                              <form action="/approvals/prolongation/requests" hx-boost="true" hx-trigger="change">
                                   <input id="id_only_pending" name="only_pending" type="checkbox"/>
                                   <label for="id_only_pending">Voir uniquement les demandes à traiter</label>
                               </form>
@@ -53,6 +53,11 @@
                                   </tbody>
                               </table>
                           </div>
+  
+                          
+  
+  
+  
                       </div>
   '''
 # ---

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -36,6 +36,7 @@ def test_list_view(snapshot, client):
         + 1  # check user memberships
         + 1  # fetch organization infos
         + 1  # fetch prolongation requests rows
+        + 1  # count prolongation requests rows (from pager)
         + 3  # savepoint, update session, release savepoint
     )
     with assertNumQueries(num_queries):
@@ -55,13 +56,13 @@ def test_list_view_only_pending_filter(client):
     client.force_login(pending_prolongation_request.validated_by)
 
     response = client.get(reverse("approvals:prolongation_requests_list"))
-    assert set(response.context["prolongation_requests"]) == {
+    assert set(response.context["pager"].object_list) == {
         pending_prolongation_request,
         *other_prolongation_requests,
     }
 
     response = client.get(reverse("approvals:prolongation_requests_list"), data={"only_pending": True})
-    assert list(response.context["prolongation_requests"]) == [pending_prolongation_request]
+    assert list(response.context["pager"].object_list) == [pending_prolongation_request]
 
 
 def test_show_view_access(client):

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -1794,6 +1794,6 @@ def test_prolongation_requests_badge(client):
     client.force_login(prescriber)
     soup = parse_response_to_soup(
         client.get(reverse("dashboard:index")),
-        f"""a[href='{reverse("approvals:prolongation_requests_list")}'] + .badge""",
+        f"""a[href^='{reverse("approvals:prolongation_requests_list")}'] + .badge""",
     )
     assert soup.text == "3"


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/URGENT-En-tant-que-prescripteur-habilit-je-peux-filtrer-les-demandes-de-prolongation-par-statut-V-00b248a4f40f4d23a9751cd555a8706b?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

- Demandes nombreuses classées de la plus récente à la plus ancienne, certains ne traitent pas forcément par ordre d’arrivée, on doit éviter que des demandes soient mises de coté car non visibles 
- Permettre aux utilisateurs qui pilotent l’activité de leur organisation d’identifier rapidement les demandes en attente

### Comment <!-- optionnel -->

- Mettre en place un filtre les demandes à traiter (pour la V1 on se contente juste d’une case à cocher)

### Captures d'écran <!-- optionnel -->
![Screenshot from 2023-08-28 19-19-29](https://github.com/betagouv/itou/assets/20045330/6059361e-9440-4b7e-bdcf-f1b6efcec867)

![Screenshot from 2023-08-28 19-18-20](https://github.com/betagouv/itou/assets/20045330/6590933b-94cc-4511-bd13-50f13635ac68)