### PR TITLE
Inscription : adapter le message aux GEIQ

### DIFF
--- a/itou/templates/signup/siae_select.html
+++ b/itou/templates/signup/siae_select.html
@@ -108,7 +108,11 @@
                                 {% endfor %}
 
                                 <p>
-                                    En cliquant sur "Envoyer ma demande de validation", un e-mail contenant un lien de confirmation sera envoyé au <b>correspondant technique de votre entreprise référencé dans l’extranet IAE 2.0 ou EA 2 de l'ASP</b>.
+                                    En cliquant sur "Envoyer ma demande de validation", un e-mail contenant un lien de confirmation sera envoyé au correspondant enregistré dans nos bases :
+                                    <br>
+                                    - Pour les SIAE et les EA, il s’agit du correspondant enregistré dans l’extranet IAE 2.0 ou EA 2 de l’ASP,
+                                    <br>
+                                    - Pour les GEIQ, il s’agit du correspondant enregistré dans la liste des GEIQ transmises par la FFGEIQ.
                                 </p>
                                 <div class="text-right">
                                     {% buttons %}


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/Ecran-d-inscription-Modifier-un-message-qui-n-est-pas-adapt-au-cas-des-GEIQ-boost-2069f423014a45ea98316f6f5b1a5128?pvs=4

### Pourquoi ?

 Le texte parle des correspondants ASP les geiq n’utilisent pas l’ASP

### Comment <!-- optionnel -->

modification du texte pour qu’il colle aux différentes situations

### Captures d'écran

![image](https://github.com/betagouv/itou/assets/11419273/26c12911-ef45-409e-9013-916b86f46f8f)