### PR TITLE
Admin - FS : Correction suite à #3090

### DIFF
--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -32,10 +32,11 @@ class EmployeeRecordAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["financial_annex"].required = False
-        self.fields["financial_annex"].queryset = siaes_models.SiaeFinancialAnnex.objects.filter(
-            convention=self.instance.job_application.to_siae.convention
-        ).order_by("-number")
+        if "financial_annex" in self.fields:
+            self.fields["financial_annex"].required = False
+            self.fields["financial_annex"].queryset = siaes_models.SiaeFinancialAnnex.objects.filter(
+                convention=self.instance.job_application.to_siae.convention
+            ).order_by("-number")
 
 
 @admin.register(models.EmployeeRecord)


### PR DESCRIPTION
Voir #3090 et 83ae104d7

### Pourquoi ?

Les utilisateurs de `itou-support-externe` n'ont pas de droits d'édition donc il n'y a pas de champs dans le formulaire.
