### PR TITLE
Améliorer le contenu de l'email de demande de prolongation de pass

### DIFF
--- a/itou/templates/approvals/email/prolongation_request/created_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/created_body.txt
@@ -1,5 +1,10 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% block body %}
+********************************************************************
+👉 Cette demande est à traiter exclusivement sur votre tableau de bord prescripteur.
+❌ Merci de ne pas transférer cette demande à notre équipe support.
+*********************************************************************
+
 Bonjour,
 
 {{ prolongation_request.declared_by.get_full_name }} de la structure {{ prolongation_request.declared_by_siae.display_name }} a besoin de votre accord pour prolonger un PASS IAE.

--- a/tests/approvals/__snapshots__/test_notifications.ambr
+++ b/tests/approvals/__snapshots__/test_notifications.ambr
@@ -1,6 +1,11 @@
 # serializer version: 1
 # name: test_prolongation_request_created[body]
   '''
+  ********************************************************************
+  👉 Cette demande est à traiter exclusivement sur votre tableau de bord prescripteur.
+  ❌ Merci de ne pas transférer cette demande à notre équipe support.
+  *********************************************************************
+  
   Bonjour,
   
   John DOE de la structure Acme inc. a besoin de votre accord pour prolonger un PASS IAE.
@@ -54,6 +59,11 @@
   Une demande de prolongation du PASS IAE a été transmise à un membre de votre organisation, cette demande est toujours en attente de réponse. Si des démarches sont en cours, veuillez ne pas tenir compte de ce message.
   
   Rappel du message initial :
+  
+  ********************************************************************
+  👉 Cette demande est à traiter exclusivement sur votre tableau de bord prescripteur.
+  ❌ Merci de ne pas transférer cette demande à notre équipe support.
+  *********************************************************************
   
   Bonjour,
   


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/En-tant-que-prescripteur-sollicit-pour-une-demande-de-prolongation-je-comprends-que-la-demande-doit-cb363e2ffb8b4860ad7f03314b667e2b?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Alerte du support, certains prescripteurs habilités continuent de transférer l’email au support alors que cela n’est plus nécessaire
