### PR TITLE
Demandes de prolongation : Procédure de refus (motifs et actions proposées)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     "anymail",
     "bootstrap4",
     "django_select2",
+    "formtools",
     "huey.contrib.djhuey",
     "rest_framework",
     "rest_framework.authtoken",

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -430,7 +430,11 @@ class ProlongationCommonAdmin(ItouModelAdmin):
 class ProlongationRequestAdmin(ProlongationCommonAdmin):
     list_display = ProlongationCommonAdmin.list_display + ("status", "processed_at")
     list_filter = ("status",) + ProlongationCommonAdmin.list_filter
-    readonly_fields = ProlongationCommonAdmin.readonly_fields + ("processed_at", "processed_by")
+    readonly_fields = ProlongationCommonAdmin.readonly_fields + ("processed_at", "processed_by", "prolongation")
+
+    @admin.display(description="prolongation créée")
+    def prolongation(self, obj):
+        return obj.prolongation
 
 
 @admin.register(models.Prolongation)

--- a/itou/approvals/enums.py
+++ b/itou/approvals/enums.py
@@ -51,3 +51,19 @@ class ProlongationRequestStatus(models.TextChoices):
     PENDING = "PENDING", "À traiter"
     GRANTED = "GRANTED", "Acceptée"
     DENIED = "DENIED", "Refusée"
+
+
+class ProlongationRequestDenyReason(models.TextChoices):
+    IAE = "IAE", "L’IAE ne correspond plus aux besoins / à la situation de la personne."
+    SIAE = "SIAE", "La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne."
+
+
+class ProlongationRequestDenyProposedAction(models.TextChoices):
+    # TODO: Clarify the actions to improve the naming
+    EXIT_IAE = (
+        "EXIT_IAE",
+        "Accompagnement à la recherche d’emploi hors IAE et mobilisation de l’offre "
+        "de services disponible au sein de votre structure ou celle d’un partenaire.",
+    )
+    SOCIAL_PARTNER = "SOCIAL_PARTNER", "Orientation vers un partenaire de l’accompagnement social/professionnel."
+    OTHER = "OTHER", "Autre"

--- a/itou/approvals/migrations/0016_prolongationrequestdenyinformation.py
+++ b/itou/approvals/migrations/0016_prolongationrequestdenyinformation.py
@@ -1,0 +1,81 @@
+import django.contrib.postgres.fields
+import django.db.models.deletion
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("approvals", "0015_alter_suspension_updated_at"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ProlongationRequestDenyInformation",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "reason",
+                    models.CharField(
+                        choices=[
+                            ("IAE", "L’IAE ne correspond plus aux besoins / à la situation de la personne."),
+                            (
+                                "SIAE",
+                                "La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne.",
+                            ),
+                        ],
+                        verbose_name="motif de refus",
+                    ),
+                ),
+                ("reason_explanation", models.TextField(verbose_name="explications du motif de refus")),
+                (
+                    "proposed_actions",
+                    django.contrib.postgres.fields.ArrayField(
+                        base_field=models.CharField(
+                            choices=[
+                                (
+                                    "EXIT_IAE",
+                                    "Accompagnement à la recherche d’emploi hors IAE et mobilisation de l’offre de "
+                                    "services disponible au sein de votre structure ou celle d’un partenaire.",
+                                ),
+                                (
+                                    "SOCIAL_PARTNER",
+                                    "Orientation vers un partenaire de l’accompagnement social/professionnel.",
+                                ),
+                                ("OTHER", "Autre"),
+                            ]
+                        ),
+                        blank=True,
+                        null=True,
+                        size=None,
+                        verbose_name="actions envisagées",
+                    ),
+                ),
+                (
+                    "proposed_actions_explanation",
+                    models.TextField(blank=True, verbose_name="explications des actions envisagées"),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(default=django.utils.timezone.now, verbose_name="date de création"),
+                ),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="date de modification")),
+                (
+                    "request",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="deny_information",
+                        to="approvals.prolongationrequest",
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="prolongationrequestdenyinformation",
+            constraint=models.CheckConstraint(
+                check=models.Q(("proposed_actions__len", 0), _negated=True),
+                name="non_empty_proposed_actions",
+                violation_error_message="Les actions envisagées ne peuvent pas être vide",
+            ),
+        ),
+    ]

--- a/itou/templates/approvals/email/prolongation_request/denied/employer_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/denied/employer_body.txt
@@ -9,5 +9,21 @@ Références :
 Numéro : {{ prolongation_request.approval.number_with_spaces }}
 Bénéficiaire : {{ prolongation_request.approval.user.get_full_name }}
 
+{% if prolongation_request.deny_information %}
+Motif de refus :
+- {{ prolongation_request.deny_information.get_reason_display }}
+- Explications du prescripteur habilité : {{ prolongation_request.deny_information.reason_explanation }}
+{% endif %}
+
+{% if prolongation_request.deny_information.proposed_actions %}
+Actions envisagées par le prescripteur :
+{% for proposed_action in prolongation_request.deny_information.get_proposed_actions_display %}
+- {{ proposed_action }}
+{% endfor %}
+{% if prolongation_request.deny_information.proposed_actions_explanation %}
+- Précisions : {{ prolongation_request.deny_information.proposed_actions_explanation }}
+{% endif %}
+{% endif %}
+
 Vous pouvez consulter la date de fin prévisionnelle du PASS IAE dans votre espace employeur sur les emplois de l’inclusion.
 {% endblock body %}

--- a/itou/templates/approvals/email/prolongation_request/denied/jobseeker_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/denied/jobseeker_body.txt
@@ -8,5 +8,20 @@ L’employeur {{ prolongation_request.declared_by_siae.display_name }} a sollici
 
 L’organisation {{ prolongation_request.prescriber_organization.display_name }} a refusé la prolongation du PASS IAE.
 
+{% if prolongation_request.deny_information %}
+Motif de refus :
+- {{ prolongation_request.deny_information.get_reason_display }}
+- Explications du prescripteur habilité : {{ prolongation_request.deny_information.reason_explanation }}
+{% endif %}
+{% if prolongation_request.deny_information.proposed_actions %}
+Actions envisagées par le prescripteur :
+{% for proposed_action in prolongation_request.deny_information.get_proposed_actions_display %}
+- {{ proposed_action }}
+{% endfor %}
+{% if prolongation_request.deny_information.proposed_actions_explanation %}
+- Précisions : {{ prolongation_request.deny_information.proposed_actions_explanation }}
+{% endif %}
+{% endif %}
+
 Vous pouvez consulter la date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur les emplois de l’inclusion.
 {% endblock body %}

--- a/itou/templates/approvals/prolongation_requests/_deny_information_card.html
+++ b/itou/templates/approvals/prolongation_requests/_deny_information_card.html
@@ -1,0 +1,26 @@
+{% if prolongation_request.deny_information %}
+    <div class="c-box mb-3 mb-lg-5">
+        <h2>Détail du refus</h2>
+        <hr>
+        <h3>Traitement de la demande</h3>
+        <p>
+            Demande refusée le {{ prolongation_request.processed_at|date:"d F Y" }} par {{ prolongation_request.processed_by.get_full_name }}
+        </p>
+        <h3>Motif du refus</h3>
+        <p>{{ prolongation_request.deny_information.get_reason_display }}</p>
+        <h3>Explications supplémentaires</h3>
+        <p>{{ prolongation_request.deny_information.reason_explanation }}</p>
+        {% if prolongation_request.deny_information.proposed_actions %}
+            <h3>Actions envisagées par le prescripteur habilité</h3>
+            <ul>
+                {% for proposed_action in prolongation_request.deny_information.get_proposed_actions_display %}
+                    <li>{{ proposed_action }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+        {% if prolongation_request.deny_information.proposed_actions_explanation %}
+            <h3>Précisions</h3>
+            <p>{{ prolongation_request.deny_information.proposed_actions_explanation }}</p>
+        {% endif %}
+    </div>
+{% endif %}

--- a/itou/templates/approvals/prolongation_requests/_status_card.html
+++ b/itou/templates/approvals/prolongation_requests/_status_card.html
@@ -5,13 +5,16 @@
                 <h4>Prolonger le PASS IAE jusqu’au {{ prolongation_request.end_at|date:"d/m/Y" }}</h4>
             </div>
             <div class="card-text">
-                <form method="post">
+                <form method="post" action="{% url "approvals:prolongation_request_grant" prolongation_request.pk %}">
                     {% csrf_token %}
-                    <button name="action" value="grant" class="btn btn-primary btn-block btn-ico justify-content-center">
+                    <button class="btn btn-primary btn-block btn-ico justify-content-center">
                         <i class="ri-check-line"></i>
                         <span>Accepter</span>
                     </button>
-                    <button name="action" value="deny" class="btn btn-outline-primary btn-block btn-ico mt-3 justify-content-center">
+                </form>
+                <form method="post" action="{% url "approvals:prolongation_request_deny" prolongation_request.pk %}">
+                    {% csrf_token %}
+                    <button class="btn btn-outline-primary btn-block btn-ico mt-3 justify-content-center">
                         <i class="ri-close-line"></i>
                         <span>Refuser</span>
                     </button>

--- a/itou/templates/approvals/prolongation_requests/_status_card.html
+++ b/itou/templates/approvals/prolongation_requests/_status_card.html
@@ -12,18 +12,12 @@
                         <span>Accepter</span>
                     </button>
                 </form>
-                <form method="post" action="{% url "approvals:prolongation_request_deny" prolongation_request.pk %}">
-                    {% csrf_token %}
-                    <button class="btn btn-outline-primary btn-block btn-ico mt-3 justify-content-center">
-                        <i class="ri-close-line"></i>
-                        <span>Refuser</span>
-                    </button>
-                </form>
+                <a class="btn btn-outline-primary btn-block btn-ico mt-3 justify-content-center" href="{% url "approvals:prolongation_request_deny" prolongation_request.pk %}?reset=1">
+                    <i class="ri-close-line"></i>
+                    <span>Refuser</span>
+                </a>
                 <p class="font-weight-bold mt-3">Précision</p>
-                <p class="mb-2">
-                    En cas de refus, vous êtes tenu de proposer une solution au candidat.
-                    Vous devez également motiver par écrit votre refus de prolongation auprès de la SIAE (Dans l'attente de la mise en œuvre du module spécifique).
-                </p>
+                <p class="mb-2">En cas de refus, vous êtes tenu de proposer une solution au candidat.</p>
             </div>
         {% elif prolongation_request.status == ProlongationRequestStatus.GRANTED %}
             <div class="card-title">

--- a/itou/templates/approvals/prolongation_requests/deny.html
+++ b/itou/templates/approvals/prolongation_requests/deny.html
@@ -1,0 +1,80 @@
+{% extends "layout/base.html" %}
+{% load bootstrap4 %}
+{% load theme_inclusion %}
+
+{% block title %}
+    Refuser la demande de prolongation - {{ prolongation_request.approval.user.get_full_name }} {{ block.super }}
+{% endblock %}
+
+{% block content_title %}
+    <h1>Refuser la demande de prolongation pour {{ prolongation_request.approval.user.get_full_name }}</h1>
+{% endblock %}
+
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="row">
+                <div class="col-12 col-lg-8">
+                    <div class="c-stepper mb-3 mb-lg-5">
+                        <div class="progress progress--emploi">
+                            <div class="progress-bar progress-bar-{{ wizard|stepper_progress }}" role="progressbar" aria-valuenow="{{ wizard|stepper_progress }}" aria-valuemin="0" aria-valuemax="100">
+                            </div>
+                        </div>
+                        <p>
+                            {% if wizard.steps.current == "reason" %}
+                                <strong>Étape 1</strong> : Motif du refus
+                            {% elif wizard.steps.current == "reason_explanation" %}
+                                <strong>Étape {{ wizard.steps.step1 }}</strong>/{{ wizard.steps.count }} : Explications supplémentaires
+                            {% elif wizard.steps.current == "proposed_actions" %}
+                                <strong>Étape {{ wizard.steps.step1 }}</strong>/{{ wizard.steps.count }} : Solution envisagée
+                            {% endif %}
+                        </p>
+                    </div>
+                    <div class="c-form mb-3 mb-lg-5">
+                        <h2 class="h4">Réponse envoyée à l'employeur et au candidat</h2>
+                        {% block form_content %}
+                            <form method="post">
+                                {% csrf_token %}
+                                {{ wizard.management_form }}
+
+                                {% bootstrap_form wizard.form alert_error_type="non_fields" %}
+
+                                {% if wizard.steps.current == "reason" %}
+                                    <div class="c-info mb-4">
+                                        <button type="button" class="c-info__summary collapsed" data-toggle="collapse" data-target="#legalInformation" aria-expanded="false" aria-controls="legalInformation">
+                                            <span>Contexte légal</span>
+                                        </button>
+                                        <div class="c-info__detail collapse" id="legalInformation">
+                                            <p>
+                                                Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
+                                            </p>
+                                            <a class="btn btn-link px-0" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043990367" aria-label="En savoir plus concernant le contexte légal" rel="noopener" target="_blank">
+                                                <span>En savoir plus</span>
+                                                <i class="ri-external-link-line ri-lg"></i>
+                                            </a>
+                                        </div>
+                                    </div>
+                                {% endif %}
+
+                                <hr>
+                                <p class="fs-xs">* champ obligatoire</p>
+                                {% buttons %}
+                                    <div class="text-right">
+                                        {% if wizard.steps.prev %}
+                                            <button formnovalidate class="btn btn-outline-primary" name="wizard_goto_step" value="{{ wizard.steps.prev }}">
+                                                Retour
+                                            </button>
+                                        {% else %}
+                                            <a class="btn btn-link btn-outline-primary" href="{% url "approvals:prolongation_request_show" prolongation_request.pk %}">Annuler</a>
+                                        {% endif %}
+                                        <button class="btn btn-primary">{{ wizard.steps.next|yesno:"Suivant,Confirmer le refus" }}</button>
+                                    </div>
+                                {% endbuttons %}
+                            </form>
+                        {% endblock %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -60,6 +60,7 @@
                             </p>
                         {% endif %}
                     </div>
+                    {% include "approvals/prolongation_requests/_deny_information_card.html" %}
                 </div>
                 <div class="col-12 col-lg-4">
                     {# Status card #}

--- a/itou/utils/templatetags/theme_inclusion.py
+++ b/itou/utils/templatetags/theme_inclusion.py
@@ -1,3 +1,5 @@
+import math
+
 from django import template
 from django.contrib.messages import constants as message_constants
 from django.templatetags.static import static
@@ -52,3 +54,8 @@ def itou_toast_content(message):
         return message.message.split("||", maxsplit=1)[1]
     except IndexError:
         return None
+
+
+@register.filter
+def stepper_progress(wizard):
+    return math.floor((wizard["steps"].step1 / wizard["steps"].count) * 100)

--- a/itou/www/approvals_views/urls.py
+++ b/itou/www/approvals_views/urls.py
@@ -33,6 +33,16 @@ urlpatterns = [
         views.prolongation_request_show,
         name="prolongation_request_show",
     ),
+    path(
+        "prolongation/request/<int:prolongation_request_id>/grant",
+        views.prolongation_request_grant,
+        name="prolongation_request_grant",
+    ),
+    path(
+        "prolongation/request/<int:prolongation_request_id>/deny",
+        views.prolongation_request_deny,
+        name="prolongation_request_deny",
+    ),
     path("suspend/<int:approval_id>", views.suspend, name="suspend"),
     path("suspension/<int:suspension_id>/edit", views.suspension_update, name="suspension_update"),
     path("suspension/<int:suspension_id>/delete", views.suspension_delete, name="suspension_delete"),

--- a/itou/www/approvals_views/urls.py
+++ b/itou/www/approvals_views/urls.py
@@ -30,17 +30,17 @@ urlpatterns = [
     path("prolongation/requests", views.prolongation_requests_list, name="prolongation_requests_list"),
     path(
         "prolongation/request/<int:prolongation_request_id>",
-        views.prolongation_request_show,
+        views.ProlongationRequestShowView.as_view(),
         name="prolongation_request_show",
     ),
     path(
         "prolongation/request/<int:prolongation_request_id>/grant",
-        views.prolongation_request_grant,
+        views.ProlongationRequestGrantView.as_view(),
         name="prolongation_request_grant",
     ),
     path(
         "prolongation/request/<int:prolongation_request_id>/deny",
-        views.prolongation_request_deny,
+        views.ProlongationRequestDenyView.as_view(),
         name="prolongation_request_deny",
     ),
     path("suspend/<int:approval_id>", views.suspend, name="suspend"),

--- a/itou/www/approvals_views/urls.py
+++ b/itou/www/approvals_views/urls.py
@@ -40,7 +40,12 @@ urlpatterns = [
     ),
     path(
         "prolongation/request/<int:prolongation_request_id>/deny",
-        views.ProlongationRequestDenyView.as_view(),
+        views.ProlongationRequestDenyView.as_view(url_name="approvals:prolongation_request_deny"),
+        name="prolongation_request_deny",
+    ),
+    path(
+        "prolongation/request/<int:prolongation_request_id>/deny/<slug:step>",
+        views.ProlongationRequestDenyView.as_view(url_name="approvals:prolongation_request_deny"),
         name="prolongation_request_deny",
     ),
     path("suspend/<int:approval_id>", views.suspend, name="suspend"),

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,9 @@ filterwarnings =
     ; TODO: Drop filter after release of
     ; https://github.com/pandas-dev/pandas/commit/71cfd3a2d56ff81404e13b7e5c6a9720d52a3a81
     ignore:np.find_common_type is deprecated.  Please use `np.result_type` or `np.promote_types`.:DeprecationWarning:pandas
+    ; TODO: Drop filter after release of
+    ; https://github.com/jazzband/django-formtools/commit/653c82cf27d5f21c3691efded466ac70659ff1c1
+    ignore:pkg_resources is deprecated as an API.:DeprecationWarning:formtools
 addopts =
     --reuse-db
     --strict-markers

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -38,6 +38,9 @@ drf-spectacular  # https://github.com/tfranzel/drf-spectacular
 # Django filter (filtering/ordering of API results)
 django-filter  # https://django-filter.readthedocs.io/en/stable/
 
+# Preview and multi-steps/wizard forms for Django
+django-formtools  # https://django-formtools.readthedocs.io/en/latest/
+
 # Front-end
 # ------------------------------------------------------------------------------
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -258,6 +258,7 @@ django==4.2.5 \
     #   django-bootstrap4
     #   django-csp
     #   django-filter
+    #   django-formtools
     #   django-hijack
     #   django-htmx
     #   django-import-export
@@ -288,6 +289,10 @@ django-csp==3.7 \
 django-filter==23.3 \
     --hash=sha256:015fe155582e1805b40629344e4a6cf3cc40450827d294d040b4b8c1749a9fa6 \
     --hash=sha256:65bc5d1d8f4fff3aaf74cb5da537b6620e9214fb4b3180f6c560776b1b6dccd0
+    # via -r requirements/base.in
+django-formtools==2.4.1 \
+    --hash=sha256:21f8d5dac737f1e636fa8a0a10969c1c32f525a6dfa27c29592827ba70d9643a \
+    --hash=sha256:49ea8a64ddef4728a558bf5f8f622c0f4053b979edcf193bf00dd80432ab2f12
     # via -r requirements/base.in
 django-hijack==3.4.1 \
     --hash=sha256:2bdd7ffa42198637f49c195468b8330ea51dc36b7c2bee0f3c220c9d7de78764 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -349,6 +349,7 @@ django==4.2.5 \
     #   django-debug-toolbar
     #   django-extensions
     #   django-filter
+    #   django-formtools
     #   django-hijack
     #   django-htmx
     #   django-import-export
@@ -389,6 +390,10 @@ django-extensions==3.2.3 \
 django-filter==23.3 \
     --hash=sha256:015fe155582e1805b40629344e4a6cf3cc40450827d294d040b4b8c1749a9fa6 \
     --hash=sha256:65bc5d1d8f4fff3aaf74cb5da537b6620e9214fb4b3180f6c560776b1b6dccd0
+    # via -r requirements/test.txt
+django-formtools==2.4.1 \
+    --hash=sha256:21f8d5dac737f1e636fa8a0a10969c1c32f525a6dfa27c29592827ba70d9643a \
+    --hash=sha256:49ea8a64ddef4728a558bf5f8f622c0f4053b979edcf193bf00dd80432ab2f12
     # via -r requirements/test.txt
 django-hijack==3.4.1 \
     --hash=sha256:2bdd7ffa42198637f49c195468b8330ea51dc36b7c2bee0f3c220c9d7de78764 \

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -319,6 +319,7 @@ django==4.2.5 \
     #   django-bootstrap4
     #   django-csp
     #   django-filter
+    #   django-formtools
     #   django-hijack
     #   django-htmx
     #   django-import-export
@@ -351,6 +352,10 @@ django-csp==3.7 \
 django-filter==23.3 \
     --hash=sha256:015fe155582e1805b40629344e4a6cf3cc40450827d294d040b4b8c1749a9fa6 \
     --hash=sha256:65bc5d1d8f4fff3aaf74cb5da537b6620e9214fb4b3180f6c560776b1b6dccd0
+    # via -r requirements/base.txt
+django-formtools==2.4.1 \
+    --hash=sha256:21f8d5dac737f1e636fa8a0a10969c1c32f525a6dfa27c29592827ba70d9643a \
+    --hash=sha256:49ea8a64ddef4728a558bf5f8f622c0f4053b979edcf193bf00dd80432ab2f12
     # via -r requirements/base.txt
 django-hijack==3.4.1 \
     --hash=sha256:2bdd7ffa42198637f49c195468b8330ea51dc36b7c2bee0f3c220c9d7de78764 \

--- a/tests/approvals/__snapshots__/test_notifications.ambr
+++ b/tests/approvals/__snapshots__/test_notifications.ambr
@@ -121,6 +121,20 @@
   Numéro : 99999 99 99999
   Bénéficiaire : John DOE
   
+  Motif de refus :
+  - L’IAE ne correspond plus aux besoins / à la situation de la personne.
+  - Explications du prescripteur habilité : [reason_explanation]
+  
+  Actions envisagées par le prescripteur :
+  
+  - Accompagnement à la recherche d’emploi hors IAE et mobilisation de l’offre de services disponible au sein de votre structure ou celle d’un partenaire.
+  
+  - Orientation vers un partenaire de l’accompagnement social/professionnel.
+  
+  - Autre
+  
+  - Précisions : [proposed_actions_explanation]
+  
   Vous pouvez consulter la date de fin prévisionnelle du PASS IAE dans votre espace employeur sur les emplois de l’inclusion.
   
   ---
@@ -139,6 +153,20 @@
   L’employeur Acme inc. a sollicité un prescripteur habilité de l’organisation Pres. org.  pour demander une prolongation de votre PASS IAE.
   
   L’organisation Pres. org. a refusé la prolongation du PASS IAE.
+  
+  Motif de refus :
+  - L’IAE ne correspond plus aux besoins / à la situation de la personne.
+  - Explications du prescripteur habilité : [reason_explanation]
+  
+  Actions envisagées par le prescripteur :
+  
+  - Accompagnement à la recherche d’emploi hors IAE et mobilisation de l’offre de services disponible au sein de votre structure ou celle d’un partenaire.
+  
+  - Orientation vers un partenaire de l’accompagnement social/professionnel.
+  
+  - Autre
+  
+  - Précisions : [proposed_actions_explanation]
   
   Vous pouvez consulter la date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur les emplois de l’inclusion.
   

--- a/tests/approvals/test_notifications.py
+++ b/tests/approvals/test_notifications.py
@@ -3,7 +3,7 @@ import datetime
 from itou.approvals import notifications
 
 from ..users.factories import PrescriberFactory
-from .factories import ProlongationRequestFactory
+from .factories import ProlongationRequestDenyInformationFactory, ProlongationRequestFactory
 
 
 def test_prolongation_request_created(snapshot):
@@ -68,7 +68,7 @@ def test_prolongation_request_granted_jobseeker(snapshot):
 
 
 def test_prolongation_request_denied_employer(snapshot):
-    prolongation_request = ProlongationRequestFactory(for_snapshot=True)
+    prolongation_request = ProlongationRequestDenyInformationFactory(for_snapshot=True).request
     email = notifications.ProlongationRequestDeniedEmployer(prolongation_request).email
 
     assert email.to == [prolongation_request.declared_by.email]
@@ -77,7 +77,7 @@ def test_prolongation_request_denied_employer(snapshot):
 
 
 def test_prolongation_request_denied_jobseeker(snapshot):
-    prolongation_request = ProlongationRequestFactory(for_snapshot=True)
+    prolongation_request = ProlongationRequestDenyInformationFactory(for_snapshot=True).request
     email = notifications.ProlongationRequestDeniedJobSeeker(prolongation_request).email
 
     assert email.to == [prolongation_request.approval.user.email]

--- a/tests/approvals/test_prolongation_requests.py
+++ b/tests/approvals/test_prolongation_requests.py
@@ -27,6 +27,11 @@ def test_unique_approval_for_pending_constraint():
         ProlongationRequest(approval=prolongation_request.approval, status=ProlongationRequestStatus.PENDING).save()
 
 
+def test_non_empty_proposed_actions_constraint():
+    with pytest.raises(IntegrityError, match="non_empty_proposed_actions"):
+        ProlongationRequestDenyInformationFactory(proposed_actions=[])
+
+
 @pytest.mark.parametrize(
     "email,phone,expected",
     [

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -153,13 +153,16 @@
                   <h4>Prolonger le PASS IAE jusqu’au 31/01/2000</h4>
               </div>
               <div class="card-text">
-                  <form method="post">
+                  <form method="post" action="/approvals/prolongation/request/666/grant">
                       
-                      <button name="action" value="grant" class="btn btn-primary btn-block btn-ico justify-content-center">
+                      <button class="btn btn-primary btn-block btn-ico justify-content-center">
                           <i class="ri-check-line"></i>
                           <span>Accepter</span>
                       </button>
-                      <button name="action" value="deny" class="btn btn-outline-primary btn-block btn-ico mt-3 justify-content-center">
+                  </form>
+                  <form method="post" action="/approvals/prolongation/request/666/deny">
+                      
+                      <button class="btn btn-outline-primary btn-block btn-ico mt-3 justify-content-center">
                           <i class="ri-close-line"></i>
                           <span>Refuser</span>
                       </button>

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -1,4 +1,379 @@
 # serializer version: 1
+# name: test_deny_view_for_reasons[IAE][proposed_actions]
+  '''
+  <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-lg-8">
+                      <div class="c-stepper mb-3 mb-lg-5">
+                          <div class="progress progress--emploi">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="33" class="progress-bar progress-bar-33" role="progressbar">
+                              </div>
+                          </div>
+                          <p>
+                              
+                                  <strong>Étape 1</strong> : Motif du refus
+                              
+                          </p>
+                      </div>
+                      <div class="c-form mb-3 mb-lg-5">
+                          <h2 class="h4">Réponse envoyée à l'employeur et au candidat</h2>
+                          
+                              <form method="post">
+                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason"/>
+  
+                                  <div class="form-group form-group-required"><label>Pour quel motif refusez-vous la prolongation du parcours IAE de John DOE ?</label><div class="radio radio-success" id="id_reason-reason"><div class="form-check">
+  <label class="form-check-label" for="id_reason-reason_0"><input checked="" class="form-check-input" id="id_reason-reason_0" name="reason-reason" required="" title="" type="radio" value="IAE"/>
+   L’IAE ne correspond plus aux besoins / à la situation de la personne.</label>
+  </div><div class="form-check">
+  <label class="form-check-label" for="id_reason-reason_1"><input class="form-check-input" id="id_reason-reason_1" name="reason-reason" required="" title="" type="radio" value="SIAE"/>
+   La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne.</label>
+  </div>
+  </div></div>
+  
+                                  
+                                      <div class="c-info mb-4">
+                                          <button aria-controls="legalInformation" aria-expanded="false" class="c-info__summary collapsed" data-target="#legalInformation" data-toggle="collapse" type="button">
+                                              <span>Contexte légal</span>
+                                          </button>
+                                          <div class="c-info__detail collapse" id="legalInformation">
+                                              <p>
+                                                  Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
+                                              </p>
+                                              <a aria-label="En savoir plus concernant le contexte légal" class="btn btn-link px-0" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043990367" rel="noopener" target="_blank">
+                                                  <span>En savoir plus</span>
+                                                  <i class="ri-external-link-line ri-lg"></i>
+                                              </a>
+                                          </div>
+                                      </div>
+                                  
+  
+                                  <hr/>
+                                  <p class="fs-xs">* champ obligatoire</p>
+                                  <div class="form-group">
+                                      <div class="text-right">
+                                          
+                                              <a class="btn btn-link btn-outline-primary" href="/approvals/prolongation/request/666">Annuler</a>
+                                          
+                                          <button class="btn btn-primary">Suivant</button>
+                                      </div>
+                                  </div>
+                              </form>
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  '''
+# ---
+# name: test_deny_view_for_reasons[IAE][reason]
+  '''
+  <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-lg-8">
+                      <div class="c-stepper mb-3 mb-lg-5">
+                          <div class="progress progress--emploi">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="50" class="progress-bar progress-bar-50" role="progressbar">
+                              </div>
+                          </div>
+                          <p>
+                              
+                                  <strong>Étape 1</strong> : Motif du refus
+                              
+                          </p>
+                      </div>
+                      <div class="c-form mb-3 mb-lg-5">
+                          <h2 class="h4">Réponse envoyée à l'employeur et au candidat</h2>
+                          
+                              <form method="post">
+                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason"/>
+  
+                                  <div class="form-group form-group-required"><label>Pour quel motif refusez-vous la prolongation du parcours IAE de John DOE ?</label><div class="radio radio-success" id="id_reason-reason"><div class="form-check">
+  <label class="form-check-label" for="id_reason-reason_0"><input class="form-check-input" id="id_reason-reason_0" name="reason-reason" required="" title="" type="radio" value="IAE"/>
+   L’IAE ne correspond plus aux besoins / à la situation de la personne.</label>
+  </div><div class="form-check">
+  <label class="form-check-label" for="id_reason-reason_1"><input class="form-check-input" id="id_reason-reason_1" name="reason-reason" required="" title="" type="radio" value="SIAE"/>
+   La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne.</label>
+  </div>
+  </div></div>
+  
+                                  
+                                      <div class="c-info mb-4">
+                                          <button aria-controls="legalInformation" aria-expanded="false" class="c-info__summary collapsed" data-target="#legalInformation" data-toggle="collapse" type="button">
+                                              <span>Contexte légal</span>
+                                          </button>
+                                          <div class="c-info__detail collapse" id="legalInformation">
+                                              <p>
+                                                  Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
+                                              </p>
+                                              <a aria-label="En savoir plus concernant le contexte légal" class="btn btn-link px-0" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043990367" rel="noopener" target="_blank">
+                                                  <span>En savoir plus</span>
+                                                  <i class="ri-external-link-line ri-lg"></i>
+                                              </a>
+                                          </div>
+                                      </div>
+                                  
+  
+                                  <hr/>
+                                  <p class="fs-xs">* champ obligatoire</p>
+                                  <div class="form-group">
+                                      <div class="text-right">
+                                          
+                                              <a class="btn btn-link btn-outline-primary" href="/approvals/prolongation/request/666">Annuler</a>
+                                          
+                                          <button class="btn btn-primary">Suivant</button>
+                                      </div>
+                                  </div>
+                              </form>
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  '''
+# ---
+# name: test_deny_view_for_reasons[IAE][reason_explanation]
+  '''
+  <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-lg-8">
+                      <div class="c-stepper mb-3 mb-lg-5">
+                          <div class="progress progress--emploi">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="33" class="progress-bar progress-bar-33" role="progressbar">
+                              </div>
+                          </div>
+                          <p>
+                              
+                                  <strong>Étape 1</strong> : Motif du refus
+                              
+                          </p>
+                      </div>
+                      <div class="c-form mb-3 mb-lg-5">
+                          <h2 class="h4">Réponse envoyée à l'employeur et au candidat</h2>
+                          
+                              <form method="post">
+                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason"/>
+  
+                                  <div class="form-group form-group-required"><label>Pour quel motif refusez-vous la prolongation du parcours IAE de John DOE ?</label><div class="radio radio-success" id="id_reason-reason"><div class="form-check">
+  <label class="form-check-label" for="id_reason-reason_0"><input checked="" class="form-check-input" id="id_reason-reason_0" name="reason-reason" required="" title="" type="radio" value="IAE"/>
+   L’IAE ne correspond plus aux besoins / à la situation de la personne.</label>
+  </div><div class="form-check">
+  <label class="form-check-label" for="id_reason-reason_1"><input class="form-check-input" id="id_reason-reason_1" name="reason-reason" required="" title="" type="radio" value="SIAE"/>
+   La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne.</label>
+  </div>
+  </div></div>
+  
+                                  
+                                      <div class="c-info mb-4">
+                                          <button aria-controls="legalInformation" aria-expanded="false" class="c-info__summary collapsed" data-target="#legalInformation" data-toggle="collapse" type="button">
+                                              <span>Contexte légal</span>
+                                          </button>
+                                          <div class="c-info__detail collapse" id="legalInformation">
+                                              <p>
+                                                  Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
+                                              </p>
+                                              <a aria-label="En savoir plus concernant le contexte légal" class="btn btn-link px-0" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043990367" rel="noopener" target="_blank">
+                                                  <span>En savoir plus</span>
+                                                  <i class="ri-external-link-line ri-lg"></i>
+                                              </a>
+                                          </div>
+                                      </div>
+                                  
+  
+                                  <hr/>
+                                  <p class="fs-xs">* champ obligatoire</p>
+                                  <div class="form-group">
+                                      <div class="text-right">
+                                          
+                                              <a class="btn btn-link btn-outline-primary" href="/approvals/prolongation/request/666">Annuler</a>
+                                          
+                                          <button class="btn btn-primary">Suivant</button>
+                                      </div>
+                                  </div>
+                              </form>
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  '''
+# ---
+# name: test_deny_view_for_reasons[IAE][title]
+  '''
+  <section class="s-title-01">
+                      <div class="s-title-01__container container">
+                          <div class="s-title-01__row row">
+                              <div class="s-title-01__col col-12">
+                                  
+      <h1>Refuser la demande de prolongation pour John DOE</h1>
+  
+                              </div>
+                          </div>
+                      </div>
+                  </section>
+  '''
+# ---
+# name: test_deny_view_for_reasons[SIAE][reason]
+  '''
+  <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-lg-8">
+                      <div class="c-stepper mb-3 mb-lg-5">
+                          <div class="progress progress--emploi">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="50" class="progress-bar progress-bar-50" role="progressbar">
+                              </div>
+                          </div>
+                          <p>
+                              
+                                  <strong>Étape 1</strong> : Motif du refus
+                              
+                          </p>
+                      </div>
+                      <div class="c-form mb-3 mb-lg-5">
+                          <h2 class="h4">Réponse envoyée à l'employeur et au candidat</h2>
+                          
+                              <form method="post">
+                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason"/>
+  
+                                  <div class="form-group form-group-required"><label>Pour quel motif refusez-vous la prolongation du parcours IAE de John DOE ?</label><div class="radio radio-success" id="id_reason-reason"><div class="form-check">
+  <label class="form-check-label" for="id_reason-reason_0"><input class="form-check-input" id="id_reason-reason_0" name="reason-reason" required="" title="" type="radio" value="IAE"/>
+   L’IAE ne correspond plus aux besoins / à la situation de la personne.</label>
+  </div><div class="form-check">
+  <label class="form-check-label" for="id_reason-reason_1"><input class="form-check-input" id="id_reason-reason_1" name="reason-reason" required="" title="" type="radio" value="SIAE"/>
+   La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne.</label>
+  </div>
+  </div></div>
+  
+                                  
+                                      <div class="c-info mb-4">
+                                          <button aria-controls="legalInformation" aria-expanded="false" class="c-info__summary collapsed" data-target="#legalInformation" data-toggle="collapse" type="button">
+                                              <span>Contexte légal</span>
+                                          </button>
+                                          <div class="c-info__detail collapse" id="legalInformation">
+                                              <p>
+                                                  Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
+                                              </p>
+                                              <a aria-label="En savoir plus concernant le contexte légal" class="btn btn-link px-0" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043990367" rel="noopener" target="_blank">
+                                                  <span>En savoir plus</span>
+                                                  <i class="ri-external-link-line ri-lg"></i>
+                                              </a>
+                                          </div>
+                                      </div>
+                                  
+  
+                                  <hr/>
+                                  <p class="fs-xs">* champ obligatoire</p>
+                                  <div class="form-group">
+                                      <div class="text-right">
+                                          
+                                              <a class="btn btn-link btn-outline-primary" href="/approvals/prolongation/request/666">Annuler</a>
+                                          
+                                          <button class="btn btn-primary">Suivant</button>
+                                      </div>
+                                  </div>
+                              </form>
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  '''
+# ---
+# name: test_deny_view_for_reasons[SIAE][reason_explanation]
+  '''
+  <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-lg-8">
+                      <div class="c-stepper mb-3 mb-lg-5">
+                          <div class="progress progress--emploi">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="50" class="progress-bar progress-bar-50" role="progressbar">
+                              </div>
+                          </div>
+                          <p>
+                              
+                                  <strong>Étape 1</strong> : Motif du refus
+                              
+                          </p>
+                      </div>
+                      <div class="c-form mb-3 mb-lg-5">
+                          <h2 class="h4">Réponse envoyée à l'employeur et au candidat</h2>
+                          
+                              <form method="post">
+                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason"/>
+  
+                                  <div class="form-group form-group-required"><label>Pour quel motif refusez-vous la prolongation du parcours IAE de John DOE ?</label><div class="radio radio-success" id="id_reason-reason"><div class="form-check">
+  <label class="form-check-label" for="id_reason-reason_0"><input class="form-check-input" id="id_reason-reason_0" name="reason-reason" required="" title="" type="radio" value="IAE"/>
+   L’IAE ne correspond plus aux besoins / à la situation de la personne.</label>
+  </div><div class="form-check">
+  <label class="form-check-label" for="id_reason-reason_1"><input checked="" class="form-check-input" id="id_reason-reason_1" name="reason-reason" required="" title="" type="radio" value="SIAE"/>
+   La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne.</label>
+  </div>
+  </div></div>
+  
+                                  
+                                      <div class="c-info mb-4">
+                                          <button aria-controls="legalInformation" aria-expanded="false" class="c-info__summary collapsed" data-target="#legalInformation" data-toggle="collapse" type="button">
+                                              <span>Contexte légal</span>
+                                          </button>
+                                          <div class="c-info__detail collapse" id="legalInformation">
+                                              <p>
+                                                  Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
+                                              </p>
+                                              <a aria-label="En savoir plus concernant le contexte légal" class="btn btn-link px-0" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043990367" rel="noopener" target="_blank">
+                                                  <span>En savoir plus</span>
+                                                  <i class="ri-external-link-line ri-lg"></i>
+                                              </a>
+                                          </div>
+                                      </div>
+                                  
+  
+                                  <hr/>
+                                  <p class="fs-xs">* champ obligatoire</p>
+                                  <div class="form-group">
+                                      <div class="text-right">
+                                          
+                                              <a class="btn btn-link btn-outline-primary" href="/approvals/prolongation/request/666">Annuler</a>
+                                          
+                                          <button class="btn btn-primary">Suivant</button>
+                                      </div>
+                                  </div>
+                              </form>
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  '''
+# ---
+# name: test_deny_view_for_reasons[SIAE][title]
+  '''
+  <section class="s-title-01">
+                      <div class="s-title-01__container container">
+                          <div class="s-title-01__row row">
+                              <div class="s-title-01__col col-12">
+                                  
+      <h1>Refuser la demande de prolongation pour John DOE</h1>
+  
+                              </div>
+                          </div>
+                      </div>
+                  </section>
+  '''
+# ---
 # name: test_list_view
   '''
   <div class="c-box">
@@ -160,18 +535,12 @@
                           <span>Accepter</span>
                       </button>
                   </form>
-                  <form method="post" action="/approvals/prolongation/request/666/deny">
-                      
-                      <button class="btn btn-outline-primary btn-block btn-ico mt-3 justify-content-center">
-                          <i class="ri-close-line"></i>
-                          <span>Refuser</span>
-                      </button>
-                  </form>
+                  <a class="btn btn-outline-primary btn-block btn-ico mt-3 justify-content-center" href="/approvals/prolongation/request/666/deny?reset=1">
+                      <i class="ri-close-line"></i>
+                      <span>Refuser</span>
+                  </a>
                   <p class="font-weight-bold mt-3">Précision</p>
-                  <p class="mb-2">
-                      En cas de refus, vous êtes tenu de proposer une solution au candidat.
-                      Vous devez également motiver par écrit votre refus de prolongation auprès de la SIAE (Dans l'attente de la mise en œuvre du module spécifique).
-                  </p>
+                  <p class="mb-2">En cas de refus, vous êtes tenu de proposer une solution au candidat.</p>
               </div>
           
       </div>


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/En-tant-que-prescripteur-habilit-qui-refuse-une-prolongation-je-justifie-par-crit-les-raisons-de-m-3e3740aa214d42b4936bde7aa39546bf?pvs=4

### Pourquoi ?

Obligation réglementaire d’avoir une notification écrite adressée à la SIAE et au bénéficiaire.

### Comment <!-- optionnel -->

- Ajout d'un parcours pour motiver le refus.
- Transmettre cette informations par email à la SIAE et au bénéficiaire

Utilisation de `django-formtools` afin de gérer facilement le découpage et l'embranchement demandé, les tests pourraient être moins verbeux mais ça me semblait prématurée de faire de l'outillage pour 1 cas d'utilisation.
Pas forcément convaincu du fait d'avoir mis les 4 nouveaux champs dans leur propre model, le but était d'éviter d'avoir un préfix `deny_` devant chaque champs et de manipuler un objet plus simple dans le parcours, donc à voir.
