### PR TITLE
Ajouter le champ commentaire dans la page d’une campagne de contrôle a posteriori

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 from django.utils.html import format_html
 
 from itou.siae_evaluations import models
-from itou.utils.admin import get_admin_view_link
+from itou.utils.admin import PkSupportRemarkInline, get_admin_view_link
 from itou.utils.export import to_streaming_response
 
 
@@ -204,6 +204,7 @@ class EvaluationCampaignAdmin(admin.ModelAdmin):
     )
     inlines = [
         EvaluatedSiaesInline,
+        PkSupportRemarkInline,
     ]
 
 


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/ADMIN-ajouter-le-champ-commentaire-dans-la-page-d-une-campagne-de-contr-le-a-posteriori-boost-a29b590a72fa4d679f2c2364fe8e0622?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Pour tracer les éventuelles actions réalisées par l’équipe