### PR TITLE
Donner plus de précisions sur le type Organisation délégataire d'un CD

### DIFF
--- a/itou/prescribers/enums.py
+++ b/itou/prescribers/enums.py
@@ -5,7 +5,7 @@ class PrescriberOrganizationKind(models.TextChoices):
     CAP_EMPLOI = "CAP_EMPLOI", "Cap emploi"
     ML = "ML", "Mission locale"
     OIL = "OIL", "Opérateur d'intermédiation locative"
-    ODC = "ODC", "Organisation délégataire d'un CD"
+    ODC = "ODC", "Organisation délégataire d'un Conseil Départemental (Orientation et suivi des BRSA)"
     PENSION = "PENSION", "Pension de famille / résidence accueil"
     PE = "PE", "Pôle emploi"
     RS_FJT = "RS_FJT", "Résidence sociale / FJT - Foyer de Jeunes Travailleurs"

--- a/itou/prescribers/migrations/0001_initial.py
+++ b/itou/prescribers/migrations/0001_initial.py
@@ -262,7 +262,10 @@ class Migration(migrations.Migration):
                             ("CAP_EMPLOI", "Cap emploi"),
                             ("ML", "Mission locale"),
                             ("OIL", "Opérateur d'intermédiation locative"),
-                            ("ODC", "Organisation délégataire d'un CD"),
+                            (
+                                "ODC",
+                                "Organisation délégataire d'un Conseil Départemental (Orientation et suivi des BRSA)",
+                            ),
                             ("PENSION", "Pension de famille / résidence accueil"),
                             ("PE", "Pôle emploi"),
                             ("RS_FJT", "Résidence sociale / FJT - Foyer de Jeunes Travailleurs"),


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Donner-plus-de-pr-cisions-sur-le-type-Organisation-d-l-gataire-d-un-CD-boost-a51e9163dcc84b3ebf83dae93be83e09?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

De nombreuses organisations concernées ne le sélectionnent pas au moment de l’inscription