### PR TITLE
Ne pas définir de mot de passe pour les utilisateurs créés via l’admin

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -333,7 +333,17 @@ class ItouUserAdmin(UserAdmin):
     assert "last_login" in fieldsets[-2][1]["fields"]
     fieldsets[-2][1]["fields"] += ("last_checked_at",)
 
-    add_fieldsets = UserAdmin.add_fieldsets + (
+    add_fieldsets = (
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "username",
+                    "email",
+                ),
+            },
+        ),
         (
             "Type d’utilisateur",
             {

--- a/itou/users/admin_forms.py
+++ b/itou/users/admin_forms.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 from django import forms
 from django.contrib.admin import widgets
-from django.contrib.auth.forms import UserChangeForm, UserCreationForm
+from django.contrib.auth.forms import UserChangeForm
 from django.core.exceptions import ValidationError
 
 from itou.users.enums import UserKind
@@ -10,10 +10,10 @@ from itou.users.models import User
 from itou.utils.apis.exceptions import AddressLookupError
 
 
-class ItouUserCreationForm(UserCreationForm):
-    class Meta(UserCreationForm.Meta):
-        model = User
-        fields = UserCreationForm.Meta.fields + ("kind",)
+class ItouUserCreationForm(forms.ModelForm):
+    def save(self, commit=True):
+        self.instance.set_unusable_password()
+        return super().save(commit=commit)
 
 
 class UserAdminForm(UserChangeForm):

--- a/itou/users/migrations/0001_initial.py
+++ b/itou/users/migrations/0001_initial.py
@@ -53,7 +53,6 @@ class Migration(migrations.Migration):
                 (
                     "email",
                     django.contrib.postgres.fields.citext.CIEmailField(
-                        blank=True,
                         db_index=True,
                         max_length=254,
                         null=True,

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -189,7 +189,6 @@ class User(AbstractUser, AddressMixin):
     )
     email = CIEmailField(
         "adresse e-mail",
-        blank=True,
         db_index=True,
         # Empty values are stored as NULL if both `null=True` and `unique=True` are set.
         # This avoids unique constraint violations when saving multiple objects with blank values.

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -20,8 +20,7 @@ def test_add_user(client):
         reverse("admin:users_user_add"),
         {
             "username": "foo",
-            "password1": "Véry_$S3C®3T!",
-            "password2": "Véry_$S3C®3T!",
+            "email": "foo@mailinator.com",
             "kind": UserKind.JOB_SEEKER,
             "utils-pksupportremark-content_type-object_id-INITIAL_FORMS": "0",
             "utils-pksupportremark-content_type-object_id-TOTAL_FORMS": "0",


### PR DESCRIPTION
### Pourquoi ?

Besoin identifié en journée support.