### PR TITLE
CSP: ajout de base-uri et suppression de redoc

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -634,7 +634,6 @@ CSP_SCRIPT_SRC = [
     "'self'",
     "https://stats.inclusion.beta.gouv.fr",
     "*.hotjar.com",
-    "https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js",
     "https://tally.so",
 ]
 # Some browsers don't seem to fallback on script-src if script-src-elem is not there

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -593,6 +593,7 @@ MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN")
 
 # Content Security Policy
 # Beware, some browser extensions may prevent the reports to be sent to sentry with CORS errors.
+CSP_BASE_URI = ["'none'"]  # We don't use any <base> element in our code, so let's forbid it
 CSP_DEFAULT_SRC = ["'self'"]
 CSP_FRAME_SRC = [
     "https://app.livestorm.co",  # Upcoming events from the homepage

--- a/itou/api/redoc_views.py
+++ b/itou/api/redoc_views.py
@@ -1,0 +1,8 @@
+from django.templatetags.static import static
+from drf_spectacular.views import SpectacularRedocView
+
+
+class ItouSpectacularRedocView(SpectacularRedocView):
+    @staticmethod
+    def _redoc_standalone():
+        return static("vendor/redoc-2.0.0/redoc.standalone.js")

--- a/itou/api/urls.py
+++ b/itou/api/urls.py
@@ -1,5 +1,5 @@
 from django.urls import include, path
-from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView
+from drf_spectacular.views import SpectacularAPIView
 from rest_framework import routers
 
 from itou.api.data_inclusion_api.views import DataInclusionStructureView
@@ -10,6 +10,7 @@ from .employee_record_api.viewsets import (
     EmployeeRecordUpdateNotificationViewSet,
     EmployeeRecordViewSet,
 )
+from .redoc_views import ItouSpectacularRedocView
 from .siae_api.viewsets import SiaeViewSet
 from .token_auth.views import ObtainAuthToken
 
@@ -44,7 +45,7 @@ urlpatterns = [
     ),
     path(
         "redoc/",
-        SpectacularRedocView.as_view(url_name="v1:openapi_schema"),
+        ItouSpectacularRedocView.as_view(url_name="v1:openapi_schema"),
         name="redoc",
     ),
 ]


### PR DESCRIPTION
### Pourquoi ?

Pour encore un peu limiter les possibilités.