### PR TITLE
tests: amélioration de la cohérence de EvaluatedJobApplicationFactory

### DIFF
--- a/tests/siae_evaluations/factories.py
+++ b/tests/siae_evaluations/factories.py
@@ -88,6 +88,7 @@ class EvaluatedJobApplicationFactory(factory.django.DjangoModelFactory):
     job_application = factory.SubFactory(
         JobApplicationFactory,
         to_siae=factory.SelfAttribute("..evaluated_siae.siae"),
+        with_approval=True,
     )
 
 


### PR DESCRIPTION
### Pourquoi ?

S'il y a un contrôle a posteriori, c'est a priori qu'il existe un Pass.

(et au passage, cela évite un certain nombre d'erreur avec l'option `--fail-on-template-vars` qui se prend les pieds dans https://github.com/betagouv/itou/blob/cab247064fd6e5156c247efb8a8dc592555b2832/itou/templates/siae_evaluations/includes/job_seeker_infos_for_institution.html#L9)

