### PR TITLE
Intergiciel ItouCurrentOrganizationMiddleware: on enrichit maintenant toujours l'objet request

### DIFF
--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -153,6 +153,7 @@ class ItouCurrentOrganizationMiddleware:
             request.path.startswith("/signup/siae/join"),  # siae staff about to join an siae
             request.path.startswith("/signup/facilitator/join"),  # facilitator about to join an siae
             request.path == reverse("account_logout"),
+            request.path.startswith("/hijack/release"),  # Allow to release hijack
         ]
         if any(skip_middleware_conditions):
             return self.get_response(request)
@@ -164,7 +165,6 @@ class ItouCurrentOrganizationMiddleware:
             and user.kind in [UserKind.PRESCRIBER, UserKind.SIAE_STAFF]
             and not request.path.startswith("/dashboard/activate_ic_account")  # Allow to access ic activation view
             and not request.path.startswith("/inclusion_connect")  # Allow to access ic views
-            and not request.path.startswith("/hijack/release")  # Allow to release hijack
             and settings.FORCE_IC_LOGIN  # Allow to disable on dev setup
         ):
             # Add request.path as next param ?

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -74,19 +74,6 @@ class ItouCurrentOrganizationMiddleware:
 
         redirect_message = None
         if user.is_authenticated:
-            # Force Inclusion Connect
-            if (
-                user.identity_provider != IdentityProvider.INCLUSION_CONNECT
-                and user.kind in [UserKind.PRESCRIBER, UserKind.SIAE_STAFF]
-                and not request.path.startswith("/dashboard/activate_ic_account")  # Allow to access ic activation view
-                and not request.path.startswith("/inclusion_connect")  # Allow to access ic views
-                and not request.path.startswith("/hijack/release")  # Allow to release hijack
-                and settings.FORCE_IC_LOGIN  # Allow to disable on dev setup
-                and request.path != reverse("account_logout")
-            ):
-                # Add request.path as next param ?
-                return HttpResponseRedirect(reverse("dashboard:activate_ic_account"))
-
             if user.is_siae_staff:
                 active_memberships = list(user.siaemembership_set.filter(is_active=True))
                 siaes = {
@@ -168,6 +155,20 @@ class ItouCurrentOrganizationMiddleware:
                         "Nous espérons cependant avoir l'occasion de vous accueillir de "
                         "nouveau."
                     )
+
+        # Force Inclusion Connect
+        if (
+            user.is_authenticated
+            and user.identity_provider != IdentityProvider.INCLUSION_CONNECT
+            and user.kind in [UserKind.PRESCRIBER, UserKind.SIAE_STAFF]
+            and not request.path.startswith("/dashboard/activate_ic_account")  # Allow to access ic activation view
+            and not request.path.startswith("/inclusion_connect")  # Allow to access ic views
+            and not request.path.startswith("/hijack/release")  # Allow to release hijack
+            and settings.FORCE_IC_LOGIN  # Allow to disable on dev setup
+            and request.path != reverse("account_logout")
+        ):
+            # Add request.path as next param ?
+            return HttpResponseRedirect(reverse("dashboard:activate_ic_account"))
 
         if redirect_message is not None and request.path != reverse("account_logout"):
             messages.warning(request, redirect_message)

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -57,21 +57,6 @@ class ItouCurrentOrganizationMiddleware:
     def __call__(self, request):
         user = request.user
 
-        # Accepting an invitation to join a group is a two-step process.
-        # - View one: account creation or login.
-        # - View two: user is added to the group.
-        # In view two, the user is authenticated but he does not belong to any group.
-        # This raises an error so we skip the middleware only in this case.
-        login_routes = [reverse(f"login:{url.name}") for url in login_urls.urlpatterns] + [reverse("account_login")]
-        skip_middleware_conditions = [
-            request.path in login_routes,
-            request.path.startswith("/invitations/") and not request.path.startswith("/invitations/invite"),
-            request.path.startswith("/signup/siae/join"),  # siae staff about to join an siae
-            request.path.startswith("/signup/facilitator/join"),  # facilitator about to join an siae
-        ]
-        if any(skip_middleware_conditions):
-            return self.get_response(request)
-
         redirect_message = None
         if user.is_authenticated:
             if user.is_siae_staff:
@@ -155,6 +140,21 @@ class ItouCurrentOrganizationMiddleware:
                         "Nous espérons cependant avoir l'occasion de vous accueillir de "
                         "nouveau."
                     )
+
+        # Accepting an invitation to join a group is a two-step process.
+        # - View one: account creation or login.
+        # - View two: user is added to the group.
+        # In view two, the user is authenticated but he does not belong to any group.
+        # This raises an error so we skip the middleware only in this case.
+        login_routes = [reverse(f"login:{url.name}") for url in login_urls.urlpatterns] + [reverse("account_login")]
+        skip_middleware_conditions = [
+            request.path in login_routes,
+            request.path.startswith("/invitations/") and not request.path.startswith("/invitations/invite"),
+            request.path.startswith("/signup/siae/join"),  # siae staff about to join an siae
+            request.path.startswith("/signup/facilitator/join"),  # facilitator about to join an siae
+        ]
+        if any(skip_middleware_conditions):
+            return self.get_response(request)
 
         # Force Inclusion Connect
         if (

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -152,6 +152,7 @@ class ItouCurrentOrganizationMiddleware:
             request.path.startswith("/invitations/") and not request.path.startswith("/invitations/invite"),
             request.path.startswith("/signup/siae/join"),  # siae staff about to join an siae
             request.path.startswith("/signup/facilitator/join"),  # facilitator about to join an siae
+            request.path == reverse("account_logout"),
         ]
         if any(skip_middleware_conditions):
             return self.get_response(request)
@@ -165,12 +166,11 @@ class ItouCurrentOrganizationMiddleware:
             and not request.path.startswith("/inclusion_connect")  # Allow to access ic views
             and not request.path.startswith("/hijack/release")  # Allow to release hijack
             and settings.FORCE_IC_LOGIN  # Allow to disable on dev setup
-            and request.path != reverse("account_logout")
         ):
             # Add request.path as next param ?
             return HttpResponseRedirect(reverse("dashboard:activate_ic_account"))
 
-        if redirect_message is not None and request.path != reverse("account_logout"):
+        if redirect_message is not None:
             messages.warning(request, redirect_message)
             return redirect("account_logout")
 

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -81,7 +81,7 @@ class ItouCurrentOrganizationMiddleware:
                 and not request.path.startswith("/inclusion_connect")  # Allow to access ic views
                 and not request.path.startswith("/hijack/release")  # Allow to release hijack
                 and settings.FORCE_IC_LOGIN  # Allow to disable on dev setup
-                and request != reverse("account_logout")
+                and request.path != reverse("account_logout")
             ):
                 # Add request.path as next param ?
                 return HttpResponseRedirect(reverse("dashboard:activate_ic_account"))

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -55,7 +55,6 @@ class ItouCurrentOrganizationMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        # Before the view is called.
         user = request.user
 
         # Accepting an invitation to join a group is a two-step process.
@@ -173,8 +172,4 @@ class ItouCurrentOrganizationMiddleware:
                     messages.warning(request, message)
                     return redirect("account_logout")
 
-        response = self.get_response(request)
-
-        # After the view is called.
-
-        return response
+        return self.get_response(request)


### PR DESCRIPTION
### Pourquoi ?

Cela permettra d'utiliser `request.current_organization` et les autres attributs dans toutes les vues sans avoir à se demander si on est dans une des vues matchant `skip_middleware_conditions`.

Au passage, je corrige:
- le logout pour les utilisateurs SIAE/prescripteur n'ayant pas activer IC.
- la libération d'un utilisateur SIAE/institution n'ayant pas d'organisation active