### PR TITLE
Admin - FS : Autoriser la modification de l'annexe financière

### DIFF
--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -158,6 +158,9 @@ class EmployeeRecordAdmin(ItouModelAdmin):
             return "Intégrée par l'ASP"
         return "-"
 
+    def has_add_permission(self, request):
+        return False
+
 
 @admin.register(models.EmployeeRecordUpdateNotification)
 class EmployeeRecordUpdateNotificationAdmin(ItouModelAdmin):


### PR DESCRIPTION
Besoin identifié suite au TZ 2982 

### Pourquoi ?

L'annexe financière est enregistrée sur la FS mais elle n'est pas utilisée dans les échanges avec l'ASP mais uniquement par les logiciels de gestion utilisant l'API FS.
Il arrive fréquemment d'avoir quelque ticket car l'employeur c'est trompé d'AF ou ne l'a pas remplis, le seul moyen pour modifier une FS est de repasser par le tunnel de création des FS ce qui est plus que problématique, par exemple si la FS a été intégrée elle sera donc renvoyée et reviendra "En Erreur"...
On peux donc se permettre l'édition de ce champs dans l'admin car il n'est que pour nous, donc même si une erreur était faite cela ne changerais rien pour les échanges avec l'ASP et nous serions en mesure de la corriger sans problème.
