### PR TITLE
Corriger une colonne UUID (& integer) dans Metabase

### DIFF
--- a/itou/metabase/tables/selected_jobs.py
+++ b/itou/metabase/tables/selected_jobs.py
@@ -6,13 +6,13 @@ TABLE.add_columns(
     [
         {
             "name": "id_fiche_de_poste",
-            "type": "int",
+            "type": "integer",
             "comment": "ID fiche de poste",
             "fn": lambda o: o["selected_jobs__id"],
         },
         {
             "name": "id_candidature",
-            "type": "varchar",
+            "type": "uuid",
             "comment": "ID de la candidature",
             "fn": lambda o: o["pk"],
         },

--- a/tests/metabase/conftest.py
+++ b/tests/metabase/conftest.py
@@ -6,6 +6,7 @@ from itou.metabase.tables.utils import (
     get_active_siae_pks,
     get_ai_stock_job_seeker_pks,
     get_insee_code_to_zrr_status_map,
+    get_post_code_to_insee_code_map,
     get_qpv_job_seeker_pks,
 )
 
@@ -45,4 +46,5 @@ def clear_pks_caches():
     get_active_siae_pks.cache_clear()
     get_ai_stock_job_seeker_pks.cache_clear()
     get_insee_code_to_zrr_status_map.cache_clear()
+    get_post_code_to_insee_code_map.cache_clear()
     get_qpv_job_seeker_pks.cache_clear()


### PR DESCRIPTION
Encore une table qui casse et qui n'était pas testée.

C'est un peu pénible à vérifier car il faut des données récentes (plusieurs GB à télécharger)
Lancer l'export complet (une à deux heures sur ma machine)
Lancer DBT run complet (une bonne quarantaine de minutes sur ma machine)

Et même là on peut encore avoir des fois quelque chose qui "tombe en marche" si les casts sont heureux, et pas plus tard.
