### PR TITLE
Stats : Ajout de stats sur les demandes de prolongations pour les DDETS IAE et DREETS IAE

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -111,6 +111,13 @@
                             <span>Suivre le contrôle à posteriori</span>
                         </a>
                     </li>
+                    <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="{% url 'stats:stats_ddets_iae_follow_prolongation' %}" class="btn-link btn-ico">
+                            <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
+                            <span>Suivre les demandes de prolongation</span>
+                        </a>
+                        <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
+                    </li>
                     <!-- Stats temporarily suspended until we stabilize them
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ddets_iae_iae' %}" class="btn-link btn-ico">
@@ -146,6 +153,13 @@
                             <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                             <span>Suivre le contrôle à posteriori</span>
                         </a>
+                    </li>
+                    <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="{% url 'stats:stats_dreets_iae_follow_prolongation' %}" class="btn-link btn-ico">
+                            <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
+                            <span>Suivre les demandes de prolongation</span>
+                        </a>
+                        <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
                     </li>
                     <!-- Stats temporarily suspended until we stabilize them
                         <li class="d-flex justify-content-between align-items-center mb-3">

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -96,6 +96,9 @@ METABASE_DASHBOARDS = {
         "tally_popup_form_id": "w2XZxV",
         "tally_embed_form_id": "n9Ba6G",
     },
+    "stats_ddets_iae_follow_prolongation": {
+        "dashboard_id": 357,
+    },
     "stats_ddets_iae_iae": {
         "dashboard_id": 117,
     },
@@ -127,6 +130,9 @@ METABASE_DASHBOARDS = {
         "dashboard_id": 265,
         "tally_popup_form_id": "w2XZxV",
         "tally_embed_form_id": "n9Ba6G",
+    },
+    "stats_dreets_iae_follow_prolongation": {
+        "dashboard_id": 357,
     },
     "stats_dreets_iae_iae": {
         "dashboard_id": 117,

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -41,6 +41,11 @@ urlpatterns = [
         views.stats_ddets_iae_follow_siae_evaluation,
         name="stats_ddets_iae_follow_siae_evaluation",
     ),
+    path(
+        "ddets/follow_prolongation",
+        views.stats_ddets_iae_follow_prolongation,
+        name="stats_ddets_iae_follow_prolongation",
+    ),
     path("ddets/iae", views.stats_ddets_iae_iae, name="stats_ddets_iae_iae"),
     path("ddets/siae_evaluation", views.stats_ddets_iae_siae_evaluation, name="stats_ddets_iae_siae_evaluation"),
     path("ddets/hiring", views.stats_ddets_iae_hiring, name="stats_ddets_iae_hiring"),
@@ -56,6 +61,11 @@ urlpatterns = [
         "dreets/follow_siae_evaluation",
         views.stats_dreets_iae_follow_siae_evaluation,
         name="stats_dreets_iae_follow_siae_evaluation",
+    ),
+    path(
+        "dreets/follow_prolongation",
+        views.stats_dreets_iae_follow_prolongation,
+        name="stats_dreets_iae_follow_prolongation",
     ),
     path("dreets/iae", views.stats_dreets_iae_iae, name="stats_dreets_iae_iae"),
     path("dreets/hiring", views.stats_dreets_iae_hiring, name="stats_dreets_iae_hiring"),

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -416,6 +416,11 @@ def stats_ddets_iae_follow_siae_evaluation(request):
 
 
 @login_required
+def stats_ddets_iae_follow_prolongation(request):
+    return render_stats_ddets_iae(request=request, page_title="Suivi des demandes de prolongation")
+
+
+@login_required
 def stats_ddets_iae_iae(request):
     return render_stats_ddets_iae(request=request, page_title="Données IAE de mon département")
 
@@ -479,6 +484,11 @@ def stats_dreets_iae_auto_prescription(request):
 @login_required
 def stats_dreets_iae_follow_siae_evaluation(request):
     return render_stats_dreets_iae(request=request, page_title="Suivi du contrôle à posteriori")
+
+
+@login_required
+def stats_dreets_iae_follow_prolongation(request):
+    return render_stats_dreets_iae(request=request, page_title="Suivi des demandes de prolongation")
 
 
 @login_required

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -155,6 +155,7 @@ def test_stats_siae_log_visit(client, view_name, settings):
     [
         "stats_ddets_iae_auto_prescription",
         "stats_ddets_iae_follow_siae_evaluation",
+        "stats_ddets_iae_follow_prolongation",
         "stats_ddets_iae_iae",
         "stats_ddets_iae_siae_evaluation",
         "stats_ddets_iae_hiring",
@@ -196,6 +197,7 @@ def test_stats_ddets_iae_log_visit(client, view_name):
     [
         "stats_dreets_iae_auto_prescription",
         "stats_dreets_iae_follow_siae_evaluation",
+        "stats_dreets_iae_follow_prolongation",
         "stats_dreets_iae_iae",
         "stats_dreets_iae_hiring",
     ],


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Prio-1-Vermeer-Mettre-en-production-un-tableau-de-bord-priv-Suivi-des-prolongations-pour-les-DDE-a13e85bde14c434e9a2534ae42b8d418**

### Pourquoi ?

Les DDETS et DREETS sont demandeuses de telles stats de suivi des prolongations.

### Captures d'écran

![image](https://github.com/betagouv/itou/assets/10533583/2db0163b-d2e4-41d0-ae87-6292c16840f1)

![image](https://github.com/betagouv/itou/assets/10533583/6c22c2ca-01be-48a7-aa8f-0478aac648a1)


