### PR TITLE
Contrôle a posteriori: correction du mail de rappel des institutions

### DIFF
--- a/itou/siae_evaluations/emails.py
+++ b/itou/siae_evaluations/emails.py
@@ -44,7 +44,7 @@ class CampaignEmailFactory:
         return get_email_message(self.recipients, {}, subject, body)
 
     def submission_frozen_reminder(self):
-        context = {"campaign": self.evaluation_campaign.institution.name}
+        context = {"institution_name": self.evaluation_campaign.institution.name}
         subject = "siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_subject.txt"
         body = "siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_body.txt"
         return get_email_message(self.recipients, context, subject, body)

--- a/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_body.txt
@@ -4,7 +4,7 @@ Bonjour,
 
 Une ou plusieurs SIAE qui ont transmis leurs justificatifs n’ont pas encore été contrôlée(s) par vos services.
 
-En tant que membre de l’organisation {{ campaign.institution.name }}, nous vous invitons à finaliser ce contrôle. Sans réponse de votre part avant la fin de cette phase*, le résultat du contrôle des SIAE non contrôlées sera par défaut positif.
+En tant que membre de l’organisation {{ institution_name }}, nous vous invitons à finaliser ce contrôle. Sans réponse de votre part avant la fin de cette phase*, le résultat du contrôle des SIAE non contrôlées sera par défaut positif.
 
 * Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel des emplois de l’inclusion.
 

--- a/tests/siae_evaluations/__snapshots__/test_management_commands.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_management_commands.ambr
@@ -5,7 +5,7 @@
   
   Une ou plusieurs SIAE qui ont transmis leurs justificatifs n’ont pas encore été contrôlée(s) par vos services.
   
-  En tant que membre de l’organisation , nous vous invitons à finaliser ce contrôle. Sans réponse de votre part avant la fin de cette phase*, le résultat du contrôle des SIAE non contrôlées sera par défaut positif.
+  En tant que membre de l’organisation DDETS 01, nous vous invitons à finaliser ce contrôle. Sans réponse de votre part avant la fin de cette phase*, le résultat du contrôle des SIAE non contrôlées sera par défaut positif.
   
   * Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel des emplois de l’inclusion.
   


### PR DESCRIPTION
### Pourquoi ?

On avait apparemment prévu de mettre le nom de l'organisation, alors on met le nom de l'organisation.
