### PR TITLE
Ajouter une règle runserver au Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ endif
 run:
 	docker compose up
 
+runserver: $(VIRTUAL_ENV)
+	python manage.py runserver
+
 $(VIRTUAL_ENV): $(REQUIREMENTS_PATH)
 	$(PYTHON_VERSION) -m venv $@
 	$@/bin/pip install -r $^

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ seront lancées directement dans votre venv si `USE_VENV=1` est utilisé.
 Cette variable devrait _normalement_ pouvoir être définie en global dans
 votre environnement shell (`export`, `.env`, ...).
 
+Pour lancer le serveur de développement :
+```sh
+$ make runserver`
+```
+Cette commande est préférable à `python manage.py runserver`, car elle vérifie
+que le Virtualenv est à jour.
+
 ### Développement avec Docker
 
 Vous devez disposer sur votre machine d'un démon `Docker` et de l'outil `Docker


### PR DESCRIPTION
### Pourquoi ?

S’assurer que le venv est à jour au lancement du serveur de développement.