### PR TITLE
Amélioration de la page "fiches salarié à mettre à jour"

### DIFF
--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -36,13 +36,13 @@
             <div class="col-12">
                 <ul class="list-unstyled fs-sm">
                     <li>
-                        Début de contrat :&nbsp;<b>{{ item.hiring_start_at|default_if_none:"Non renseigné" }}</b>
+                        Numéro de PASS IAE : <b>{{ item.approval.number|format_approval_number }}</b>
                     </li>
                     <li>
-                        Fin de contrat :&nbsp;<b>{{ item.hiring_end_at|default_if_none:"Non renseigné" }}</b>
+                        Date de début : <b>{{ item.approval.start_at|date:"d/m/Y" }}</b>
                     </li>
                     <li>
-                        Numéro de PASS IAE :&nbsp;<b>{{ item.approval.number|format_approval_number }}</b>
+                        Date de fin prévisionnelle : <b>{{ item.approval.end_at|date:"d/m/Y" }}</b>
                     </li>
                 </ul>
             </div>

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.test import override_settings
@@ -87,22 +89,17 @@ class ListEmployeeRecordsTest(TestCase):
         self.assertContains(response, approval_number_formatted)
         self.assertContains(response, other_approval_number_formatted)
 
-    def test_employee_records_with_hiring_end_at(self):
+    def test_employee_records_approval_display(self):
         self.client.force_login(self.user)
-        hiring_end_at = self.job_application.hiring_end_at
+        approval = self.job_application.approval
+        approval.start_at = datetime.date(2023, 9, 2)
+        approval.end_at = datetime.date(2024, 10, 11)
+        approval.save()
 
         response = self.client.get(self.url)
 
-        self.assertContains(response, f"Fin de contrat :&nbsp;<b>{hiring_end_at.strftime('%e').lstrip()}")
-
-    def test_employee_records_without_hiring_end_at(self):
-        self.client.force_login(self.user)
-        self.job_application.hiring_end_at = None
-        self.job_application.save()
-
-        response = self.client.get(self.url)
-
-        self.assertContains(response, "Fin de contrat :&nbsp;<b>Non renseigné")
+        self.assertContains(response, "Date de début : <b>02/09/2023</b>")
+        self.assertContains(response, "Date de fin prévisionnelle : <b>11/10/2024</b>")
 
     def test_employee_records_with_a_suspension_need_to_be_updated(self):
         self.client.force_login(self.user)


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/fiches-salari-mettre-jour-En-tant-qu-employeur-je-veux-voir-les-dates-du-PASS-et-non-celles-e8686d21bf3b4338a32c9d1848d0ce1d?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Éviter que les employeurs sollicitent le support pour comprendre
