### PR TITLE
jobs: utilisation du SearchQuery de Django plutôt qu'un extra

### DIFF
--- a/itou/jobs/models.py
+++ b/itou/jobs/models.py
@@ -2,7 +2,7 @@ import re
 import string
 
 from django.contrib.postgres.indexes import GinIndex
-from django.contrib.postgres.search import SearchVectorField
+from django.contrib.postgres.search import SearchQuery, SearchVectorField
 from django.db import models
 
 
@@ -50,7 +50,7 @@ class AppellationQuerySet(models.QuerySet):
         words = re.sub(f"[{string.punctuation}]", " ", search_string).split()
         words = [word + ":*" for word in words]
         tsquery = " & ".join(words)
-        queryset = self.extra(where=["full_text @@ to_tsquery('french_unaccent', %s)"], params=[tsquery])
+        queryset = self.filter(full_text=SearchQuery(tsquery, config="french_unaccent", search_type="raw"))
         if rome_code:
             queryset = queryset.filter(rome__code=rome_code)
         queryset = queryset.select_related("rome")


### PR DESCRIPTION
### Pourquoi ?

Plus propre.

Avant:

```
In [2]: str(models.Appellation.objects.autocomplete("toto,titi,tutu").query)
Out[2]: 'SELECT "jobs_appellation"."updated_at", "jobs_appellation"."code", "jobs_appellation"."name", "jobs_appellation"."rome_id", "jobs_appellation"."full_text", "jobs_rome"."updated_at", "jobs_rome"."code", "jobs_rome"."name" FROM "jobs_appellation" LEFT OUTER JOIN "jobs_rome" ON ("jobs_appellation"."rome_id" = "jobs_rome"."code") WHERE (full_text @@ to_tsquery(\'french_unaccent\', toto:* & titi:* & tutu:*)) ORDER BY "jobs_appellation"."name" ASC LIMIT 10'
```

Après:
```
In [2]: str(models.Appellation.objects.autocomplete("toto,titi,tutu").query)
Out[2]: 'SELECT "jobs_appellation"."updated_at", "jobs_appellation"."code", "jobs_appellation"."name", "jobs_appellation"."rome_id", "jobs_appellation"."full_text", "jobs_rome"."updated_at", "jobs_rome"."code", "jobs_rome"."name" FROM "jobs_appellation" LEFT OUTER JOIN "jobs_rome" ON ("jobs_appellation"."rome_id" = "jobs_rome"."code") WHERE "jobs_appellation"."full_text" @@ (to_tsquery(french_unaccent::regconfig, toto:* & titi:* & tutu:*)) ORDER BY "jobs_appellation"."name" ASC LIMIT 10'
```
