### PR TITLE
Ne plus avoir de champs combinant `auto_now=True` et `null=True`

### DIFF
--- a/itou/approvals/migrations/0015_alter_suspension_updated_at.py
+++ b/itou/approvals/migrations/0015_alter_suspension_updated_at.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("approvals", "0014_migrate_triggers"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "UPDATE approvals_suspension SET updated_at = created_at WHERE updated_at IS NULL;",
+            reverse_sql=migrations.RunSQL.noop,
+            elidable=True,
+        ),
+        migrations.AlterField(
+            model_name="suspension",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True, verbose_name="date de modification"),
+        ),
+    ]

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -808,8 +808,7 @@ class Suspension(models.Model):
         on_delete=models.SET_NULL,
         related_name="approvals_suspended_set",
     )
-    # FIXME(rsebille): Remove the null=True. But beware, it will force PG to rewrite almost all the rows.
-    updated_at = models.DateTimeField(verbose_name="date de modification", auto_now=True, null=True)
+    updated_at = models.DateTimeField(verbose_name="date de modification", auto_now=True)
     updated_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         verbose_name="mis à jour par",

--- a/itou/job_applications/migrations/0015_alter_jobapplication_updated_at.py
+++ b/itou/job_applications/migrations/0015_alter_jobapplication_updated_at.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("job_applications", "0014_jobapplication_inverted_vae_contract"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "UPDATE job_applications_jobapplication SET updated_at = created_at WHERE updated_at IS NULL;",
+            reverse_sql=migrations.RunSQL.noop,
+            elidable=True,
+        ),
+        migrations.AlterField(
+            model_name="jobapplication",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True, db_index=True, verbose_name="date de modification"),
+        ),
+    ]

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -602,8 +602,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     )
 
     created_at = models.DateTimeField(verbose_name="date de création", default=timezone.now, db_index=True)
-    # FIXME(rsebille): Remove the null=True. But beware, it will force PG to rewrite almost all the rows.
-    updated_at = models.DateTimeField(verbose_name="date de modification", auto_now=True, db_index=True, null=True)
+    updated_at = models.DateTimeField(verbose_name="date de modification", auto_now=True, db_index=True)
 
     # GEIQ only
     prehiring_guidance_days = models.PositiveSmallIntegerField(


### PR DESCRIPTION
### Pourquoi ?

Car c'est contradictoire :).
Suite et fin de 925118bf829bc5c5914fa6b1c096858df625f818.

### Comment <!-- optionnel -->

Déploiement en 2 étapes :
1. Script `fill_update_at` pour remplir les valeurs manquantes (140k+ `Suspension`, 0 `JobApplication` :thinking:) : ~2 min (sans `time.sleep`) en local
2. Migration du DDL avec voiture balais : ~10s en local