### PR TITLE
Suppression de la fonction `get_user_info`

### DIFF
--- a/itou/utils/perms/user.py
+++ b/itou/utils/perms/user.py
@@ -1,46 +1,10 @@
 import logging
-from collections import namedtuple
 
 from django.conf import settings
 from hijack import signals
 
-from itou.utils.perms.prescriber import get_current_org_or_404
-from itou.utils.perms.siae import get_current_siae_or_404
-
 
 logger = logging.getLogger(__name__)
-
-# FIXME(vperron): This namedtuple seems like an intermediate object that is maybe no longer justified.
-# From afar it looks like a code smell or something we could/should get rid of. Beware.
-# (ikarius) : same verdict, this tuple is reused for eligibility diagnosis creation, and will have to be removed
-# or at least limited to permissions domain.
-UserInfo = namedtuple("UserInfo", ["user", "kind", "prescriber_organization", "is_authorized_prescriber", "siae"])
-
-
-def get_user_info(request):
-    """
-    Return a namedtuple containing information about the current logged user.
-    """
-
-    kind = None
-    siae = None
-    prescriber_organization = None
-
-    if request.user.is_job_seeker:
-        kind = request.user.kind
-
-    if request.user.is_siae_staff:
-        kind = request.user.kind
-        siae = get_current_siae_or_404(request)
-
-    if request.user.is_prescriber:
-        kind = request.user.kind
-        if request.user.is_prescriber_with_org:
-            prescriber_organization = get_current_org_or_404(request)
-
-    is_authorized_prescriber = prescriber_organization.is_authorized if prescriber_organization else False
-
-    return UserInfo(request.user, kind, prescriber_organization, is_authorized_prescriber, siae)
 
 
 def has_hijack_perm(*, hijacker, hijacked):

--- a/itou/www/apply/views/common.py
+++ b/itou/www/apply/views/common.py
@@ -18,7 +18,6 @@ from itou.users.enums import UserKind
 from itou.users.models import ApprovalAlreadyExistsError
 from itou.utils import constants as global_constants
 from itou.utils.htmx import hx_trigger_modal_control
-from itou.utils.perms.user import get_user_info
 from itou.utils.urls import add_url_params, get_external_link_markup
 from itou.www.apply.forms import (
     AcceptForm,
@@ -208,9 +207,11 @@ def _eligibility(request, siae, job_seeker, cancel_url, next_url, template_name,
 
     form_administrative_criteria = AdministrativeCriteriaForm(request.user, siae=siae, data=request.POST or None)
     if request.method == "POST" and form_administrative_criteria.is_valid():
-        user_info = get_user_info(request)
         EligibilityDiagnosis.create_diagnosis(
-            job_seeker, user_info, administrative_criteria=form_administrative_criteria.cleaned_data
+            job_seeker,
+            author=request.user,
+            author_organization=request.current_organization,
+            administrative_criteria=form_administrative_criteria.cleaned_data,
         )
         messages.success(request, "Éligibilité confirmée !")
         return HttpResponseRedirect(next_url)

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -28,9 +28,7 @@ from itou.siae_evaluations.models import (
     validate_institution,
 )
 from itou.siaes.enums import SiaeKind
-from itou.users.enums import KIND_SIAE_STAFF
 from itou.utils.models import InclusiveDateRange
-from itou.utils.perms.user import UserInfo
 from tests.approvals.factories import ApprovalFactory
 from tests.eligibility.factories import EligibilityDiagnosisFactory
 from tests.institutions.factories import InstitutionFactory, InstitutionWith2MembershipFactory
@@ -375,14 +373,11 @@ class EvaluationCampaignManagerTest(TestCase):
         siae = SiaeFactory(department=evaluation_campaign.institution.department, with_membership=True)
         job_seeker = JobSeekerFactory()
         user = siae.members.first()
-        user_info = UserInfo(
-            user=user, kind=KIND_SIAE_STAFF, siae=siae, prescriber_organization=None, is_authorized_prescriber=False
-        )
         criteria1 = AdministrativeCriteria.objects.get(
             level=AdministrativeCriteriaLevel.LEVEL_1, name="Bénéficiaire du RSA"
         )
         eligibility_diagnosis = EligibilityDiagnosis.create_diagnosis(
-            job_seeker, user_info, administrative_criteria=[criteria1]
+            job_seeker, author=user, author_organization=siae, administrative_criteria=[criteria1]
         )
         JobApplicationFactory.create_batch(
             evaluation_enums.EvaluationJobApplicationsBoundariesNumber.MIN,

--- a/tests/www/eligibility_views/tests.py
+++ b/tests/www/eligibility_views/tests.py
@@ -4,8 +4,6 @@ from django.utils import timezone
 from itou.eligibility.enums import AdministrativeCriteriaLevel
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.siaes.enums import SiaeKind
-from itou.users.enums import KIND_SIAE_STAFF
-from itou.utils.perms.user import UserInfo
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm, AdministrativeCriteriaOfJobApplicationForm
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
@@ -192,13 +190,10 @@ class AdministrativeCriteriaOfJobApplicationFormTest(TestCase):
 
         job_seeker = JobSeekerFactory()
 
-        user_info = UserInfo(
-            user=user, kind=KIND_SIAE_STAFF, siae=siae, prescriber_organization=None, is_authorized_prescriber=False
-        )
-
         eligibility_diagnosis = EligibilityDiagnosis.create_diagnosis(
             job_seeker,
-            user_info,
+            author=user,
+            author_organization=siae,
             administrative_criteria=[
                 AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_1).first()
             ]

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -18,8 +18,6 @@ from itou.siae_evaluations.models import (
     EvaluationCampaign,
     Sanctions,
 )
-from itou.users.enums import KIND_SIAE_STAFF
-from itou.utils.perms.user import UserInfo
 from itou.utils.templatetags.format_filters import format_approval_number
 from itou.utils.types import InclusiveDateRange
 from itou.www.siae_evaluations_views.forms import LaborExplanationForm, SetChosenPercentForm
@@ -44,13 +42,9 @@ def create_evaluated_siae_consistent_datas(evaluation_campaign, extra_evaluated_
 
     job_seeker = JobSeekerFactory()
 
-    user_info = UserInfo(
-        user=user, kind=KIND_SIAE_STAFF, siae=siae, prescriber_organization=None, is_authorized_prescriber=False
-    )
-
     administrative_criteria = AdministrativeCriteria.objects.get(pk=1)
     eligibility_diagnosis = EligibilityDiagnosis.create_diagnosis(
-        job_seeker, user_info, administrative_criteria=[administrative_criteria]
+        job_seeker, author=user, author_organization=siae, administrative_criteria=[administrative_criteria]
     )
 
     job_application = JobApplicationFactory(

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -8,8 +8,6 @@ from itou.eligibility.enums import AdministrativeCriteriaLevel
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.siae_evaluations import enums as evaluation_enums
 from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria
-from itou.users.enums import KIND_SIAE_STAFF
-from itou.utils.perms.user import UserInfo
 from itou.utils.storage.s3 import S3Upload
 from tests.institutions.factories import InstitutionMembershipFactory
 from tests.job_applications.factories import JobApplicationFactory
@@ -29,13 +27,10 @@ from tests.utils.test import BASE_NUM_QUERIES, TestCase, assertMessages
 def create_evaluated_siae_with_consistent_datas(siae, user, level_1=True, level_2=False, institution=None):
     job_seeker = JobSeekerFactory()
 
-    user_info = UserInfo(
-        user=user, kind=KIND_SIAE_STAFF, siae=siae, prescriber_organization=None, is_authorized_prescriber=False
-    )
-
     eligibility_diagnosis = EligibilityDiagnosis.create_diagnosis(
         job_seeker,
-        user_info,
+        author=user,
+        author_organization=siae,
         administrative_criteria=list(
             AdministrativeCriteria.objects.filter(
                 level__in=[AdministrativeCriteriaLevel.LEVEL_1 if level_1 else None]


### PR DESCRIPTION
### Pourquoi ?

- Simplification
- Évite de refaire une nouvelle fois les requêtes vérifiant l'organisation active de l'utilisateur en réutilisant les attributs de l'objet `request`

