### PR TITLE
Ajout d'une colonne : motif_de_refus sur la table demandes_de_prolongation

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -375,7 +375,10 @@ class Command(BaseCommand):
         populate_table(prolongations.TABLE, batch_size=1000, querysets=[queryset])
 
     def populate_prolongation_requests(self):
-        queryset = ProlongationRequest.objects.select_related("prolongation").all()
+        queryset = ProlongationRequest.objects.select_related(
+            "prolongation",
+            "deny_information",
+        ).all()
         populate_table(prolongation_requests.TABLE, batch_size=1000, querysets=[queryset])
 
     def populate_institutions(self):

--- a/itou/metabase/tables/prolongation_requests.py
+++ b/itou/metabase/tables/prolongation_requests.py
@@ -33,6 +33,12 @@ TABLE.add_columns(
             "fn": lambda o: get_choice(choices=ProlongationRequestStatus.choices, key=o.status),
         },
         {
+            "name": "motif_de_refus",
+            "type": "varchar",
+            "comment": "Motif de refus de la demande",
+            "fn": lambda o: o.deny_information.reason,
+        },
+        {
             "name": "date_de_demande",
             "type": "date",
             "comment": "Date de la demande",

--- a/itou/metabase/tables/prolongations.py
+++ b/itou/metabase/tables/prolongations.py
@@ -10,6 +10,12 @@ TABLE = MetabaseTable(name="prolongations")
 TABLE.add_columns(
     get_common_prolongation_columns(get_field_fn=get_field)
     + [
+        {
+            "name": "date_de_création",
+            "type": "date",
+            "comment": "Date de création",
+            "fn": lambda o: o.created_at.date(),
+        },
         get_column_from_field(get_field("request_id"), name="id_demande_de_prolongation"),
     ]
 )

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -4,7 +4,15 @@ from operator import attrgetter
 
 from django.conf import settings
 from django.db.models import JSONField
-from django.db.models.fields import AutoField, CharField, DateField, PositiveIntegerField, TextField, UUIDField
+from django.db.models.fields import (
+    AutoField,
+    CharField,
+    DateField,
+    DateTimeField,
+    PositiveIntegerField,
+    TextField,
+    UUIDField,
+)
 from django.db.models.fields.related import ForeignKey
 from django.utils import timezone
 
@@ -46,6 +54,8 @@ def get_field_type_from_field(field):
         return "integer"
     if isinstance(field, UUIDField):
         return "uuid"
+    if isinstance(field, DateTimeField):
+        return "timestamp with time zone"
     if isinstance(field, DateField):
         return "date"
     if isinstance(field, ForeignKey):

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -20,6 +20,7 @@ from tests.analytics.factories import DatumFactory, StatsDashboardVisitFactory
 from tests.approvals.factories import (
     ApprovalFactory,
     PoleEmploiApprovalFactory,
+    ProlongationRequestDenyInformationFactory,
     ProlongationWithRequestFactory,
 )
 from tests.eligibility.factories import EligibilityDiagnosisFactory
@@ -607,6 +608,7 @@ def test_populate_prolongations():
                 prolongation.declared_by_siae_id,
                 prolongation.validated_by_id,
                 prolongation.prescriber_organization_id,
+                prolongation.created_at.date(),
                 prolongation_request.pk,
                 datetime.date(2023, 2, 1),
             ),
@@ -619,6 +621,9 @@ def test_populate_prolongations():
 def test_populate_prolongation_requests():
     prolongation = ProlongationWithRequestFactory()
     prolongation_request = prolongation.request
+
+    deny_information = ProlongationRequestDenyInformationFactory.build(request=None)
+    prolongation_request.deny(prolongation_request.validated_by, deny_information)
 
     num_queries = 1  # Count prolongation_requests
     num_queries += 1  # COMMIT Queryset counts (autocommit mode)
@@ -649,6 +654,7 @@ def test_populate_prolongation_requests():
                 prolongation_request.prescriber_organization_id,
                 prolongation.pk,
                 prolongation_request.get_status_display(),
+                str(deny_information.reason),
                 prolongation_request.created_at.date(),
                 prolongation_request.processed_at,
                 prolongation_request.processed_by_id,


### PR DESCRIPTION
**Carte Notion : **

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

A la demande du métier, ajout de la colonne motif_de_refus sur la tble demandes_de_prolongation

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

