### PR TITLE
Retrait de l’acceptation automatique à J+30 + modif des relances email 

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -14,7 +14,6 @@
   "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
   "30 1 * * * $ROOT/clevercloud/run_management_command.sh new_users_to_mailjet --wet-run",
   "0 3 * * * $ROOT/clevercloud/run_management_command.sh clearsessions",
-  "5 5 * * * $ROOT/clevercloud/run_management_command.sh prolongation_requests_chores auto_grant --wet-run",
   "15 5 * * * $ROOT/clevercloud/run_management_command.sh prolongation_requests_chores email_reminder --wet-run",
   "0 12 * * * $ROOT/clevercloud/run_management_command.sh evaluation_campaign_notify",
   "30 20 * * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --daily",

--- a/tests/approvals/test_prolongation_requests.py
+++ b/tests/approvals/test_prolongation_requests.py
@@ -1,5 +1,4 @@
 import contextlib
-import datetime
 import io
 import itertools
 
@@ -12,7 +11,7 @@ from freezegun import freeze_time
 
 from itou.approvals.enums import ProlongationRequestStatus
 from itou.approvals.management.commands import prolongation_requests_chores
-from itou.approvals.models import Prolongation, ProlongationRequest
+from itou.approvals.models import ProlongationRequest
 from tests.approvals.factories import ProlongationRequestDenyInformationFactory, ProlongationRequestFactory
 
 
@@ -85,29 +84,6 @@ def test_deny():
         [prolongation_request.declared_by.email],
         [prolongation_request.approval.user.email],
     ]
-
-
-@pytest.mark.parametrize(
-    "wet_run,expected",
-    [
-        (True, 1),  # Only the old PENDING will be granted
-        (False, 0),
-    ],
-)
-def test_chores_grant_older_pending_requests(faker, snapshot, command, wet_run, expected):
-    parameters = itertools.product(
-        ProlongationRequestStatus,
-        [
-            faker.date_time_between(end_date="-30d", tzinfo=datetime.UTC),
-            faker.date_time_between(start_date="-30d", tzinfo=datetime.UTC),
-        ],
-    )
-    for status, created_at in parameters:
-        ProlongationRequestFactory(status=status, created_at=created_at)
-
-    command.handle(command="auto_grant", wet_run=wet_run)
-    assert Prolongation.objects.count() == expected
-    assert command.stdout.getvalue() == snapshot
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Retrait-de-l-acceptation-automatique-J-30-modif-des-relances-email-046c5b63c30c4a6f9cafdcb285e6ea82?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Demandes du groupe projet PASS AI (DGEFP, PE, Réseaux AI) :
- Retirer l’acceptation automatique à J+30
- Reprendre le mail de rappel initialement utilisé à J+7 pour le mettre à J+10 J+20 J+30

### Comment <!-- optionnel -->

La suppression du code de l'auto-acceptation est dans un commit séparé pour facilité le _revert_ si besoin.
