### PR TITLE
BOOST - Modification des labels des champs concernant la qualification pour les GEIQ

### DIFF
--- a/itou/job_applications/migrations/0011_added_geiq_qualification_and_training_fields.py
+++ b/itou/job_applications/migrations/0011_added_geiq_qualification_and_training_fields.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
                     ("NOT_RELEVANT", "Non concerné"),
                 ],
                 max_length=40,
-                verbose_name="niveau de qualification",
+                verbose_name="niveau de qualification visé",
             ),
         ),
         migrations.AddField(
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
                     ("CCN", "Positionnement de CCN"),
                 ],
                 max_length=20,
-                verbose_name="type de qualification",
+                verbose_name="type de qualification visé",
             ),
         ),
         migrations.AddConstraint(

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -632,13 +632,13 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     contract_type_details = models.TextField(verbose_name="précisions sur le type de contrat", blank=True)
 
     qualification_type = models.CharField(
-        verbose_name="type de qualification",
+        verbose_name="type de qualification visé",
         max_length=20,
         choices=QualificationType.choices,
         blank=True,
     )
     qualification_level = models.CharField(
-        verbose_name="niveau de qualification",
+        verbose_name="niveau de qualification visé",
         max_length=40,
         choices=QualificationLevel.choices,
         blank=True,

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -111,7 +111,7 @@
   '''
   
   <div id="geiq_qualification_fields_block">
-      <div class="form-group form-group-required"><label for="id_qualification_type">Type de qualification</label><select name="qualification_type" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-target="#geiq_qualification_fields_block" class="form-control" title="" required id="id_qualification_type">
+      <div class="form-group form-group-required"><label for="id_qualification_type">Type de qualification visé</label><select name="qualification_type" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-target="#geiq_qualification_fields_block" class="form-control" title="" required id="id_qualification_type">
     <option value="">---------</option>
   
     <option value="STATE_DIPLOMA">Diplôme d&#x27;état ou titre homologué</option>
@@ -142,7 +142,7 @@
   '''
   
   <div id="geiq_qualification_fields_block">
-      <div class="form-group form-group-required"><label for="id_qualification_type">Type de qualification</label><select name="qualification_type" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-target="#geiq_qualification_fields_block" class="form-control" title="" required id="id_qualification_type">
+      <div class="form-group form-group-required"><label for="id_qualification_type">Type de qualification visé</label><select name="qualification_type" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-target="#geiq_qualification_fields_block" class="form-control" title="" required id="id_qualification_type">
     <option value="">---------</option>
   
     <option value="STATE_DIPLOMA">Diplôme d&#x27;état ou titre homologué</option>
@@ -173,7 +173,7 @@
   '''
   
   <div id="geiq_qualification_fields_block">
-      <div class="form-group form-group-required"><label for="id_qualification_type">Type de qualification</label><select name="qualification_type" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-target="#geiq_qualification_fields_block" class="form-control" title="" required id="id_qualification_type">
+      <div class="form-group form-group-required"><label for="id_qualification_type">Type de qualification visé</label><select name="qualification_type" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-target="#geiq_qualification_fields_block" class="form-control" title="" required id="id_qualification_type">
     <option value="">---------</option>
   
     <option value="STATE_DIPLOMA" selected>Diplôme d&#x27;état ou titre homologué</option>


### PR DESCRIPTION
**Carte Notion :**

https://www.notion.so/plateforme-inclusion/Modifier-wording-dans-les-champs-du-formulaire-d-embauche-des-GEIQ-pour-pr-ciser-qu-il-s-agit-de-la-246fa053deda4f62a07d26260b849d81?pvs=4

### Pourquoi ?

Risque possible de confusion sur les libellés

### Comment 

Modification directe du modèle et de la migration pour en éviter une nouvelle.

