### PR TITLE
Admin : Permettre aux membres du support de pouvoir transférer tous les objets d’une fiche utilisateur (candidat) vers une autre, en une seule fois

### DIFF
--- a/itou/templates/admin/users/change_user_form.html
+++ b/itou/templates/admin/users/change_user_form.html
@@ -8,6 +8,12 @@
         <li>{% include 'hijack/contrib/admin/button.html' with another_user=original is_user_admin=True next=login_url %}</li>
     {% endif %}
 
+    {% if original.is_job_seeker and has_change_permission %}
+        <li>
+            <a href="{% url 'admin:transfer_user_data' from_user_pk=original.pk %}">Transférer</a>
+        </li>
+    {% endif %}
+
     {{ block.super }}
 
 {% endblock %}

--- a/itou/templates/admin/users/transfer_user.html
+++ b/itou/templates/admin/users/transfer_user.html
@@ -1,0 +1,96 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{# Adapted from Django's admin/change_form.html #}
+{% block extrahead %}
+    {{ block.super }}
+    <script src="{% url 'admin:jsi18n' %}"></script>
+    {{ media }}
+    <script nonce="{{ CSP_NONCE }}">
+        document.addEventListener('DOMContentLoaded', function() {
+            const buttons = document.getElementsByClassName("with-confirm");
+            Array.from(buttons).forEach(function(button) {
+                button.addEventListener("click", function(event) {
+                    if (!confirm('Êtes vous certain ?')) {
+                        event.preventDefault();
+                    }
+                });
+            });
+        });
+    </script>
+{% endblock %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
+{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+        &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+        &rsaquo;
+        {% if has_view_permission %}
+            <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+        {% else %}
+            {{ opts.verbose_name_plural|capfirst }}
+        {% endif %}
+        &rsaquo; Transférer les données de <a href="{% url opts|admin_urlname:'change' object_id=from_user.pk %}">{{ from_user|truncatewords:"18" }}</a>
+        {% if to_user %}
+            vers <a href="{% url opts|admin_urlname:'change' object_id=to_user.pk %}">{{ to_user|truncatewords:"18" }}</a>
+        {% endif %}
+    </div>
+{% endblock %}
+
+{% block content %}
+    <h1>
+        Transfert des données de {{ from_user }}
+        {% if to_user %}vers {{ to_user }}{% endif %}
+    </h1>
+    <h2>Données à transférer</h2>
+    {% for data in transfer_data %}
+        <h3>{{ data.title }}</h3>
+        <div class="form-row">
+            <div>
+                <h3>{{ from_user }}</h3>
+                <ul>
+                    {% for item in data.from %}
+                        <li>
+                            <a href="{{ item.admin_link }}">{{ item }}</a>
+                        </li>
+                    {% empty %}
+                        <li>- Rien à transférer</li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% if to_user %}
+                <div>
+                    <h3>{{ to_user }}</h3>
+                    <ul>
+                        {% for item in data.to %}
+                            <li>
+                                <a href="{{ item.admin_link }}">{{ item }}</a>
+                            </li>
+                        {% empty %}
+                            <li>- Pas de données</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            {% endif %}
+        </div>
+    {% endfor %}
+
+    <h2>Transfert</h2>
+    {% if nothing_to_transfer %}
+        Transfert impossible: aucune donnée à transférer
+    {% else %}
+        <form method="post" novalidate>
+            {% csrf_token %}
+            <div class="form-row">{{ form }}</div>
+            <div class="submit-row">
+                <input class="default{% if to_user %} with-confirm{% endif %}" type="submit" value="Valider">
+            </div>
+        </form>
+    {% endif %}
+
+{% endblock %}

--- a/tests/users/test_admin.py
+++ b/tests/users/test_admin.py
@@ -1,5 +1,5 @@
 from itou.users import admin
-from itou.users.models import JobSeekerProfile
+from itou.users.models import JobSeekerProfile, User
 from tests.users.factories import JobSeekerFactory
 
 
@@ -36,3 +36,66 @@ def test_filter():
     )
     profiles = filter.queryset(None, JobSeekerProfile.objects.all())
     assert list(profiles) == list(JobSeekerProfile.objects.all())
+
+
+def test_get_fields_to_transfer_for_job_seekers():
+    # Get list of fields pointing to the User models
+    relation_fields = {field for field in User._meta.get_fields() if field.is_relation and not field.many_to_one}
+    fields_to_ignore = {
+        "administrativecriteria",  # AdministrativeCriteria.created_by
+        "approval",  # Approval.created_by
+        "approval_manually_delivered",  # JobApplication.approval_manually_delivered_by
+        "approval_manually_refused",  # JobApplication.approval_manually_refused_by
+        "approvals_suspended_set",  # Suspension.created_by
+        "auth_token",  # rest_framework.authtoken.models.Token.user
+        "authorization_status_set",  # PrescriberOrganization.authorization_updated_by
+        "commune",  # Commune.created_by
+        "created_prescriber_organization_set",  # PrescriberOrganization.created_by
+        "created_siae_set",  # Siae.created_by
+        "eligibilitydiagnosis",  # EligibilityDiagnosis.author
+        "emailaddress",  # allauth.account.models.EmailAddress.user
+        "externaldataimport",  # ExternalDataImport.user: this seems largely unused
+        "geiqadministrativecriteria",  # GEIQAdministrativeCriteria.created_by
+        "geiqeligibilitydiagnosis",  # GEIQEligibilityDiagnosis.author
+        "groups",  # django.contrib.auth.models.Group
+        "institution",  # Institution.members
+        "institution_invitations",  # LaborInspectorInvitation.sender
+        "institutionmembership",  # InstitutionMembership.user
+        "job_applications_sent",  # JobApplication.sender
+        "jobapplication",  # JobApplication.transferred_by
+        "jobapplicationtransitionlog",  # JobApplicationTransitionLog.user
+        "jobseeker_profile",  # JobSeekerProfile.user: the target already has one
+        "jobseekerexternaldata",  # JobSeekerExternalData.user: this seems largely unused
+        "logentry",  # django.contrib.admin.models.LogEntry.user
+        "prescriber_org_invitations",  # PrescriberWithOrgInvitation.sender
+        "prescribermembership",  # PrescriberMembership.user
+        "prescriberorganization",  # PrescriberOrganization.members
+        "prolongationrequest_processed",  # ProlongationRequest.processed_by
+        "prolongationrequests_created",  # ProlongationRequest.created_by
+        "prolongationrequests_declared",  # ProlongationRequest.declared_by
+        "prolongationrequests_updated",  # ProlongationRequest.updated_by
+        "prolongationrequests_validated",  # ProlongationRequest.validated_by
+        "prolongations_created",  # Prolongation.created_by
+        "prolongations_declared",  # Prolongation.declared_by
+        "prolongations_updated",  # Prolongation.updated_by
+        "prolongations_validated",  # Prolongation.validated_by
+        "reactivated_siae_convention_set",  # SiaeConvention.reactivated_by
+        "siae",  # Siae.members
+        "siae_invitations",  # SiaeStaffInvitation.sender
+        "siaemembership",  # SiaeMembership.user
+        "socialaccount",  # allauth.socialaccount.models.SocialAccount.user
+        "suspension",  # Suspension.updated_by
+        "updated_institutionmembership_set",  # InstitutionMembership.updated_by
+        "updated_prescribermembership_set",  # PrescriberMembership.updated_by
+        "updated_siaemembership_set",  # SiaeMembership.updated_by
+        "user",  # User.created_by
+        "user_permissions",  # django.contrib.auth.models.Permission
+    }
+    fields_to_transfer = {f.name for f in admin.get_fields_to_transfer_for_job_seekers()}
+    # Check that all fields have been accounted for
+    # If this test fails:
+    # - either a new relation has been added
+    #   (and the dev must decide if it needs to be transfered or ignored in the transfer)
+    # - either an existing relation has been dropped (and the relation can be removed from the relevant list)
+    assert not fields_to_transfer & fields_to_ignore, fields_to_transfer & fields_to_ignore
+    assert {f.name for f in relation_fields} == fields_to_transfer | fields_to_ignore


### PR DESCRIPTION
**Carte Notion : **
https://www.notion.so/plateforme-inclusion/Admin-Permettre-aux-membres-du-support-de-pouvoir-transf-rer-tous-les-objets-d-une-fiche-utilisate-24aea387d0b04c3aa546bc4fda0201da?pvs=4

### Pourquoi ?

Faire gagner du temps au support