### PR TITLE
docker-compose: limiter la visibilité de postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - ./docker/dev/postgres/psql_init.sh:/docker-entrypoint-initdb.d/postgres-init.sh
     restart: always
     ports:
-      - "${POSTGRES_PORT_ON_DOCKER_HOST:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_PORT_ON_DOCKER_HOST:-5432}:5432"
 
   django:
     container_name: itou_django
@@ -60,7 +60,7 @@ services:
       - .:/app
     restart: always
     ports:
-      - "${DJANGO_PORT_ON_DOCKER_HOST:-8000}:8000"
+      - "127.0.0.1:${DJANGO_PORT_ON_DOCKER_HOST:-8000}:8000"
     # Make interactive debugging possible.
     # Source: https://stackoverflow.com/questions/36249744/interactive-shell-using-docker-compose
     # Run the usual `make run` (`docker-compose up`) and then in a second terminal run `docker attach itou_django`.


### PR DESCRIPTION
### Pourquoi ?

A priori, seuls les processus de nos machines ont besoin de communiquer avec...

