### PR TITLE
Définir EvaluatedSiae.verbose_name comme “entreprise contrôlée”

### DIFF
--- a/itou/siae_evaluations/migrations/0001_initial.py
+++ b/itou/siae_evaluations/migrations/0001_initial.py
@@ -118,7 +118,8 @@ class Migration(migrations.Migration):
                 ("reminder_sent_at", models.DateTimeField(blank=True, null=True, verbose_name="rappel envoyé le")),
             ],
             options={
-                "verbose_name": "entreprise",
+                "verbose_name": "entreprise contrôlée",
+                "verbose_name_plural": "entreprises contrôlées",
                 "unique_together": {("evaluation_campaign", "siae")},
             },
         ),

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -472,7 +472,8 @@ class EvaluatedSiae(models.Model):
     objects = EvaluatedSiaeQuerySet.as_manager()
 
     class Meta:
-        verbose_name = "entreprise"
+        verbose_name = "entreprise contrôlée"
+        verbose_name_plural = "entreprises contrôlées"
         unique_together = ("evaluation_campaign", "siae")
         constraints = [
             models.CheckConstraint(


### PR DESCRIPTION
### Pourquoi ?

Éviter la confusion avec `Siae.verbose_name`.