### PR TITLE
Harmoniser l'affichage du nom des utilisateurs

### DIFF
--- a/itou/templates/admin/approvals/includes/job_application_details.html
+++ b/itou/templates/admin/approvals/includes/job_application_details.html
@@ -9,7 +9,7 @@
     <ul>
         <li>
             <b>Nom : </b>
-            {{ job_seeker.last_name }}
+            {{ job_seeker.last_name|upper }}
             <small>
                 (<a href="{% url "admin:approvals_poleemploiapproval_changelist" %}?q={{ job_seeker.last_name|urlencode }}" target="_blank">
                 rechercher dans les agréments Pôle emploi
@@ -18,7 +18,7 @@
     </li>
     <li>
         <b>Prénom : </b>
-        {{ job_seeker.first_name }}
+        {{ job_seeker.first_name|title }}
     </li>
     <li>
         <b>Date de naissance : </b>

--- a/itou/templates/apply/edit_contract_start_date.html
+++ b/itou/templates/apply/edit_contract_start_date.html
@@ -5,7 +5,7 @@
 
 {% block content_title %}
     <h1>
-        Candidature de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title }}</span>
+        Candidature de <span class="text-muted">{{ job_application.job_seeker.get_full_name }}</span>
     </h1>
 {% endblock %}
 

--- a/itou/templates/apply/email/accept_for_proxy_body.txt
+++ b/itou/templates/apply/email/accept_for_proxy_body.txt
@@ -1,7 +1,7 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% block body %}
 
-Nous sommes ravis de vous annoncer que la candidature de {{ job_application.job_seeker.get_full_name|title }}, adressée par {{ job_application.sender.get_full_name|title }}, a été acceptée par {{ job_application.to_siae.display_name }}.
+Nous sommes ravis de vous annoncer que la candidature de {{ job_application.job_seeker.get_full_name }}, adressée par {{ job_application.sender.get_full_name }}, a été acceptée par {{ job_application.to_siae.display_name }}.
 
 - Date de début du contrat : {{ job_application.hiring_start_at|date:"d/m/Y" }}
 - Date de fin du contrat : {{ job_application.hiring_end_at|date:"d/m/Y"|default:"Non renseigné" }}

--- a/itou/templates/apply/email/cancel_body.txt
+++ b/itou/templates/apply/email/cancel_body.txt
@@ -11,8 +11,8 @@ Nous vous confirmons que l'embauche de {{ job_application.job_seeker.get_full_na
 
 *Candidat* :
 
-- Nom : {{ job_application.job_seeker.last_name }}
-- Prénom : {{ job_application.job_seeker.first_name }}{% if job_application.job_seeker.email %}
+- Nom : {{ job_application.job_seeker.last_name|upper }}
+- Prénom : {{ job_application.job_seeker.first_name|title }}{% if job_application.job_seeker.email %}
 - Email : {{ job_application.job_seeker.email }}{% endif %}{% if job_application.job_seeker.phone %}
 - Téléphone : {{ job_application.job_seeker.phone|format_phone }}{% endif %}{% if job_application.job_seeker.birthdate %}
 - Date de naissance : {{ job_application.job_seeker.birthdate|date:"d/m/Y" }}{% endif %}

--- a/itou/templates/apply/email/new_for_job_seeker_body.txt
+++ b/itou/templates/apply/email/new_for_job_seeker_body.txt
@@ -5,8 +5,8 @@
 
 {% if job_application.is_sent_by_proxy %}
 
-{{ job_application.sender.get_full_name|title }} a envoyé votre candidature chez {{ job_application.to_siae.display_name }}.
-Vous et {{ job_application.sender.get_full_name|title }} serez tous les deux informés de l'avancement de cette candidature.
+{{ job_application.sender.get_full_name }} a envoyé votre candidature chez {{ job_application.to_siae.display_name }}.
+Vous et {{ job_application.sender.get_full_name }} serez tous les deux informés de l'avancement de cette candidature.
 
 {% else %}
 Candidature chez {{ job_application.to_siae.display_name }} envoyée avec succès !
@@ -36,7 +36,7 @@ Candidature chez {{ job_application.to_siae.display_name }} envoyée avec succè
 
 *Informations transmises à la structure* :
 
-- Nom : {{ job_application.job_seeker.last_name|title }}
+- Nom : {{ job_application.job_seeker.last_name|upper }}
 - Prénom : {{ job_application.job_seeker.first_name|title }}{% if job_application.job_seeker.email %}
 - Email : {{ job_application.job_seeker.email }}{% endif %}{% if job_application.job_seeker.phone %}
 - Téléphone : {{ job_application.job_seeker.phone|format_phone }}{% endif %}{% if job_application.job_seeker.birthdate %}
@@ -50,7 +50,7 @@ Candidature chez {{ job_application.to_siae.display_name }} envoyée avec succè
 
 *Candidature envoyée par* :
 
-- {{ job_application.sender.get_full_name|title }}{% if job_application.sender_prescriber_organization %}
+- {{ job_application.sender.get_full_name }}{% if job_application.sender_prescriber_organization %}
 - {{ job_application.sender_prescriber_organization.display_name }}{% endif %}
 
 {% endif %}

--- a/itou/templates/apply/email/new_for_prescriber_body.txt
+++ b/itou/templates/apply/email/new_for_prescriber_body.txt
@@ -7,7 +7,7 @@ La candidature suivante a été envoyée avec succès à l'entreprise {{ job_app
 
 *Candidat* :
 
-- Nom : {{ job_application.job_seeker.last_name|title }}
+- Nom : {{ job_application.job_seeker.last_name|upper }}
 - Prénom : {{ job_application.job_seeker.first_name|title }}{% if job_application.job_seeker.email %}
 - Email : {{ job_application.job_seeker.email }}{% endif %}{% if job_application.job_seeker.phone %}
 - Téléphone : {{ job_application.job_seeker.phone|format_phone }}{% endif %}{% if job_application.job_seeker.birthdate %}
@@ -38,7 +38,7 @@ La candidature suivante a été envoyée avec succès à l'entreprise {{ job_app
 -----
 
 *Candidature envoyée par* :
-- {{ job_application.sender.get_full_name|title }}{% if job_application.sender_prescriber_organization %}
+- {{ job_application.sender.get_full_name }}{% if job_application.sender_prescriber_organization %}
 - {{ job_application.sender_prescriber_organization.display_name }}{% endif %}
 - {{ job_application.sender.email }}{% if job_application.sender.phone %}
 - {{ job_application.sender.phone|format_phone }}{% endif %}

--- a/itou/templates/apply/email/new_for_siae_body.txt
+++ b/itou/templates/apply/email/new_for_siae_body.txt
@@ -7,8 +7,8 @@ Vous avez reçu une nouvelle candidature !
 
 *Candidat* :
 
-- Nom : {{ job_application.job_seeker.last_name }}
-- Prénom : {{ job_application.job_seeker.first_name }}{% if job_application.job_seeker.email %}
+- Nom : {{ job_application.job_seeker.last_name|upper }}
+- Prénom : {{ job_application.job_seeker.first_name|title }}{% if job_application.job_seeker.email %}
 - Email : {{ job_application.job_seeker.email }}{% endif %}{% if job_application.job_seeker.phone %}
 - Téléphone : {{ job_application.job_seeker.phone|format_phone }}{% endif %}{% if job_application.job_seeker.birthdate %}
 - Date de naissance : {{ job_application.job_seeker.birthdate|date:"d/m/Y" }}{% endif %}

--- a/itou/templates/apply/email/refuse_body_for_proxy.txt
+++ b/itou/templates/apply/email/refuse_body_for_proxy.txt
@@ -1,10 +1,10 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% block body %}
 
-La candidature de {{ job_application.job_seeker.get_full_name|title }} envoyée par {{ job_application.sender.get_full_name|title }} chez {{ job_application.to_siae.display_name }} n'a malheureusement pas pu aboutir.
+La candidature de {{ job_application.job_seeker.get_full_name }} envoyée par {{ job_application.sender.get_full_name }} chez {{ job_application.to_siae.display_name }} n'a malheureusement pas pu aboutir.
 
 {% if job_application.is_refused_due_to_deactivation %}
-Pour l'instant cette SIAE n'est plus habilitée à recevoir de candidatures. 
+Pour l'instant cette SIAE n'est plus habilitée à recevoir de candidatures.
 {% endif %}
 
 {% if job_application.answer %}

--- a/itou/templates/apply/email/transfer_origin_siae_body.txt
+++ b/itou/templates/apply/email/transfer_origin_siae_body.txt
@@ -3,8 +3,8 @@
 
 Candidature transférée
 
-{{ transferred_by.first_name}} {{ transferred_by.last_name}} a transféré la candidature de : {{ job_application.job_seeker.first_name }} {{ job_application.job_seeker.last_name }} 
-de la structure {{ origin_siae.display_name }} 
+{{ transferred_by.get_full_name }} a transféré la candidature de : {{ job_application.job_seeker.get_full_name }}
+de la structure {{ origin_siae.display_name }}
 vers la structure {{ target_siae.display_name }}.
 
 {% endblock body %}

--- a/itou/templates/apply/email/transfer_origin_siae_subject.txt
+++ b/itou/templates/apply/email/transfer_origin_siae_subject.txt
@@ -1,4 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
-La candidature de {{ job_application.job_seeker.first_name }} {{ job_application.job_seeker.last_name }} a été transférée
+La candidature de {{ job_application.job_seeker.get_full_name }} a été transférée
 {% endblock %}

--- a/itou/templates/apply/email/transfer_prescriber_body.txt
+++ b/itou/templates/apply/email/transfer_prescriber_body.txt
@@ -3,8 +3,8 @@
 
 Candidature transférée
 
-{{ transferred_by.first_name }} {{ transferred_by.last_name }} a transféré la candidature de : {{ job_application.job_seeker.first_name }} {{ job_application.job_seeker.last_name }} 
-de la structure {{ origin_siae.display_name }}  
-vers la structure {{ target_siae.display_name }}.   
+{{ transferred_by.get_full_name }} a transféré la candidature de : {{ job_application.job_seeker.get_full_name }}
+de la structure {{ origin_siae.display_name }}
+vers la structure {{ target_siae.display_name }}.
 
 {% endblock body %}

--- a/itou/templates/apply/email/transfer_prescriber_subject.txt
+++ b/itou/templates/apply/email/transfer_prescriber_subject.txt
@@ -1,4 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
-La candidature de {{ job_application.job_seeker.first_name }} {{ job_application.job_seeker.last_name }} a été transférée 
+La candidature de {{ job_application.job_seeker.get_full_name }} a été transférée
 {% endblock %}

--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -56,7 +56,7 @@
                     <a class="btn btn-block btn-outline-primary" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Retour</a>
                 </div>
                 <div class="form-group mb-0 col-6 col-lg-auto">
-                    <button class="btn btn-ico btn-block btn-primary" aria-label="Valider l’embauche de {{ job_application.job_seeker.get_full_name|title|mask_unless:can_view_personal_information }}">
+                    <button class="btn btn-ico btn-block btn-primary" aria-label="Valider l’embauche de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}">
                         <i class="ri-check-line ri-xl"></i>
                         <span>Valider l’embauche</span>
                     </button>

--- a/itou/templates/apply/includes/job_application_sender_info.html
+++ b/itou/templates/apply/includes/job_application_sender_info.html
@@ -1,11 +1,11 @@
 {% load format_filters %}
 <ul>
     <li>
-        Prénom : <b>{{ job_application.sender.first_name }}</b>
+        Prénom : <b>{{ job_application.sender.first_name|title }}</b>
     </li>
 
     <li>
-        Nom : <b>{{ job_application.sender.last_name }}</b>
+        Nom : <b>{{ job_application.sender.last_name|upper }}</b>
     </li>
 
     <li>

--- a/itou/templates/apply/includes/state_transition_siae.html
+++ b/itou/templates/apply/includes/state_transition_siae.html
@@ -82,7 +82,7 @@
                     Si vous annulez cette embauche, vous ne pourrez pas prétendre à l'aide au poste pour les jours éventuellement travaillés.
                 </p>
                 <p>
-                    {{ job_application.job_seeker.get_full_name|title }} restera éligible à l'IAE et pourra de nouveau vous envoyer une candidature dans le futur.
+                    {{ job_application.job_seeker.get_full_name }} restera éligible à l'IAE et pourra de nouveau vous envoyer une candidature dans le futur.
                 </p>
             {% endif %}
             <p>

--- a/itou/templates/apply/includes/transfer_job_application.html
+++ b/itou/templates/apply/includes/transfer_job_application.html
@@ -40,7 +40,7 @@
                             </div>
                             <div class="modal-body">
                                 <p>
-                                    Êtes-vous sûr de vouloir transférer la candidature de <b>{{ job_application.job_seeker.first_name }} {{ job_application.job_seeker.last_name }}</b> dans la structure suivante ?
+                                    Êtes-vous sûr de vouloir transférer la candidature de <b>{{ job_application.job_seeker.get_full_name }}</b> dans la structure suivante ?
                                 </p>
                                 {% include "siaes/includes/_siae_info.html" %}
                             </div>

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -21,7 +21,7 @@
                 </div>
                 <div class="modal-body">
                     <p>
-                        Êtes-vous sûr(e) de vouloir confirmer l’embauche de <strong>{{ job_application.job_seeker.first_name }} {{ job_application.job_seeker.last_name }}</strong> dans la structure suivante ?
+                        Êtes-vous sûr(e) de vouloir confirmer l’embauche de <strong>{{ job_application.job_seeker.get_full_name }}</strong> dans la structure suivante ?
                     </p>
                     {% include "siaes/includes/_siae_info.html" with siae=job_application.to_siae %}
                 </div>

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -11,7 +11,7 @@
 
 {% block content_title %}
     <h1>
-        Candidature de <span class="text-muted">{{ job_application.job_seeker.get_full_name|title|mask_unless:can_view_personal_information }}</span>
+        Candidature de <span class="text-muted">{{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}</span>
     </h1>
     <p>{% state_badge job_application %}</p>
 {% endblock %}

--- a/itou/templates/apply/process_geiq_eligibility.html
+++ b/itou/templates/apply/process_geiq_eligibility.html
@@ -7,7 +7,7 @@
 {% block content_title %}
     <h1>
         Candidature de
-        <span class="text-muted">{{ job_application.job_seeker.get_full_name|title|mask_unless:can_view_personal_information }}</span>
+        <span class="text-muted">{{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}</span>
     </h1>
 {% endblock %}
 

--- a/itou/templates/apply/process_postpone.html
+++ b/itou/templates/apply/process_postpone.html
@@ -17,7 +17,7 @@
                         <a class="btn btn-outline-primary btn-block" href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}">Annuler</a>
                     </div>
                     <div class="form-group mb-0 col-6 col-lg-auto">
-                        <button class="btn btn-block btn-success" aria-label="Mettre la candidature de {{ job_application.job_seeker.get_full_name|title|mask_unless:can_view_personal_information }} en liste d'attente">
+                        <button class="btn btn-block btn-success" aria-label="Mettre la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }} en liste d'attente">
                             Mettre en liste d'attente
                         </button>
                     </div>

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -13,7 +13,7 @@
     <h1>
         Déclarer une prolongation de PASS IAE
         <br>
-        <span class="text-muted">{{ approval.user.get_full_name|title }}</span>
+        <span class="text-muted">{{ approval.user.get_full_name }}</span>
     </h1>
 {% endblock %}
 
@@ -54,7 +54,7 @@
                                     {% if form.instance.validated_by.email %}
                                         <p class="card-text">
                                             Un e-mail sera envoyé au prescripteur habilité désigné pour autoriser la prolongation :
-                                            <b>{{ form.instance.validated_by.get_full_name|title }}</b>
+                                            <b>{{ form.instance.validated_by.get_full_name }}</b>
                                             ({{ form.instance.validated_by.email }})
                                         </p>
                                     {% endif %}

--- a/itou/templates/approvals/detail.html
+++ b/itou/templates/approvals/detail.html
@@ -2,7 +2,7 @@
 
 {% block title %}Profil salarié - {{ approval.user.get_full_name }} {{ block.super }}{% endblock %}
 
-{% block content_title %}<h1>{{ approval.user.get_full_name|title }}</h1>{% endblock %}
+{% block content_title %}<h1>{{ approval.user.get_full_name }}</h1>{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/approvals/email/deliver_body.txt
+++ b/itou/templates/approvals/email/deliver_body.txt
@@ -8,8 +8,8 @@ PASS IAE N° : {{ job_application.approval.number_with_spaces }}
 Nombre de jours restants sur le PASS IAE débutant le {{ job_application.approval.start_at|date:"d/m/Y" }} : {{ job_application.approval.remainder.days }} jours*.
 
 Délivré pour l'embauche de :
-Nom : {{ job_application.approval.user.last_name }}
-Prénom : {{ job_application.approval.user.first_name }}
+Nom : {{ job_application.approval.user.last_name|upper }}
+Prénom : {{ job_application.approval.user.first_name|title }}
 Date de naissance : {{ job_application.approval.user.birthdate|date:"d/m/Y" }}
 
 Pour un contrat d'insertion :

--- a/itou/templates/approvals/email/manual_delivery_required_notification_body.txt
+++ b/itou/templates/approvals/email/manual_delivery_required_notification_body.txt
@@ -6,8 +6,8 @@ Informations pour l'obtention d'un PASS IAE suite à l'embauche de votre candida
 
 *Candidat* :
 
-- Nom : {{ job_application.job_seeker.last_name }}
-- Prénom : {{ job_application.job_seeker.first_name }}{% if job_application.job_seeker.email %}
+- Nom : {{ job_application.job_seeker.last_name|upper }}
+- Prénom : {{ job_application.job_seeker.first_name|title }}{% if job_application.job_seeker.email %}
 - Email : {{ job_application.job_seeker.email }}{% endif %}
 - Date de naissance : {{ job_application.job_seeker.birthdate|date:"d/m/Y" }}
 

--- a/itou/templates/approvals/email/prolongation_request/created_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/created_body.txt
@@ -2,7 +2,7 @@
 {% block body %}
 Bonjour,
 
-{{ prolongation_request.declared_by.get_full_name|title }} de la structure {{ prolongation_request.declared_by_siae.display_name }} a besoin de votre accord pour prolonger un PASS IAE.
+{{ prolongation_request.declared_by.get_full_name }} de la structure {{ prolongation_request.declared_by_siae.display_name }} a besoin de votre accord pour prolonger un PASS IAE.
 
 {% if prolongation_request.require_phone_interview %}
 L'employeur souhaite vous apporter des explications supplémentaires par téléphone. Vous trouverez ci-dessous ses coordonnées pour le contacter :
@@ -13,7 +13,7 @@ L'employeur souhaite vous apporter des explications supplémentaires par télép
 
 - Numéro de PASS : {{ prolongation_request.approval.number }}
 - Prénom : {{ prolongation_request.approval.user.first_name|title }}
-- Nom : {{ prolongation_request.approval.user.last_name|title }}
+- Nom : {{ prolongation_request.approval.user.last_name|upper }}
 - Date de naissance : {{ prolongation_request.approval.user.birthdate|date:"d/m/Y" }}
 - Début de la prolongation : {{ prolongation_request.start_at|date:"d/m/Y" }}
 - Fin de la prolongation : {{ prolongation_request.end_at|date:"d/m/Y" }}

--- a/itou/templates/approvals/email/prolongation_request/created_subject.txt
+++ b/itou/templates/approvals/email/prolongation_request/created_subject.txt
@@ -1,4 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
-Demande de prolongation du PASS IAE de {{ prolongation_request.approval.user.get_full_name|title }}
+Demande de prolongation du PASS IAE de {{ prolongation_request.approval.user.get_full_name }}
 {% endblock %}

--- a/itou/templates/approvals/email/prolongation_request/denied/employer_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/denied/employer_body.txt
@@ -7,7 +7,7 @@ L’organisation {{ prolongation_request.prescriber_organization.display_name }}
 
 Références :
 Numéro : {{ prolongation_request.approval.number_with_spaces }}
-Bénéficiaire : {{ prolongation_request.approval.user.get_full_name|title }}
+Bénéficiaire : {{ prolongation_request.approval.user.get_full_name }}
 
 Vous pouvez consulter la date de fin prévisionnelle du PASS IAE dans votre espace employeur sur les emplois de l’inclusion.
 {% endblock body %}

--- a/itou/templates/approvals/email/prolongation_request/denied/employer_subject.txt
+++ b/itou/templates/approvals/email/prolongation_request/denied/employer_subject.txt
@@ -1,4 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
-Prolongation du PASS IAE de {{ prolongation_request.approval.user.get_full_name|title }} refusée
+Prolongation du PASS IAE de {{ prolongation_request.approval.user.get_full_name }} refusée
 {% endblock %}

--- a/itou/templates/approvals/email/prolongation_request/granted/employer_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/granted/employer_body.txt
@@ -7,7 +7,7 @@ L’organisation {{ prolongation_request.prescriber_organization.display_name }}
 
 Références :
 Numéro : {{ prolongation_request.approval.number_with_spaces }}
-Bénéficiaire : {{ prolongation_request.approval.user.get_full_name|title }}
+Bénéficiaire : {{ prolongation_request.approval.user.get_full_name }}
 
 Vous pouvez consulter la nouvelle date de fin prévisionnelle du PASS IAE dans votre espace employeur sur les emplois de l’inclusion.
 {% endblock body %}

--- a/itou/templates/approvals/email/prolongation_request/granted/employer_subject.txt
+++ b/itou/templates/approvals/email/prolongation_request/granted/employer_subject.txt
@@ -1,4 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
-Prolongation du PASS IAE de {{ prolongation_request.approval.user.get_full_name|title }} acceptée
+Prolongation du PASS IAE de {{ prolongation_request.approval.user.get_full_name }} acceptée
 {% endblock %}

--- a/itou/templates/approvals/includes/list_card.html
+++ b/itou/templates/approvals/includes/list_card.html
@@ -4,7 +4,7 @@
     <div class="card-header pb-3">
         <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
             <div class="order-2 order-md-1 flex-fill-1">
-                <h3 class="h3 mb-1">{{ approval.user.get_full_name|title }}</h3>
+                <h3 class="h3 mb-1">{{ approval.user.get_full_name }}</h3>
                 <p class="fs-sm mb-0">Pass N° {{ approval|format_approval_number }}</p>
             </div>
             <div class="order-1 order-md-2 mb-2 mb-md-0">

--- a/itou/templates/approvals/includes/prolongations_list.html
+++ b/itou/templates/approvals/includes/prolongations_list.html
@@ -5,7 +5,7 @@
             <small class="ml-3">{{ p.get_reason_display }}</small>
             {% if p.validated_by %}
                 <small class="d-block mb-2">
-                    Autorisée par <i>{{ p.validated_by.get_full_name|title }}</i>
+                    Autorisée par <i>{{ p.validated_by.get_full_name }}</i>
                     {% if p.prescriber_organization %}({{ p.prescriber_organization.display_name }}){% endif %}
                 </small>
             {% endif %}

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -53,7 +53,7 @@ Arguments:
         <p class="mb-1">Date de début : {{ common_approval.start_at|date:"d/m/Y" }}</p>
         <ul class="list-unstyled">
             <li class="h4 mt-4 mb-2">
-                Nombre de jours restants sur le PASS IAE : {{ common_approval.remainder.days }} jour{{ common_approval.remainder.days|pluralizefr }} 
+                Nombre de jours restants sur le PASS IAE : {{ common_approval.remainder.days }} jour{{ common_approval.remainder.days|pluralizefr }}
                 <i class="ri-information-line ri-xl"
                    data-toggle="tooltip"
                    title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
@@ -158,7 +158,7 @@ Arguments:
                                     {% if prolongation_request.status == ProlongationRequestStatus.PENDING %}
                                         En cours
                                     {% elif prolongation_request.status == ProlongationRequestStatus.DENIED %}
-                                        Refusée par <i>{{ prolongation_request.processed_by.get_full_name|title }}</i> ({{ prolongation_request.prescriber_organization.display_name }})
+                                        Refusée par <i>{{ prolongation_request.processed_by.get_full_name }}</i> ({{ prolongation_request.prescriber_organization.display_name }})
                                     {% endif %}
                                 </small>
                             </li>

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -35,7 +35,7 @@
                             <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
                         {% else %}
                             <p>
-                                L'agrément <strong>{{ approval.number }}</strong> a été délivré pour <strong>{{ approval.first_name|title }} {{ approval.last_name|title }}</strong>.
+                                L'agrément <strong>{{ approval.number }}</strong> a été délivré pour <strong>{{ approval.first_name|title }} {{ approval.last_name|upper }}</strong>.
                             </p>
                             <p>Nous allons l'importer dans votre compte pour vous permettre de le suspendre ou de le prolonger.</p>
                             <p>Mais avant, nous avons besoin de connaître l'adresse e-mail de votre salarié(e).</p>

--- a/itou/templates/approvals/pe_approval_search_user.html
+++ b/itou/templates/approvals/pe_approval_search_user.html
@@ -6,7 +6,7 @@
 {% block content_title %}
     {{ block.super }}
     <h1>Prolonger ou suspendre un agrément émis par Pôle emploi</h1>
-    <h2>{{ pe_approval.first_name|title }} {{ pe_approval.last_name|title }}</h2>
+    <h2>{{ pe_approval.first_name|title }} {{ pe_approval.last_name|upper }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/printable_approval.html
+++ b/itou/templates/approvals/printable_approval.html
@@ -3,7 +3,7 @@
 {% load format_filters %}
 
 {% block title %}
-    Attestation de délivrance d'agrément pour {{ approval.user.get_full_name|title }}.
+    Attestation de délivrance d'agrément pour {{ approval.user.get_full_name }}.
     {{ block.super }}
 {% endblock %}
 
@@ -76,7 +76,7 @@
 
                 {% endif %}
 
-                la situation sociale et professionnelle de {{ approval.user.get_full_name|title }}
+                la situation sociale et professionnelle de {{ approval.user.get_full_name }}
                 et de votre promesse d'embauche, les emplois de l'inclusion vous délivrent
                 un PASS IAE pour un parcours d'insertion par l'activité économique,
                 conformément aux dispositions des articles L 5132-1 à L 5132-17 du code du travail.

--- a/itou/templates/approvals/prolongation_requests/list.html
+++ b/itou/templates/approvals/prolongation_requests/list.html
@@ -37,7 +37,7 @@
                                     {% for prolongation_request in prolongation_requests %}
                                         <tr>
                                             <th scope="row">{{ forloop.counter }}</th>
-                                            <td class="font-weight-bold">{{ prolongation_request.approval.user.get_full_name|title }}</td>
+                                            <td class="font-weight-bold">{{ prolongation_request.approval.user.get_full_name }}</td>
                                             <td>{{ prolongation_request.approval.number|format_approval_number }}</td>
                                             <td>{{ prolongation_request.declared_by_siae }}</td>
                                             <td>{{ prolongation_request.created_at|date:"d/m/Y" }}</td>

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content_title %}
-    <h1>Demande de prolongation pour {{ prolongation_request.approval.user.get_full_name|title }}</h1>
+    <h1>Demande de prolongation pour {{ prolongation_request.approval.user.get_full_name }}</h1>
     {% include "approvals/prolongation_requests/_status_badge.html" %}
 {% endblock %}
 

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -7,7 +7,7 @@
     <h1>
         Suspendre le PASS IAE
         <br>
-        <span class="text-muted">{{ approval.user.get_full_name|title }}</span>
+        <span class="text-muted">{{ approval.user.get_full_name }}</span>
     </h1>
 {% endblock %}
 

--- a/itou/templates/approvals/suspension_delete.html
+++ b/itou/templates/approvals/suspension_delete.html
@@ -7,7 +7,7 @@
     <h1>
         Annuler la suspension de PASS IAE
         <br>
-        <span class="text-muted">{{ suspension.approval.user.get_full_name|title }}</span>
+        <span class="text-muted">{{ suspension.approval.user.get_full_name }}</span>
     </h1>
 {% endblock %}
 

--- a/itou/templates/approvals/suspension_update.html
+++ b/itou/templates/approvals/suspension_update.html
@@ -7,7 +7,7 @@
     <h1>
         Modifier la suspension de PASS IAE
         <br>
-        <span class="text-muted">{{ suspension.approval.user.get_full_name|title }}</span>
+        <span class="text-muted">{{ suspension.approval.user.get_full_name }}</span>
     </h1>
 {% endblock %}
 

--- a/itou/templates/common/emails/request_for_invitation_body.txt
+++ b/itou/templates/common/emails/request_for_invitation_body.txt
@@ -2,7 +2,7 @@
 {% load format_filters %}
 {% block body %}
 
-Bonjour {{ to.get_full_name|title }},
+Bonjour {{ to.get_full_name }},
 
 {{ full_name|title }} a demandé à rejoindre votre organisation « {{ organization.display_name }} ».
 

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -26,7 +26,7 @@
                     <a href="{% url 'siaes_views:edit_siae_step_contact_infos' %}">Indiquez une autre adresse</a>
                 {% else %}
                     {% with current_siae.active_admin_members.first as admin %}
-                        Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
+                        Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name.get_full_name }}) pour qu'il ou elle indique une autre adresse
                     {% endwith %}
                 {% endif %}
                 ou <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" aria-label="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
@@ -47,7 +47,7 @@
                     <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a>
                 {% else %}
                     {% with current_prescriber_organization.active_admin_members.first as admin %}
-                        Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle indique une autre adresse
+                        Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name.get_full_name }}) pour qu'il ou elle indique une autre adresse
                     {% endwith %}
                 {% endif %}
                 ou <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" aria-label="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
@@ -73,7 +73,7 @@
                     <br>
                 {% else %}
                     {% with current_siae.active_admin_members.first as admin %}
-                        Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name|title }} {{ admin.last_name|title }}) pour qu'il ou elle régularise la situation de votre structure.
+                        Veuillez contacter un de vos administrateurs (par exemple {{ admin.first_name.get_full_name }}) pour qu'il ou elle régularise la situation de votre structure.
                     {% endwith %}
                 {% endif %}
             </p>

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -2,11 +2,11 @@
 {% load bootstrap4 %}
 {% load static %}
 
-{% block title %}Informations personnelles de {{ job_seeker.get_full_name|title }} {{ block.super }}{% endblock %}
+{% block title %}Informations personnelles de {{ job_seeker.get_full_name }} {{ block.super }}{% endblock %}
 
 {% block content_title %}
     <h1>
-        Informations personnelles de <span class="text-muted">{{ job_seeker.get_full_name|title }}</span>
+        Informations personnelles de <span class="text-muted">{{ job_seeker.get_full_name }}</span>
     </h1>
     <div class="alert alert-warning">
         <p>

--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -35,9 +35,9 @@
                                         {% csrf_token %}
                                         {% if ic_account_url %}
                                             <div>
-                                                Prénom : <strong>{{ user.first_name }}</strong>
+                                                Prénom : <strong>{{ user.first_name|title }}</strong>
                                                 <br>
-                                                Nom : <strong>{{ user.last_name }}</strong>
+                                                Nom : <strong>{{ user.last_name|upper }}</strong>
                                                 <br>
                                                 Adresse e-mail : <strong>{{ user.email }}</strong>
                                             </div>

--- a/itou/templates/employee_record/create.html
+++ b/itou/templates/employee_record/create.html
@@ -8,9 +8,7 @@
     Nouvelle fiche salarié ASP - étape {{ step }} - {{ current_siae.display_name }} {{ block.super }}
 {% endblock %}
 
-{% block content_title %}
-    <h1>Fiches salarié ASP : {{ job_application.job_seeker.get_full_name|title }}</h1>
-{% endblock %}
+{% block content_title %}<h1>Fiches salarié ASP : {{ job_application.job_seeker.get_full_name }}</h1>{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/employee_record/disable.html
+++ b/itou/templates/employee_record/disable.html
@@ -7,7 +7,7 @@
 
 {% block content_title %}
     <h1>Désactiver la fiche salarié ASP</h1>
-    <h2 class="text-muted">{{ employee_record.job_seeker.get_full_name|title }}</h2>
+    <h2 class="text-muted">{{ employee_record.job_seeker.get_full_name }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -4,7 +4,7 @@
     <div class="card-body">
         <div class="row mb-3">
             <div class="col-12 col-md">
-                <h3 class="h3 m-0">{{ item.job_seeker.get_full_name|title }}</h3>
+                <h3 class="h3 m-0">{{ item.job_seeker.get_full_name }}</h3>
             </div>
             {# Statuses #}
             <div class="col-12 col-md-auto">

--- a/itou/templates/employee_record/reactivate.html
+++ b/itou/templates/employee_record/reactivate.html
@@ -7,7 +7,7 @@
 
 {% block content_title %}
     <h1>Réactiver la fiche salarié ASP</h1>
-    <h2 class="text-muted">{{ employee_record.job_seeker.get_full_name|title }}</h2>
+    <h2 class="text-muted">{{ employee_record.job_seeker.get_full_name }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -6,7 +6,7 @@
 {% block title %}Détail fiche salarié ASP - {{ current_siae.display_name }} {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>Détail fiche salarié ASP: {{ employee_record.job_seeker.get_full_name|title }}</h1>
+    <h1>Détail fiche salarié ASP: {{ employee_record.job_seeker.get_full_name }}</h1>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/institutions/members.html
+++ b/itou/templates/institutions/members.html
@@ -7,7 +7,7 @@
     <h2>{{ institution.display_name }}</h2>
     <div class="alert alert-info">
         <p class="mb-0">
-            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
         </p>
     </div>
 {% endblock %}

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -77,8 +77,8 @@
                                     <tbody>
                                         {% for invitation in pending_invitations %}
                                             <tr>
-                                                <td>{{ invitation.first_name }}</td>
-                                                <td>{{ invitation.last_name }}</td>
+                                                <td>{{ invitation.first_name|title }}</td>
+                                                <td>{{ invitation.last_name|upper }}</td>
                                                 <td>{{ invitation.email }}</td>
                                                 <td>{{ invitation.sent_at|date }}</td>
                                             </tr>

--- a/itou/templates/invitations_views/email/accepted_notif_establishment_sender_body.txt
+++ b/itou/templates/invitations_views/email/accepted_notif_establishment_sender_body.txt
@@ -1,12 +1,12 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% block body %}
 
-{{ first_name|capfirst }} {{ last_name|capfirst }} est désormais membre de la structure {{ establishment_name }}.
+{{ first_name|title }} {{ last_name|upper }} est désormais membre de la structure {{ establishment_name }}.
 
 Détails
 -------------------
-- Prénom : {{ first_name }}
-- Nom : {{ last_name }}
+- Prénom : {{ first_name|title }}
+- Nom : {{ last_name|upper }}
 - Adresse e-mail : {{ email }}
 
 {% endblock %}

--- a/itou/templates/invitations_views/email/accepted_notif_sender_subject.txt
+++ b/itou/templates/invitations_views/email/accepted_notif_sender_subject.txt
@@ -1,4 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
-{{ first_name|capfirst }} {{ last_name|capfirst }} a accepté votre invitation.
+{{ first_name|title }} {{ last_name|upper }} a accepté votre invitation.
 {% endblock %}

--- a/itou/templates/invitations_views/email/invitation_establishment_body.txt
+++ b/itou/templates/invitations_views/email/invitation_establishment_body.txt
@@ -1,7 +1,7 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% block body %}
 
-Bonjour {{ first_name|capfirst }} {{ last_name|capfirst }} !
+Bonjour {{ first_name|title }} {{ last_name|upper }} !
 
 Vous avez été invité(e) à vous rattacher au compte de la structure {{ establishment.display_name }} sur les emplois de l'inclusion. Cliquez sur le lien ci-dessous pour vous inscrire en quelques clics. Nous sommes ravis de vous accueillir sur les emplois de l'inclusion !
 

--- a/itou/templates/invitations_views/email/invitation_establishment_subject.txt
+++ b/itou/templates/invitations_views/email/invitation_establishment_subject.txt
@@ -1,6 +1,6 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
 
-{{ sender.get_full_name|title }} vous a invité(e) à rejoindre l'organisation {{ establishment.display_name|truncatechars:80 }} sur les emplois de l'inclusion.
+{{ sender.get_full_name }} vous a invité(e) à rejoindre l'organisation {{ establishment.display_name|truncatechars:80 }} sur les emplois de l'inclusion.
 
 {% endblock %}

--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -24,7 +24,7 @@
                 {% for invitation in pending_invitations %}
                     <tr>
                         <th scope="row">{{ forloop.counter }}</th>
-                        <td>{{ invitation.first_name }} {{ invitation.last_name }}</td>
+                        <td>{{ invitation.first_name|title }} {{ invitation.last_name|upper }}</td>
                         <td>
                             <a href="mailto:{{ invitation.email }}">{{ invitation.email }}</a>
                         </td>

--- a/itou/templates/invitations_views/new_ic_user.html
+++ b/itou/templates/invitations_views/new_ic_user.html
@@ -4,7 +4,7 @@
 {% block title %}Invitation {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>Bienvenue {{ invitation.first_name }} {{ invitation.last_name }} !</h1>
+    <h1>Bienvenue {{ invitation.first_name|title }} {{ invitation.last_name|upper }} !</h1>
     <p>
         Vous allez rejoindre le tableau de bord de <span class="font-weight-bold">{{ invitation.organization.name }}{{ invitation.siae.display_name }}</span>
     </p>

--- a/itou/templates/invitations_views/new_user.html
+++ b/itou/templates/invitations_views/new_user.html
@@ -3,7 +3,9 @@
 
 {% block title %}Invitation {{ block.super }}{% endblock %}
 
-{% block content_title %}<h1>Bienvenue {{ invitation.first_name }} {{ invitation.last_name }} !</h1>{% endblock %}
+{% block content_title %}
+    <h1>Bienvenue {{ invitation.first_name|title }} {{ invitation.last_name|upper }} !</h1>
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/prescribers/list_accredited_organizations.html
+++ b/itou/templates/prescribers/list_accredited_organizations.html
@@ -63,7 +63,7 @@
                                                     {% for membership in org.prescribermembership_set.all %}
                                                         <tr>
                                                             <th scope="row">{{ forloop.counter }}</th>
-                                                            <td>{{ membership.user.last_name|title }}</td>
+                                                            <td>{{ membership.user.last_name|upper }}</td>
                                                             <td>{{ membership.user.first_name|title }}</td>
                                                             <td>
                                                                 <a href="mailto:{{ membership.user.email }}">{{ membership.user.email }}</a>

--- a/itou/templates/prescribers/members.html
+++ b/itou/templates/prescribers/members.html
@@ -7,7 +7,7 @@
     <h2>{{ organization.display_name }}</h2>
     <div class="alert alert-info">
         <p class="mb-0">
-            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
         </p>
     </div>
 {% endblock %}

--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html
@@ -3,7 +3,7 @@
     <div class="col-md-8">
         <h3 class="h2">
             Auto-prescription pour
-            <span class="text-muted">{{ job_seeker.get_full_name|title }}</span>
+            <span class="text-muted">{{ job_seeker.get_full_name }}</span>
         </h3>
         <p class="m-0">
             PASS IAE :&nbsp;<b>{{ approval.number|format_approval_number }}</b> délivré le {{ approval.start_at|date:"d E Y" }}

--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
@@ -3,7 +3,7 @@
     <div class="col-lg-8 col-md-7 col-12">
         <h3 class="h2">
             Auto-prescription pour
-            <span class="text-muted">{{ job_seeker.get_full_name|title }}</span>
+            <span class="text-muted">{{ job_seeker.get_full_name }}</span>
         </h3>
     </div>
     <div class="col-lg-4 col-md-5 col-12 text-right">

--- a/itou/templates/siaes/members.html
+++ b/itou/templates/siaes/members.html
@@ -7,7 +7,7 @@
     <h2>{{ siae.display_name }}</h2>
     <div class="alert alert-info">
         <p class="mb-0">
-            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name|title }}</b> ({{ user.email }})
+            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
         </p>
     </div>
 {% endblock %}

--- a/itou/templates/signup/includes/prescriber_card.html
+++ b/itou/templates/signup/includes/prescriber_card.html
@@ -23,7 +23,7 @@
                 {# For security, display only the first char of the last name. #}
                 <i>
                     Demandez une invitation à
-                    {{ membership.user.first_name|title }} {{ membership.user.last_name|slice:1 }}.
+                    {{ membership.user.first_name|title }} {{ membership.user.last_name|slice:1|upper }}.
                     pour rejoindre cette organisation.
                 </i>
                 <br>

--- a/itou/templates/signup/prescriber_request_invitation.html
+++ b/itou/templates/signup/prescriber_request_invitation.html
@@ -12,7 +12,7 @@
     </h1>
     <div class="alert alert-info">
         <p class="mb-0">
-            Renseignez vos coordonnées afin d'être invité par {{ prescriber.first_name|title }} {{ prescriber.last_name|slice:1 }} de l'organisation « {{ organization.display_name }} ».
+            Renseignez vos coordonnées afin d'être invité par {{ prescriber.first_name|title }} {{ prescriber.last_name|slice:1|upper }} de l'organisation « {{ organization.display_name }} ».
         </p>
     </div>
 {% endblock %}

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -147,7 +147,7 @@
                                         {# note: memberships.first does not work, it does not take the prefetch into account. #}
                                         {% with siae.memberships.all.0.user as admin %}
                                             {# For security, display only the first char of the last name. #}
-                                            Pour obtenir une invitation, <b>veuillez contacter {{ admin.first_name|title }} {{ admin.last_name|slice:1 }}</b>.
+                                            Pour obtenir une invitation, <b>veuillez contacter {{ admin.first_name|title }} {{ admin.last_name|slice:1|upper }}</b>.
                                         {% endwith %}
                                     </p>
                                 </div>

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -542,7 +542,7 @@ class JobSeekerProfileAdmin(admin.ModelAdmin):
 
     @admin.display(description="nom complet")
     def username(self, obj):
-        return f"{obj.user.first_name} {obj.user.last_name}"
+        return obj.user.get_full_name()
 
     @admin.display(description="identifiant Pôle emploi")
     def pole_emploi_id(self, obj):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -433,6 +433,13 @@ class User(AbstractUser, AddressMixin):
                 self.jobseeker_profile.pe_last_certification_attempt_at = None
                 self.jobseeker_profile.save(update_fields=["pe_obfuscated_nir", "pe_last_certification_attempt_at"])
 
+    def get_full_name(self):
+        """
+        Return the first_name plus the last_name, with a space in between.
+        """
+        full_name = "%s %s" % (self.first_name.strip().title(), self.last_name.upper())
+        return full_name.strip()
+
     @property
     def is_job_seeker(self):
         return self.kind == UserKind.JOB_SEEKER

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -515,7 +515,7 @@ def archive(request, job_application_id):
 
     if request.method == "POST":
         try:
-            username = f"{job_application.job_seeker.first_name} {job_application.job_seeker.last_name}"
+            username = job_application.job_seeker.get_full_name()
             siae_name = job_application.to_siae.display_name
 
             job_application.hidden_for_siae = True

--- a/tests/approvals/__snapshots__/test_notifications.ambr
+++ b/tests/approvals/__snapshots__/test_notifications.ambr
@@ -3,7 +3,7 @@
   '''
   Bonjour,
   
-  John Doe de la structure Acme inc. a besoin de votre accord pour prolonger un PASS IAE.
+  John DOE de la structure Acme inc. a besoin de votre accord pour prolonger un PASS IAE.
   
   L'employeur souhaite vous apporter des explications supplémentaires par téléphone. Vous trouverez ci-dessous ses coordonnées pour le contacter :
   
@@ -12,7 +12,7 @@
   
   - Numéro de PASS : 999999999999
   - Prénom : John
-  - Nom : Doe
+  - Nom : DOE
   - Date de naissance : 01/01/2000
   - Début de la prolongation : 01/01/2000
   - Fin de la prolongation : 30/12/2004
@@ -45,7 +45,7 @@
   '''
 # ---
 # name: test_prolongation_request_created[subject]
-  'Demande de prolongation du PASS IAE de John Doe'
+  'Demande de prolongation du PASS IAE de John DOE'
 # ---
 # name: test_prolongation_request_created_reminder[body]
   '''
@@ -57,7 +57,7 @@
   
   Bonjour,
   
-  John Doe de la structure Acme inc. a besoin de votre accord pour prolonger un PASS IAE.
+  John DOE de la structure Acme inc. a besoin de votre accord pour prolonger un PASS IAE.
   
   L'employeur souhaite vous apporter des explications supplémentaires par téléphone. Vous trouverez ci-dessous ses coordonnées pour le contacter :
   
@@ -66,7 +66,7 @@
   
   - Numéro de PASS : 999999999999
   - Prénom : John
-  - Nom : Doe
+  - Nom : DOE
   - Date de naissance : 01/01/2000
   - Début de la prolongation : 01/01/2000
   - Fin de la prolongation : 30/12/2004
@@ -99,7 +99,7 @@
   '''
 # ---
 # name: test_prolongation_request_created_reminder[subject]
-  'Relance - Demande de prolongation du PASS IAE de John Doe'
+  'Relance - Demande de prolongation du PASS IAE de John DOE'
 # ---
 # name: test_prolongation_request_denied_employer[body]
   '''
@@ -109,7 +109,7 @@
   
   Références :
   Numéro : 99999 99 99999
-  Bénéficiaire : John Doe
+  Bénéficiaire : John DOE
   
   Vous pouvez consulter la date de fin prévisionnelle du PASS IAE dans votre espace employeur sur les emplois de l’inclusion.
   
@@ -120,7 +120,7 @@
   '''
 # ---
 # name: test_prolongation_request_denied_employer[subject]
-  'Prolongation du PASS IAE de John Doe refusée'
+  'Prolongation du PASS IAE de John DOE refusée'
 # ---
 # name: test_prolongation_request_denied_jobseeker[body]
   '''
@@ -149,7 +149,7 @@
   
   Références :
   Numéro : 99999 99 99999
-  Bénéficiaire : John Doe
+  Bénéficiaire : John DOE
   
   Vous pouvez consulter la nouvelle date de fin prévisionnelle du PASS IAE dans votre espace employeur sur les emplois de l’inclusion.
   
@@ -160,7 +160,7 @@
   '''
 # ---
 # name: test_prolongation_request_granted_employer[subject]
-  'Prolongation du PASS IAE de John Doe acceptée'
+  'Prolongation du PASS IAE de John DOE acceptée'
 # ---
 # name: test_prolongation_request_granted_jobseeker[body]
   '''

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
@@ -43,7 +43,7 @@
   Preflight activated, checking for possible serialization errors...
   Found 1 object(s) to check, split in chunks of 700 objects.
   Checking file #1 (chunk of 1 objects)
-  ERROR: serialization of PK:42 PASS:XXXXX3724456 SIRET:17483349486512 JA:49536a29-88b5-49c3-8c46-333bbbc36308 JOBSEEKER:Jonathan Martinez — email@example.com STATUS:READY ASP_ID:21 failed!
+  ERROR: serialization of PK:42 PASS:XXXXX3724456 SIRET:17483349486512 JA:49536a29-88b5-49c3-8c46-333bbbc36308 JOBSEEKER:Jonathan MARTINEZ — email@example.com STATUS:READY ASP_ID:21 failed!
   > Got AttributeError when attempting to get a value for field `codeinseecom` on serializer `_AddressSerializer`.
   > The serializer field might be named incorrectly and not match any attribute or key on the `User` instance.
   > Original exception text was: 'NoneType' object has no attribute 'code'.

--- a/tests/invitations/tests.py
+++ b/tests/invitations/tests.py
@@ -1,5 +1,4 @@
 import pytest
-from django.template.defaultfilters import capfirst
 from django.test import SimpleTestCase
 from django.utils import timezone
 
@@ -81,11 +80,11 @@ class InvitationEmailsTest(SimpleTestCase):
         email = invitation.email_invitation
 
         # Subject
-        assert invitation.sender.get_full_name().title() in email.subject
+        assert invitation.sender.get_full_name() in email.subject
 
         # Body
-        assert capfirst(invitation.first_name) in email.body
-        assert capfirst(invitation.last_name) in email.body
+        assert invitation.first_name.title() in email.body
+        assert invitation.last_name.upper() in email.body
         assert invitation.acceptance_link in email.body
 
         assert str(timezone.localdate(invitation.expiration_date).day) in email.body
@@ -128,12 +127,12 @@ class TestPrescriberWithOrgInvitationEmails(SimpleTestCase):
         email = invitation.email_accepted_notif_sender
 
         # Subject
-        assert capfirst(invitation.first_name) in email.subject
-        assert capfirst(invitation.last_name) in email.subject
+        assert invitation.first_name.title() in email.subject
+        assert invitation.last_name.upper() in email.subject
 
         # Body
-        assert capfirst(invitation.first_name) in email.body
-        assert capfirst(invitation.last_name) in email.body
+        assert invitation.first_name.title() in email.body
+        assert invitation.last_name.upper() in email.body
         assert invitation.email in email.body
         assert invitation.organization.display_name in email.body
 
@@ -148,8 +147,8 @@ class TestPrescriberWithOrgInvitationEmails(SimpleTestCase):
         assert invitation.organization.display_name in email.subject
 
         # Body
-        assert capfirst(invitation.first_name) in email.body
-        assert capfirst(invitation.last_name) in email.body
+        assert invitation.first_name.title() in email.body
+        assert invitation.last_name.upper() in email.body
         assert invitation.acceptance_link in email.body
         assert invitation.organization.display_name in email.body
 
@@ -184,12 +183,12 @@ class TestSiaeInvitationEmails(SimpleTestCase):
         email = invitation.email_accepted_notif_sender
 
         # Subject
-        assert capfirst(invitation.first_name) in email.subject
-        assert capfirst(invitation.last_name) in email.subject
+        assert invitation.first_name.title() in email.subject
+        assert invitation.last_name.upper() in email.subject
 
         # Body
-        assert capfirst(invitation.first_name) in email.body
-        assert capfirst(invitation.last_name) in email.body
+        assert invitation.first_name.title() in email.body
+        assert invitation.last_name.upper() in email.body
         assert invitation.email in email.body
         assert invitation.siae.display_name in email.body
 
@@ -204,8 +203,8 @@ class TestSiaeInvitationEmails(SimpleTestCase):
         assert invitation.siae.display_name in email.subject
 
         # Body
-        assert capfirst(invitation.first_name) in email.body
-        assert capfirst(invitation.last_name) in email.body
+        assert invitation.first_name.title() in email.body
+        assert invitation.last_name.upper() in email.body
         assert invitation.acceptance_link in email.body
         assert invitation.siae.display_name in email.body
 

--- a/tests/job_applications/test_transfer.py
+++ b/tests/job_applications/test_transfer.py
@@ -195,10 +195,7 @@ class JobApplicationTransferModelTest(TestCase):
 
         assert len(mail.outbox[0].to) == 1
         assert origin_user.email in mail.outbox[0].to
-        assert (
-            f"La candidature de {job_seeker.first_name} {job_seeker.last_name} a été transférée"
-            in mail.outbox[0].subject
-        )
+        assert f"La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[0].subject
         assert "a transféré la candidature de :" in mail.outbox[0].body
 
         assert len(mail.outbox[1].to) == 1
@@ -231,10 +228,7 @@ class JobApplicationTransferModelTest(TestCase):
         # Focusing on prescriber email content
         assert len(mail.outbox[2].to) == 1
         assert job_application.sender.email in mail.outbox[2].to
-        assert (
-            f"La candidature de {job_seeker.first_name} {job_seeker.last_name} a été transférée"
-            in mail.outbox[2].subject
-        )
+        assert f"La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[2].subject
         assert "a transféré la candidature de :" in mail.outbox[2].body
 
     def test_transfer_notifications_to_many_siae_members(self):
@@ -261,8 +255,5 @@ class JobApplicationTransferModelTest(TestCase):
         assert len(mail.outbox[0].to) == 2
         assert origin_user_1.email in mail.outbox[0].to
         assert origin_user_2.email in mail.outbox[0].to
-        assert (
-            f"La candidature de {job_seeker.first_name} {job_seeker.last_name} a été transférée"
-            in mail.outbox[0].subject
-        )
+        assert f"La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[0].subject
         assert "a transféré la candidature de :" in mail.outbox[0].body

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -9,7 +9,6 @@ from django.core import mail
 from django.core.exceptions import ValidationError
 from django.db.models import Max
 from django.forms.models import model_to_dict
-from django.template.defaultfilters import title
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -690,8 +689,8 @@ class JobApplicationNotificationsTest(TestCase):
         assert len(email.to) == 1
 
         # Body.
-        assert job_application.job_seeker.first_name in email.body
-        assert job_application.job_seeker.last_name in email.body
+        assert job_application.job_seeker.first_name.title() in email.body
+        assert job_application.job_seeker.last_name.upper() in email.body
         assert job_application.job_seeker.birthdate.strftime("%d/%m/%Y") in email.body
         assert job_application.job_seeker.email in email.body
         assert format_filters.format_phone(job_application.job_seeker.phone) in email.body
@@ -721,14 +720,14 @@ class JobApplicationNotificationsTest(TestCase):
 
         # Body.
         assert job_application.job_seeker.first_name.title() in email.body
-        assert job_application.job_seeker.last_name.title() in email.body
+        assert job_application.job_seeker.last_name.upper() in email.body
         assert job_application.job_seeker.birthdate.strftime("%d/%m/%Y") in email.body
         assert job_application.job_seeker.email in email.body
         assert format_filters.format_phone(job_application.job_seeker.phone) in email.body
         assert job_application.message in email.body
         for job in job_application.selected_jobs.all():
             assert job.display_name in email.body
-        assert job_application.sender.get_full_name().title() in email.body
+        assert job_application.sender.get_full_name() in email.body
         assert job_application.sender.email in email.body
         assert format_filters.format_phone(job_application.sender.phone) in email.body
         assert job_application.to_siae.display_name in email.body
@@ -737,7 +736,7 @@ class JobApplicationNotificationsTest(TestCase):
 
         # Assert the Job Seeker does not have access to confidential information.
         email = job_application.email_new_for_job_seeker()
-        assert job_application.sender.get_full_name().title() in email.body
+        assert job_application.sender.get_full_name() in email.body
         assert job_application.sender_prescriber_organization.display_name in email.body
         assert job_application.sender.email not in email.body
         assert format_filters.format_phone(job_application.sender.phone) not in email.body
@@ -756,17 +755,13 @@ class JobApplicationNotificationsTest(TestCase):
 
         # Body.
         assert job_application.job_seeker.first_name.title() in email.body
-        assert job_application.job_seeker.last_name.title() in email.body
+        assert job_application.job_seeker.last_name.upper() in email.body
         assert job_application.job_seeker.birthdate.strftime("%d/%m/%Y") in email.body
         assert job_application.job_seeker.email in email.body
         assert format_filters.format_phone(job_application.job_seeker.phone) in email.body
         assert job_application.message in email.body
         for job in job_application.selected_jobs.all():
             assert job.display_name in email.body
-        assert job_application.sender.first_name.title() in email.body
-        assert job_application.sender.last_name.title() in email.body
-        assert job_application.sender.email in email.body
-        assert format_filters.format_phone(job_application.sender.phone) in email.body
         assert job_application.to_siae.display_name in email.body
         assert reverse("login:job_seeker") in email.body
         assert reverse("account_reset_password") in email.body
@@ -797,8 +792,8 @@ class JobApplicationNotificationsTest(TestCase):
         # Subject.
         assert "Candidature acceptée et votre avis sur les emplois de l'inclusion" in email.subject
         # Body.
-        assert title(job_application.job_seeker.get_full_name()) in email.body
-        assert title(job_application.sender.get_full_name()) in email.body
+        assert job_application.job_seeker.get_full_name() in email.body
+        assert job_application.sender.get_full_name() in email.body
         assert job_application.to_siae.display_name in email.body
         assert job_application.answer in email.body
         assert "Date de début du contrat" in email.body
@@ -824,8 +819,8 @@ class JobApplicationNotificationsTest(TestCase):
         assert settings.ITOU_EMAIL_CONTACT in email.to
         assert len(email.to) == 1
         # Body.
-        assert job_application.job_seeker.first_name in email.body
-        assert job_application.job_seeker.last_name in email.body
+        assert job_application.job_seeker.first_name.title() in email.body
+        assert job_application.job_seeker.last_name.upper() in email.body
         assert job_application.job_seeker.email in email.body
         assert job_application.job_seeker.birthdate.strftime("%d/%m/%Y") in email.body
         assert job_application.to_siae.siret in email.body
@@ -862,10 +857,8 @@ class JobApplicationNotificationsTest(TestCase):
         assert job_application.sender.email in email.to
         assert len(email.to) == 1
         # Body.
-        assert job_application.sender.first_name.title() in email.body
-        assert job_application.sender.last_name.title() in email.body
-        assert job_application.job_seeker.first_name.title() in email.body
-        assert job_application.job_seeker.last_name.title() in email.body
+        assert job_application.sender.get_full_name() in email.body
+        assert job_application.job_seeker.get_full_name() in email.body
         assert job_application.to_siae.display_name in email.body
         assert job_application.answer in email.body
         assert job_application.answer_to_prescriber in email.body
@@ -904,8 +897,8 @@ class JobApplicationNotificationsTest(TestCase):
         assert approval.number_with_spaces in email.body
         assert approval.start_at.strftime("%d/%m/%Y") in email.body
         assert f"{approval.remainder.days} jours" in email.body
-        assert approval.user.last_name in email.body
-        assert approval.user.first_name in email.body
+        assert approval.user.last_name.upper() in email.body
+        assert approval.user.first_name.title() in email.body
         assert approval.user.birthdate.strftime("%d/%m/%Y") in email.body
         assert job_application.hiring_start_at.strftime("%d/%m/%Y") in email.body
         assert job_application.hiring_end_at.strftime("%d/%m/%Y") in email.body
@@ -1011,10 +1004,8 @@ class JobApplicationNotificationsTest(TestCase):
         assert len(email.bcc) == 1
         # Body.
         assert "annulée" in email.body
-        assert job_application.sender.first_name in email.body
-        assert job_application.sender.last_name in email.body
-        assert job_application.job_seeker.first_name in email.body
-        assert job_application.job_seeker.last_name in email.body
+        assert job_application.sender.get_full_name() in email.body
+        assert job_application.job_seeker.get_full_name() in email.body
 
         # When sent by jobseeker.
         job_application = JobApplicationSentByJobSeekerFactory(state=JobApplicationWorkflow.STATE_ACCEPTED)

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -449,11 +449,11 @@ class TestCommandNewUsersToMailJet:
         assert json.loads(postcall.request.content) == {
             "Action": "addnoforce",
             "Contacts": [
-                {"Email": "annie.amma@mailinator.com", "Name": "Annie Amma"},
-                {"Email": "bob.bailey@mailinator.com", "Name": "Bob Bailey"},
-                {"Email": "cindy.cinnamon@mailinator.com", "Name": "Cindy Cinnamon"},
-                {"Email": "dave.doll@mailinator.com", "Name": "Dave Doll"},
-                {"Email": "eve.ebi@mailinator.com", "Name": "Eve Ebi"},
+                {"Email": "annie.amma@mailinator.com", "Name": "Annie AMMA"},
+                {"Email": "bob.bailey@mailinator.com", "Name": "Bob BAILEY"},
+                {"Email": "cindy.cinnamon@mailinator.com", "Name": "Cindy CINNAMON"},
+                {"Email": "dave.doll@mailinator.com", "Name": "Dave DOLL"},
+                {"Email": "eve.ebi@mailinator.com", "Name": "Eve EBI"},
             ],
         }
         assert caplog.record_tuples == [
@@ -561,14 +561,14 @@ class TestCommandNewUsersToMailJet:
         [pe_postcall] = pe_post_mock.calls
         assert json.loads(pe_postcall.request.content) == {
             "Action": "addnoforce",
-            "Contacts": [{"Email": "alice.aamar@mailinator.com", "Name": "Alice Aamar"}],
+            "Contacts": [{"Email": "alice.aamar@mailinator.com", "Name": "Alice AAMAR"}],
         }
         [other_org_postcall] = other_org_post_mock.calls
         assert json.loads(other_org_postcall.request.content) == {
             "Action": "addnoforce",
             "Contacts": [
-                {"Email": "alice.aamar@mailinator.com", "Name": "Alice Aamar"},
-                {"Email": "justin.wood@mailinator.com", "Name": "Justin Wood"},
+                {"Email": "alice.aamar@mailinator.com", "Name": "Alice AAMAR"},
+                {"Email": "justin.wood@mailinator.com", "Name": "Justin WOOD"},
             ],
         }
         assert caplog.record_tuples == [
@@ -661,9 +661,9 @@ class TestCommandNewUsersToMailJet:
         assert json.loads(postcall.request.content) == {
             "Action": "addnoforce",
             "Contacts": [
-                {"Email": "billy.boo@mailinator.com", "Name": "Billy Boo"},
-                {"Email": "sonny.sunder@mailinator.com", "Name": "Sonny Sunder"},
-                {"Email": "timmy.timber@mailinator.com", "Name": "Timmy Timber"},
+                {"Email": "billy.boo@mailinator.com", "Name": "Billy BOO"},
+                {"Email": "sonny.sunder@mailinator.com", "Name": "Sonny SUNDER"},
+                {"Email": "timmy.timber@mailinator.com", "Name": "Timmy TIMBER"},
             ],
         }
         assert caplog.record_tuples == [
@@ -750,13 +750,13 @@ class TestCommandNewUsersToMailJet:
         assert json.loads(postcall1.request.content) == {
             "Action": "addnoforce",
             "Contacts": [
-                {"Email": "annie.amma@mailinator.com", "Name": "Annie Amma"},
+                {"Email": "annie.amma@mailinator.com", "Name": "Annie AMMA"},
             ],
         }
         assert json.loads(postcall2.request.content) == {
             "Action": "addnoforce",
             "Contacts": [
-                {"Email": "bob.bailey@mailinator.com", "Name": "Bob Bailey"},
+                {"Email": "bob.bailey@mailinator.com", "Name": "Bob BAILEY"},
             ],
         }
         assert caplog.record_tuples == [
@@ -817,7 +817,7 @@ class TestCommandNewUsersToMailJet:
         assert json.loads(postcall.request.content) == {
             "Action": "addnoforce",
             "Contacts": [
-                {"Email": "annie.amma@mailinator.com", "Name": "Annie Amma"},
+                {"Email": "annie.amma@mailinator.com", "Name": "Annie AMMA"},
             ],
         }
         assert caplog.record_tuples == [

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -984,6 +984,17 @@ class ModelTest(TestCase):
                 else:
                     factory(identity_provider=identity_provider)
 
+    def test_get_full_name(self):
+        assert JobSeekerFactory(first_name="CLÉMENT", last_name="Dupont").get_full_name() == "Clément DUPONT"
+        assert (
+            JobSeekerFactory(first_name="JEAN-FRANÇOIS", last_name="de Saint Exupéry").get_full_name()
+            == "Jean-François DE SAINT EXUPÉRY"
+        )
+        assert (
+            JobSeekerFactory(first_name=" marie aurore", last_name="maréchal").get_full_name()
+            == "Marie Aurore MARÉCHAL"
+        )
+
 
 def mock_get_geocoding_data(address, post_code=None, limit=1):
     return RESULTS_BY_ADDRESS.get(address)

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -61,7 +61,7 @@
   
   <div class="card-header">
       <p class="mb-0">
-          <b>Jacques Henry</b>
+          <b>Jacques HENRY</b>
           chez
           <b>
               <a href="/siae/42/card?back_url=/apply/job_seeker/list">
@@ -93,7 +93,7 @@
               <p class="font-weight-bold mb-1">Envoyée par :</p>
               <p class="fs-sm card-text">
                   
-                      Max Throughput
+                      Max THROUGHPUT
                   
   
                   
@@ -129,7 +129,7 @@
   
   <div class="card-header">
       <p class="mb-0">
-          <b>Jacques Henry</b>
+          <b>Jacques HENRY</b>
           chez
           <b>
               <a href="/siae/42/card?back_url=/apply/job_seeker/list">
@@ -161,7 +161,7 @@
               <p class="font-weight-bold mb-1">Envoyée par :</p>
               <p class="fs-sm card-text">
                   
-                      Max Throughput
+                      Max THROUGHPUT
                   
   
                   
@@ -197,7 +197,7 @@
   
   <div class="card-header">
       <p class="mb-0">
-          <b>Jacques Henry</b>
+          <b>Jacques HENRY</b>
           chez
           <b>
               <a href="/siae/42/card?back_url=/apply/job_seeker/list">
@@ -229,7 +229,7 @@
               <p class="font-weight-bold mb-1">Envoyée par :</p>
               <p class="fs-sm card-text">
                   
-                      Max Throughput
+                      Max THROUGHPUT
                   
   
                   
@@ -544,7 +544,7 @@
   
           
               
-                  <strong class="mr-2">Max Throughput</strong>
+                  <strong class="mr-2">Max THROUGHPUT</strong>
               
               
                   <i aria-hidden="true" class="ri-group-line mr-2"></i>Orienteur
@@ -569,7 +569,7 @@
       <div class="row">
           <div class="col-12 col-lg-5 mb-3 mb-lg-0">
               <h3 class="h3 mb-1">
-                  Jacques Henry
+                  Jacques HENRY
               </h3>
               
   
@@ -594,7 +594,7 @@
   
                                       <div class="card-footer text-right bg-light">
                                           
-                                          <a aria-label="Gérer la candidature de Jacques Henry" class="btn btn-sm btn-outline-primary bg-white" href="/apply/11111111-1111-1111-1111-111111111111/siae/details?back_url=/apply/siae/list">
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" href="/apply/11111111-1111-1111-1111-111111111111/siae/details?back_url=/apply/siae/list">
                                               Voir sa candidature
                                           </a>
                                       </div>
@@ -646,7 +646,7 @@
   
           
               
-                  <strong class="mr-2">Max Throughput</strong>
+                  <strong class="mr-2">Max THROUGHPUT</strong>
               
               
                   <i aria-hidden="true" class="ri-group-line mr-2"></i>Orienteur
@@ -671,7 +671,7 @@
       <div class="row">
           <div class="col-12 col-lg-5 mb-3 mb-lg-0">
               <h3 class="h3 mb-1">
-                  Jacques Henry
+                  Jacques HENRY
               </h3>
               
   
@@ -701,7 +701,7 @@
                                                   En attente de réponse depuis 3 semaines.
                                               </span>
                                           
-                                          <a aria-label="Gérer la candidature de Jacques Henry" class="btn btn-sm btn-outline-primary bg-white" href="/apply/22222222-2222-2222-2222-222222222222/siae/details?back_url=/apply/siae/list">
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" href="/apply/22222222-2222-2222-2222-222222222222/siae/details?back_url=/apply/siae/list">
                                               Voir sa candidature
                                           </a>
                                       </div>
@@ -722,7 +722,7 @@
   
           
               
-                  <strong class="mr-2">Max Throughput</strong>
+                  <strong class="mr-2">Max THROUGHPUT</strong>
               
               
                   <i aria-hidden="true" class="ri-group-line mr-2"></i>Orienteur
@@ -747,7 +747,7 @@
       <div class="row">
           <div class="col-12 col-lg-5 mb-3 mb-lg-0">
               <h3 class="h3 mb-1">
-                  Jacques Henry
+                  Jacques HENRY
               </h3>
               
   
@@ -777,7 +777,7 @@
                                                   En attente de réponse depuis 8 semaines.
                                               </span>
                                           
-                                          <a aria-label="Gérer la candidature de Jacques Henry" class="btn btn-sm btn-outline-primary bg-white" href="/apply/33333333-3333-3333-3333-333333333333/siae/details?back_url=/apply/siae/list">
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" href="/apply/33333333-3333-3333-3333-333333333333/siae/details?back_url=/apply/siae/list">
                                               Voir sa candidature
                                           </a>
                                       </div>

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -2066,7 +2066,7 @@ class UpdateJobSeekerViewTestCase(TestCase):
         # Step END
         response = self.client.get(self.step_end_url)
         self.assertContains(response, PROCESS_TITLE, html=True)
-        self.assertContains(response, NEW_FIRST_NAME)
+        self.assertContains(response, NEW_FIRST_NAME.title())  # User.get_full_name() changes the firstname display
         self.assertContains(response, NEW_ADDRESS_LINE)
         self.assertContains(response, "Formation de niveau BAC")
         self.assertContains(response, "Valider les informations")

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -81,7 +81,7 @@
 # ---
 # name: TestApprovalDetailView.test_remove_approval_button[bouton de suppression d'un PASS IAE]
   '''
-  <a aria-label="Mettre fin au PASS IAE de Doe John" class="btn btn-outline-warning" href="https://tally.so/r/3je84Q?siaeID=999999&amp;nomSIAE=Aci+de+la+rochelle&amp;prenomemployeur=Milady&amp;nomemployeur=de+Winter&amp;emailemployeur=oph%40dewinter.com&amp;userID=123456&amp;numPASS=XXXXX+12+34568&amp;prenomsalarie=Doe&amp;nomsalarie=John" id="approval-deletion-link" target="_blank">
+  <a aria-label="Mettre fin au PASS IAE de Doe JOHN" class="btn btn-outline-warning" href="https://tally.so/r/3je84Q?siaeID=999999&amp;nomSIAE=Aci+de+la+rochelle&amp;prenomemployeur=Milady&amp;nomemployeur=de+Winter&amp;emailemployeur=oph%40dewinter.com&amp;userID=123456&amp;numPASS=XXXXX+12+34568&amp;prenomsalarie=Doe&amp;nomsalarie=John" id="approval-deletion-link" target="_blank">
                                           Clôturer
                                       </a>
   '''

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -24,7 +24,7 @@
                                       
                                           <tr>
                                               <th scope="row">1</th>
-                                              <td class="font-weight-bold">John Doe</td>
+                                              <td class="font-weight-bold">John DOE</td>
                                               <td><span>99999</span><span class="ml-1">99</span><span class="ml-1">99999</span></td>
                                               <td>ACME Inc.</td>
                                               <td>01/01/2000</td>
@@ -67,7 +67,7 @@
                                   Le bilan des actions réalisées et actions prévues avec le salarié, rempli par l’employeur est présent sur le document excel téléchargeable ci-dessous.
                               </p>
                               <p>
-                                  <a class="btn btn-secondary btn-ico" download="Bilan prolongation PASS IAE 999999999999 John Doe.xlsx" href="https://None/None/f0r_5n4p5h07">
+                                  <a class="btn btn-secondary btn-ico" download="Bilan prolongation PASS IAE 999999999999 John DOE.xlsx" href="https://None/None/f0r_5n4p5h07">
                                       <i class="ri-download-line ri-lg font-weight-normal"></i>
                                       <span>Télécharger le bilan</span>
                                   </a>
@@ -105,7 +105,7 @@
               </div>
               <div class="card-text">
                   <p class="mb-2">
-                      Demande refusée le 01 janvier 2000 par John Doe
+                      Demande refusée le 01 janvier 2000 par John DOE
                   </p>
               </div>
           
@@ -124,7 +124,7 @@
               </div>
               <div class="card-text">
                   <p class="mb-2">
-                      Demande acceptée le 01 janvier 2000 par John Doe
+                      Demande acceptée le 01 janvier 2000 par John DOE
                   </p>
               </div>
           

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -45,7 +45,7 @@ class TestApprovalsListView:
         response = client.get(url)
 
         assertContains(response, "2 résultats")
-        assertContains(response, approval.user.get_full_name(), count=3)
+        assertContains(response, approval.user.get_full_name(), count=2)
         assertContains(response, reverse("approvals:detail", kwargs={"pk": approval.pk}))
         assertContains(response, reverse("approvals:detail", kwargs={"pk": another_approval.pk}))
 

--- a/tests/www/approvals_views/test_pe_approval.py
+++ b/tests/www/approvals_views/test_pe_approval.py
@@ -180,7 +180,7 @@ class PoleEmploiApprovalSearchUserTest(TestCase):
         url = reverse("approvals:pe_approval_search_user", kwargs={"pe_approval_id": pe_approval.id})
 
         response = self.client.get(url)
-        self.assertContains(response, pe_approval.last_name.title())
+        self.assertContains(response, pe_approval.last_name.upper())
         self.assertContains(response, pe_approval.first_name.title())
 
     def test_invalid_pe_approval(self):

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -96,7 +96,7 @@ def test_show_view_action(client, action, expected_status, expected_message):
     assertRedirects(response, reverse("approvals:prolongation_requests_list"), fetch_redirect_response=False)
     assertMessages(
         response,
-        [(messages.SUCCESS, f"La prolongation de John Doe a bien été {expected_message}.")],
+        [(messages.SUCCESS, f"La prolongation de John DOE a bien été {expected_message}.")],
     )
     prolongation_request.refresh_from_db()
     assert prolongation_request.status == expected_status

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -877,8 +877,8 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         self.assertNotContains(response, "id_lack_of_nir")
         self.assertNotContains(response, "id_lack_of_nir_reason")
         self.assertNotContains(response, "birthdate")
-        self.assertContains(response, f"Prénom : <strong>{user.first_name}</strong>")
-        self.assertContains(response, f"Nom : <strong>{user.last_name}</strong>")
+        self.assertContains(response, f"Prénom : <strong>{user.first_name.title()}</strong>")
+        self.assertContains(response, f"Nom : <strong>{user.last_name.upper()}</strong>")
         self.assertContains(response, f"Adresse e-mail : <strong>{user.email}</strong>")
         self.assertContains(response, "Modifier ces informations")
 

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -965,7 +965,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.assertContains(response, evaluated_siae)
         formatted_number = format_approval_number(evaluated_job_application.job_application.approval.number)
         self.assertContains(response, formatted_number, html=True, count=1)
-        self.assertContains(response, evaluated_job_application.job_application.job_seeker.last_name)
+        self.assertContains(response, evaluated_job_application.job_application.job_seeker.get_full_name())
         assert response.context["back_url"] == reverse(
             "siae_evaluations_views:institution_evaluated_siae_list",
             kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
@@ -1261,7 +1261,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.assertContains(response, evaluated_siae)
         formatted_number = format_approval_number(evaluated_job_application.job_application.approval.number)
         self.assertContains(response, formatted_number, html=True, count=1)
-        self.assertContains(response, evaluated_job_application.job_application.job_seeker.last_name)
+        self.assertContains(response, evaluated_job_application.job_application.job_seeker.get_full_name())
         assert response.context["back_url"] == reverse(
             "siae_evaluations_views:institution_evaluated_siae_list",
             kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -240,7 +240,7 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
                     <div class="row">
                         <div class="col-lg-8 col-md-7 col-12">
                             <h3 class="h2">
-                                Auto-prescription pour <span class="text-muted">Manny Calavera</span>
+                                Auto-prescription pour <span class="text-muted">Manny CALAVERA</span>
                             </h3>
                         </div>
                         <div class="col-lg-4 col-md-5 col-12 text-right">
@@ -315,7 +315,7 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
                     <div class="row">
                         <div class="col-lg-8 col-md-7 col-12">
                             <h3 class="h2">
-                                Auto-prescription pour <span class="text-muted">Manny Calavera</span>
+                                Auto-prescription pour <span class="text-muted">Manny CALAVERA</span>
                             </h3>
                         </div>
                         <div class="col-lg-4 col-md-5 col-12 text-right">
@@ -347,7 +347,7 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
             <div class="row">
                 <div class="col-lg-8 col-md-7 col-12">
                     <h3 class="h2">
-                        Auto-prescription pour <span class="text-muted">Manny Calavera</span>
+                        Auto-prescription pour <span class="text-muted">Manny CALAVERA</span>
                     </h3>
                 </div>
                 <div class="col-lg-4 col-md-5 col-12 text-right">

--- a/tests/www/signup/test_prescriber.py
+++ b/tests/www/signup/test_prescriber.py
@@ -716,7 +716,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         mail_subject = mail.outbox[0].subject
         assert f"Demande pour rejoindre {prescriber_org.display_name}" in mail_subject
         mail_body = mail.outbox[0].body
-        assert prescriber_membership.user.get_full_name().title() in mail_body
+        assert prescriber_membership.user.get_full_name() in mail_body
         assert prescriber_membership.organization.display_name in mail_body
         invitation_url = f'{reverse("invitations_views:invite_prescriber_with_org")}?{urlencode(requestor)}'
         assert invitation_url in mail_body


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Harmonisation-de-l-affichage-du-Pr-nom-et-NOM-sur-le-site-boost-909237b6e2aa43bcaee08d120964768d?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Aide à identifier d’éventuelles inversion de nom prénom 

Je suis finalement allé plus loin que juste les get_full_name : j'ai regardé pour remplacé les first_name + last_name dans les templates là où c'était possible, et j'ai appliqué les mêmes règles partout ailleurs (title sur first_name pour avoir une majuscule sur les 2ndes parties de prénom, et upper pour last_name)
