### PR TITLE
Renommer la table candidats en candidats_v0 

### DIFF
--- a/itou/metabase/tables/job_seekers.py
+++ b/itou/metabase/tables/job_seekers.py
@@ -179,7 +179,7 @@ def get_job_seeker_qpv_info(job_seeker):
 
 
 def get_table():
-    job_seekers_table = MetabaseTable(name="candidats")
+    job_seekers_table = MetabaseTable(name="candidats_v0")
 
     job_seekers_table.add_columns(
         [

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -214,7 +214,7 @@ def test_populate_job_seekers():
         management.call_command("populate_metabase_emplois", mode="job_seekers")
 
     with connection.cursor() as cursor:
-        cursor.execute("SELECT * FROM candidats ORDER BY id")
+        cursor.execute("SELECT * FROM candidats_v0 ORDER BY id")
         rows = cursor.fetchall()
 
     assert rows == [


### PR DESCRIPTION
### Pourquoi ?

Tout comme pour la table organisations, candidats devient candidats_v0, ce qui nous permet d'enrichir la table candidat au besoin côté c2 sans avoir à refaire de nombreux indicateurs.

Accompagne cette PR : https://github.com/gip-inclusion/pilotage-airflow/pull/138

