### PR TITLE
Corriger le SSO d'un employeur des fixtures

### DIFF
--- a/itou/fixtures/django/05_test_users.json
+++ b/itou/fixtures/django/05_test_users.json
@@ -1120,7 +1120,7 @@
       "geocoding_updated_at": null,
       "groups": [],
       "has_completed_welcoming_tour": true,
-      "identity_provider": "DJANGO",
+      "identity_provider": "IC",
       "is_active": true,
       "is_staff": false,
       "is_superuser": false,


### PR DESCRIPTION
Sinon, on ne peut pas le détourner dans les review apps pour accéder aux vues du controle à posteriori des SIAEs
