### PR TITLE
Correction : Les SIAE ne peuvent plus modifier leur fiches de poste

### DIFF
--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -34,7 +34,7 @@ def job_description_card(request, job_description_id, template_name="siaes/job_d
     job_description = get_object_or_404(SiaeJobDescription, pk=job_description_id)
     back_url = get_safe_url(request, "back_url")
     siae = job_description.siae
-    can_update_job_description = request.session.get("current_siae") == siae.pk
+    can_update_job_description = request.user.is_authenticated and request.current_organization.pk == siae.pk
 
     # select_related on siae, location useful for _list_siae_actives_jobs_row.html template
     others_active_jobs = (


### PR DESCRIPTION
### Pourquoi ?

Le nom de la session était en dure et depuis 4c2cd64f21cd306c1d1cd4775e9081db60ef0289 on n'y met plus rien, les tests étaient aussi trop large car le `"Modifier"` est aussi dans le header (_Modifier mon profil_).
