### PR TITLE
metabase: Correction d'un nouveau crash qui était jusque là non testé

### DIFF
--- a/itou/metabase/db.py
+++ b/itou/metabase/db.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.utils import timezone
 from psycopg import sql
 
-from itou.metabase.utils import chunked_queryset, compose, convert_boolean_to_int, convert_uuid_to_str
+from itou.metabase.utils import chunked_queryset, compose, convert_boolean_to_int
 
 
 class MetabaseDatabaseCursor:
@@ -275,9 +275,6 @@ def populate_table(table, batch_size, querysets=None, extra_object=None):
         if c["type"] == "boolean":
             c["type"] = "integer"
             c["fn"] = compose(convert_boolean_to_int, c["fn"])
-        elif c["type"] == "varchar":
-            # Force uuid as strings as UUIDDUmper does not include hyphens
-            c["fn"] = compose(convert_uuid_to_str, c["fn"])
 
     print(f"Injecting {total_rows} rows with {len(table.columns)} columns into table {table_name}:")
 

--- a/itou/metabase/tables/insee_codes.py
+++ b/itou/metabase/tables/insee_codes.py
@@ -18,13 +18,13 @@ TABLE.add_columns(
         },
         {
             "name": "latitude",
-            "type": "float",
+            "type": "double precision",
             "comment": "Latitude",
             "fn": lambda o: o.latitude,
         },
         {
             "name": "longitude",
-            "type": "float",
+            "type": "double precision",
             "comment": "Longitude",
             "fn": lambda o: o.longitude,
         },

--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -116,7 +116,7 @@ TABLE.add_columns(
     [
         {
             "name": "id",
-            "type": "varchar",
+            "type": "uuid",
             "comment": "ID C1 de la candidature",
             "fn": lambda o: o.pk,
         },

--- a/itou/metabase/tables/siaes.py
+++ b/itou/metabase/tables/siaes.py
@@ -102,7 +102,7 @@ TABLE.add_columns(
         },
         {
             "name": "taux_conversion_30j",
-            "type": "float",
+            "type": "double precision",
             "comment": "Taux de conversion des candidatures en embauches dans les 30 jours glissants",
             "fn": lambda o: round(
                 1.0 * o.total_embauches_30j / o.total_candidatures_30j if o.total_candidatures_30j else 0.0,

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -217,13 +217,13 @@ def get_address_columns(name_suffix="", comment_suffix="", custom_fn=lambda o: o
             },
             {
                 "name": f"longitude{name_suffix}",
-                "type": "float",
+                "type": "double precision",
                 "comment": f"Longitude{comment_suffix}",
                 "fn": lambda o: custom_fn(o).longitude,
             },
             {
                 "name": f"latitude{name_suffix}",
-                "type": "float",
+                "type": "double precision",
                 "comment": f"Latitude{comment_suffix}",
                 "fn": lambda o: custom_fn(o).latitude,
             },

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -45,7 +45,7 @@ def get_field_type_from_field(field):
     if isinstance(field, AutoField) and field.name == "id":
         return "integer"
     if isinstance(field, UUIDField):
-        return "varchar"
+        return "uuid"
     if isinstance(field, DateField):
         return "date"
     if isinstance(field, ForeignKey):

--- a/itou/metabase/utils.py
+++ b/itou/metabase/utils.py
@@ -1,15 +1,6 @@
-import uuid
-
-
 def convert_boolean_to_int(b):
     # True => 1, False => 0, None => None.
     return None if b is None else int(b)
-
-
-def convert_uuid_to_str(value):
-    if isinstance(value, uuid.UUID):
-        return str(value)
-    return value
 
 
 def compose(f, g):

--- a/tests/metabase/conftest.py
+++ b/tests/metabase/conftest.py
@@ -2,7 +2,12 @@ import pytest
 from django.db import connection
 
 from itou.metabase import dataframes, db
-from itou.metabase.tables.utils import get_insee_code_to_zrr_status_map, get_qpv_job_seeker_pks
+from itou.metabase.tables.utils import (
+    get_active_siae_pks,
+    get_ai_stock_job_seeker_pks,
+    get_insee_code_to_zrr_status_map,
+    get_qpv_job_seeker_pks,
+)
 
 
 @pytest.fixture(name="metabase")
@@ -36,14 +41,8 @@ def metabase_fixture(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def clear_qpv_cache():
-    # Clear cache on get_qpv_job_seeker_pks to ensure we have the correct data
-    # and that the query is always performed
-    get_qpv_job_seeker_pks.cache_clear()
-
-
-@pytest.fixture(autouse=True)
-def clear_zrr_cache():
-    # Clear cache on get_insee_code_to_zrr_status_map to ensure we have the correct data
-    # and that the query is always performed
+def clear_pks_caches():
+    get_active_siae_pks.cache_clear()
+    get_ai_stock_job_seeker_pks.cache_clear()
     get_insee_code_to_zrr_status_map.cache_clear()
+    get_qpv_job_seeker_pks.cache_clear()

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -428,7 +428,7 @@ def test_populate_job_applications():
         assert len(rows) == 1
         assert rows == [
             (
-                str(ja.pk),
+                ja.pk,
                 hash_content(ja.pk),
                 ja.created_at.date(),
                 ja.hiring_start_at,
@@ -752,7 +752,7 @@ def test_populate_evaluated_job_applications():
         assert rows == [
             (
                 evaluated_job_application.id,
-                str(evaluated_job_application.job_application_id),
+                evaluated_job_application.job_application_id,
                 evaluated_job_application.evaluated_siae_id,
                 evaluated_job_application.compute_state(),
                 datetime.date(2023, 2, 1),

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -895,12 +895,6 @@ def test_data_inconsistencies(capsys):
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.usefixtures("metabase")
 def test_populate_fiches_de_poste():
-    # clear the active SIAE pks cache for now, is responsible for some flakyness.
-    # FIXME(dejafait,vperron): Find  a better system that does not give me a 4 hours headache.
-    from itou.metabase.tables.utils import get_active_siae_pks
-
-    get_active_siae_pks.cache_clear()
-
     create_test_romes_and_appellations(["M1805"], appellations_per_rome=1)
     siae = SiaeFactory(
         for_snapshot=True,


### PR DESCRIPTION
Le type "float" n'existe pas en postgresql.

De même, les type sdéclarés en majuscules ne passent plus à la déclaration stricte avec COPY FORMAT BINARY.

Par contre cela permet de déclarer des colonnes de type UUID natif et de les valider.
