### PR TITLE
Retrait de la cible PHONY run au profit de runserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ export PATH := $(VIRTUAL_ENV)/bin:$(PATH)
 
 VENV_REQUIREMENT := $(VIRTUAL_ENV)
 
-.PHONY: run venv clean quality fix compile-deps
+.PHONY: runserver venv clean quality fix compile-deps
 
 runserver: $(VIRTUAL_ENV)
 	python manage.py runserver


### PR DESCRIPTION
### Pourquoi ?

Cible `run` retirée dans 94db4cbac973724ceb1807bc6ab8a7a665a705d6.