### PR TITLE
Ajout de l'ID 336 de dashboard metabase

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -436,7 +436,9 @@ METABASE_HASH_SALT = os.getenv("METABASE_HASH_SALT")
 ASP_ITOU_PREFIX = "99999"
 
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(
-    os.getenv("PILOTAGE_DASHBOARDS_WHITELIST", "[63, 90, 32, 52, 54, 116, 43, 136, 140, 129, 150, 217, 218, 216, 300]")
+    os.getenv(
+        "PILOTAGE_DASHBOARDS_WHITELIST", "[63, 90, 32, 52, 54, 116, 43, 136, 140, 129, 150, 217, 218, 216, 300, 336]"
+    )
 )
 
 # Only ACIs given by Convergence France may access some contracts


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Mise-en-production-du-tableau-de-bord-Suivi-des-demandes-de-prolongation-ebd620b3c59f40449d12eff435e96dd2?pvs=4

### Pourquoi ?

Pour pouvoir partager un nouveau tableau de bord Metabase en <iframe> sur le site du Pilotage

### Comment (optionnel)

Ajout d'un ID de dashboard metabase à la constante `PILOTAGE_DASHBOARDS_WHITELIST`
