### PR TITLE
Ajouter un security.txt

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+Communication en français ou en anglais.
+*Please use French or English for communications.*
+*English version below.*
+
+# Révéler un problème de sécurité
+
+Merci de ne pas révéler les problèmes de sécurité sur GitHub, mais de suivre la
+politique définie par le document
+[security.txt](https://emplois.inclusion.beta.gouv.fr/.well-known/security.txt).
+
+Vous devriez recevoir une réponse sous 1 jour ouvré.
+
+Merci d’inclure autant d’éléments que possible dans votre rapport pour nous
+aider à identifier et reproduire le problème :
+
+- Type de problème (e.g. dépassement de mémoire, injection SQL, cross-site
+  scripting, etc.)
+- Chemin vers les fichiers sources liés au problème
+- URL, branches / tags ou commit affecté par le problème
+- Votre configuration (compte utilisateur, etc.)
+- Instructions pas à pas pour reproduire le problème
+- Impact du problème, dont des pistes pour qu’un utilisateur malveillant
+  exploite la vulnérabilité
+
+# Reporting Security Issues
+
+Please do not report security vulnerabilities through GitHub. Instead, follow
+the policy defined by the
+[security.txt](https://emplois.inclusion.beta.gouv.fr/.well-known/security.txt).
+
+You should receive a response on the next working day.
+
+Please include the requested information listed below (as much as you can
+provide) to help us better understand the nature and scope of the possible
+issue:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue

--- a/config/urls.py
+++ b/config/urls.py
@@ -78,6 +78,7 @@ urlpatterns = [
     path("legal/notice/", TemplateView.as_view(template_name="static/legal/notice.html"), name="legal-notice"),
     path("legal/privacy/", TemplateView.as_view(template_name="static/legal/privacy.html"), name="legal-privacy"),
     path("legal/terms/", TemplateView.as_view(template_name="static/legal/terms.html"), name="legal-terms"),
+    path("", include("itou.www.security.urls")),
 ]
 
 if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:

--- a/itou/templates/static/security/security.txt
+++ b/itou/templates/static/security/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:tech@inclusion.beta.gouv.fr
+Expires: 2024-03-19T12:00:00.000Z
+Preferred-Languages: fr,en
+Canonical: https://emplois.inclusion.beta.gouv.fr/.well-known/security.txt
+Policy: https://github.com/betagouv/itou/blob/master/.github/SECURITY.md

--- a/itou/www/security/urls.py
+++ b/itou/www/security/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from itou.www.security import views
+
+
+urlpatterns = [
+    path(".well-known/security.txt", views.security_txt, name="security-txt"),
+]

--- a/itou/www/security/views.py
+++ b/itou/www/security/views.py
@@ -1,0 +1,13 @@
+from django.shortcuts import render
+from django.views.decorators.http import require_safe
+
+
+@require_safe
+def security_txt(request):
+    # https://www.rfc-editor.org/rfc/rfc9116
+    # https://securitytxt.org/ can be helpful in generating the document.
+    return render(
+        request,
+        template_name="static/security/security.txt",
+        content_type="text/plain; charset=utf-8",
+    )

--- a/tests/www/security.py
+++ b/tests/www/security.py
@@ -1,0 +1,19 @@
+import datetime
+import re
+
+from django.urls import reverse
+
+
+def test_security_txt_is_valid(client):
+    response = client.get(reverse("security-txt"))
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/plain; charset=utf-8"
+
+    expire_re = re.compile(r"^Expires: (?P<expires>.*)$")
+    for line in response.content.decode().splitlines():
+        if match := expire_re.match(line):
+            expiry = match.group("expires")
+            expiry = datetime.datetime.fromisoformat(expiry)
+            break
+
+    assert expiry - datetime.datetime.now(tz=datetime.timezone.utc) >= datetime.timedelta(days=14)


### PR DESCRIPTION
### Pourquoi ?

Faciliter la remontée de faille de sécurité en suivant la RFC 9116 [1].

[1] https://www.rfc-editor.org/rfc/rfc9116