### PR TITLE
Retirer fonts.googleapis.com de CSP_STYLE_SRC

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -605,7 +605,6 @@ CSP_STYLE_SRC = [
     "'self'",
     # It would be better to whilelist styles hashes but it's to much work for now.
     "'unsafe-inline'",
-    "https://fonts.googleapis.com/",  # Used in theme-inclusion
 ]
 CSP_FONT_SRC = [
     "'self'",


### PR DESCRIPTION
### Pourquoi ?

Les polices Google ne sont actuellement pas chargées (problème avec la CSP), et seront auto-hébergées avec la prochaine version du thème.

https://itou-inclusion.slack.com/archives/CQ6D0QPPZ/p1695300407115159?thread_ts=1695292442.473209&cid=CQ6D0QPPZ