### PR TITLE
Changer certaines alertes en du texte simple.

### DIFF
--- a/itou/templates/institutions/members.html
+++ b/itou/templates/institutions/members.html
@@ -4,17 +4,15 @@
 
 {% block content_title %}
     <h1>Collaborateurs</h1>
-    <h2>{{ institution.display_name }}</h2>
-    <div class="alert alert-info">
-        <p class="mb-0">
-            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
-        </p>
-    </div>
+    <p class="mb-0">
+        Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
+    </p>
 {% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
+            <h2>{{ institution.display_name }}</h2>
             <div class="row">
                 <div class="col-12">
                     <div class="c-box">

--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -1,13 +1,11 @@
 <div class="c-box mt-3 mt-md-5">
     <h3 class="h4">Invitations en attente</h3>
-    <div class="alert alert-warning">
-        <p>
-            Chaque collaborateur invité reçoit son propre lien d'invitation.
-            Lorsque le lien expire, l'invitation n'est plus affichée ci-dessous.
-            Ce lien d'invitation est transmis automatiquement par e-mail.
-        </p>
-        <p class="mb-0">En cas de besoin, vous pouvez également le copier depuis la colonne « Lien d'invitation ».</p>
-    </div>
+    <p>
+        Chaque collaborateur invité reçoit son propre lien d'invitation.
+        Lorsque le lien expire, l'invitation n'est plus affichée ci-dessous et vos collaborateurs devront être réinvités.
+        Ce lien d'invitation est transmis automatiquement par e-mail.
+        Vous pouvez également copier le lien d'invitation.
+    </p>
 
     <div class="table-responsive-lg mt-3">
         <table class="table">

--- a/itou/templates/prescribers/members.html
+++ b/itou/templates/prescribers/members.html
@@ -4,17 +4,15 @@
 
 {% block content_title %}
     <h1>Collaborateurs</h1>
-    <h2>{{ organization.display_name }}</h2>
-    <div class="alert alert-info">
-        <p class="mb-0">
-            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
-        </p>
-    </div>
+    <p class="mb-0">
+        Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
+    </p>
 {% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
+            <h2>{{ organization.display_name }}</h2>
             <div class="row">
                 <div class="col-12">
                     <div class="c-box">

--- a/itou/templates/siaes/members.html
+++ b/itou/templates/siaes/members.html
@@ -4,17 +4,15 @@
 
 {% block content_title %}
     <h1>Collaborateurs</h1>
-    <h2>{{ siae.display_name }}</h2>
-    <div class="alert alert-info">
-        <p class="mb-0">
-            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
-        </p>
-    </div>
+    <p class="mb-0">
+        Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
+    </p>
 {% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
+            <h2>{{ siae.display_name }}</h2>
             <div class="row">
                 <div class="col-12">
                     <div class="c-box">

--- a/itou/templates/siaes/show_financial_annexes.html
+++ b/itou/templates/siaes/show_financial_annexes.html
@@ -2,47 +2,39 @@
 
 {% block title %}Annexes financières {{ block.super }}{% endblock %}
 
-{% block messages %}
-    {{ block.super }}
-
-    <div class="alert alert-success">
-        <p class="mb-0">
-            Cette interface vous permet de vous assurer que votre structure est associée aux bonnes annexes financières. La gestion de vos annexes financières continue de se faire dans l'extranet 2.0 de l'ASP.
-        </p>
-    </div>
-
-    {% if siae.is_active %}
-        <div class="alert alert-success" role="status">
-            <p class="mb-0">
-                Votre structure est active car elle est associée à au moins une annexe financière valide listée ci-dessous ou bien elle a été manuellement activée par notre support. Vous n'avez rien à faire.
-            </p>
-        </div>
-    {% elif siae_is_asp %}
-        <div class="alert alert-danger" role="status">
-            <p class="mb-0">
-                {# Inactive siaes of ASP source cannot be fixed by user. #}
-                Votre structure est inactive car elle n'est associée à aucune annexe financière valide. Contactez-nous via la rubrique correspondant à votre structure sur
-                <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" aria-label="{{ ITOU_HELP_CENTER_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_HELP_CENTER_URL }}</a>
-            </p>
-        </div>
-    {% elif siae_is_user_created %}
-        <div class="alert alert-danger" role="status">
-            <p class="mb-0">
-                {# Inactive user created siaes can be fixed by the user. #}
-                Votre structure sera prochainement désactivée car elle n'est associée à aucune annexe financière valide. Veuillez dès que possible procéder à la sélection d'une annexe financière valide ci-dessous.
-            </p>
-        </div>
-    {% endif %}
-{% endblock %}
 
 {% block content_title %}
     <h1>Annexes financières</h1>
-    <h2 class="text-muted">{{ siae.display_name }}</h2>
+    <p class="mb-0">
+        Cette interface vous permet de vous assurer que votre structure est associée aux bonnes annexes financières.
+        <br>
+        La gestion de vos annexes financières continue de se faire dans l'extranet 2.0 de l'ASP.
+    </p>
 {% endblock %}
 
 {% block content %}
+
     <section class="s-section">
         <div class="s-section__container container">
+            {% if not siae.is_active %}
+                {% if siae_is_asp %}
+                    <div class="alert alert-danger" role="status">
+                        <p class="mb-0">
+                            {# Inactive siaes of ASP source cannot be fixed by user. #}
+                            Votre structure est inactive car elle n'est associée à aucune annexe financière valide. Contactez-nous via la rubrique correspondant à votre structure sur
+                            <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" aria-label="{{ ITOU_HELP_CENTER_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_HELP_CENTER_URL }}</a>
+                        </p>
+                    </div>
+                {% elif siae_is_user_created %}
+                    <div class="alert alert-danger" role="status">
+                        <p class="mb-0">
+                            {# Inactive user created siaes can be fixed by the user. #}
+                            Votre structure sera prochainement désactivée car elle n'est associée à aucune annexe financière valide. Veuillez dès que possible procéder à la sélection d'une annexe financière valide ci-dessous.
+                        </p>
+                    </div>
+                {% endif %}
+            {% endif %}
+            <h2 class="text-muted">{{ siae.display_name }}</h2>
             <div class="row">
                 <div class="col-12">
                     <div class="table-responsive">

--- a/itou/templates/signup/includes/authorization_proof.html
+++ b/itou/templates/signup/includes/authorization_proof.html
@@ -1,6 +1,0 @@
-
-<div class="alert alert-warning" role="status">
-    <p class="mb-0">
-        Afin d'enregistrer votre habilitation à valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique, <b>nous vous demanderons de nous transmettre l'arrêté préfectoral</b> portant mention de cette habilitation.
-    </p>
-</div>

--- a/itou/templates/signup/includes/submit_rgpd.html
+++ b/itou/templates/signup/includes/submit_rgpd.html
@@ -1,24 +1,19 @@
 {% load bootstrap4 %}
 
-<div class="alert alert-warning">
-    <p>
-        <small>
-            Le Ministère du Travail (DGEFP) et Pôle emploi traitent vos données personnelles. Ce site est ouvert aux acteurs de l'inclusion et permet de simplifier le recrutement des personnes éligibles aux structures de l'Insertion par l'Activité Économique (IAE). Il est une composante du Pacte ambition IAE.
-        </small>
-    </p>
-    <p class="mb-0">
-        <small>
-            Pour plus d'information sur le traitement de vos données personnelles ou pour exercer vos droits, consultez
-            <a href="{% url 'legal-privacy' %}" rel="noopener" target="_blank" aria-label="Consultez la section Protection des données (ouverture dans une nouvel onglet)">
-                la section Protection des données
-            </a><i class="ri-external-link-line ml-1"></i>.
-            En cliquant sur le bouton "Inscription", vous acceptez
-            <a href="{% url 'legal-terms' %}" rel="noopener" target="_blank" aria-label="Acceptez les conditions générales d'utilisation (ouverture dans une nouvel onglet)">
-                les conditions générales d'utilisation
-            </a><i class="ri-external-link-line ml-1"></i>.
-        </small>
-    </p>
-</div>
+<p>
+    Pour plus d'information sur le traitement de vos données personnelles ou pour exercer vos droits, consultez
+    <a href="{% url 'legal-privacy' %}" rel="noopener" target="_blank" aria-label="Consultez la section Protection des données (ouverture dans une nouvel onglet)">
+        la section Protection des données
+    </a><i class="ri-external-link-line ml-1"></i>.
+</p>
+<p>
+    En cliquant sur le bouton "Inscription", vous acceptez
+    <a href="{% url 'legal-terms' %}" rel="noopener" target="_blank" aria-label="Acceptez les conditions générales d'utilisation (ouverture dans une nouvel onglet)">
+        les conditions générales d'utilisation
+    </a><i class="ri-external-link-line ml-1"></i>.
+</p>
 {% buttons %}
-    <button class="btn btn-primary">Inscription</button>
+    <div class="text-right">
+        <button class="btn btn-primary">Inscription</button>
+    </div>
 {% endbuttons %}

--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -72,10 +72,9 @@
 
                         </form>
 
-                        <div class="mt-5 mb-5">
-                            <p>Vous avez déjà un compte ?</p>
+                        <div class="mt-5 mb-5 text-right">
                             <p>
-                                <a class="btn btn-outline-primary" href="{% url 'login:job_seeker' %}">Connexion</a>
+                                Vous avez déjà un compte ? <a href="{% url 'login:job_seeker' %}">Connexion</a>
                             </p>
                         </div>
                     </div>

--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -9,17 +9,6 @@
         Inscription
         <small class="text-muted">Prescripteur/Orienteur</small>
     </h1>
-    <div class="alert alert-warning">
-        <p>
-            Les organisations habilitées permettent à leurs collaborateurs de valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique. Cette habilitation est officialisée par arrêté préfectoral.
-        </p>
-        <p class="mb-0">
-            <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14741016074385--Les-prescripteurs-habilités"
-               rel="noopener"
-               target="_blank"
-               aria-label="En savoir plus sur les différents prescripteurs (ouverture dans un nouvel onglet)">En savoir plus sur les différents prescripteurs</a><i class="ri-external-link-line ml-1"></i>
-        </p>
-    </div>
 {% endblock %}
 
 {% block content %}
@@ -27,18 +16,35 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 col-lg-8">
-                    <form method="post" class="js-prevent-multiple-submit">
+                    <div class="c-card card">
+                        <div class="card-body">
+                            <p>
+                                Les organisations habilitées permettent à leurs collaborateurs de valider l'éligibilité d'une personne candidate au dispositif d'Insertion par l'Activité Économique. Cette habilitation est officialisée par arrêté préfectoral.
+                            </p>
 
-                        {% csrf_token %}
+                            <p>
+                                <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14741016074385--Les-prescripteurs-habilités"
+                                   rel="noopener"
+                                   target="_blank"
+                                   aria-label="En savoir plus sur les différents prescripteurs (ouverture dans un nouvel onglet)">En savoir plus sur les différents prescripteurs</a><i class="ri-external-link-line ml-1"></i>
+                            </p>
+                            <form method="post" class="js-prevent-multiple-submit">
 
-                        {% bootstrap_form form alert_error_type="all" %}
+                                {% csrf_token %}
 
-                        {% buttons %}
-                            <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            <button class="btn btn-primary">Continuer</button>
-                        {% endbuttons %}
+                                {% bootstrap_form form alert_error_type="all" %}
 
-                    </form>
+                                {% buttons %}
+                                    <hr class="my-5">
+                                    <div class="text-right">
+                                        <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
+                                        <button class="btn btn-primary">Continuer</button>
+                                    </div>
+                                {% endbuttons %}
+
+                            </form>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/itou/templates/signup/prescriber_confirm_authorization.html
+++ b/itou/templates/signup/prescriber_confirm_authorization.html
@@ -16,20 +16,30 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 col-lg-8">
-                    <form method="post" class="js-prevent-multiple-submit">
+                    <div class="c-card card">
+                        <div class="card-body">
+                            <form method="post" class="js-prevent-multiple-submit">
 
-                        {% csrf_token %}
+                                {% csrf_token %}
 
-                        {% include "signup/includes/authorization_proof.html" %}
+                                <p>
+                                    <strong>{{ form.confirm_authorization.label }}</strong>
+                                </p>
+                                <p>
+                                    L’arrêté préfectoral portant mention de cette habilitation vous sera demandé pour valider votre compte de prescripteur habilité.
+                                </p>
 
-                        {% bootstrap_form form alert_error_type="all" %}
+                                {% bootstrap_form_errors form type="all" %}
+                                {% bootstrap_field form.confirm_authorization show_label=False %}
 
-                        {% buttons %}
-                            <a class="btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            <button class="btn btn-primary">Continuer</button>
-                        {% endbuttons %}
+                                {% buttons %}
+                                    <a class="btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
+                                    <button class="btn btn-primary">Continuer</button>
+                                {% endbuttons %}
 
-                    </form>
+                            </form>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/itou/templates/signup/prescriber_user.html
+++ b/itou/templates/signup/prescriber_user.html
@@ -16,33 +16,32 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 col-lg-8">
-                    {% if join_authorized_org and kind_label and not kind_is_other %}
-                        {# Display kind's full name if known. #}
-                        <div class="alert alert-emploi">
-                            <p class="mb-0">{{ kind_label }}</p>
-                        </div>
-                    {% endif %}
 
                     {% if prescriber_org_data %}
-                        <div class="alert alert-emploi">
-                            <p class="mb-0">
-                                <b>{{ prescriber_org_data.name }}</b> - {{ prescriber_org_data.siret|format_siret }}
-                                <br>
-                                {% if prescriber_org_data.address_line_1 %}
-                                    {{ prescriber_org_data.address_line_1 }}
-                                    <br>
-                                {% endif %}
-                                {% if prescriber_org_data.address_line_2 %}
-                                    {{ prescriber_org_data.address_line_2 }}
-                                    <br>
-                                {% endif %}
-                                {{ prescriber_org_data.post_code }} {{ prescriber_org_data.city }}
-                            </p>
-                        </div>
-                    {% endif %}
+                        <div class="c-card card my-4">
+                            <div class="card-body">
+                                <p class="mb-0">
+                                    {% if join_authorized_org and kind_label and not kind_is_other %}
+                                        {# Display kind's full name if known. #}
+                                        <p>
+                                            <b>{{ kind_label }}</b>
+                                        </p>
+                                    {% endif %}
 
-                    {% if join_authorized_org and kind_is_other %}
-                        {% include "signup/includes/authorization_proof.html" %}
+                                    <b>{{ prescriber_org_data.name }}</b> - {{ prescriber_org_data.siret|format_siret }}
+                                    <br>
+                                    {% if prescriber_org_data.address_line_1 %}
+                                        {{ prescriber_org_data.address_line_1 }}
+                                        <br>
+                                    {% endif %}
+                                    {% if prescriber_org_data.address_line_2 %}
+                                        {{ prescriber_org_data.address_line_2 }}
+                                        <br>
+                                    {% endif %}
+                                    {{ prescriber_org_data.post_code }} {{ prescriber_org_data.city }}
+                                </p>
+                            </div>
+                        </div>
                     {% endif %}
 
                     {% include "inclusion_connect/includes/description.html" %}

--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -31,36 +31,41 @@
 
 
                     {% if siren_form.cleaned_data and not siaes_without_members and not siaes_with_members %}
-                        <div class="alert alert-emploi mt-5" role="status">
+                        <div class="alert alert-warning mt-5" role="status">
                             <p class="mb-0">
-                                Aucun résultat pour <b>{{ siren_form.cleaned_data.siren }}</b>.
+                                <i class="ri-information-line ri-xl text-warning mr-2"></i>
+                                <strong>Aucun résultat pour {{ siren_form.cleaned_data.siren }}</strong>.
                             </p>
                         </div>
 
-                        <div class="alert alert-danger mt-2" role="status">
+                        <div>
+                            <h3>Si vous tentez d'inscrire :</h3>
                             <p>
-                                <strong>Si vous êtes une SIAE</strong> :
+                                <strong>Une SIAE</strong>
                                 <br>
-                                Merci de vérifier dans l’extranet IAE 2.0 de l’ASP si votre annexe financière “valide” ou “provisoire” est déjà enregistrée.
-                            </p>
-                            <p>
-                                <i>Si c’est le cas</i>, tentez de vous reconnecter dans une dizaine de jours, le temps que l’ASP nous transmette l’information.
-                            </p>
-                            <p>
-                                <i>Si ce n’est pas le cas</i>, demandez à votre DDETS d’enregistrer au plus vite l’annexe financière dans l’ASP.
-                            </p>
-                            <p>
-                                En cas de nécessité d’inscription rapide, demandez à votre DDETS de nous contacter via <a href="{{ ITOU_HELP_CENTER_URL }}/requests/new" target="_blank" rel="noopener" aria-label="lien de contact pour votre DDETS (ouverture dans un nouvel onglet)">ce formulaire</a>.
+                                Vérifier que l’annexe financière valide ou provisoire de la structure a bien été enregistrée dans l’extranet IAE 2.0 de l’ASP :
+                                <ul>
+                                    <li>
+                                        Si oui, le délai de réception des données de l’ASP peut prendre une dizaine de jours. Merci de retenter l’inscription après ce délai.
+                                    </li>
+                                    <li>Si non, faire une demande d’enregistrement de l’annexe financière dans l’ASP auprès de votre DDETS.</li>
+                                </ul>
+                                En cas de nécessité, contacter l’<a href="{{ ITOU_HELP_CENTER_URL }}/requests/new" target="_blank" rel="noopener" aria-label="lien de contact pour votre DDETS (ouverture dans un nouvel onglet)">Aide & Assistance</a>.
+                                <i class="ri-external-link-line ri-xl"></i>
                             </p>
 
                             <p>
-                                <strong>Si vous tentez d'inscrire une Entreprise Adaptée ou un GEIQ</strong> :
-                                Utilisez <a href="{% tally_form_url "wA799W" %}" target="_blank" rel="noopener" aria-label="lien pour une Entreprise Adaptée ou un GEIQ (ouverture dans un nouvel onglet)">ce formulaire</a>.
+                                <strong>Une Entreprise Adaptée & GEIQ</strong> :
+                                <br>
+                                Complétez <a href="{% tally_form_url "wA799W" %}" target="_blank" rel="noopener" aria-label="lien pour une Entreprise Adaptée ou un GEIQ (ouverture dans un nouvel onglet)">ce formulaire de demande d'inscription</a>.
+                                <i class="ri-external-link-line ri-xl"></i>
                             </p>
 
                             <p class="mb-0">
                                 <strong>Si votre organisation est porteuse de la clause sociale</strong> :
-                                Utilisez <a href="{% url "signup:facilitator_search" %}" rel="noopener" aria-label="lien pour une organisation porteuse de la clause sociale">ce formulaire</a>.
+                                <br>
+                                Complétez <a href="{% url "signup:facilitator_search" %}" rel="noopener" aria-label="lien pour une organisation porteuse de la clause sociale">ce formulaire de demande d'inscription</a>.
+                                <i class="ri-external-link-line ri-xl"></i>
                             </p>
                         </div>
                     {% endif %}


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/3-X-Alertes-Changer-certaines-alertes-en-du-texte-simple-pas-boost-bdadbb5222fb49299fe490db16eb6ae7?pvs=4
 
<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Améliorer la lisibilité des messages.
