### PR TITLE
Activation de l'option FAIL_INVALID_TEMPLATE_VARS de pytest-django

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = config.settings.test
+FAIL_INVALID_TEMPLATE_VARS = True
 python_files = tests*.py test_*.py
 filterwarnings =
     error

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -786,6 +786,10 @@ parso==0.8.3 \
     --hash=sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0 \
     --hash=sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75
     # via jedi
+patchy==2.8.0 \
+    --hash=sha256:0b7837f90f9729361a2a8ae7daef3a42bb81a8346d27945c125e312c3fe0fd05 \
+    --hash=sha256:ae7fbcdde436272fb32485e4392c2b3cd2d0c1ac91b0af76b41242e92ff084ec
+    # via -r requirements/test.txt
 pathspec==0.11.1 \
     --hash=sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687 \
     --hash=sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -14,6 +14,7 @@ shellcheck-py  # https://github.com/shellcheck-py/shellcheck-py
 beautifulsoup4  # https://code.launchpad.net/beautifulsoup
 factory-boy  # https://github.com/FactoryBoy/factory_boy
 freezegun  # https://github.com/spulec/freezegun
+patchy  # https://github.com/adamchainz/patchy
 pytest  # https://github.com/pytest-dev/pytest
 pytest-django # https://github.com/pytest-dev/pytest-django/
 pytest-mock  # https://github.com/pytest-dev/pytest-mock/

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -695,6 +695,10 @@ paramiko==3.3.1 \
     --hash=sha256:6a3777a961ac86dbef375c5f5b8d50014a1a96d0fd7f054a43bc880134b0ff77 \
     --hash=sha256:b7bc5340a43de4287bbe22fe6de728aa2c22468b2a849615498dd944c2f275eb
     # via -r requirements/base.txt
+patchy==2.8.0 \
+    --hash=sha256:0b7837f90f9729361a2a8ae7daef3a42bb81a8346d27945c125e312c3fe0fd05 \
+    --hash=sha256:ae7fbcdde436272fb32485e4392c2b3cd2d0c1ac91b0af76b41242e92ff084ec
+    # via -r requirements/test.in
 pathspec==0.11.1 \
     --hash=sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687 \
     --hash=sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293

--- a/tests/allauth_adapters/peamu/tests.py
+++ b/tests/allauth_adapters/peamu/tests.py
@@ -2,6 +2,7 @@
 # https://github.com/pennersr/django-allauth/blob/master/allauth/socialaccount/providers/google/tests.py
 from unittest import mock
 
+import pytest
 from allauth.account.models import EmailAddress, EmailConfirmation
 from allauth.account.signals import user_signed_up
 from allauth.socialaccount.models import SocialAccount
@@ -17,6 +18,9 @@ from itou.users.models import User
 from itou.utils import constants as global_constants
 from tests.users.factories import JobSeekerFactory
 from tests.utils.test import TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 @override_settings(

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -43,6 +43,9 @@ from tests.users.factories import ItouStaffFactory, JobSeekerFactory
 from tests.utils.test import TestCase, assertMessages
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 class CommonApprovalQuerySetTest(TestCase):
     def test_valid_for_pole_emploi_approval_model(self):
         start_at = timezone.localdate() - relativedelta(years=1)

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -59,6 +59,9 @@ from tests.users.factories import ItouStaffFactory, JobSeekerFactory, Prescriber
 from tests.utils.test import TestCase, get_rows_from_streaming_response
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 @override_settings(
     API_ESD={
         "BASE_URL": "https://base.domain",

--- a/tests/openid_connect/inclusion_connect/tests.py
+++ b/tests/openid_connect/inclusion_connect/tests.py
@@ -44,6 +44,8 @@ from tests.users.factories import (
 from tests.utils.test import assertMessages
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
 OIDC_USERINFO = {
     "given_name": "Michel",
     "family_name": "AUDIARD",

--- a/tests/settings_viewer/tests.py
+++ b/tests/settings_viewer/tests.py
@@ -6,6 +6,9 @@ from pytest_django.asserts import assertContains, assertNotContains
 from tests.users.factories import ItouStaffFactory
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 @pytest.mark.filterwarnings(
     "ignore:"
     "The DEFAULT_FILE_STORAGE setting is deprecated. Use STORAGES instead.:"

--- a/tests/status/tests.py
+++ b/tests/status/tests.py
@@ -3,6 +3,7 @@ import textwrap
 from unittest import mock
 
 import factory
+import pytest
 from django import urls
 from django.core import management
 from django.utils import timezone
@@ -13,6 +14,8 @@ from itou.status.management.commands import run_status_probes
 from tests.status import factories
 from tests.utils.test import TestCase
 
+
+pytestmark = pytest.mark.ignore_template_errors
 
 fake = Faker()
 

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
@@ -11,6 +12,9 @@ from itou.utils.models import PkSupportRemark
 from tests.job_applications.factories import JobApplicationFactory
 from tests.users.factories import ItouStaffFactory, JobSeekerFactory
 from tests.utils.test import assertMessages
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 def test_add_user(client):

--- a/tests/utils/htmx/tests.py
+++ b/tests/utils/htmx/tests.py
@@ -9,6 +9,9 @@ from tests.utils.htmx.test import HtmxTestCase, assertSoupEqual, update_page_wit
 from tests.utils.test import parse_response_to_soup
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 # Unittest style
 class HtmxRequestFactoryTest(HtmxTestCase):
     def test_get(self):

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -82,6 +82,9 @@ from tests.users.factories import (
 from tests.utils.test import TestCase, assertMessagesFromRequest, parse_response_to_soup
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 def get_response_for_middlewaremixin(request):
     """
     `SessionMiddleware` inherits from `MiddlewareMixin` which requires

--- a/tests/www/api/tests.py
+++ b/tests/www/api/tests.py
@@ -1,6 +1,10 @@
+import pytest
 from django.conf import settings
 from django.urls import reverse
 from pytest_django.asserts import assertContains
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 def test_index(client):

--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -1,3 +1,4 @@
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.test import TestCase
 from django.urls import reverse
@@ -11,6 +12,9 @@ from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from tests.siaes.factories import SiaeWithMembershipAndJobsFactory
 from tests.users.factories import JobSeekerFactory, JobSeekerWithAddressFactory
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class JobApplicationGEIQEligibilityDetailsTest(TestCase):

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -1,6 +1,7 @@
 import datetime
 import uuid
 
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.contrib import messages
 from django.test import override_settings
@@ -45,6 +46,9 @@ from tests.users.factories import (
 )
 from tests.utils.storage.test import S3AccessingTestCase
 from tests.utils.test import TestCase, assertMessages
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class ApplyTest(S3AccessingTestCase):

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -61,6 +61,9 @@ from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, Prescriber
 from tests.utils.test import TestCase, parse_response_to_soup
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 class DashboardViewTest(TestCase):
     NO_PRESCRIBER_ORG_MSG = "Votre compte utilisateur n’est rattaché à aucune organisation."
     NO_PRESCRIBER_ORG_FOR_PE_MSG = (

--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -18,6 +18,9 @@ from tests.users.factories import JobSeekerWithAddressFactory, JobSeekerWithMock
 from tests.utils.test import TestCase
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 # Helper functions
 def _get_user_form_data(user):
     form_data = {

--- a/tests/www/employee_record_views/test_disable.py
+++ b/tests/www/employee_record_views/test_disable.py
@@ -10,6 +10,9 @@ from tests.siaes.factories import SiaeWithMembershipAndJobsFactory
 from tests.utils.test import TestCase
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 @pytest.mark.usefixtures("unittest_compatibility")
 class DisableEmployeeRecordsTest(TestCase):
     def setUp(self):

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -16,6 +16,9 @@ from tests.siaes.factories import SiaeWithMembershipAndJobsFactory
 from tests.utils.test import BASE_NUM_QUERIES, TestCase
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 @pytest.mark.usefixtures("unittest_compatibility")
 class ListEmployeeRecordsTest(TestCase):
     def setUp(self):

--- a/tests/www/employee_record_views/test_reactivate.py
+++ b/tests/www/employee_record_views/test_reactivate.py
@@ -9,6 +9,9 @@ from tests.siaes.factories import SiaeWithMembershipAndJobsFactory
 from tests.utils.test import TestCase
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 @pytest.mark.usefixtures("unittest_compatibility")
 class ReactivateEmployeeRecordsTest(TestCase):
     def setUp(self):

--- a/tests/www/employee_record_views/test_summary.py
+++ b/tests/www/employee_record_views/test_summary.py
@@ -1,9 +1,13 @@
+import pytest
 from django.urls import reverse
 
 from tests.employee_record.factories import EmployeeRecordUpdateNotificationFactory, EmployeeRecordWithProfileFactory
 from tests.job_applications.factories import JobApplicationWithCompleteJobSeekerProfileFactory
 from tests.siaes.factories import SiaeWithMembershipAndJobsFactory
 from tests.utils.test import TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class SummaryEmployeeRecordsTest(TestCase):

--- a/tests/www/home/tests.py
+++ b/tests/www/home/tests.py
@@ -1,7 +1,11 @@
+import pytest
 from django.urls import reverse
 
 from tests.users.factories import PrescriberFactory
 from tests.utils.test import TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class SearchSiaeTest(TestCase):

--- a/tests/www/invitations_views/test_new_user.py
+++ b/tests/www/invitations_views/test_new_user.py
@@ -1,6 +1,10 @@
 import uuid
 
+import pytest
 from django.shortcuts import reverse
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class TestNewUser:

--- a/tests/www/invitations_views/test_prescriber_organization.py
+++ b/tests/www/invitations_views/test_prescriber_organization.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from urllib.parse import urlencode
 
+import pytest
 import respx
 from allauth.account.models import EmailAddress
 from django.conf import settings
@@ -24,6 +25,9 @@ from tests.prescribers.factories import PrescriberOrganizationWithMembershipFact
 from tests.siaes.factories import SiaeFactory
 from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory
 from tests.utils.test import TestCase, assertMessages
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 POST_DATA = {

--- a/tests/www/invitations_views/test_siae_accept.py
+++ b/tests/www/invitations_views/test_siae_accept.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlencode
 
+import pytest
 import respx
 from django.conf import settings
 from django.contrib import messages
@@ -19,6 +20,9 @@ from tests.prescribers.factories import PrescriberOrganizationWithMembershipFact
 from tests.siaes.factories import SiaeFactory
 from tests.users.factories import SiaeStaffFactory
 from tests.utils.test import assertMessages
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class TestAcceptInvitation(InclusionConnectBaseTestCase):

--- a/tests/www/invitations_views/test_siae_send.py
+++ b/tests/www/invitations_views/test_siae_send.py
@@ -1,3 +1,4 @@
+import pytest
 from django.core import mail
 from django.shortcuts import reverse
 from django.utils import timezone
@@ -10,6 +11,9 @@ from tests.prescribers.factories import PrescriberOrganizationWithMembershipFact
 from tests.siaes.factories import SiaeFactory, SiaeMembershipFactory
 from tests.users.factories import JobSeekerFactory, SiaeStaffFactory
 from tests.utils.test import TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 INVITATION_URL = reverse("invitations_views:invite_siae_staff")

--- a/tests/www/login/tests.py
+++ b/tests/www/login/tests.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlencode
 
+import pytest
 import respx
 from django.contrib import messages
 from django.test import override_settings
@@ -24,6 +25,9 @@ from tests.users.factories import (
     SiaeStaffFactory,
 )
 from tests.utils.test import TestCase, assertMessages, reload_module
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class ItouLoginTest(TestCase):

--- a/tests/www/prescribers_views/test_edit.py
+++ b/tests/www/prescribers_views/test_edit.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pytest
 from django.urls import reverse
 from pytest_django.asserts import assertContains
 
@@ -8,6 +9,9 @@ from itou.prescribers.models import PrescriberOrganization
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
 from tests.prescribers.factories import PrescriberOrganizationFactory, PrescriberOrganizationWithMembershipFactory
 from tests.utils.test import TestCase, parse_response_to_soup
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class CardViewTest(TestCase):

--- a/tests/www/prescribers_views/test_members.py
+++ b/tests/www/prescribers_views/test_members.py
@@ -1,3 +1,4 @@
+import pytest
 from django.core import mail
 from django.urls import reverse
 
@@ -7,6 +8,9 @@ from tests.prescribers.factories import (
     PrescriberOrganizationWithMembershipFactory,
 )
 from tests.utils.test import TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class MembersTest(TestCase):

--- a/tests/www/releases/tests.py
+++ b/tests/www/releases/tests.py
@@ -1,6 +1,10 @@
+import pytest
 from django.urls import reverse
 
 from tests.utils.test import TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class ReleaseTest(TestCase):

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib.gis.geos import Point
 from django.template.defaultfilters import capfirst
 from django.test import override_settings
@@ -13,6 +14,9 @@ from tests.jobs.factories import create_test_romes_and_appellations
 from tests.prescribers.factories import PrescriberOrganizationFactory
 from tests.siaes.factories import SiaeFactory, SiaeJobDescriptionFactory, SiaeMembershipFactory
 from tests.utils.test import BASE_NUM_QUERIES, TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class SearchSiaeTest(TestCase):

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -1,3 +1,4 @@
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.core import mail
 from django.urls import reverse
@@ -21,6 +22,9 @@ from tests.siaes.factories import SiaeMembershipFactory
 from tests.users.factories import JobSeekerFactory
 from tests.utils.storage.test import S3AccessingTestCase
 from tests.utils.test import BASE_NUM_QUERIES, TestCase, assertMessages
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 # fixme vincentporte : convert this method into factory

--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -1,5 +1,6 @@
 import datetime
 
+import pytest
 from django.urls import reverse
 from django.utils import timezone
 
@@ -10,6 +11,9 @@ from tests.institutions.factories import InstitutionMembershipFactory
 from tests.siae_evaluations.factories import EvaluatedSiaeFactory
 from tests.siaes.factories import SiaeMembershipFactory
 from tests.utils.test import TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class EvaluatedSiaeSanctionViewTest(TestCase):

--- a/tests/www/siaes_views/test_job_description_views.py
+++ b/tests/www/siaes_views/test_job_description_views.py
@@ -17,6 +17,9 @@ from tests.users.factories import JobSeekerFactory
 from tests.utils.test import BASE_NUM_QUERIES, TestCase, assertMessages
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 class JobDescriptionAbstractTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/www/siaes_views/test_views.py
+++ b/tests/www/siaes_views/test_views.py
@@ -23,6 +23,9 @@ from tests.siaes.factories import (
 from tests.utils.test import TestCase, parse_response_to_soup
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 @pytest.mark.usefixtures("unittest_compatibility")
 class CardViewTest(TestCase):
     OTHER_TAB_ID = "autres-metiers"

--- a/tests/www/signup/test_job_seeker.py
+++ b/tests/www/signup/test_job_seeker.py
@@ -1,5 +1,6 @@
 import uuid
 
+import pytest
 import respx
 from allauth.account.models import EmailConfirmationHMAC
 from django.conf import settings
@@ -16,6 +17,9 @@ from tests.cities.factories import create_test_cities
 from tests.openid_connect.france_connect.tests import FC_USERINFO, mock_oauth_dance
 from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
 from tests.utils.test import TestCase, reload_module
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class JobSeekerSignupTest(TestCase):

--- a/tests/www/signup/test_password.py
+++ b/tests/www/signup/test_password.py
@@ -1,3 +1,4 @@
+import pytest
 from allauth.account.forms import default_token_generator
 from allauth.account.utils import user_pk_to_url_str
 from django.conf import settings
@@ -7,6 +8,9 @@ from django.utils.http import urlencode
 
 from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
 from tests.utils.test import TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class PasswordResetTest(TestCase):

--- a/tests/www/signup/test_prescriber.py
+++ b/tests/www/signup/test_prescriber.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import httpx
+import pytest
 import respx
 from django.conf import settings
 from django.contrib import auth, messages
@@ -29,6 +30,9 @@ from tests.prescribers.factories import (
 )
 from tests.users.factories import PrescriberFactory, SiaeStaffFactory
 from tests.utils.test import assertMessages
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 @override_settings(

--- a/tests/www/signup/test_siae.py
+++ b/tests/www/signup/test_siae.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import httpx
+import pytest
 import respx
 from django.conf import settings
 from django.contrib import messages
@@ -25,6 +26,9 @@ from tests.openid_connect.inclusion_connect.tests import OIDC_USERINFO, mock_oau
 from tests.siaes.factories import SiaeFactory, SiaeMembershipFactory, SiaeWithMembershipAndJobsFactory
 from tests.users.factories import DEFAULT_PASSWORD, PrescriberFactory, SiaeStaffFactory
 from tests.utils.test import BASE_NUM_QUERIES, TestCase, assertMessages
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class SiaeSignupTest(InclusionConnectBaseTestCase):

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -17,6 +17,9 @@ from tests.users.factories import PrescriberFactory
 from tests.utils.test import TestCase
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 class StatsViewTest(TestCase):
     @override_settings(METABASE_SITE_URL="http://metabase.fake", METABASE_SECRET_KEY="foobar")
     def test_stats_public(self):

--- a/tests/www/welcoming_tour/tests.py
+++ b/tests/www/welcoming_tour/tests.py
@@ -1,3 +1,4 @@
+import pytest
 import respx
 from allauth.account.adapter import get_adapter
 from allauth.account.models import EmailConfirmationHMAC
@@ -12,6 +13,9 @@ from tests.openid_connect.inclusion_connect.tests import mock_oauth_dance
 from tests.siaes.factories import SiaeFactory
 from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
 from tests.utils.test import TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 def get_confirm_email_url(request, email):


### PR DESCRIPTION
### Pourquoi ?

Option trouvée par @vperron : https://pytest-django.readthedocs.io/en/latest/usage.html#fail-on-template-vars-fail-for-invalid-variables-in-templates

Elle permet de détecter des erreurs de variables inexistantes dans nos templates.

Comme on a actuellement ~300 tests en erreurs j'ai préféré ignorer ces erreurs pour activer l'option pour tous les fichiers non concernés. Le plan étant naturellement de supprimer **rapidement** tous ces markers pour que tous nos templates soient concernés.