### PR TITLE
fix: workaround for email sending crash

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -27,7 +27,7 @@ from itou.siaes.models import Siae, SiaeJobDescription
 from itou.users.enums import UserKind
 from itou.users.models import JobSeekerProfile, User
 from itou.utils.apis.exceptions import AddressLookupError
-from itou.utils.emails import redact_email_address
+from itou.utils.emails import redact_email_address, send_email_messages
 from itou.utils.session import SessionNamespace, SessionNamespaceRequiredMixin
 from itou.utils.storage.s3 import S3Upload
 from itou.www.apply.forms import (
@@ -1063,10 +1063,14 @@ class ApplicationResumeView(ApplicationBaseView):
                     notification = NewQualifiedJobAppEmployersNotification(job_application=job_application)
 
                 notification.send()
-                job_application.email_new_for_job_seeker().send()
 
-                if job_application.is_sent_by_proxy:
-                    job_application.email_new_for_prescriber.send()
+                job_application_emails = [job_application.email_new_for_job_seeker()]
+
+                if request.user.is_prescriber:
+                    job_application_emails.append(job_application.email_new_for_prescriber)
+
+                send_email_messages(job_application_emails)
+
             finally:
                 # We are done, send to the (mostly) stateless final page as we now have no session.
                 # "siae_pk" is kinda useless with "application_pk" but is kept for URL consistency.


### PR DESCRIPTION
Occurs when refusing a job application when 'sender' field is None. Nearly 2k job applications have no sender, mostly with a `prescriber` sender kind This fix is *temporary*, while investigating the real source of the 'leak'. It will/may be removed if we can find a proper way for processing / exterminating 'null' senders.