### PR TITLE
Suppression de matomo_custom_variables du contexte

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -135,7 +135,7 @@
                                         <div class="col-12 col-md-auto mt-2">
                                             <a href="{{ ic_activate_url }}"
                                                class="btn btn-primary btn-block matomo-event"
-                                               data-matomo-category="activation {{ matomo_custom_variables.account_type }}"
+                                               data-matomo-category="activation {{ request.user.kind }}"
                                                data-matomo-action="clic"
                                                data-matomo-option="activer-son-compte-inclusion-connect-bandeau">Activer Inclusion Connect</a>
                                         </div>

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -1,116 +1,46 @@
-from itou.users.enums import IdentityProvider
-
-
 def sort_organizations(collection):
     return sorted(collection, key=lambda o: (o.kind, o.display_name))
 
 
 def get_current_organization_and_perms(request):
     if request.user.is_authenticated:
-        context, extra_context, extra_matomo_context = {}, {}, {}
-        matomo_context = {"is_authenticated": "yes"} | user_to_account_type(request.user)
+        context, extra_context = {}, {}
 
         if getattr(request, "current_organization", None) is not None:
             if request.user.is_siae_staff:
-                extra_context, extra_matomo_context = get_context_siae(request)
+                extra_context = get_context_siae(request)
 
             if request.user.is_prescriber:
-                extra_context, extra_matomo_context = get_context_prescriber(request)
+                extra_context = get_context_prescriber(request)
 
             if request.user.is_labor_inspector:
-                extra_context, extra_matomo_context = get_context_institution(request)
+                extra_context = get_context_institution(request)
 
         context.update(extra_context)
-        return context | {"matomo_custom_variables": matomo_context | extra_matomo_context}
+        return context
 
-    return {
-        "matomo_custom_variables": {
-            "is_authenticated": "no",
-            "account_type": "anonymous",
-            "account_sub_type": "anonymous",
-        }
-    }
+    return {}
 
 
 def get_context_siae(request):
-    return (
-        # context
-        {
-            "current_siae": request.current_organization,
-            "user_is_siae_admin": request.is_current_organization_admin,
-            "user_siaes": sort_organizations(request.organizations),
-        },
-        # matomo_context
-        {
-            "account_current_siae_id": request.current_organization.pk,
-            "account_sub_type": "employer_admin" if request.is_current_organization_admin else "employer_not_admin",
-        },
-    )
+    return {
+        "current_siae": request.current_organization,
+        "user_is_siae_admin": request.is_current_organization_admin,
+        "user_siaes": sort_organizations(request.organizations),
+    }
 
 
 def get_context_prescriber(request):
-    return (
-        # context
-        {
-            "current_prescriber_organization": request.current_organization,
-            "user_is_prescriber_org_admin": request.is_current_organization_admin,
-            "user_prescriberorganizations": sort_organizations(request.organizations),
-        },
-        # matomo_context
-        {
-            "account_current_prescriber_org_id": request.current_organization.pk,
-            "account_sub_type": "prescriber_with_authorized_org"
-            if request.current_organization.is_authorized
-            else "prescriber_with_unauthorized_org",
-        },
-    )
+    return {
+        "current_prescriber_organization": request.current_organization,
+        "user_is_prescriber_org_admin": request.is_current_organization_admin,
+        "user_prescriberorganizations": sort_organizations(request.organizations),
+    }
 
 
 def get_context_institution(request):
-    return (
-        # context
-        {
-            "current_institution": request.current_organization,
-            "user_is_institution_admin": request.is_current_organization_admin,
-            "user_institutions": sort_organizations(request.organizations),
-        },
-        # matomo_context
-        {
-            "account_current_institution_id": request.current_organization.pk,
-            "account_sub_type": "inspector_admin" if request.is_current_organization_admin else "inspector_not_admin",
-        },
-    )
-
-
-def user_to_account_type(user):
-    account_type = user.kind
-    if user.is_job_seeker:
-        return {
-            "account_type": account_type,
-            "account_sub_type": (
-                "job_seeker_with_peconnect"
-                if user.identity_provider == IdentityProvider.PE_CONNECT
-                else "job_seeker_without_peconnect"
-            ),
-        }
-    elif user.is_siae_staff:
-        return {
-            "account_type": account_type,
-            "account_sub_type": "employer_not_admin",
-        }
-    elif user.is_prescriber:
-        return {
-            "account_type": account_type,
-            "account_sub_type": "prescriber_without_org",
-        }
-    elif user.is_labor_inspector:
-        return {
-            "account_type": account_type,
-            "account_sub_type": "inspector_not_admin",
-        }
-
-    # especially usual in tests.
     return {
-        "account_type": account_type,
-        "account_sub_type": "unknown",
+        "current_institution": request.current_organization,
+        "user_is_institution_admin": request.is_current_organization_admin,
+        "user_institutions": sort_organizations(request.organizations),
     }

--- a/itou/utils/perms/context_processors.py
+++ b/itou/utils/perms/context_processors.py
@@ -3,23 +3,15 @@ def sort_organizations(collection):
 
 
 def get_current_organization_and_perms(request):
-    if request.user.is_authenticated:
-        context, extra_context = {}, {}
-
-        if getattr(request, "current_organization", None) is not None:
-            if request.user.is_siae_staff:
-                extra_context = get_context_siae(request)
-
-            if request.user.is_prescriber:
-                extra_context = get_context_prescriber(request)
-
-            if request.user.is_labor_inspector:
-                extra_context = get_context_institution(request)
-
-        context.update(extra_context)
-        return context
-
-    return {}
+    context = {}
+    if request.user.is_authenticated and getattr(request, "current_organization", None) is not None:
+        if request.user.is_siae_staff:
+            context = get_context_siae(request)
+        elif request.user.is_prescriber:
+            context = get_context_prescriber(request)
+        elif request.user.is_labor_inspector:
+            context = get_context_institution(request)
+    return context
 
 
 def get_context_siae(request):

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -371,12 +371,6 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                 "current_siae": siae,
                 "user_is_siae_admin": True,
                 "user_siaes": [siae],
-                "matomo_custom_variables": {
-                    "is_authenticated": "yes",
-                    "account_type": "siae_staff",
-                    "account_sub_type": "employer_admin",
-                    "account_current_siae_id": siae.pk,
-                },
             }
 
     def test_siae_multiple_memberships(self):
@@ -401,12 +395,6 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                 "current_siae": siae2,
                 "user_is_siae_admin": False,
                 "user_siaes": [siae1, siae2],
-                "matomo_custom_variables": {
-                    "is_authenticated": "yes",
-                    "account_type": "siae_staff",
-                    "account_sub_type": "employer_not_admin",
-                    "account_current_siae_id": siae2.pk,
-                },
             }
 
     def test_prescriber_organization_one_membership(self):
@@ -426,12 +414,6 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                 "current_prescriber_organization": organization,
                 "user_prescriberorganizations": [organization],
                 "user_is_prescriber_org_admin": True,
-                "matomo_custom_variables": {
-                    "is_authenticated": "yes",
-                    "account_type": "prescriber",
-                    "account_sub_type": "prescriber_with_unauthorized_org",
-                    "account_current_prescriber_org_id": organization.pk,
-                },
             }
 
     def test_prescriber_organization_multiple_membership(self):
@@ -455,12 +437,6 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                 "current_prescriber_organization": organization1,
                 "user_prescriberorganizations": [organization1, organization2],
                 "user_is_prescriber_org_admin": True,
-                "matomo_custom_variables": {
-                    "is_authenticated": "yes",
-                    "account_type": "prescriber",
-                    "account_sub_type": "prescriber_with_unauthorized_org",
-                    "account_current_prescriber_org_id": organization1.pk,
-                },
             }
 
     def test_labor_inspector_one_institution(self):
@@ -480,12 +456,6 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                 "current_institution": institution,
                 "user_institutions": [institution],
                 "user_is_institution_admin": True,
-                "matomo_custom_variables": {
-                    "is_authenticated": "yes",
-                    "account_type": "labor_inspector",
-                    "account_sub_type": "inspector_admin",
-                    "account_current_institution_id": institution.pk,
-                },
             }
 
     def test_labor_inspector_multiple_institutions(self):
@@ -509,12 +479,6 @@ class ContextProcessorsGetCurrentOrganizationAndPermsTest(TestCase):
                 "current_institution": institution2,
                 "user_institutions": [institution1, institution2],
                 "user_is_institution_admin": False,
-                "matomo_custom_variables": {
-                    "is_authenticated": "yes",
-                    "account_type": "labor_inspector",
-                    "account_sub_type": "inspector_not_admin",
-                    "account_current_institution_id": institution2.pk,
-                },
             }
 
 


### PR DESCRIPTION
### Pourquoi ?

`Par ailleurs, a noter que le matomo_context est a priori non utilisé de nos jours car nous n'avons plus de "custom variables" (deprecated coté Matomo, et jamais utilisé par nos analystes au final) donc si il pose des batons dans les roues, on peut le retirer.`
(de https://github.com/betagouv/itou/pull/2937#pullrequestreview-1600649841)

Cf https://github.com/betagouv/itou/commit/16ef33e807a35586da3466cf766a53f2c724dc52

Une fois ce nettoyage effectué, on pourra également totalement supprimer le context processor `get_current_organization_and_perms`  qui ne fait que reprendre des infos présentes sur l'objet `request` (objet déjà présent dans le `context` via `django.template.context_processors.request`).