### PR TITLE
Suppression des vues dépréciées de changement d'organisation

### DIFF
--- a/itou/www/dashboard/urls.py
+++ b/itou/www/dashboard/urls.py
@@ -15,11 +15,6 @@ urlpatterns = [
     path("edit_job_seeker_info/<uuid:job_application_id>", views.edit_job_seeker_info, name="edit_job_seeker_info"),
     path("edit_job_seeker_info/<int:job_seeker_pk>", views.edit_job_seeker_info, name="edit_job_seeker_info"),
     path("switch-organization", views.switch_organization, name="switch_organization"),
-    path("switch_siae", views.switch_siae, name="switch_siae"),
-    path(
-        "switch_prescriber_organization", views.switch_prescriber_organization, name="switch_prescriber_organization"
-    ),
-    path("switch_institution", views.switch_institution, name="switch_institution"),
     path(
         "activate_ic_account",
         views.AccountMigrationView.as_view(),

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -338,56 +338,6 @@ def switch_organization(request):
     return HttpResponseRedirect(reverse("dashboard:index"))
 
 
-# TODO(xfernandez): remove those switch_xxx views in a week when
-# most users will have reloaded their pages
-@login_required
-@require_POST
-def switch_siae(request):
-    """
-    Switch to the dashboard of another SIAE of the same SIREN.
-    """
-    dashboard_url = reverse_lazy("dashboard:index")
-
-    pk = request.POST["siae_id"]
-    queryset = Siae.objects.active_or_in_grace_period().member_required(request.user)
-    siae = get_object_or_404(queryset, pk=pk)
-    request.session[global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY] = siae.pk
-
-    return HttpResponseRedirect(dashboard_url)
-
-
-@login_required
-@require_POST
-def switch_prescriber_organization(request):
-    """
-    Switch prescriber organization for a user with multiple memberships.
-    """
-    dashboard_url = reverse_lazy("dashboard:index")
-
-    pk = request.POST["prescriber_organization_id"]
-    queryset = PrescriberOrganization.objects.member_required(request.user)
-    prescriber_organization = get_object_or_404(queryset, pk=pk)
-    request.session[global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY] = prescriber_organization.pk
-
-    return HttpResponseRedirect(dashboard_url)
-
-
-@login_required
-@require_POST
-def switch_institution(request):
-    """
-    Switch prescriber organization for a user with multiple memberships.
-    """
-    dashboard_url = reverse_lazy("dashboard:index")
-
-    pk = request.POST["institution_id"]
-    queryset = Institution.objects.member_required(request.user)
-    institution = get_object_or_404(queryset, pk=pk)
-    request.session[global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY] = institution.pk
-
-    return HttpResponseRedirect(dashboard_url)
-
-
 @login_required
 def edit_user_notifications(request, template_name="dashboard/edit_user_notifications.html"):
     if not request.user.is_siae_staff:

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -1404,10 +1404,7 @@ class EditUserEmailFormTest(TestCase):
         assert form.is_valid()
 
 
-class SwitchSiaeTest:
-    switch_view_name = None
-    switch_POST_key = None
-
+class SwitchSiaeTest(TestCase):
     def test_switch_siae(self):
         siae = SiaeFactory(with_membership=True)
         user = siae.members.first()
@@ -1427,8 +1424,8 @@ class SwitchSiaeTest:
         assert response.context["request"].current_organization == siae
         assert response.context["siae"] == siae
 
-        url = reverse(self.switch_view_name)
-        response = self.client.post(url, data={self.switch_POST_key: related_siae.pk})
+        url = reverse("dashboard:switch_organization")
+        response = self.client.post(url, data={"organization_id": related_siae.pk})
         assert response.status_code == 302
 
         url = reverse("dashboard:index")
@@ -1465,8 +1462,8 @@ class SwitchSiaeTest:
         assert response.status_code == 200
         assert response.context["request"].current_organization == siae
 
-        url = reverse(self.switch_view_name)
-        response = self.client.post(url, data={self.switch_POST_key: related_siae.pk})
+        url = reverse("dashboard:switch_organization")
+        response = self.client.post(url, data={"organization_id": related_siae.pk})
         assert response.status_code == 302
 
         # User has indeed switched.
@@ -1490,8 +1487,8 @@ class SwitchSiaeTest:
 
         # Switching to that siae is not even possible in practice because
         # it does not even show up in the menu.
-        url = reverse(self.switch_view_name)
-        response = self.client.post(url, data={self.switch_POST_key: related_siae.pk})
+        url = reverse("dashboard:switch_organization")
+        response = self.client.post(url, data={"organization_id": related_siae.pk})
         assert response.status_code == 404
 
         # User is still working on the main active siae.
@@ -1499,11 +1496,6 @@ class SwitchSiaeTest:
         response = self.client.get(url)
         assert response.status_code == 200
         assert response.context["request"].current_organization == siae
-
-
-class NewSwitchSiaeTest(SwitchSiaeTest, TestCase):
-    switch_view_name = "dashboard:switch_organization"
-    switch_POST_key = "organization_id"
 
 
 class EditUserPreferencesTest(TestCase):
@@ -1639,10 +1631,7 @@ class EditUserPreferencesExceptionsTest(TestCase):
         assert response.status_code == 403
 
 
-class SwitchOrganizationTest:
-    switch_view_name = None
-    switch_POST_key = None
-
+class SwitchOrganizationTest(TestCase):
     def test_not_allowed_user(self):
         organization = prescribers_factories.PrescriberOrganizationFactory()
 
@@ -1651,26 +1640,26 @@ class SwitchOrganizationTest:
             PrescriberFactory(),
         ):
             self.client.force_login(user)
-            url = reverse(self.switch_view_name)
-            response = self.client.post(url, data={self.switch_POST_key: organization.pk})
+            url = reverse("dashboard:switch_organization")
+            response = self.client.post(url, data={"organization_id": organization.pk})
             assert response.status_code == 404
 
     def test_usual_case(self):
-        url = reverse(self.switch_view_name)
+        url = reverse("dashboard:switch_organization")
 
         user = PrescriberFactory()
         orga1 = prescribers_factories.PrescriberMembershipFactory(user=user).organization
         orga2 = prescribers_factories.PrescriberMembershipFactory(user=user).organization
         self.client.force_login(user)
 
-        response = self.client.post(url, data={self.switch_POST_key: orga1.pk})
+        response = self.client.post(url, data={"organization_id": orga1.pk})
         assert response.status_code == 302
 
         response = self.client.get(reverse("dashboard:index"))
         assert response.status_code == 200
         assert response.context["request"].current_organization == orga1
 
-        response = self.client.post(url, data={self.switch_POST_key: orga2.pk})
+        response = self.client.post(url, data={"organization_id": orga2.pk})
         assert response.status_code == 302
 
         response = self.client.get(reverse("dashboard:index"))
@@ -1678,15 +1667,7 @@ class SwitchOrganizationTest:
         assert response.context["request"].current_organization == orga2
 
 
-class NewSwitchOrganizationTest(SwitchOrganizationTest, TestCase):
-    switch_view_name = "dashboard:switch_organization"
-    switch_POST_key = "organization_id"
-
-
-class SwitchInstitutionTest:
-    switch_view_name = None
-    switch_POST_key = None
-
+class SwitchInstitutionTest(TestCase):
     def test_not_allowed_user(self):
         institution = InstitutionFactory()
 
@@ -1697,36 +1678,31 @@ class SwitchInstitutionTest:
             InstitutionMembershipFactory().user,
         ):
             self.client.force_login(user)
-            url = reverse(self.switch_view_name)
-            response = self.client.post(url, data={self.switch_POST_key: institution.pk})
+            url = reverse("dashboard:switch_organization")
+            response = self.client.post(url, data={"organization_id": institution.pk})
             assert response.status_code == 404
 
     def test_usual_case(self):
-        url = reverse(self.switch_view_name)
+        url = reverse("dashboard:switch_organization")
 
         user = LaborInspectorFactory()
         institution1 = InstitutionMembershipFactory(user=user).institution
         institution2 = InstitutionMembershipFactory(user=user).institution
         self.client.force_login(user)
 
-        response = self.client.post(url, data={self.switch_POST_key: institution1.pk})
+        response = self.client.post(url, data={"organization_id": institution1.pk})
         assert response.status_code == 302
 
         response = self.client.get(reverse("dashboard:index"))
         assert response.status_code == 200
         assert response.context["request"].current_organization == institution1
 
-        response = self.client.post(url, data={self.switch_POST_key: institution2.pk})
+        response = self.client.post(url, data={"organization_id": institution2.pk})
         assert response.status_code == 302
 
         response = self.client.get(reverse("dashboard:index"))
         assert response.status_code == 200
         assert response.context["request"].current_organization == institution2
-
-
-class NewSwitchInstitutionTest(SwitchInstitutionTest, TestCase):
-    switch_view_name = "dashboard:switch_organization"
-    switch_POST_key = "organization_id"
 
 
 TOKEN_MENU_STR = "Accès aux APIs"

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -1501,11 +1501,6 @@ class SwitchSiaeTest:
         assert response.context["request"].current_organization == siae
 
 
-class OldSwitchSiaeTest(SwitchSiaeTest, TestCase):
-    switch_view_name = "dashboard:switch_siae"
-    switch_POST_key = "siae_id"
-
-
 class NewSwitchSiaeTest(SwitchSiaeTest, TestCase):
     switch_view_name = "dashboard:switch_organization"
     switch_POST_key = "organization_id"
@@ -1683,11 +1678,6 @@ class SwitchOrganizationTest:
         assert response.context["request"].current_organization == orga2
 
 
-class OldSwitchOrganizationTest(SwitchOrganizationTest, TestCase):
-    switch_view_name = "dashboard:switch_prescriber_organization"
-    switch_POST_key = "prescriber_organization_id"
-
-
 class NewSwitchOrganizationTest(SwitchOrganizationTest, TestCase):
     switch_view_name = "dashboard:switch_organization"
     switch_POST_key = "organization_id"
@@ -1732,11 +1722,6 @@ class SwitchInstitutionTest:
         response = self.client.get(reverse("dashboard:index"))
         assert response.status_code == 200
         assert response.context["request"].current_organization == institution2
-
-
-class OldSwitchInstitutionTest(SwitchInstitutionTest, TestCase):
-    switch_view_name = "dashboard:switch_institution"
-    switch_POST_key = "institution_id"
 
 
 class NewSwitchInstitutionTest(SwitchInstitutionTest, TestCase):


### PR DESCRIPTION
### Pourquoi ?

Suite de #3010

Cela fait maintenant ~ 2 semaines que la PR a été mergée, il y a peu de chance qu'un utilisateur ait encore une page chargée pointant vers une de ces anciennes URLs.
