### PR TITLE
Mettre à dispo le lien du calendrier de la campagne de contrôle côté SIAE

### DIFF
--- a/itou/templates/dashboard/includes/labor_inspector_evaluation_campains_card.html
+++ b/itou/templates/dashboard/includes/labor_inspector_evaluation_campains_card.html
@@ -22,7 +22,7 @@
                                 </a>
                             {% endif %}
                         </li>
-                        {% if active_campaign.calendar %}
+                        {% if active_campaign.calendar_id %}
                             <li class="d-flex justify-content-between align-items-center mb-3">
                                 <a href="{% url 'siae_evaluations_views:campaign_calendar' active_campaign.pk %}" class="btn-link btn-ico">
                                     {% comment %} TODO(cms): change icon {% endcomment %}

--- a/itou/templates/dashboard/includes/siae_evaluation_campains_card.html
+++ b/itou/templates/dashboard/includes/siae_evaluation_campains_card.html
@@ -18,6 +18,15 @@
                                 <span class="badge badge-xs badge-pill badge-warning-lighter text-warning"><i class="ri-error-warning-line" aria-hidden="true"></i>Action à faire</span>
                             {% endif %}
                         </li>
+                        {% if evaluated_siae.evaluation_campaign.calendar_id %}
+                            <li class="d-flex justify-content-between align-items-center mb-3">
+                                <a href="{% url 'siae_evaluations_views:campaign_calendar' evaluated_siae.evaluation_campaign.pk %}" class="btn-link btn-ico">
+                                    {% comment %} TODO(cms): change icon {% endcomment %}
+                                    <i class="ri-calendar-line ri-lg font-weight-normal"></i>
+                                    <span>Calendrier</span>
+                                </a>
+                            </li>
+                        {% endif %}
                     {% endfor %}
                 </ul>
             {% endif %}

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -63,7 +63,9 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         current_org = get_current_siae_or_404(request)
         can_show_financial_annexes = current_org.convention_can_be_accessed_by(request.user)
         can_show_employee_records = current_org.can_use_employee_record
-        active_campaigns = EvaluatedSiae.objects.for_siae(current_org).in_progress()
+        active_campaigns = (
+            EvaluatedSiae.objects.for_siae(current_org).in_progress().select_related("evaluation_campaign")
+        )
         evaluated_siae_notifications = (
             EvaluatedSiae.objects.for_siae(current_org)
             .exclude(notified_at=None)

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -22,6 +22,7 @@ from itou.siae_evaluations.models import (
     EvaluationCampaign,
     Sanctions,
 )
+from itou.siaes.models import Siae
 from itou.utils.emails import send_email_messages
 from itou.utils.perms.institution import get_current_institution_or_404
 from itou.utils.perms.siae import get_current_siae_or_404
@@ -80,10 +81,20 @@ def campaign_calendar(request, evaluation_campaign_pk, template_name="siae_evalu
     )
 
     back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
-    breadcrumbs = {
-        "Contrôle a posteriori": reverse(
+
+    if isinstance(request.current_organization, Siae):
+        evaluated_siae = get_object_or_404(
+            EvaluatedSiae,
+            evaluation_campaign=evaluation_campaign,
+            siae=request.current_organization,
+        )
+        evaluation_url = reverse("siae_evaluations_views:siae_job_applications_list", args=[evaluated_siae.pk])
+    else:
+        evaluation_url = reverse(
             "siae_evaluations_views:institution_evaluated_siae_list", args=[evaluation_campaign.pk]
-        ),
+        )
+    breadcrumbs = {
+        "Contrôle a posteriori": evaluation_url,
         "Calendrier": request.path,
     }
     context = {


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Mettre-dispo-le-lien-du-calendrier-de-la-campagne-de-contr-le-c-t-SIAE-d8a0ee41329d4c12826a4011dcc443b7?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Rendre le calendrier de la campagne en cours accessible également pour les SIAE
