### PR TITLE
github: add check to detect fixup commits

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
### Pourquoi ?

Èviter de merger une PR en oubliant de squasher les fixups.
