### PR TITLE
Revert "Run git fixup check in merge queue only"

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,6 +1,6 @@
 name: Git Checks
 
-on: [merge_group]
+on: [pull_request]
 
 jobs:
   block-fixup:


### PR DESCRIPTION
Reverts betagouv/itou#3108

Le check ne fonctionne que sur les pull requests et non les merge queues...

Cf https://github.com/betagouv/itou/actions/runs/6377687401/job/17306810374