### PR TITLE
BOOST : le contenu du menu de sélection de structure peut être trop long

### DIFF
--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -26,7 +26,7 @@
         {% if user.is_siae_staff and user_siaes|length > 1 %}
             <li class="dropdown">
                 <button type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="switchUserDropdown{% if is_mobile %}Mobile{% endif %}" aria-expanded="false">
-                    ({{ current_siae.kind }}) {{ current_siae.display_name|truncatechars:50 }}
+                    ({{ current_siae.kind }}) {{ current_siae.display_name|truncatechars:40 }}
                 </button>
                 <div class="dropdown-menu" id="switchUserDropdown{% if is_mobile %}Mobile{% endif %}">
                     <form action="{% url 'dashboard:switch_siae' %}" method="post">
@@ -50,7 +50,7 @@
         {% if user.is_prescriber and user_prescriberorganizations|length > 1 %}
             <li class="dropdown">
                 <button type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="switchUserDropdown{% if is_mobile %}Mobile{% endif %}" aria-expanded="false">
-                    ({{ current_prescriber_organization.kind }}) {{ current_prescriber_organization.display_name|truncatechars:50 }}
+                    ({{ current_prescriber_organization.kind }}) {{ current_prescriber_organization.display_name|truncatechars:40 }}
                 </button>
                 <div class="dropdown-menu" id="switchUserDropdown{% if is_mobile %}Mobile{% endif %}">
                     <form action="{% url 'dashboard:switch_prescriber_organization' %}" method="post">
@@ -75,7 +75,7 @@
         {% if user.is_labor_inspector and user_institutions|length > 1 %}
             <li class="dropdown">
                 <button type="button" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-controls="switchUserDropdown{% if is_mobile %}Mobile{% endif %}" aria-expanded="false">
-                    ({{ current_institution.kind }}) {{ current_institution.display_name|truncatechars:50 }}
+                    ({{ current_institution.kind }}) {{ current_institution.display_name|truncatechars:40 }}
                 </button>
                 <div class="dropdown-menu" id="switchUserDropdown{% if is_mobile %}Mobile{% endif %}">
                     <form action="{% url 'dashboard:switch_institution' %}" method="post">
@@ -86,7 +86,7 @@
                                     <li>
                                         <button class="dropdown-item font-weight-bold" name="institution_id" value="{{ i.pk }}">
                                             <span class="badge badge-xs badge-pill badge-primary mr-1">{{ i.kind }}</span>
-                                            {{ i.display_name|truncatechars:50 }}
+                                            {{ i.display_name|truncatechars:40 }}
                                         </button>
                                     </li>
                                 {% endif %}


### PR DESCRIPTION
**Carte Notion :**

yanapa

### Pourquoi ?

Voir captures 

### Captures d'écran 

Avant : 
![image](https://github.com/betagouv/itou/assets/147232/6802f951-a227-41a6-b46e-2a8c3ab6100b)

Après : 
![image](https://github.com/betagouv/itou/assets/147232/f44c3011-594f-41f3-afad-e098f965678e)


