### PR TITLE
fix: first and last name were inverted in applicants API

### DIFF
--- a/itou/api/applicants_api/serializers.py
+++ b/itou/api/applicants_api/serializers.py
@@ -7,8 +7,8 @@ class ApplicantSerializer(serializers.ModelSerializer):
     """Applicant serializer: job seeker field of a job application"""
 
     civilite = serializers.SerializerMethodField()
-    nom = serializers.CharField(source="first_name")
-    prenom = serializers.CharField(source="last_name")
+    nom = serializers.CharField(source="last_name")
+    prenom = serializers.CharField(source="first_name")
     courriel = serializers.CharField(source="email")
     telephone = serializers.CharField(source="phone")
     adresse = serializers.CharField(source="address_line_1")

--- a/tests/api/applicants_api/tests.py
+++ b/tests/api/applicants_api/tests.py
@@ -125,8 +125,8 @@ class ApplicantsAPITest(APITestCase):
         ):
             assert {
                 "civilite": job_seeker.title,
-                "nom": job_seeker.first_name,
-                "prenom": job_seeker.last_name,
+                "nom": job_seeker.last_name,
+                "prenom": job_seeker.first_name,
                 "courriel": job_seeker.email,
                 "telephone": job_seeker.phone,
                 "adresse": job_seeker.address_line_1,


### PR DESCRIPTION
### Pourquoi ?

Oups. tout est dans le titre.

