### PR TITLE
Réduction du nombre de requêtes SQL sur de nombreuses vues

### DIFF
--- a/itou/utils/perms/institution.py
+++ b/itou/utils/perms/institution.py
@@ -1,11 +1,7 @@
-from django.shortcuts import get_object_or_404
-
-from itou.institutions.models import Institution
-from itou.utils import constants as global_constants
+from django.http import Http404
 
 
 def get_current_institution_or_404(request):
-    pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY)
-    queryset = Institution.objects.member_required(request.user)
-    institution = get_object_or_404(queryset, pk=pk)
-    return institution
+    if request.user.is_labor_inspector and request.current_organization:  # Set by middleware for labor_inspector
+        return request.current_organization
+    raise Http404("L'utilisateur n'est pas membre d'une organisation")

--- a/itou/utils/perms/prescriber.py
+++ b/itou/utils/perms/prescriber.py
@@ -1,15 +1,11 @@
 from django.db.models import Q
-from django.shortcuts import get_object_or_404
-
-from itou.prescribers.models import PrescriberOrganization
-from itou.utils import constants as global_constants
+from django.http import Http404
 
 
 def get_current_org_or_404(request):
-    pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY)
-    queryset = PrescriberOrganization.objects.member_required(request.user)
-    organization = get_object_or_404(queryset, pk=pk)
-    return organization
+    if request.user.is_prescriber and request.current_organization:  # Set by middleware for prescriber users
+        return request.current_organization
+    raise Http404("L'utilisateur n'est pas membre d'une organisation")
 
 
 def get_all_available_job_applications_as_prescriber(request):

--- a/itou/utils/perms/siae.py
+++ b/itou/utils/perms/siae.py
@@ -1,12 +1,9 @@
-from django.shortcuts import get_object_or_404
+from django.http import Http404
 
 from itou.siaes.models import Siae
-from itou.utils import constants as global_constants
 
 
-def get_current_siae_or_404(request) -> Siae:
-    pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY)
-    queryset = Siae.objects.member_required(request.user)
-
-    siae = get_object_or_404(queryset, pk=pk)
-    return siae
+def get_current_siae_or_404(request) -> Siae:  # Set by middleware for siae_staff
+    if request.user.is_siae_staff and request.current_organization:
+        return request.current_organization
+    raise Http404("L'utilisateur n'est pas membre d'une organisation")

--- a/itou/utils/perms/siae.py
+++ b/itou/utils/perms/siae.py
@@ -4,12 +4,9 @@ from itou.siaes.models import Siae
 from itou.utils import constants as global_constants
 
 
-def get_current_siae_or_404(request, with_job_descriptions=False) -> Siae:
+def get_current_siae_or_404(request) -> Siae:
     pk = request.session.get(global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY)
     queryset = Siae.objects.member_required(request.user)
-
-    if with_job_descriptions:
-        queryset = queryset.prefetch_job_description_through()
 
     siae = get_object_or_404(queryset, pk=pk)
     return siae

--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -77,7 +77,7 @@ def job_description_card(request, job_description_id, template_name="siaes/job_d
 
 @login_required
 def job_description_list(request, template_name="siaes/job_description_list.html"):
-    siae = get_current_siae_or_404(request, with_job_descriptions=True)
+    siae = get_current_siae_or_404(request)
     job_descriptions = (
         SiaeJobDescription.objects.filter(siae__pk=siae.pk)
         .select_related("location")

--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -31,7 +31,7 @@ ITOU_SESSION_JOB_DESCRIPTION_KEY = "edit_job_description_key"
 
 
 def job_description_card(request, job_description_id, template_name="siaes/job_description_card.html"):
-    job_description = get_object_or_404(SiaeJobDescription, pk=job_description_id)
+    job_description = get_object_or_404(SiaeJobDescription.objects.select_related("location"), pk=job_description_id)
     back_url = get_safe_url(request, "back_url")
     siae = job_description.siae
     can_update_job_description = (
@@ -80,6 +80,7 @@ def job_description_list(request, template_name="siaes/job_description_list.html
     siae = get_current_siae_or_404(request, with_job_descriptions=True)
     job_descriptions = (
         SiaeJobDescription.objects.filter(siae__pk=siae.pk)
+        .select_related("location")
         .prefetch_related("appellation", "appellation__rome", "siae")
         .order_by_most_recent()
     )

--- a/tests/www/apply/test_list.py
+++ b/tests/www/apply/test_list.py
@@ -216,7 +216,7 @@ class ProcessListSiaeTest(ProcessListTest):
             BASE_NUM_QUERIES
             + 1  # fetch django session
             + 1  # fetch user
-            + 3  # check for membership & infos
+            + 2  # check for membership & infos
             #
             # SiaeFilterJobApplicationsForm:
             + 1  # get list of senders (distinct sender_id)

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -106,7 +106,6 @@ class TestApprovalDetailView:
             + 1  # verify user is active (middleware)
             + 1  # fetch siae membership and siae infos (middleware)
             + 1  # place savepoint right after the middlewares
-            + 1  # get_current_siae_or_404 (ApprovalBaseViewMixin.setup)
             + 1  # job_seeker.approval
             + 1  # select all latest suspensions to check their end date
             + 1  # job_application.with_accepted_at annotation coming from next query
@@ -184,7 +183,6 @@ class TestApprovalDetailView:
             + 1  # fetch authenticated user
             + 1  # verify user is active (middleware)
             + 1  # place savepoint right after the middlewares
-            + 1  # fetch siae infos
             + 1  # get approval infos (get_object)
             # get_context_data
             + 1  # select all latest suspensions to check their end date (with prefetch)

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -88,7 +88,6 @@ class TestApprovalsListView:
             + 1  # fetch django session
             + 1  # fetch user
             + 2  # fetch siae memberships & its active/grace_period (middleware)
-            + 1  # fetch SIAE (get_current_siae_or_404)
             + 1  # fetch job seekers (ApprovalForm._get_choices_for_job_seekers)
             + 1  # count (from paginator)
             + 1  # fetch approvals

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -34,7 +34,6 @@ def test_list_view(snapshot, client):
         + 1  # fetch django session
         + 1  # fetch user
         + 1  # check user memberships
-        + 1  # fetch organization infos
         + 1  # fetch prolongation requests rows
         + 1  # count prolongation requests rows (from pager)
         + 3  # savepoint, update session, release savepoint

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from datetime import date, datetime
 from functools import partial
 from urllib.parse import urlencode
@@ -33,8 +32,6 @@ from itou.users.enums import IdentityProvider, LackOfNIRReason, UserKind
 from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.models import InclusiveDateRange
-from itou.utils.perms.institution import get_current_institution_or_404
-from itou.utils.perms.prescriber import get_current_org_or_404
 from itou.utils.templatetags.format_filters import format_approval_number, format_siret
 from itou.www.dashboard.forms import EditUserEmailForm
 from tests.approvals.factories import ApprovalFactory, ProlongationRequestFactory
@@ -1647,9 +1644,6 @@ class EditUserPreferencesExceptionsTest(TestCase):
         assert response.status_code == 403
 
 
-FakeRequest = namedtuple("FakeRequest", ("user", "session"))
-
-
 class SwitchOrganizationTest:
     switch_view_name = None
     switch_POST_key = None
@@ -1676,11 +1670,17 @@ class SwitchOrganizationTest:
 
         response = self.client.post(url, data={self.switch_POST_key: orga1.pk})
         assert response.status_code == 302
-        assert get_current_org_or_404(FakeRequest(user, self.client.session)) == orga1
+
+        response = self.client.get(reverse("dashboard:index"))
+        assert response.status_code == 200
+        assert response.context["request"].current_organization == orga1
 
         response = self.client.post(url, data={self.switch_POST_key: orga2.pk})
         assert response.status_code == 302
-        assert get_current_org_or_404(FakeRequest(user, self.client.session)) == orga2
+
+        response = self.client.get(reverse("dashboard:index"))
+        assert response.status_code == 200
+        assert response.context["request"].current_organization == orga2
 
 
 class OldSwitchOrganizationTest(SwitchOrganizationTest, TestCase):
@@ -1721,11 +1721,17 @@ class SwitchInstitutionTest:
 
         response = self.client.post(url, data={self.switch_POST_key: institution1.pk})
         assert response.status_code == 302
-        assert get_current_institution_or_404(FakeRequest(user, self.client.session)) == institution1
+
+        response = self.client.get(reverse("dashboard:index"))
+        assert response.status_code == 200
+        assert response.context["request"].current_organization == institution1
 
         response = self.client.post(url, data={self.switch_POST_key: institution2.pk})
         assert response.status_code == 302
-        assert get_current_institution_or_404(FakeRequest(user, self.client.session)) == institution2
+
+        response = self.client.get(reverse("dashboard:index"))
+        assert response.status_code == 200
+        assert response.context["request"].current_organization == institution2
 
 
 class OldSwitchInstitutionTest(SwitchInstitutionTest, TestCase):

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -265,12 +265,12 @@ class ListEmployeeRecordsTest(TestCase):
         num_queries = BASE_NUM_QUERIES
         num_queries += 1  # Get django session
         num_queries += 3  # Get current user and siae
+        num_queries += 1  # get_current_siae_or_404
         num_queries += 1  # Select job seeker for filters
         num_queries += 1  # Select employee_records status count
         num_queries += 1  # Get Siae Convention
         num_queries += 1  # Select ordered job applications
         num_queries += 1  # Select EmployeeRecords
-        num_queries += 1  # Select siae members
         with self.assertNumQueries(num_queries):
             self.client.get(self.url)
 

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -265,7 +265,6 @@ class ListEmployeeRecordsTest(TestCase):
         num_queries = BASE_NUM_QUERIES
         num_queries += 1  # Get django session
         num_queries += 3  # Get current user and siae
-        num_queries += 1  # get_current_siae_or_404
         num_queries += 1  # Select job seeker for filters
         num_queries += 1  # Select employee_records status count
         num_queries += 1  # Get Siae Convention

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -610,7 +610,6 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
             BASE_NUM_QUERIES
             + 1  # django session
             + 2  # fetch user & its memberships (middleware)
-            + 1  # fetch institution membership
             + 1  # fetch evaluation campaign
             + 3  # fetch evaluated_siae and its prefetch_related eval_job_app & eval_admin_crit
             + 3  # savepoint, update session, release savepoint
@@ -1709,7 +1708,6 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
             BASE_NUM_QUERIES
             + 1  # django session
             + 2  # fetch user & its memberships (middleware)
-            + 1  # fetch institution membership
             + 3  # fetch evaluated_siae, evaluated_jobapp & criteria
             + 3  # fetch jobapplication, approvals & users
             + 3  # savepoint, update session, release savepoint
@@ -1964,7 +1962,6 @@ class InstitutionEvaluatedSiaeNotifyViewAccessTestMixin:
             BASE_NUM_QUERIES
             + 1  # Load session
             + 2  # Check user & its memberships
-            + 1  # Laod institution infos
             + 1  # Load evaluated siae infos
             + 1  # Load evaluated job applications
             + 3  # Load evaluated siae infos + job application + criteria for previous campaigns
@@ -3622,7 +3619,6 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
             BASE_NUM_QUERIES
             + 1  # django session
             + 2  # fetch user & its memberships (middleware)
-            + 1  # fetch institution membership
             + 3  # fetch evaluated_jobapp & criteria
             + 3  # jobapp, approvals & users
             + 2  # evaljobapp & its evalcriteria

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -89,7 +89,7 @@ class SiaeJobApplicationListViewTest(S3AccessingTestCase):
             + 1  # fetch django session
             + 1  # fetch user
             + 1  # verify user is active (middleware)
-            + 2  # fetch siae membership and siae infos
+            + 1  # fetch siae membership
             + 1  # fetch evaluated siae
             + 2  # fetch evaluatedjobapplication and its prefetched evaluatedadministrativecriteria
             # NOTE(vperron): the prefetch is necessary to check the SUBMITTABLE state of the evaluated siae
@@ -910,7 +910,7 @@ class SiaeSubmitProofsViewTest(TestCase):
             + 1  # fetch django session
             + 1  # fetch user
             + 1  # fetch siae membership
-            + 2  # fetch siae infos
+            + 1  # fetch siae infos
             + 3  # fetch evaluatedsiae, evaluatedjobapplication and evaluatedadministrativecriteria
             + 1  # update evaluatedadministrativecriteria
             + 1  # update evaluatedsiae submission_freezed_at
@@ -1004,7 +1004,7 @@ class SiaeSubmitProofsViewTest(TestCase):
             + 1  # fetch django session
             + 1  # fetch user
             + 1  # fetch siae membership
-            + 2  # fetch siae infos
+            + 1  # fetch siae infos
             + 1  # fetch evaluatedsiae and see that submission is freezed, abort
             + 3  # savepoint, update session, release savepoint
         ):

--- a/tests/www/siaes_views/test_job_description_views.py
+++ b/tests/www/siaes_views/test_job_description_views.py
@@ -44,7 +44,7 @@ class JobDescriptionAbstractTest(TestCase):
         )
         siae.jobs.add(*self.appellations)
 
-        # Make sure at least one SiaeJobDescription has a location
+        # Make sure at least two SiaeJobDescription have a location
         SiaeJobDescription.objects.filter(pk=siae.job_description_through.last().pk).update(
             location=City.objects.create(
                 name="Rennes",
@@ -53,6 +53,16 @@ class JobDescriptionAbstractTest(TestCase):
                 post_codes=["35000"],
                 code_insee="35000",
                 coords=Point(-1.7, 45),
+            )
+        )
+        SiaeJobDescription.objects.filter(pk=siae.job_description_through.first().pk).update(
+            location=City.objects.create(
+                name="Lille",
+                slug="lille",
+                department="35",
+                post_codes=["59000"],
+                code_insee="59000",
+                coords=Point(3, 50.5),
             )
         )
 
@@ -90,7 +100,7 @@ class JobDescriptionListViewTest(JobDescriptionAbstractTest):
             + 1  # count job descriptions
             + 1  # fetch job descriptions
             + 3  # prefetch appelation, rome & siae
-            + 1  # select city (job_description.display_location)
+            + 2  # select city (job_description.display_location)
             + 3  # update session
         ):
             response = self.client.get(self.url)
@@ -521,6 +531,7 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             + 1  # fetch siaes_siaejobdescription
             + 1  # fetch siaes infos
             + 1  # fetch jobappelation
+            + 1  # fetch city (job.display_location)
             + 1  # fetch other job infos
             + 3  # update session
         ):
@@ -546,6 +557,7 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             + 1  # fetch siaes_siaejobdescription
             + 1  # fetch siaes infos
             + 1  # fetch jobappelation
+            + 1  # fetch city (job.display_location)
             + 1  # fetch other job infos
             + 3  # update session
         ):

--- a/tests/www/siaes_views/test_job_description_views.py
+++ b/tests/www/siaes_views/test_job_description_views.py
@@ -100,7 +100,6 @@ class JobDescriptionListViewTest(JobDescriptionAbstractTest):
             + 1  # count job descriptions
             + 1  # fetch job descriptions
             + 3  # prefetch appelation, rome & siae
-            + 2  # select city (job_description.display_location)
             + 3  # update session
         ):
             response = self.client.get(self.url)
@@ -531,7 +530,6 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             + 1  # fetch siaes_siaejobdescription
             + 1  # fetch siaes infos
             + 1  # fetch jobappelation
-            + 1  # fetch city (job.display_location)
             + 1  # fetch other job infos
             + 3  # update session
         ):
@@ -557,7 +555,6 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             + 1  # fetch siaes_siaejobdescription
             + 1  # fetch siaes infos
             + 1  # fetch jobappelation
-            + 1  # fetch city (job.display_location)
             + 1  # fetch other job infos
             + 3  # update session
         ):

--- a/tests/www/siaes_views/test_job_description_views.py
+++ b/tests/www/siaes_views/test_job_description_views.py
@@ -96,7 +96,6 @@ class JobDescriptionListViewTest(JobDescriptionAbstractTest):
             + 1  # fetch user
             + 2  # fetch user memberships (and if siae is active/in grace period)
             + 1  # get_current_siae_or_404
-            + 1  # with_job_descriptions=True
             + 1  # count job descriptions
             + 1  # fetch job descriptions
             + 3  # prefetch appelation, rome & siae

--- a/tests/www/siaes_views/test_job_description_views.py
+++ b/tests/www/siaes_views/test_job_description_views.py
@@ -95,7 +95,6 @@ class JobDescriptionListViewTest(JobDescriptionAbstractTest):
             + 1  # fetch django session
             + 1  # fetch user
             + 2  # fetch user memberships (and if siae is active/in grace period)
-            + 1  # get_current_siae_or_404
             + 1  # count job descriptions
             + 1  # fetch job descriptions
             + 3  # prefetch appelation, rome & siae

--- a/tests/www/siaes_views/test_job_description_views.py
+++ b/tests/www/siaes_views/test_job_description_views.py
@@ -79,7 +79,21 @@ class JobDescriptionListViewTest(JobDescriptionAbstractTest):
         self.url = self.list_url + "?page=1"
 
     def test_job_application_list_response_content(self):
-        response = self._login(self.user)
+        self.client.force_login(self.user)
+        with self.assertNumQueries(
+            BASE_NUM_QUERIES
+            + 1  # fetch django session
+            + 1  # fetch user
+            + 2  # fetch user memberships (and if siae is active/in grace period)
+            + 1  # get_current_siae_or_404
+            + 1  # with_job_descriptions=True
+            + 1  # count job descriptions
+            + 1  # fetch job descriptions
+            + 3  # prefetch appelation, rome & siae
+            + 1  # select city (job_description.display_location)
+            + 3  # update session
+        ):
+            response = self.client.get(self.url)
 
         assert self.siae.job_description_through.count() == 4
         self.assertContains(


### PR DESCRIPTION
### Pourquoi ?

Trop de requêtes, cela fatigue un peu Postgresql et beaucoup les devs qui écrivent des `assertNumQueries`.

Relecture commit par commit encouragée.