### PR TITLE
Passage à PostgreSQL 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     services:
       postgres:
         # Docker Hub image
-        image: postgis/postgis:14-master
+        image: postgis/postgis:15-master
         env:
           POSTGRES_PASSWORD: password
         ports:

--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: 🗃 Create database addon
       run: |
-        $CLEVER_CLI addon create postgresql-addon $REVIEW_APP_DB_NAME --org itou_review_apps --plan xxs_sml --yes
+        $CLEVER_CLI addon create postgresql-addon $REVIEW_APP_DB_NAME --org itou_review_apps --plan xxs_sml --yes --addon-version 15
         $CLEVER_CLI service link-addon $REVIEW_APP_DB_NAME
 
     - name: 🤝 Link addons & add environment variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   # https://hub.docker.com/r/mdillon/postgis/tags
   postgres:
     container_name: itou_postgres
-    image: postgis/postgis:14-master
+    image: postgis/postgis:15-master
     # Disable some safety switches for a faster postgres: https://www.postgresql.org/docs/current/non-durability.html
     command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off
     environment:
@@ -47,7 +47,7 @@ services:
         APP_USER: app
         APP_DIR: /app
         PYTHON_VERSION: 3.11
-        PG_MAJOR: 14
+        PG_MAJOR: 15
     volumes:
       # Mount the current directory into `/app` inside the running container.
       - .:/app


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Mettre-jour-Postgres-sur-la-derni-re-version-15-boost-ed9c92020475411f939bae5d6a3e04b6**

Pour info, Clever met à jour la DB de prod demain à 17h.

### Pourquoi ?
Mise à jour de performance et de sécurité.

### Comment
On met à jour  la base de données de dev, on lance les tests, on vérifie en recette. On ne peut pas faire grand-chose de plus.
