### PR TITLE
metabase.job_applications: Fix contract_type

### DIFF
--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -288,7 +288,7 @@ TABLE.add_columns(
             "name": "type_contrat",
             "type": "varchar",
             "comment": "Type de contrat",
-            "fn": lambda o: o.contract_type.label if o.contract_type else "",
+            "fn": lambda o: o.contract_type if o.contract_type else "",
         },
     ]
 )

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -13,6 +13,7 @@ from itou.common_apps.address.departments import DEPARTMENTS
 from itou.eligibility.models import AdministrativeCriteria
 from itou.geo.utils import coords_to_geometry
 from itou.metabase.tables.utils import hash_content
+from itou.siaes.enums import ContractType
 from itou.siaes.models import SiaeJobDescription
 from itou.users.enums import IdentityProvider
 from tests.analytics.factories import DatumFactory, StatsDashboardVisitFactory
@@ -414,7 +415,7 @@ def test_populate_job_applications():
         kind="GEIQ",
     )
     job = SiaeJobDescriptionFactory(is_active=True, siae=siae)
-    ja = JobApplicationFactory()
+    ja = JobApplicationFactory(with_geiq_eligibility_diagnosis=True, contract_type=ContractType.APPRENTICESHIP)
     ja.selected_jobs.add(job)
 
     num_queries = 1  # Select siaes for get_active_siae_pks()


### PR DESCRIPTION
.label makes it crash.

We want the base value, not the french translation anyway. Let the analysts do their translation in a dashboard.
