### PR TITLE
Invitations : Correction mineure de l'interface sur le fait que la durée des invitations n'est pas toujours de 15 jours

### DIFF
--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -2,7 +2,8 @@
     <h3 class="h4">Invitations en attente</h3>
     <div class="alert alert-warning">
         <p>
-            Chaque collaborateur invité reçoit son propre lien d'invitation, ce lien est valable 15 jours (lorsque le lien expire, l'invitation n'est plus affichée ci-dessus).
+            Chaque collaborateur invité reçoit son propre lien d'invitation.
+            Lorsque le lien expire, l'invitation n'est plus affichée ci-dessous.
             Ce lien d'invitation est transmis automatiquement par e-mail.
         </p>
         <p class="mb-0">En cas de besoin, vous pouvez également le copier depuis la colonne « Lien d'invitation ».</p>
@@ -17,6 +18,7 @@
                     <th scope="col">Nom</th>
                     <th scope="col">Email</th>
                     <th scope="col">Envoyée le</th>
+                    <th scope="col">Valable jusqu'au</th>
                     <th scope="col">Lien d'invitation</th>
                 </tr>
             </thead>
@@ -29,6 +31,7 @@
                             <a href="mailto:{{ invitation.email }}">{{ invitation.email }}</a>
                         </td>
                         <td>{{ invitation.sent_at|date:"d F Y à H:i" }}</td>
+                        <td>{{ invitation.expiration_date|date:"d F Y à H:i" }}</td>
                         <td>
                             {% include 'includes/copy_to_clipboard.html' with content=invitation.acceptance_link css_classes="btn-outline-primary btn-sm" %}
                         </td>


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/C01AQKD7MAN/p1694511293405909**

### Pourquoi ?

Essentiellement pour corriger un oubli de ma part dans cette PR précédente : https://github.com/betagouv/itou/pull/2788

### Comment

Modifications de l'interface :
- Retrait de la mention de la durée de 15 jours
- Ajout de la colonne "Valable jusqu'à" qui permet d'un coup d'oeil de savoir quand l'invitation expire, peu importe qu'elle dure 15 ou 90 jours.

### Captures d'écran

Avant :

<img width="784" alt="image" src="https://github.com/betagouv/itou/assets/10533583/49721435-4627-46b1-b8bc-a962479e52cd">


Après :

![image](https://github.com/betagouv/itou/assets/10533583/e2fcbf4f-5570-4030-88d6-3454678d5709)



