### PR TITLE
Run git fixup check in merge queue only

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,6 +1,6 @@
 name: Git Checks
 
-on: [pull_request]
+on: [merge_group]
 
 jobs:
   block-fixup:


### PR DESCRIPTION
### Pourquoi ?

Pour pouvoir mettre ce check comme bloquant l'intégration dans master sans bloquer la merge queue

