### PR TITLE
Fiches salarié : Ne pas archiver celles modifiés récemment

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -135,7 +135,8 @@ class EmployeeRecordQuerySet(models.QuerySet):
             )
             .filter(
                 approval_is_valid=False,
-                created_at__lt=timezone.now() - relativedelta(months=6),  # Keep them at least 6 months
+                created_at__lt=timezone.now() - relativedelta(months=6),  # 6-months grace period if recently created
+                updated_at__lt=timezone.now() - relativedelta(months=1),  # 1-month grace period if recently updated
             )
         )
 

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -126,7 +126,6 @@ class EmployeeRecordQuerySet(models.QuerySet):
         return self.filter(asp_batch_file=filename, asp_batch_line_number=line_number)
 
     def archivable(self):
-        prolongation_cutoff = timezone.now()
         return (
             self.annotate(
                 approval_is_valid=Exists(Approval.objects.filter(number=OuterRef("approval_number")).valid())
@@ -136,7 +135,6 @@ class EmployeeRecordQuerySet(models.QuerySet):
             )
             .filter(
                 approval_is_valid=False,
-                job_application__approval__end_at__lt=prolongation_cutoff,
                 created_at__lt=timezone.now() - relativedelta(months=6),  # Keep them at least 6 months
             )
         )

--- a/tests/employee_record/test_archive_employee_records.py
+++ b/tests/employee_record/test_archive_employee_records.py
@@ -36,5 +36,5 @@ def test_management_command_wet_run(command, snapshot):
     assert command.stdout.getvalue() == snapshot
 
 
-def test_management_command_name(faker):
+def test_management_command_name():
     call_command("archive_employee_records")

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -191,11 +191,16 @@ class EmployeeRecordModelTest(TestCase):
                 self.faker.date_time_between(start_date="-1y", end_date="-6M", tzinfo=datetime.UTC),
                 self.faker.date_time_between(start_date="-6M", tzinfo=datetime.UTC),
             ],
+            [
+                self.faker.date_time_between(start_date="-1y", end_date="-1M", tzinfo=datetime.UTC),
+                self.faker.date_time_between(start_date="-1M", tzinfo=datetime.UTC),
+            ],
         )
-        for expired, created_at in parameters:
+        for expired, created_at, updated_at in parameters:
             EmployeeRecordFactory(
                 job_application__approval__expired=expired,
                 created_at=created_at,
+                updated_at=updated_at,
             )
 
         assert EmployeeRecord.objects.archivable().count() == 1

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -185,26 +185,27 @@ class EmployeeRecordModelTest(TestCase):
         assert result.id == employee_record.id
 
     def test_archivable(self):
-        # note (fV): test updated because prolongation validity period has changed (impacting approval validity dates)
         parameters = itertools.product(
             [False, True],
-            [
-                self.faker.date_time_between(start_date="-1y", end_date="-3M", tzinfo=datetime.UTC),
-                self.faker.date_time_between(start_date="-3M", tzinfo=datetime.UTC),
-            ],
             [
                 self.faker.date_time_between(start_date="-1y", end_date="-6M", tzinfo=datetime.UTC),
                 self.faker.date_time_between(start_date="-6M", tzinfo=datetime.UTC),
             ],
         )
-        for expired, end_at, created_at in parameters:
+        for expired, created_at in parameters:
             EmployeeRecordFactory(
                 job_application__approval__expired=expired,
-                job_application__approval__end_at=end_at,
                 created_at=created_at,
             )
 
-        assert EmployeeRecord.objects.archivable().count() == 2
+        assert EmployeeRecord.objects.archivable().count() == 1
+
+    def test_archivable_with_archived_employee_record(self):
+        EmployeeRecordFactory(
+            status=Status.ARCHIVED,
+            archivable=True,
+        )
+        assert EmployeeRecord.objects.archivable().count() == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Pourquoi ?

On peux se retrouver dans le cas où un employeur nous demande à renvoyer une FS pour un PASS IAE déjà expiré, dans cette situation la FS aura été passée en `ARCHIVED` et ne sera donc plus utilisable, modifier le statut peux suffire mais demande de se coordonner avec l'employeur pour qu'il la complète avant que le cron d'archivage ne repasse, ce n'est pas le plus pratique :).

### Comment ?

Ajout d'une nouvelle clause dans `EmployeeRecordQuerySet().archivable()`