### PR TITLE
Correction de l'icone de lien de la page de Stats

### DIFF
--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -14,11 +14,11 @@
 
     {% if is_stats_public %}
         <div class="mb-4">
-            <i class="ri-external-link-line ri-lg mr-1"></i>.
             Cette page a pour objectif de présenter l'impact des emplois de l'inclusion. Pour retrouver les indicateurs qui étaient présentés ici, merci de vous rendre sur le
             <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" aria-label="Vous rendre sur le pilotage de l'inclusion (ouverture dans un nouvel onglet)">
                 pilotage de l'inclusion
             </a>
+            <i class="ri-external-link-line ri-lg mr-1"></i>
         </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/ic-ne-mal-plac-058cc2a65ac641cfa5a1d5eba4b971c0?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Elle est mal placé