### PR TITLE
Retirer une condition de la règle venv du Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,7 @@ runserver: $(VIRTUAL_ENV)
 $(VIRTUAL_ENV): $(REQUIREMENTS_PATH)
 	$(PYTHON_VERSION) -m venv $@
 	$@/bin/pip install -r $^
-ifeq ($(shell uname -s),Linux)
 	$@/bin/pip-sync $^
-endif
 	touch $@
 
 venv: $(VIRTUAL_ENV)


### PR DESCRIPTION
### Pourquoi ?

Plus utile depuis `dev-mac.txt` (3ff5f6182f4f9b55b2061b5d006680809d5fbbfa).

### Comment tester ?

Si `make venv` s’exécute bien (dans `itou_django` et sur votre machine hôte (= Mac)), tout va bien. :)