### PR TITLE
Harmonisation des badges Pass IAE

### DIFF
--- a/itou/templates/apply/includes/list_card_body_siae.html
+++ b/itou/templates/apply/includes/list_card_body_siae.html
@@ -20,19 +20,19 @@
             {% if siae.is_subject_to_eligibility_rules %}
                 {% with approval=job_application.job_seeker.latest_common_approval %}
                     {% if approval %}
-                        <span class="badge badge-xs badge-pill{% if approval.state == 'EXPIRED' %} badge-emploi-light{% else %} badge-success-lighter{% endif %} text-primary">
-                            <i class="{% if approval.state == 'EXPIRED' %}ri-close-circle-line{% elif approval.state == 'SUSPENDED' %}ri-pause-circle-line{% else %}ri-checkbox-circle-line{% endif %}"></i>
+                        <span class="badge badge-xs badge-pill {% if approval.state == 'EXPIRED' %} bg-emploi-light text-primary{% else %} badge-success-lighter text-success{% endif %}">
+                            <i class="{% if approval.state == 'EXPIRED' %}ri-pass-expired-line{% elif approval.state == 'SUSPENDED' %}ri-pass-pending-line{% else %}ri-pass-valid-line{% endif %}" aria-hidden="true"></i>
                             PASS IAE {{ approval.get_state_display|lower }}
                         </span>
                     {% else %}
                         {% if job_application.eligibility_diagnosis_by_siae_required %}
-                            <span class="badge badge-xs badge-pill badge-accent-02-lighter text-primary">
-                                <i class="ri-error-warning-line"></i>
-                                Éligibilité à l’IAE à valider
+                            <span class="badge badge-base badge-pill badge-accent-02-lighter text-primary">
+                                <i class="ri-error-warning-line" aria-hidden="true"></i>
+                                Éligibilité IAE à valider
                             </span>
                         {% else %}
-                            <span class="badge badge-xs badge-pill badge-success-light text-primary">
-                                <i class="ri-check-line"></i>
+                            <span class="badge badge-base badge-pill badge-success-lighter text-success">
+                                <i class="ri-check-line" aria-hidden="true"></i>
                                 Éligible à l’IAE
                             </span>
                         {% endif %}

--- a/itou/templates/approvals/includes/list_card.html
+++ b/itou/templates/approvals/includes/list_card.html
@@ -8,9 +8,9 @@
                 <p class="fs-sm mb-0">Pass N° {{ approval|format_approval_number }}</p>
             </div>
             <div class="order-1 order-md-2 mb-2 mb-md-0">
-                <span class="badge badge-sm badge-pill text-wrap{% if approval.state == 'EXPIRED' %} badge-dark{% else %} badge-success{% endif %}">
-                    <i class="{% if approval.state == 'EXPIRED' %}ri-forbid-2-line{% elif approval.state == 'SUSPENDED' %}ri-error-warning-line{% else %}ri-checkbox-circle-line{% endif %} ri-xl" aria-hidden="true"></i>
-                    PASS IAE {{ approval.get_state_display }}
+                <span class="badge badge-sm badge-pill text-wrap {% if approval.state == 'EXPIRED' %} bg-emploi-light text-primary{% else %} badge-success-lighter text-success{% endif %}">
+                    <i class="{% if approval.state == 'EXPIRED' %}ri-pass-expired-line{% elif approval.state == 'SUSPENDED' %}ri-pass-pending-line{% else %}ri-pass-valid-line{% endif %} ri-xl" aria-hidden="true"></i>
+                    PASS IAE {{ approval.get_state_display|lower }}
                 </span>
             </div>
         </div>

--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -114,13 +114,15 @@
             </div>
         </li>
     {% else %}
-        <a type="button" class="btn btn-ico btn-outline-primary" href="{% url "signup:choose_user_kind" %}">
-            <i class="ri-user-add-line"></i>
-            <span>S'inscrire</span>
-        </a>
+        <li>
+            <a type="button" class="btn btn-ico btn-outline-primary" href="{% url "signup:choose_user_kind" %}">
+                <i class="ri-user-add-line" aria-hidden="true"></i>
+                <span>S'inscrire</span>
+            </a>
+        </li>
         <li class="dropdown">
-            <button type="button" class="btn btn-icon btn-primary" data-toggle="dropdown" aria-haspopup="true" aria-controls="loginUserDropdown{% if is_mobile %}Mobile{% endif %}" aria-expanded="false">
-                <i class="ri-login-box-line"></i>
+            <button class="btn btn-icon btn-primary" data-toggle="dropdown" aria-haspopup="true" aria-controls="loginUserDropdown{% if is_mobile %}Mobile{% endif %}" aria-expanded="false">
+                <i class="ri-login-box-line" aria-hidden="true"></i>
                 <span>Se connecter</span>
             </button>
             <div class="dropdown-menu" id="loginUserDropdown{% if is_mobile %}Mobile{% endif %}">

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -577,8 +577,8 @@
                   
                       
                           
-                              <span class="badge badge-xs badge-pill badge-success-light text-primary">
-                                  <i class="ri-check-line"></i>
+                              <span class="badge badge-base badge-pill badge-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line"></i>
                                   Éligible à l’IAE
                               </span>
                           
@@ -679,8 +679,8 @@
                   
                       
                           
-                              <span class="badge badge-xs badge-pill badge-success-light text-primary">
-                                  <i class="ri-check-line"></i>
+                              <span class="badge badge-base badge-pill badge-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line"></i>
                                   Éligible à l’IAE
                               </span>
                           
@@ -755,8 +755,8 @@
                   
                       
                           
-                              <span class="badge badge-xs badge-pill badge-success-light text-primary">
-                                  <i class="ri-check-line"></i>
+                              <span class="badge badge-base badge-pill badge-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line"></i>
                                   Éligible à l’IAE
                               </span>
                           

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -184,33 +184,33 @@ class TestApprovalsListView:
 
         assertContains(
             response,
-            """<span class="badge badge-sm badge-pill text-wrap badge-success">
-                <i class="ri-checkbox-circle-line ri-xl" aria-hidden="true"></i>
-                PASS IAE Valide
+            """<span class="badge badge-sm badge-pill text-wrap badge-success-lighter text-success">
+                <i class="ri-pass-valid-line ri-xl" aria-hidden="true"></i>
+                PASS IAE valide
             </span>""",
             html=True,
         )
         assertContains(
             response,
-            """<span class="badge badge-sm badge-pill text-wrap badge-success">
-                <i class="ri-checkbox-circle-line ri-xl" aria-hidden="true"></i>
-                PASS IAE Valide (non démarré)
+            """<span class="badge badge-sm badge-pill text-wrap badge-success-lighter text-success">
+                <i class="ri-pass-valid-line ri-xl" aria-hidden="true"></i>
+                PASS IAE valide (non démarré)
             </span>""",
             html=True,
         )
         assertContains(
             response,
-            """<span class="badge badge-sm badge-pill text-wrap badge-success">
-                <i class="ri-error-warning-line ri-xl" aria-hidden="true"></i>
-                PASS IAE Valide (suspendu)
+            """<span class="badge badge-sm badge-pill text-wrap badge-success-lighter text-success">
+                <i class="ri-pass-pending-line ri-xl" aria-hidden="true"></i>
+                PASS IAE valide (suspendu)
             </span>""",
             html=True,
         )
         assertContains(
             response,
-            """<span class="badge badge-sm badge-pill text-wrap badge-dark">
-                <i class="ri-forbid-2-line ri-xl" aria-hidden="true"></i>
-                PASS IAE Expiré
+            """<span class="badge badge-sm badge-pill text-wrap bg-emploi-light text-primary">
+                <i class="ri-pass-expired-line ri-xl" aria-hidden="true"></i>
+                PASS IAE expiré
             </span>""",
             html=True,
         )


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/5-4-Refonte-carte-candidature-employeur-petite-boostinette-14289125206f4aab98b5208787df1fb7?pvs=4

### Pourquoi ?

Pour respecter l'UX définies dans l'UI Kit et ZeroHeight et pour utiliser les icones `ri-pass-*`

### Remarque
Au passage, correction d'une petite erreur de DOM dans le menu du header

