### PR TITLE
Utilisation de `django-pgtrigger` pour gérer nos triggers PostgreSQL

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -57,6 +57,7 @@ THIRD_PARTY_APPS = [
     "import_export",
     "hijack",
     "hijack.contrib.admin",
+    "pgtrigger",
 ]
 
 

--- a/itou/approvals/migrations/0001_initial.py
+++ b/itou/approvals/migrations/0001_initial.py
@@ -682,6 +682,7 @@ class Migration(migrations.Migration):
                 DROP TRIGGER IF EXISTS trigger_update_approval_end_at ON approvals_suspension;
                 DROP FUNCTION IF EXISTS update_approval_end_at();
             """,
+            elidable=True,
         ),
         migrations.RunSQL(
             sql="""
@@ -730,5 +731,6 @@ class Migration(migrations.Migration):
                 DROP TRIGGER IF EXISTS trigger_update_approval_end_at_for_prolongation ON approvals_prolongation;
                 DROP FUNCTION IF EXISTS update_approval_end_at_for_prolongation();
             """,
+            elidable=True,
         ),
     ]

--- a/itou/approvals/migrations/0014_migrate_triggers.py
+++ b/itou/approvals/migrations/0014_migrate_triggers.py
@@ -1,0 +1,71 @@
+import pgtrigger.compiler
+import pgtrigger.migrations
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("approvals", "0013_prolongationrequest_reminder_sent_at"),
+        ("employee_record", "0005_stop_using_notification_type_field"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+            -- Suspension
+            DROP TRIGGER IF EXISTS trigger_update_approval_end_at ON approvals_suspension;
+            DROP FUNCTION IF EXISTS update_approval_end_at();
+            -- Prolongation
+            DROP TRIGGER IF EXISTS trigger_update_approval_end_at_for_prolongation ON approvals_prolongation;
+            DROP FUNCTION IF EXISTS update_approval_end_at_for_prolongation();
+            -- Employee record notification
+            DROP TRIGGER IF EXISTS trigger_employee_record_approval_update_notification ON approvals_approval;
+            DROP FUNCTION IF EXISTS create_employee_record_approval_notification();
+            """,
+            elidable=True,
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name="prolongation",
+            trigger=pgtrigger.compiler.Trigger(
+                name="update_approval_end_at",
+                sql=pgtrigger.compiler.UpsertTriggerSql(
+                    func="\n                    --\n                    -- When a prolongation is inserted/updated/deleted, the end date\n                    -- of its approval is automatically pushed back or forth.\n                    --\n                    -- See:\n                    -- https://www.postgresql.org/docs/12/triggers.html\n                    -- https://www.postgresql.org/docs/12/plpgsql-trigger.html#PLPGSQL-TRIGGER-AUDIT-EXAMPLE\n                    --\n                    IF (TG_OP = 'DELETE') THEN\n                        -- At delete time, the approval's end date is pushed back if the prolongation\n                        -- was validated.\n                        UPDATE approvals_approval\n                        SET end_at = end_at - (OLD.end_at - OLD.start_at)\n                        WHERE id = OLD.approval_id;\n                    ELSIF (TG_OP = 'INSERT') THEN\n                        -- At insert time, the approval's end date is pushed forward if the prolongation\n                        -- is validated.\n                        UPDATE approvals_approval\n                        SET end_at = end_at + (NEW.end_at - NEW.start_at)\n                        WHERE id = NEW.approval_id;\n                    ELSIF (TG_OP = 'UPDATE') THEN\n                        -- At update time, the approval's end date is first reset before\n                        -- being pushed forward.\n                        UPDATE approvals_approval\n                        SET end_at = end_at - (OLD.end_at - OLD.start_at) + (NEW.end_at - NEW.start_at)\n                        WHERE id = NEW.approval_id;\n                    END IF;\n                    RETURN NULL;\n                ",  # noqa: E501
+                    hash="68d9afbacb095f4426a5a5d0065acc16dd2cdc36",
+                    operation="INSERT OR UPDATE OR DELETE",
+                    pgid="pgtrigger_update_approval_end_at_d9288",
+                    table="approvals_prolongation",
+                    when="AFTER",
+                ),
+            ),
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name="suspension",
+            trigger=pgtrigger.compiler.Trigger(
+                name="update_approval_end_at",
+                sql=pgtrigger.compiler.UpsertTriggerSql(
+                    func="\n                    --\n                    -- When a suspension is inserted/updated/deleted, the end date\n                    -- of its approval is automatically pushed back or forth.\n                    --\n                    -- See:\n                    -- https://www.postgresql.org/docs/12/triggers.html\n                    -- https://www.postgresql.org/docs/12/plpgsql-trigger.html#PLPGSQL-TRIGGER-AUDIT-EXAMPLE\n                    --\n                    IF (TG_OP = 'DELETE') THEN\n                        -- At delete time, the approval's end date is pushed back.\n                        UPDATE approvals_approval\n                        SET end_at = end_at - (OLD.end_at - OLD.start_at)\n                        WHERE id = OLD.approval_id;\n                    ELSIF (TG_OP = 'INSERT') THEN\n                        -- At insert time, the approval's end date is pushed forward.\n                        UPDATE approvals_approval\n                        SET end_at = end_at + (NEW.end_at - NEW.start_at)\n                        WHERE id = NEW.approval_id;\n                    ELSIF (TG_OP = 'UPDATE') THEN\n                        -- At update time, the approval's end date is first reset before\n                        -- being pushed forward, e.g.:\n                        --     * step 1 \"create new 90 days suspension\":\n                        --         * extend approval: approval.end_date + 90 days\n                        --     * step 2 \"edit 60 days instead of 90 days\":\n                        --         * reset approval: approval.end_date - 90 days\n                        --         * extend approval: approval.end_date + 60 days\n                        UPDATE approvals_approval\n                        SET end_at = end_at - (OLD.end_at - OLD.start_at) + (NEW.end_at - NEW.start_at)\n                        WHERE id = NEW.approval_id;\n                    END IF;\n                    RETURN NULL;\n                ",  # noqa: E501
+                    hash="051cd1df6304c50f45e9564921ac2c2b5b902d6d",
+                    operation="INSERT OR UPDATE OR DELETE",
+                    pgid="pgtrigger_update_approval_end_at_6c264",
+                    table="approvals_suspension",
+                    when="AFTER",
+                ),
+            ),
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name="approval",
+            trigger=pgtrigger.compiler.Trigger(
+                name="create_employee_record_notification",
+                sql=pgtrigger.compiler.UpsertTriggerSql(
+                    condition='WHEN (OLD."end_at" IS DISTINCT FROM (NEW."end_at") OR OLD."start_at" IS DISTINCT FROM (NEW."start_at"))',  # noqa: E501
+                    declare="DECLARE current_employee_record_id INT;",
+                    func="\n                    -- If there is an \"UPDATE\" action on 'approvals_approval' table (Approval model object):\n                    -- create an `EmployeeRecordUpdateNotification` object for each PROCESSED `EmployeeRecord`\n                    -- linked to this approval\n                    IF (TG_OP = 'UPDATE') THEN\n                        -- Only for update operations:\n                        -- iterate through processed employee records linked to this approval\n                        FOR current_employee_record_id IN\n                            SELECT id FROM employee_record_employeerecord\n                            WHERE approval_number = NEW.number\n                            AND status = 'PROCESSED'\n                            LOOP\n                                -- Create `EmployeeRecordUpdateNotification` object\n                                -- with the correct type and status\n                                INSERT INTO employee_record_employeerecordupdatenotification\n                                    (employee_record_id, created_at, updated_at, status)\n                                SELECT current_employee_record_id, NOW(), NOW(), 'NEW'\n                                -- Update it if already created (UPSERT)\n                                -- On partial indexes conflict, the where clause of the index must be added here\n                                ON conflict(employee_record_id) WHERE status = 'NEW'\n                                DO\n                                -- Not exactly the same syntax as a standard update op\n                                UPDATE SET updated_at = NOW();\n                            END LOOP;\n                    END IF;\n                    RETURN NULL;\n                ",  # noqa: E501
+                    hash="fccf85ab0214d6439e66fdf5eeb3dd9c4b114561",
+                    operation='UPDATE OF "start_at", "end_at"',
+                    pgid="pgtrigger_create_employee_record_notification_0b059",
+                    table="approvals_approval",
+                    when="AFTER",
+                ),
+            ),
+        ),
+    ]

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -152,7 +152,7 @@ class Command(EmployeeRecordTransferCommand):
                             pass  # No point to send a notification about an approval if it doesn't exist
                         else:
                             if approval.suspension_set.exists() or approval.prolongation_set.exists():
-                                # Mimic the SQL function "create_employee_record_approval_notification()"
+                                # Mimic the SQL trigger function "create_employee_record_notification()"
                                 EmployeeRecordUpdateNotification.objects.update_or_create(
                                     employee_record=employee_record,
                                     defaults={"updated_at": timezone.now},

--- a/itou/employee_record/migrations/0002_add_notification_update_trigger.py
+++ b/itou/employee_record/migrations/0002_add_notification_update_trigger.py
@@ -71,5 +71,6 @@ class Migration(migrations.Migration):
                         DROP FUNCTION IF EXISTS create_employee_record_approval_notification();
                         DROP INDEX IF EXISTS partial_unique_new_notification;
                         """,
+            elidable=True,
         )
     ]

--- a/itou/employee_record/migrations/0005_stop_using_notification_type_field.py
+++ b/itou/employee_record/migrations/0005_stop_using_notification_type_field.py
@@ -89,6 +89,7 @@ class Migration(migrations.Migration):
                 END;
             $approval_notification$ LANGUAGE plpgsql;
             """,
+            elidable=True,
         ),
         migrations.RunSQL(
             sql="DROP INDEX IF EXISTS partial_unique_new_notification;",
@@ -97,5 +98,6 @@ class Migration(migrations.Migration):
             ON employee_record_employeerecordupdatenotification (employee_record_id, notification_type)
             WHERE status = 'NEW';
             """,
+            elidable=True,
         ),
     ]

--- a/itou/jobs/migrations/0002_create_full_text_trigger.py
+++ b/itou/jobs/migrations/0002_create_full_text_trigger.py
@@ -17,5 +17,6 @@ class Migration(migrations.Migration):
             reverse_sql="""
                 DROP TRIGGER IF EXISTS jobs_appellation_full_text_trigger ON jobs_appellation;
             """,
+            elidable=True,
         )
     ]

--- a/itou/jobs/migrations/0003_migrate_trigger.py
+++ b/itou/jobs/migrations/0003_migrate_trigger.py
@@ -1,0 +1,31 @@
+import pgtrigger.compiler
+import pgtrigger.migrations
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("jobs", "0002_create_full_text_trigger"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="DROP TRIGGER IF EXISTS jobs_appellation_full_text_trigger ON jobs_appellation;",
+            elidable=True,
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name="appellation",
+            trigger=pgtrigger.compiler.Trigger(
+                name="jobs_appellation_full_text_trigger",
+                sql=pgtrigger.compiler.UpsertTriggerSql(
+                    execute='tsvector_update_trigger("full_text", "public.french_unaccent", "name", "rome_id")',
+                    func="",
+                    hash="b06f63ec0910f1c669dca88dcfa3f3ec69c23af5",
+                    operation='INSERT OR UPDATE OF "name", "rome_id"',
+                    pgid="pgtrigger_jobs_appellation_full_text_trigger_de796",
+                    table="jobs_appellation",
+                    when="BEFORE",
+                ),
+            ),
+        ),
+    ]

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -23,6 +23,9 @@ django-allauth==0.51.0 # https://github.com/pennersr/django-allauth
 # django-anymail
 django-anymail  # https://github.com/anymail/django-anymail
 
+# django-pgtrigger (PostgresSQL triggers in models)
+django-pgtrigger  # https://github.com/Opus10/django-pgtrigger
+
 # Django-XWorkflows
 django-xworkflows  # https://github.com/rbarrois/django_xworkflows
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -261,6 +261,7 @@ django==4.2.5 \
     #   django-hijack
     #   django-htmx
     #   django-import-export
+    #   django-pgtrigger
     #   django-select2
     #   django-xworkflows
     #   djangorestframework
@@ -299,6 +300,10 @@ django-htmx==1.16.0 \
 django-import-export==3.2.0 \
     --hash=sha256:1d3f2cb2ee3cca0386ed60651fa1623be989f130d9fbdf98a67f7dc3a94b8a37 \
     --hash=sha256:38fd7b9439b9e3aa1a4747421c1087a5bc194e915a28d795fb8429a5f8028f2d
+    # via -r requirements/base.in
+django-pgtrigger==4.7.0 \
+    --hash=sha256:20a4139cccb17b75d065fbfd2cc8f47e3696379d7be4139ef6a67c8d14897a8d \
+    --hash=sha256:978e998f5c7bdfaf3edbb01c2075be329ce679bd87a89c5bfdf95405905885bd
     # via -r requirements/base.in
 django-select2==8.1.2 \
     --hash=sha256:dc09e09299988dd7cc1f31c27582976377f0e1479101be1f3bb0d1f24216477f \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -352,6 +352,7 @@ django==4.2.5 \
     #   django-hijack
     #   django-htmx
     #   django-import-export
+    #   django-pgtrigger
     #   django-select2
     #   django-xworkflows
     #   djangorestframework
@@ -400,6 +401,10 @@ django-htmx==1.16.0 \
 django-import-export==3.2.0 \
     --hash=sha256:1d3f2cb2ee3cca0386ed60651fa1623be989f130d9fbdf98a67f7dc3a94b8a37 \
     --hash=sha256:38fd7b9439b9e3aa1a4747421c1087a5bc194e915a28d795fb8429a5f8028f2d
+    # via -r requirements/test.txt
+django-pgtrigger==4.7.0 \
+    --hash=sha256:20a4139cccb17b75d065fbfd2cc8f47e3696379d7be4139ef6a67c8d14897a8d \
+    --hash=sha256:978e998f5c7bdfaf3edbb01c2075be329ce679bd87a89c5bfdf95405905885bd
     # via -r requirements/test.txt
 django-select2==8.1.2 \
     --hash=sha256:dc09e09299988dd7cc1f31c27582976377f0e1479101be1f3bb0d1f24216477f \

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -322,6 +322,7 @@ django==4.2.5 \
     #   django-hijack
     #   django-htmx
     #   django-import-export
+    #   django-pgtrigger
     #   django-select2
     #   django-xworkflows
     #   djangorestframework
@@ -362,6 +363,10 @@ django-htmx==1.16.0 \
 django-import-export==3.2.0 \
     --hash=sha256:1d3f2cb2ee3cca0386ed60651fa1623be989f130d9fbdf98a67f7dc3a94b8a37 \
     --hash=sha256:38fd7b9439b9e3aa1a4747421c1087a5bc194e915a28d795fb8429a5f8028f2d
+    # via -r requirements/base.txt
+django-pgtrigger==4.7.0 \
+    --hash=sha256:20a4139cccb17b75d065fbfd2cc8f47e3696379d7be4139ef6a67c8d14897a8d \
+    --hash=sha256:978e998f5c7bdfaf3edbb01c2075be329ce679bd87a89c5bfdf95405905885bd
     # via -r requirements/base.txt
 django-select2==8.1.2 \
     --hash=sha256:dc09e09299988dd7cc1f31c27582976377f0e1479101be1f3bb0d1f24216477f \

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1312,12 +1312,12 @@ class ProlongationManagerTest(TestCase):
 
 class ProlongationModelTestTrigger(TestCase):
     """
-    Test `trigger_update_approval_end_at_for_prolongation`.
+    Test `update_approval_end_at`.
     """
 
     def test_save(self):
         """
-        Test `trigger_update_approval_end_at_for_prolongation` with SQL INSERT.
+        Test `update_approval_end_at` with SQL INSERT.
         An approval's `end_at` is automatically pushed forward when it is prolongated.
         """
         start_at = timezone.localdate()
@@ -1332,7 +1332,7 @@ class ProlongationModelTestTrigger(TestCase):
 
     def test_delete(self):
         """
-        Test `trigger_update_approval_end_at_for_prolongation` with SQL DELETE.
+        Test `update_approval_end_at` with SQL DELETE.
         An approval's `end_at` is automatically pushed back when its prolongation
         is deleted.
         """
@@ -1352,7 +1352,7 @@ class ProlongationModelTestTrigger(TestCase):
 
     def test_save_and_edit(self):
         """
-        Test `trigger_update_approval_end_at_for_prolongation` with SQL UPDATE.
+        Test `update_approval_end_at` with SQL UPDATE.
         An approval's `end_at` is automatically pushed back and forth when
         one of its valid prolongation is saved, then edited to be shorter.
         """


### PR DESCRIPTION
### Pourquoi ?

Meilleure traçabilité des modifications et des utilisations.
Permet aussi de se faire la main avant la [mise en place de la table d'audit](https://www.notion.so/plateforme-inclusion/Am-lioration-ADMIN-En-tant-que-membre-ITOU-je-ne-veux-plus-qu-un-PASS-IAE-soit-totalement-supprim--5d303e5a620944909ffde8ff00fd7a01?pvs=4).