### PR TITLE
Renommer la table candidats en candidats_v0

### DIFF
--- a/itou/metabase/sql/035_suivi_cap.sql
+++ b/itou/metabase/sql/035_suivi_cap.sql
@@ -2,23 +2,23 @@ with nb_structures_par_dept as (
 -- nb de structures référencées par dept
     select
         département,
-        nom_département,
+        "nom_département",
         count(*) as nb_struct
     from
         structures
     group by
         département,
-        nom_département
+        "nom_département"
 )
 select
     cap_camp.nom,
-    struct.nom_département as nom_département,
-    struct.région,
-    -- récupération du pct de séléction attendu
-    max(cap_camp.pourcentage_sélection) as pct_selection,
+    struct."nom_département" as "nom_département",
+    struct."région",
+    -- récupération du pct de sélection attendu
+    max(cap_camp."pourcentage_sélection") as pct_sélection,
     --nb controlees : ie celles qui ont une date de contrôle non null
     sum(
-        case when cap_struct.date_contrôle is not null then
+        case when cap_struct."date_contrôle" is not null then
             1
         else
             0
@@ -27,7 +27,7 @@ select
     -- ie celles qui ont une date de contrôle non null
     -- sur toutes les SIAE référencées dans la table structure
     CAST(sum(
-            case when cap_struct.date_contrôle is not null then
+            case when cap_struct."date_contrôle" is not null then
                 1
             else
                 0
@@ -37,13 +37,13 @@ select
             1
         else
             0
-        end) as nb_acceptees,
+        end) as nb_acceptées,
     -- nb de structures refusées
     sum(case when cap_struct.état = 'REFUSED' then
             1
         else
             0
-        end) as nb_refusees,
+        end) as nb_refusées,
     -- nb de structures en attente notif
     sum(case when cap_struct.état = 'NOTIFICATION_PENDING' then
             1
@@ -54,9 +54,9 @@ from
     cap_structures cap_struct
     left join structures struct on cap_struct.id_structure = struct.id
     left join cap_campagnes cap_camp on cap_camp.id = cap_struct.id_cap_campagne
-    left join nb_structures_par_dept nb_tot_dep on nb_tot_dep.nom_département = struct.nom_département
+    left join nb_structures_par_dept nb_tot_dep on nb_tot_dep."nom_département" = struct."nom_département"
 group by
     cap_camp.nom,
-    struct.région,
-    struct.nom_département
-order by struct.nom_département;
+    struct."région",
+    struct."nom_département"
+order by struct."nom_département";

--- a/itou/metabase/sql/035_suivi_cap.sql
+++ b/itou/metabase/sql/035_suivi_cap.sql
@@ -52,14 +52,15 @@ select
     struct. "nom_département" as "nom_département",
     struct. "région",
     -- récupération du pct de sélection attendu
-    max(cap_camp. "pourcentage_sélection") as "pct_sélection",
+    -- que l'on divise par 100 pour permettre l'affichage correct sur metabase
+    max(cap_camp. "pourcentage_sélection")/100 as "part_structures_à_contrôler",
     sum(cap_struct_cnt. "nb_contrôlées") as "nb_contrôlées",
     sum(cap_struct_cnt. "nb_acceptées") as "nb_acceptées",
     sum(cap_struct_cnt. "nb_refusées") as "nb_refusées",
     sum(cap_struct_cnt. "nb_attente") as "nb_attente",
     -- pourcentage de SIAE contrôlées :
     -- les contrôlées / ttes les siae
-    sum(cap_struct_cnt. "nb_contrôlées") / max(nb_tot_dep.nb_struct) * 100 as "pct_contrôlées"
+    sum(cap_struct_cnt. "nb_contrôlées") / max(nb_tot_dep.nb_struct) as "part_structures_contrôlées"
 from
     cap_struct_counts cap_struct_cnt
     left join structures struct on cap_struct_cnt.id_structure = struct.id

--- a/itou/metabase/sql/035_suivi_cap.sql
+++ b/itou/metabase/sql/035_suivi_cap.sql
@@ -1,61 +1,73 @@
 with nb_structures_par_dept as (
     select
-        département,
+        "département",
         "nom_département",
-        count(*) as nb_struct
+        cast(count(*) as float) as nb_struct
     from
         structures
     group by
         "département",
         "nom_département"
+),
+cap_struct_counts as (
+    select
+        cap_struct.id_structure,
+        cap_struct.id_cap_campagne,
+        --nb controlees : ie celles qui ont une date de contrôle non null
+        cast(sum(
+                case when cap_struct. "date_contrôle" is not null then
+                    1
+                else
+                    0
+                end) as float) as "nb_contrôlées",
+        -- nb de structures acceptées
+        cast(sum(
+                case when cap_struct. "état" = 'ACCEPTED' then
+                    1
+                else
+                    0
+                end) as float) as "nb_acceptées",
+        -- nb de structures refusées
+        cast(sum(
+                case when cap_struct. "état" = 'REFUSED' then
+                    1
+                else
+                    0
+                end) as float) as "nb_refusées",
+        -- nb de structures en attente notif
+        cast(sum(
+                case when cap_struct. "état" = 'NOTIFICATION_PENDING' then
+                    1
+                else
+                    0
+                end) as float) as nb_attente
+    from
+        cap_structures cap_struct
+    group by
+        cap_struct.id_cap_campagne,
+        cap_struct.id_structure
 )
 select
     cap_camp.nom,
-    struct."nom_département" as "nom_département",
-    struct."région",
+    struct. "nom_département" as "nom_département",
+    struct. "région",
     -- récupération du pct de sélection attendu
-    max(cap_camp."pourcentage_sélection") as "pct_sélection",
-    --nb controlees : ie celles qui ont une date de contrôle non null
-    sum(
-        case when cap_struct."date_contrôle" is not null then
-            1
-        else
-            0
-        end) as nb_contrôlées,
+    max(cap_camp. "pourcentage_sélection") as "pct_sélection",
+    sum(cap_struct_cnt. "nb_contrôlées") as "nb_contrôlées",
+    sum(cap_struct_cnt. "nb_acceptées") as "nb_acceptées",
+    sum(cap_struct_cnt. "nb_refusées") as "nb_refusées",
+    sum(cap_struct_cnt. "nb_attente") as "nb_attente",
     -- pourcentage de SIAE contrôlées :
-    -- ie celles qui ont une date de contrôle non null
-    -- sur toutes les SIAE référencées dans la table structure
-    CAST(sum(
-            case when cap_struct."date_contrôle" is not null then
-                1
-            else
-                0
-            end) as float) / max(nb_tot_dep.nb_struct) * 100 as "pct_contrôlées",
-    -- nb de structures acceptées
-    sum(case when cap_struct."état" = 'ACCEPTED' then
-            1
-        else
-            0
-        end) as "nb_acceptées",
-    -- nb de structures refusées
-    sum(case when cap_struct."état" = 'REFUSED' then
-            1
-        else
-            0
-        end) as "nb_refusées",
-    -- nb de structures en attente notif
-    sum(case when cap_struct."état" = 'NOTIFICATION_PENDING' then
-            1
-        else
-            0
-        end) as nb_attente
+    -- les contrôlées / ttes les siae
+    sum(cap_struct_cnt. "nb_contrôlées") / max(nb_tot_dep.nb_struct) * 100 as "pct_contrôlées"
 from
-    cap_structures cap_struct
-    left join structures struct on cap_struct.id_structure = struct.id
-    left join cap_campagnes cap_camp on cap_camp.id = cap_struct.id_cap_campagne
-    left join nb_structures_par_dept nb_tot_dep on nb_tot_dep."nom_département" = struct."nom_département"
+    cap_struct_counts cap_struct_cnt
+    left join structures struct on cap_struct_cnt.id_structure = struct.id
+    left join cap_campagnes cap_camp on cap_camp.id = cap_struct_cnt.id_cap_campagne
+    left join nb_structures_par_dept nb_tot_dep on nb_tot_dep. "nom_département" = struct. "nom_département"
 group by
     cap_camp.nom,
-    struct."région",
-    struct."nom_département"
-order by struct."nom_département";
+    struct. "région",
+    struct. "nom_département"
+order by
+    struct. "nom_département";

--- a/itou/metabase/sql/035_suivi_cap.sql
+++ b/itou/metabase/sql/035_suivi_cap.sql
@@ -13,6 +13,7 @@ with nb_structures_par_dept as (
 select
     cap_camp.nom,
     struct.nom_département as nom_département,
+    struct.région,
     -- récupération du pct de séléction attendu
     max(cap_camp.pourcentage_sélection) as pct_selection,
     --nb controlees : ie celles qui ont une date de contrôle non null
@@ -56,5 +57,6 @@ from
     left join nb_structures_par_dept nb_tot_dep on nb_tot_dep.nom_département = struct.nom_département
 group by
     cap_camp.nom,
+    struct.région,
     struct.nom_département
 order by struct.nom_département;

--- a/itou/metabase/sql/035_suivi_cap.sql
+++ b/itou/metabase/sql/035_suivi_cap.sql
@@ -7,7 +7,7 @@ with nb_structures_par_dept as (
     from
         structures
     group by
-        département,
+        "département",
         "nom_département"
 )
 select
@@ -15,7 +15,7 @@ select
     struct."nom_département" as "nom_département",
     struct."région",
     -- récupération du pct de sélection attendu
-    max(cap_camp."pourcentage_sélection") as pct_sélection,
+    max(cap_camp."pourcentage_sélection") as "pct_sélection",
     --nb controlees : ie celles qui ont une date de contrôle non null
     sum(
         case when cap_struct."date_contrôle" is not null then
@@ -31,21 +31,21 @@ select
                 1
             else
                 0
-            end) as float) / max(nb_tot_dep.nb_struct) * 100 as pct_contrôlées,
+            end) as float) / max(nb_tot_dep.nb_struct) * 100 as "pct_contrôlées",
     -- nb de structures acceptées
-    sum(case when cap_struct.état = 'ACCEPTED' then
+    sum(case when cap_struct."état" = 'ACCEPTED' then
             1
         else
             0
-        end) as nb_acceptées,
+        end) as "nb_acceptées",
     -- nb de structures refusées
-    sum(case when cap_struct.état = 'REFUSED' then
+    sum(case when cap_struct."état" = 'REFUSED' then
             1
         else
             0
-        end) as nb_refusées,
+        end) as "nb_refusées",
     -- nb de structures en attente notif
-    sum(case when cap_struct.état = 'NOTIFICATION_PENDING' then
+    sum(case when cap_struct."état" = 'NOTIFICATION_PENDING' then
             1
         else
             0

--- a/itou/metabase/sql/035_suivi_cap.sql
+++ b/itou/metabase/sql/035_suivi_cap.sql
@@ -53,7 +53,7 @@ select
     struct. "région",
     -- récupération du pct de sélection attendu
     -- que l'on divise par 100 pour permettre l'affichage correct sur metabase
-    max(cap_camp. "pourcentage_sélection")/100 as "part_structures_à_contrôler",
+    cast(max(cap_camp. "pourcentage_sélection") as float)/100 as "part_structures_à_contrôler",
     sum(cap_struct_cnt. "nb_contrôlées") as "nb_contrôlées",
     sum(cap_struct_cnt. "nb_acceptées") as "nb_acceptées",
     sum(cap_struct_cnt. "nb_refusées") as "nb_refusées",

--- a/itou/metabase/sql/035_suivi_cap.sql
+++ b/itou/metabase/sql/035_suivi_cap.sql
@@ -1,5 +1,4 @@
 with nb_structures_par_dept as (
--- nb de structures référencées par dept
     select
         département,
         "nom_département",

--- a/itou/metabase/sql/035_suivi_cap.sql
+++ b/itou/metabase/sql/035_suivi_cap.sql
@@ -1,0 +1,60 @@
+with nb_structures_par_dept as (
+-- nb de structures référencées par dept
+    select
+        département,
+        nom_département,
+        count(*) as nb_struct
+    from
+        structures
+    group by
+        département,
+        nom_département
+)
+select
+    cap_camp.nom,
+    struct.nom_département as nom_département,
+    -- récupération du pct de séléction attendu
+    max(cap_camp.pourcentage_sélection) as pct_selection,
+    --nb controlees : ie celles qui ont une date de contrôle non null
+    sum(
+        case when cap_struct.date_contrôle is not null then
+            1
+        else
+            0
+        end) as nb_contrôlées,
+    -- pourcentage de SIAE contrôlées :
+    -- ie celles qui ont une date de contrôle non null
+    -- sur toutes les SIAE référencées dans la table structure
+    CAST(sum(
+            case when cap_struct.date_contrôle is not null then
+                1
+            else
+                0
+            end) as float) / max(nb_tot_dep.nb_struct) * 100 as pct_contrôlées,
+    -- nb de structures acceptées
+    sum(case when cap_struct.état = 'ACCEPTED' then
+            1
+        else
+            0
+        end) as nb_acceptees,
+    -- nb de structures refusées
+    sum(case when cap_struct.état = 'REFUSED' then
+            1
+        else
+            0
+        end) as nb_refusees,
+    -- nb de structures en attente notif
+    sum(case when cap_struct.état = 'NOTIFICATION_PENDING' then
+            1
+        else
+            0
+        end) as nb_attente
+from
+    cap_structures cap_struct
+    left join structures struct on cap_struct.id_structure = struct.id
+    left join cap_campagnes cap_camp on cap_camp.id = cap_struct.id_cap_campagne
+    left join nb_structures_par_dept nb_tot_dep on nb_tot_dep.nom_département = struct.nom_département
+group by
+    cap_camp.nom,
+    struct.nom_département
+order by struct.nom_département;

--- a/itou/metabase/sql/037_suivi_cap.sql
+++ b/itou/metabase/sql/037_suivi_cap.sql
@@ -1,3 +1,4 @@
+create table suivi_cap as
 with nb_structures_par_dept as (
     select
         "département",

--- a/itou/metabase/sql/037_suivi_cap.sql
+++ b/itou/metabase/sql/037_suivi_cap.sql
@@ -1,4 +1,3 @@
-create table suivi_cap as
 with nb_structures_par_dept as (
     select
         "département",

--- a/itou/metabase/tables/job_seekers.py
+++ b/itou/metabase/tables/job_seekers.py
@@ -177,7 +177,7 @@ def get_job_seeker_qpv_info(job_seeker):
 
 
 def get_table():
-    job_seekers_table = MetabaseTable(name="candidats")
+    job_seekers_table = MetabaseTable(name="candidats_v0")
 
     job_seekers_table.add_columns(
         [


### PR DESCRIPTION
### Pourquoi ?

Tout comme pour la table organisations, candidats devient candidats_v0, ce qui nous permet d'enrichir la table candidat au besoin côté c2 sans avoir à refaire de nombreux indicateurs. 
