### PR TITLE
Admin : Préchargement des objets liés lors de l'édition d'un objet et pour les _Inline_

### DIFF
--- a/itou/analytics/admin.py
+++ b/itou/analytics/admin.py
@@ -1,10 +1,11 @@
 from django.contrib import admin
 
+from ..utils.admin import ItouModelAdmin
 from .models import Datum, StatsDashboardVisit
 
 
 @admin.register(Datum)
-class DatumAdmin(admin.ModelAdmin):
+class DatumAdmin(ItouModelAdmin):
     list_display = ["pk", "code", "bucket", "value", "measured_at"]
     list_filter = ["code"]
     ordering = ["-measured_at", "code"]
@@ -21,7 +22,7 @@ class DatumAdmin(admin.ModelAdmin):
 
 
 @admin.register(StatsDashboardVisit)
-class StatsDashboardVisitAdmin(admin.ModelAdmin):
+class StatsDashboardVisitAdmin(ItouModelAdmin):
     list_display = [
         "measured_at",
         "dashboard_id",

--- a/itou/antivirus/admin.py
+++ b/itou/antivirus/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.db.models import Case, F, Q, When
 
 from itou.antivirus.models import Scan
+from itou.utils.admin import ItouModelAdmin
 
 
 class SuspiciousFilter(admin.SimpleListFilter):
@@ -22,7 +23,7 @@ class SuspiciousFilter(admin.SimpleListFilter):
 
 
 @admin.register(Scan)
-class ScanAdmin(admin.ModelAdmin):
+class ScanAdmin(ItouModelAdmin):
     list_display = ["file_id", "suspicious", "infected", "clamav_signature", "clamav_completed_at"]
     readonly_fields = ["clamav_completed_at", "clamav_signature"]
     fields = ["clamav_completed_at", "clamav_signature", "infected", "comment"]

--- a/itou/api/admin.py
+++ b/itou/api/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from rest_framework.authtoken.admin import TokenAdmin
 
+from ..utils.admin import ItouModelAdmin
 from .models import SiaeApiToken
 
 
@@ -11,7 +12,7 @@ TokenAdmin.raw_id_fields = ("user",)
 
 
 @admin.register(SiaeApiToken)
-class SiaeApiTokenAdmin(admin.ModelAdmin):
+class SiaeApiTokenAdmin(ItouModelAdmin):
     list_display = ["key", "label", "created_at"]
     ordering = ["-created_at"]
     read_only_fields = ["key", "created_at"]

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -11,10 +11,16 @@ from itou.employee_record import enums as employee_record_enums
 from itou.employee_record.constants import EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE
 from itou.employee_record.models import EmployeeRecord
 from itou.job_applications.models import JobApplication
-from itou.utils.admin import PkSupportRemarkInline, get_admin_view_link
+from itou.utils.admin import (
+    ItouModelAdmin,
+    ItouStackedInline,
+    ItouTabularInline,
+    PkSupportRemarkInline,
+    get_admin_view_link,
+)
 
 
-class JobApplicationInline(admin.StackedInline):
+class JobApplicationInline(ItouStackedInline):
     model = JobApplication
     extra = 0
     show_change_link = True
@@ -35,6 +41,7 @@ class JobApplicationInline(admin.StackedInline):
         "job_seeker",
         "approval_manually_delivered_by",
     )
+    list_select_related = ("to_siae",)
 
     # Mandatory for "custom" inline fields
     readonly_fields = ("employee_record_status", "to_siae_link")
@@ -93,7 +100,7 @@ class JobApplicationInline(admin.StackedInline):
         return "-"
 
 
-class SuspensionInline(admin.TabularInline):
+class SuspensionInline(ItouTabularInline):
     model = models.Suspension
     extra = 0
     show_change_link = True
@@ -108,7 +115,7 @@ class SuspensionInline(admin.TabularInline):
         return False
 
 
-class ProlongationInline(admin.TabularInline):
+class ProlongationInline(ItouTabularInline):
     model = models.Prolongation
     extra = 0
     show_change_link = True
@@ -166,7 +173,7 @@ class StartDateFilter(admin.SimpleListFilter):
 
 
 @admin.register(models.Approval)
-class ApprovalAdmin(admin.ModelAdmin):
+class ApprovalAdmin(ItouModelAdmin):
     form = ApprovalAdminForm
     list_display = (
         "pk",
@@ -330,7 +337,7 @@ class FromProlongationRequest(admin.SimpleListFilter):
 
 
 @admin.register(models.Suspension)
-class SuspensionAdmin(admin.ModelAdmin):
+class SuspensionAdmin(ItouModelAdmin):
     list_display = (
         "pk",
         "approval",
@@ -363,7 +370,7 @@ class SuspensionAdmin(admin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
 
-class ProlongationCommonAdmin(admin.ModelAdmin):
+class ProlongationCommonAdmin(ItouModelAdmin):
     list_display = (
         "pk",
         "approval",
@@ -444,7 +451,7 @@ class ProlongationAdmin(ProlongationCommonAdmin):
 
 
 @admin.register(models.PoleEmploiApproval)
-class PoleEmploiApprovalAdmin(admin.ModelAdmin):
+class PoleEmploiApprovalAdmin(ItouModelAdmin):
     list_display = (
         "pk",
         "pole_emploi_id",

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -429,6 +429,7 @@ class ProlongationRequestAdmin(ProlongationCommonAdmin):
 @admin.register(models.Prolongation)
 class ProlongationAdmin(ProlongationCommonAdmin):
     list_display = ProlongationCommonAdmin.list_display + ("is_in_progress", "from_prolongation_request")
+    list_select_related = ProlongationCommonAdmin.list_select_related + ("request",)
     raw_id_fields = ProlongationCommonAdmin.raw_id_fields + ("request",)
     list_filter = (
         IsInProgressFilter,

--- a/itou/asp/admin.py
+++ b/itou/asp/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin, messages
 
 from itou.asp import models
-from itou.utils.admin import PkSupportRemarkInline
+from itou.utils.admin import ItouModelAdmin, PkSupportRemarkInline
 
 
 class PeriodFilter(admin.SimpleListFilter):
@@ -38,7 +38,7 @@ class CountryFilter(admin.SimpleListFilter):
         return queryset
 
 
-class ASPModelAdmin(admin.ModelAdmin):
+class ASPModelAdmin(ItouModelAdmin):
     list_display = ("pk", "code", "name", "start_date", "end_date")
     list_filter = (PeriodFilter,)
     readonly_fields = ("pk",)
@@ -75,7 +75,7 @@ class DepartmentAdmin(ASPModelAdmin):
 
 
 @admin.register(models.Country)
-class CountryAdmin(admin.ModelAdmin):
+class CountryAdmin(ItouModelAdmin):
     list_display = ("pk", "code", "name")
     readonly_fields = ("pk",)
     ordering = ("name",)

--- a/itou/cities/admin.py
+++ b/itou/cities/admin.py
@@ -2,11 +2,11 @@ from django.contrib import admin
 
 from itou.cities import models
 from itou.geo.models import ZRR
-from itou.utils.admin import ItouGISMixin
+from itou.utils.admin import ItouGISMixin, ItouModelAdmin
 
 
 @admin.register(models.City)
-class CityAdmin(ItouGISMixin, admin.ModelAdmin):
+class CityAdmin(ItouGISMixin, ItouModelAdmin):
     list_display = ("name", "department", "post_codes", "code_insee")
 
     list_filter = ("department",)

--- a/itou/common_apps/organizations/admin.py
+++ b/itou/common_apps/organizations/admin.py
@@ -1,8 +1,10 @@
 from django.contrib import admin, messages
 from django.db.models import Count
 
+from itou.utils.admin import ItouModelAdmin, ItouTabularInline
 
-class MembersInline(admin.TabularInline):
+
+class MembersInline(ItouTabularInline):
     # Remember to specify the model in child class. Example:
     # model = models.Siae.members.through
     extra = 1
@@ -26,7 +28,7 @@ class HasMembersFilter(admin.SimpleListFilter):
         return queryset
 
 
-class OrganizationAdmin(admin.ModelAdmin):
+class OrganizationAdmin(ItouModelAdmin):
     @admin.display(ordering="_member_count")
     def member_count(self, obj):
         return obj._member_count

--- a/itou/eligibility/admin.py
+++ b/itou/eligibility/admin.py
@@ -4,10 +4,10 @@ from django.utils.html import format_html
 from itou.approvals import models as approvals_models
 from itou.eligibility import models
 from itou.job_applications import models as job_applications_models
-from itou.utils.admin import PkSupportRemarkInline, get_admin_view_link
+from itou.utils.admin import ItouModelAdmin, ItouTabularInline, PkSupportRemarkInline, get_admin_view_link
 
 
-class AbstractAdministrativeCriteriaInline(admin.TabularInline):
+class AbstractAdministrativeCriteriaInline(ItouTabularInline):
     extra = 1
     raw_id_fields = ("administrative_criteria",)
     readonly_fields = ("created_at",)
@@ -21,7 +21,7 @@ class GEIQAdministrativeCriteriaInline(AbstractAdministrativeCriteriaInline):
     model = models.GEIQEligibilityDiagnosis.administrative_criteria.through
 
 
-class ApprovalInline(admin.TabularInline):
+class ApprovalInline(ItouTabularInline):
     model = approvals_models.Approval
     extra = 0
     can_delete = False
@@ -44,7 +44,7 @@ class ApprovalInline(admin.TabularInline):
         return obj.is_valid()
 
 
-class JobApplicationInline(admin.TabularInline):
+class JobApplicationInline(ItouTabularInline):
     model = job_applications_models.JobApplication
     extra = 0
     can_delete = False
@@ -57,6 +57,7 @@ class JobApplicationInline(admin.TabularInline):
         "approval",
     )
     readonly_fields = fields
+    list_select_related = ("to_siae",)
 
     def has_change_permission(self, request, obj=None):
         return False
@@ -106,7 +107,7 @@ class HasApprovalFilter(admin.SimpleListFilter):
         return queryset
 
 
-class AbstractEligibilityDiagnosisAdmin(admin.ModelAdmin):
+class AbstractEligibilityDiagnosisAdmin(ItouModelAdmin):
     list_display = (
         "pk",
         "job_seeker",
@@ -198,7 +199,7 @@ class GEIQEligibilityDiagnosisAdmin(AbstractEligibilityDiagnosisAdmin):
         return f"{obj.allowance_amount} EUR"
 
 
-class AbstractAdministrativeCriteriaAdmin(admin.ModelAdmin):
+class AbstractAdministrativeCriteriaAdmin(ItouModelAdmin):
     list_display_links = ("pk", "name")
     list_filter = ("level",)
     raw_id_fields = ("created_by",)

--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -3,12 +3,12 @@ from django.utils import timezone
 
 import itou.employee_record.models as models
 
-from ..utils.admin import get_admin_view_link
+from ..utils.admin import ItouModelAdmin, ItouTabularInline, get_admin_view_link
 from ..utils.templatetags.str_filters import pluralizefr
 from .enums import Status
 
 
-class EmployeeRecordUpdateNotificationInline(admin.TabularInline):
+class EmployeeRecordUpdateNotificationInline(ItouTabularInline):
     model = models.EmployeeRecordUpdateNotification
 
     fields = (
@@ -27,7 +27,7 @@ class EmployeeRecordUpdateNotificationInline(admin.TabularInline):
 
 
 @admin.register(models.EmployeeRecord)
-class EmployeeRecordAdmin(admin.ModelAdmin):
+class EmployeeRecordAdmin(ItouModelAdmin):
     @admin.action(description="Marquer les fiches salarié selectionnées comme COMPLETÉES")
     def update_employee_record_as_ready(self, _request, queryset):
         queryset.update(status=Status.READY)
@@ -160,7 +160,7 @@ class EmployeeRecordAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.EmployeeRecordUpdateNotification)
-class EmployeeRecordUpdateNotificationAdmin(admin.ModelAdmin):
+class EmployeeRecordUpdateNotificationAdmin(ItouModelAdmin):
     list_display = (
         "pk",
         "created_at",

--- a/itou/external_data/admin.py
+++ b/itou/external_data/admin.py
@@ -1,17 +1,18 @@
 from django.contrib import admin
 
 from itou.external_data import models
+from itou.utils.admin import ItouModelAdmin
 
 
 @admin.register(models.ExternalDataImport)
-class ExternalDataImportAdmin(admin.ModelAdmin):
+class ExternalDataImportAdmin(ItouModelAdmin):
     raw_id_fields = ("user",)
     list_display = ("pk", "source", "status", "created_at")
     list_filter = ("source", "status")
 
 
 @admin.register(models.RejectedEmailEventData)
-class RejectedEmailEventDataAdmin(admin.ModelAdmin):
+class RejectedEmailEventDataAdmin(ItouModelAdmin):
     list_filter = ("reason",)
     list_display = ("pk", "recipient", "reason", "created_at")
     search_fields = ("recipient",)

--- a/itou/files/admin.py
+++ b/itou/files/admin.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 
 from itou.files.models import File
+from itou.utils.admin import ItouModelAdmin
 
 
 @admin.register(File)
-class FileAdmin(admin.ModelAdmin):
+class FileAdmin(ItouModelAdmin):
     list_display = ["key", "last_modified"]
     readonly_fields = ["key", "last_modified"]

--- a/itou/geo/admin.py
+++ b/itou/geo/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.contrib.gis.admin import GISModelAdmin
 
+from ..utils.admin import ItouModelAdmin
 from .models import QPV, ZRR
 
 
@@ -33,7 +34,7 @@ class QPVAdmin(GISModelAdmin):
 
 
 @admin.register(ZRR)
-class ZRRAdmin(admin.ModelAdmin):
+class ZRRAdmin(ItouModelAdmin):
     list_display = ("pk", "insee_code", "status")
     list_filter = ("status",)
 

--- a/itou/invitations/admin.py
+++ b/itou/invitations/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 
+from ..utils.admin import ItouModelAdmin
 from .models import LaborInspectorInvitation, PrescriberWithOrgInvitation, SiaeStaffInvitation
 
 
@@ -19,7 +20,7 @@ class IsValidFilter(admin.SimpleListFilter):
         return queryset
 
 
-class BaseInvitationAdmin(admin.ModelAdmin):
+class BaseInvitationAdmin(ItouModelAdmin):
     date_hierarchy = "sent_at"
     list_display = ("email", "first_name", "last_name", "sender", "sent_at", "is_valid", "accepted")
     ordering = ("-sent_at",)

--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -10,11 +10,11 @@ from itou.job_applications import models
 from itou.job_applications.admin_forms import JobApplicationAdminForm
 from itou.job_applications.enums import Origin
 from itou.users.models import User
-from itou.utils.admin import UUIDSupportRemarkInline, get_admin_view_link
+from itou.utils.admin import ItouModelAdmin, ItouTabularInline, UUIDSupportRemarkInline, get_admin_view_link
 from itou.utils.templatetags.str_filters import pluralizefr
 
 
-class TransitionLogInline(admin.TabularInline):
+class TransitionLogInline(ItouTabularInline):
     model = models.JobApplicationTransitionLog
     extra = 0
     raw_id_fields = ("user",)
@@ -25,7 +25,7 @@ class TransitionLogInline(admin.TabularInline):
         return False
 
 
-class PriorActionInline(admin.TabularInline):
+class PriorActionInline(ItouTabularInline):
     model = models.PriorAction
     extra = 0
     can_delete = False
@@ -36,7 +36,7 @@ class PriorActionInline(admin.TabularInline):
         return False
 
 
-class JobsInline(admin.TabularInline):
+class JobsInline(ItouTabularInline):
     model = models.JobApplication.selected_jobs.through
     verbose_name_plural = "fiches de poste"
     extra = 1
@@ -58,7 +58,7 @@ class ManualApprovalDeliveryRequiredFilter(admin.SimpleListFilter):
 
 
 @admin.register(models.JobApplication)
-class JobApplicationAdmin(admin.ModelAdmin):
+class JobApplicationAdmin(ItouModelAdmin):
     form = JobApplicationAdminForm
     list_display = ("pk", "job_seeker", "state", "sender_kind", "created_at")
     show_full_result_count = False
@@ -256,7 +256,7 @@ class JobApplicationAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.JobApplicationTransitionLog)
-class JobApplicationTransitionLogAdmin(admin.ModelAdmin):
+class JobApplicationTransitionLogAdmin(ItouModelAdmin):
     actions = None
     date_hierarchy = "timestamp"
     list_display = ("job_application", "transition", "from_state", "to_state", "user", "timestamp")

--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -261,6 +261,7 @@ class JobApplicationTransitionLogAdmin(admin.ModelAdmin):
     date_hierarchy = "timestamp"
     list_display = ("job_application", "transition", "from_state", "to_state", "user", "timestamp")
     list_filter = ("transition",)
+    list_select_related = ("job_application", "user")
     raw_id_fields = ("job_application", "user")
     readonly_fields = ("job_application", "transition", "from_state", "to_state", "user", "timestamp")
     search_fields = ("transition", "user__username", "job_application__pk")

--- a/itou/jobs/admin.py
+++ b/itou/jobs/admin.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 
 from itou.jobs import models
+from itou.utils.admin import ItouModelAdmin, ItouTabularInline
 
 
-class AppellationsInline(admin.TabularInline):
+class AppellationsInline(ItouTabularInline):
     model = models.Appellation
     readonly_fields = ("code", "name")
     can_delete = False
@@ -13,14 +14,14 @@ class AppellationsInline(admin.TabularInline):
 
 
 @admin.register(models.Rome)
-class RomeAdmin(admin.ModelAdmin):
+class RomeAdmin(ItouModelAdmin):
     list_display = ("code", "name")
     search_fields = ("code", "name")
     inlines = (AppellationsInline,)
 
 
 @admin.register(models.Appellation)
-class AppellationAdmin(admin.ModelAdmin):
+class AppellationAdmin(ItouModelAdmin):
     list_display = ("code", "name")
     search_fields = ("code", "name", "rome__code")
     raw_id_fields = ("rome",)

--- a/itou/settings_viewer/admin.py
+++ b/itou/settings_viewer/admin.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 
+from ..utils.admin import ItouModelAdmin
 from . import models, views
 
 
-class SettingAdmin(admin.ModelAdmin):
+class SettingAdmin(ItouModelAdmin):
     """Admin View for settings"""
 
     def has_add_permission(self, request):

--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -3,14 +3,14 @@ from django.utils import timezone
 from django.utils.html import format_html
 
 from itou.siae_evaluations import models
-from itou.utils.admin import PkSupportRemarkInline, get_admin_view_link
+from itou.utils.admin import ItouModelAdmin, ItouTabularInline, PkSupportRemarkInline, get_admin_view_link
 from itou.utils.export import to_streaming_response
 
 
 admin.site.register(models.Calendar)
 
 
-class EvaluatedSiaesInline(admin.TabularInline):
+class EvaluatedSiaesInline(ItouTabularInline):
     model = models.EvaluatedSiae
     fields = ("id_link", "reviewed_at", "state")
     readonly_fields = ("id_link", "reviewed_at", "state")
@@ -33,11 +33,12 @@ class EvaluatedSiaesInline(admin.TabularInline):
         return get_admin_view_link(obj, content=format_html("Lien vers la Siae évaluée <strong>{}</strong>", obj))
 
 
-class EvaluatedJobApplicationsInline(admin.TabularInline):
+class EvaluatedJobApplicationsInline(ItouTabularInline):
     model = models.EvaluatedJobApplication
     fields = ("id_link", "approval", "job_seeker", "state")
     readonly_fields = ("id_link", "approval", "job_seeker", "state")
     extra = 0
+    list_select_related = ("job_application__approval", "job_application__job_seeker")
 
     def get_queryset(self, request):
         return super().get_queryset(request).prefetch_related("evaluated_administrative_criteria")
@@ -62,7 +63,7 @@ class EvaluatedJobApplicationsInline(admin.TabularInline):
         return "-"
 
 
-class EvaluatedAdministrativeCriteriaInline(admin.TabularInline):
+class EvaluatedAdministrativeCriteriaInline(ItouTabularInline):
     model = models.EvaluatedAdministrativeCriteria
     fields = ("id_link", "uploaded_at", "submitted_at", "review_state")
     readonly_fields = ("id_link", "uploaded_at", "submitted_at", "review_state")
@@ -105,7 +106,7 @@ def _evaluated_siae_serializer(queryset):
 
 
 @admin.register(models.EvaluationCampaign)
-class EvaluationCampaignAdmin(admin.ModelAdmin):
+class EvaluationCampaignAdmin(ItouModelAdmin):
     @admin.action(description="Exporter les SIAE des campagnes sélectionnées")
     def export_siaes(self, request, queryset):
         export_qs = (
@@ -209,7 +210,7 @@ class EvaluationCampaignAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.EvaluatedSiae)
-class EvaluatedSiaeAdmin(admin.ModelAdmin):
+class EvaluatedSiaeAdmin(ItouModelAdmin):
     list_display = ["evaluation_campaign", "siae", "state", "reviewed_at"]
     list_display_links = ("siae",)
     readonly_fields = (
@@ -248,7 +249,7 @@ class EvaluatedSiaeAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.EvaluatedJobApplication)
-class EvaluatedJobApplicationAdmin(admin.ModelAdmin):
+class EvaluatedJobApplicationAdmin(ItouModelAdmin):
     list_display = ("evaluated_siae", "job_application", "approval", "job_seeker")
     list_display_links = ("job_application",)
     list_select_related = ("evaluated_siae__siae", "job_application__approval", "job_application__job_seeker")
@@ -275,7 +276,7 @@ class EvaluatedJobApplicationAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.EvaluatedAdministrativeCriteria)
-class EvaluatedAdministrativeCriteriaAdmin(admin.ModelAdmin):
+class EvaluatedAdministrativeCriteriaAdmin(ItouModelAdmin):
     list_display = ("evaluated_job_application", "administrative_criteria", "submitted_at", "review_state")
     list_display_links = ("administrative_criteria",)
     readonly_fields = (
@@ -289,7 +290,7 @@ class EvaluatedAdministrativeCriteriaAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.Sanctions)
-class SanctionsAdmin(admin.ModelAdmin):
+class SanctionsAdmin(ItouModelAdmin):
     list_display = [
         "evaluated_siae",
         "evaluation_campaign",

--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -251,6 +251,7 @@ class EvaluatedSiaeAdmin(admin.ModelAdmin):
 class EvaluatedJobApplicationAdmin(admin.ModelAdmin):
     list_display = ("evaluated_siae", "job_application", "approval", "job_seeker")
     list_display_links = ("job_application",)
+    list_select_related = ("evaluated_siae__siae", "job_application__approval", "job_application__job_seeker")
     readonly_fields = ("evaluated_siae", "job_application", "approval", "job_seeker", "state")
     inlines = [
         EvaluatedAdministrativeCriteriaInline,
@@ -294,7 +295,7 @@ class SanctionsAdmin(admin.ModelAdmin):
         "evaluation_campaign",
         "institution",
     ]
-    list_select_related = ["evaluated_siae__evaluation_campaign__institution"]
+    list_select_related = ["evaluated_siae__evaluation_campaign__institution", "evaluated_siae__siae"]
     search_fields = ["evaluated_siae__siae__name"]
     readonly_fields = [
         "evaluated_siae",

--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -10,7 +10,13 @@ from import_export.fields import Field
 from itou.common_apps.organizations.admin import HasMembersFilter, MembersInline, OrganizationAdmin
 from itou.siaes import enums, models
 from itou.siaes.admin_forms import SiaeAdminForm
-from itou.utils.admin import ItouGISMixin, PkSupportRemarkInline, get_admin_view_link
+from itou.utils.admin import (
+    ItouGISMixin,
+    ItouModelAdmin,
+    ItouTabularInline,
+    PkSupportRemarkInline,
+    get_admin_view_link,
+)
 from itou.utils.apis.exceptions import GeocodingDataError
 
 
@@ -20,7 +26,7 @@ class SiaeMembersInline(MembersInline):
     raw_id_fields = ("user",)
 
 
-class JobsInline(admin.TabularInline):
+class JobsInline(ItouTabularInline):
     model = models.Siae.jobs.through
     extra = 1
     fields = (
@@ -45,7 +51,7 @@ class JobsInline(admin.TabularInline):
         return get_admin_view_link(obj, content=format_html("<strong>Fiche de poste ID: {}</strong>", obj.id))
 
 
-class FinancialAnnexesInline(admin.TabularInline):
+class FinancialAnnexesInline(ItouTabularInline):
     model = models.SiaeFinancialAnnex
     fields = ("number", "state", "start_at", "end_at", "is_active")
     readonly_fields = ("number", "state", "start_at", "end_at", "is_active")
@@ -64,7 +70,7 @@ class FinancialAnnexesInline(admin.TabularInline):
         return False
 
 
-class SiaesInline(admin.TabularInline):
+class SiaesInline(ItouTabularInline):
     model = models.Siae
     fields = ("siae_id_link", "kind", "siret", "source", "name", "brand")
     readonly_fields = ("siae_id_link", "kind", "siret", "source", "name", "brand")
@@ -242,7 +248,7 @@ class SiaeAdmin(ItouGISMixin, ExportActionMixin, OrganizationAdmin):
 
 
 @admin.register(models.SiaeJobDescription)
-class SiaeJobDescriptionAdmin(admin.ModelAdmin):
+class SiaeJobDescriptionAdmin(ItouModelAdmin):
     list_display = (
         "display_name",
         "siae",
@@ -275,7 +281,7 @@ class SiaeJobDescriptionAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.SiaeConvention)
-class SiaeConventionAdmin(admin.ModelAdmin):
+class SiaeConventionAdmin(ItouModelAdmin):
     list_display = ("kind", "siret_signature", "is_active")
     list_filter = ("kind", "is_active")
     raw_id_fields = ("reactivated_by",)
@@ -345,7 +351,7 @@ class SiaeConventionAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.SiaeFinancialAnnex)
-class SiaeFinancialAnnexAdmin(admin.ModelAdmin):
+class SiaeFinancialAnnexAdmin(ItouModelAdmin):
     list_display = ("number", "state", "start_at", "end_at")
     list_filter = ("state",)
     raw_id_fields = ("convention",)

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -22,11 +22,11 @@ from itou.siaes.models import SiaeMembership
 from itou.users import models
 from itou.users.admin_forms import ChooseFieldsToTransfer, ItouUserCreationForm, SelectTargetUserForm, UserAdminForm
 from itou.users.enums import IdentityProvider, UserKind
-from itou.utils.admin import PkSupportRemarkInline, get_admin_view_link
+from itou.utils.admin import ItouModelAdmin, ItouTabularInline, PkSupportRemarkInline, get_admin_view_link
 from itou.utils.models import PkSupportRemark
 
 
-class EmailAddressInline(admin.TabularInline):
+class EmailAddressInline(ItouTabularInline):
     model = EmailAddress
     extra = 0
     can_delete = False
@@ -44,7 +44,7 @@ class EmailAddressInline(admin.TabularInline):
         return get_admin_view_link(obj, content=obj.email)
 
 
-class SiaeMembershipInline(admin.TabularInline):
+class SiaeMembershipInline(ItouTabularInline):
     model = SiaeMembership
     extra = 0
     raw_id_fields = ("siae",)
@@ -72,7 +72,7 @@ class SiaeMembershipInline(admin.TabularInline):
         return get_admin_view_link(obj.siae)
 
 
-class PrescriberMembershipInline(admin.TabularInline):
+class PrescriberMembershipInline(ItouTabularInline):
     model = PrescriberMembership
     extra = 0
     raw_id_fields = ("organization",)
@@ -98,7 +98,7 @@ class PrescriberMembershipInline(admin.TabularInline):
         return get_admin_view_link(obj.organization)
 
 
-class InstitutionMembershipInline(admin.TabularInline):
+class InstitutionMembershipInline(ItouTabularInline):
     model = InstitutionMembership
     extra = 0
     raw_id_fields = (
@@ -128,13 +128,14 @@ class InstitutionMembershipInline(admin.TabularInline):
         return get_admin_view_link(obj.institution)
 
 
-class JobApplicationInline(admin.TabularInline):
+class JobApplicationInline(ItouTabularInline):
     model = JobApplication
     fk_name = "job_seeker"
     extra = 0
     can_delete = False
     fields = ("pk_link", "sender_kind", "to_siae_link", "state")
     readonly_fields = fields
+    list_select_related = ("to_siae",)
 
     def has_change_permission(self, request, obj=None):
         return False
@@ -167,7 +168,7 @@ class SentJobApplicationInline(JobApplicationInline):
         return get_admin_view_link(obj.job_seeker, content=obj.job_seeker.get_full_name())
 
 
-class EligibilityDiagnosisInline(admin.TabularInline):
+class EligibilityDiagnosisInline(ItouTabularInline):
     model = EligibilityDiagnosis
     fk_name = "job_seeker"
     extra = 0
@@ -199,7 +200,7 @@ class GEIQEligibilityDiagnosisInline(EligibilityDiagnosisInline):
     model = GEIQEligibilityDiagnosis
 
 
-class ApprovalInline(admin.TabularInline):
+class ApprovalInline(ItouTabularInline):
     model = Approval
     fk_name = "user"
     extra = 0
@@ -584,7 +585,7 @@ class IsPECertifiedFilter(admin.SimpleListFilter):
 
 
 @admin.register(models.JobSeekerProfile)
-class JobSeekerProfileAdmin(admin.ModelAdmin):
+class JobSeekerProfileAdmin(ItouModelAdmin):
     """
     Inlines would only be possible the other way around
     """


### PR DESCRIPTION
### Pourquoi ?

Réduire et stabiliser le nombre de requête SQL dans l'admin.

### Comment <!-- optionnel -->

Ajout de classes d'admin de base pour propager le comportement partout

Pour `ItouModelAdmin` le gain est moindre qu'attendu (entre 0 et 5 requêtes suivant les cas) car `ForeignKeyRawIdWidget` (les champs listés dans `raw_id_fields`) n'utilise pas l'objet préchargé, chaque widget fait sa propre requête : https://github.com/django/django/blob/613b7ba212d773e8b8a4ecb8236ef575c153a9a6/django/contrib/admin/widgets.py#L195.
J'ai essayé de jouer avec les fonctions de surcharge de admin et les formfield mais je n'ai pas trouvé le moyen d'avoir l'objet édité :'(.

`ItouStackedInline` et `ItouTabularInline` sont plus situationnelles mais permettent de gagner beaucoup sur les pages les plus lourdes.

Bonus : Quelques `list_select_related` qui manquaient.
