### PR TITLE
Admin - Prolongation : Correction de l'affichage des actions envisagées

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -445,7 +445,7 @@ class ProlongationRequestAdmin(ProlongationCommonAdmin):
 
     @admin.display(description="actions envisagées")
     def denied_proposed_actions(self, obj):
-        if obj.proposed_actions is None:
+        if obj.deny_information.proposed_actions is None:
             return "-"
         return "\n".join(obj.deny_information.get_proposed_actions_display())
 


### PR DESCRIPTION
Un point en moins pour le fait d'avoir fait un modèle séparé, ou de ne pas avoir utiliser un _inline_ dans l'admin :grinning:.