### PR TITLE
Ne plus afficher le PASS IAE dans le parcours d'embauche GEIQ

### DIFF
--- a/itou/templates/apply/submit_base.html
+++ b/itou/templates/apply/submit_base.html
@@ -11,7 +11,9 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 col-lg-8">
-                    {% include "approvals/includes/card.html" with common_approval=job_seeker.latest_common_approval %}
+                    {% if is_subject_to_eligibility_rules %}
+                        {% include "approvals/includes/card.html" with common_approval=job_seeker.latest_common_approval %}
+                    {% endif %}
 
                     {% block content_extend %}{% endblock %}
                 </div>


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Anomalie-dans-le-parcours-d-enregistrement-d-une-candidature-GEIQ-BOOST-17207fe470074112954d7fe1f921f4c5?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Les geiq ne sont pas concernés par les PASS IAE donc on ne doit pas afficher cet encart lorsqu’on oriente en GEIQ 

