### PR TITLE
Modifier la couleur du badge de nombre de demande de prolongations à traiter

### DIFF
--- a/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
@@ -12,7 +12,7 @@
                         <span>Gérer mes prolongations de PASS IAE</span>
                     </a>
                     {% if pending_prolongation_requests %}
-                        <span class="badge badge-pill badge-xs badge-info-lighter text-info">{{ pending_prolongation_requests }}</span>
+                        <span class="badge badge-pill badge-xs badge-warning">{{ pending_prolongation_requests }}</span>
                     {% endif %}
                 </li>
                 {% if request.current_organization.kind == precriber_kind_pe %}


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Modifier-la-couleur-de-la-pastille-des-demandes-de-prolongation-traiter-26bb1b3e2d954f5cbe2d24e4ff419d0a

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Pole emploi remonte que les conseillers ne voient pas les demandes en attente avec cette couleur 
