### PR TITLE
Déclaration de prolongation

### DIFF
--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -83,44 +83,46 @@
 {% block script %}
     {{ block.super }}
     <!-- Dropzone -->
-    <script src='{% static "vendor/dropzone/dropzone.min.js" %}'></script>
-    <script src='{% static "js/s3_upload.js" %}'></script>
-    {{ s3_upload.form_values|json_script:"s3-form-values" }}
-    {{ s3_upload.config|json_script:"s3-upload-config" }}
-    <script nonce="{{ CSP_NONCE }}">
-        function _onLoad(target) {
-            if (!$("#report_file_form", target).length) {
-                // Upload form is not there, no dropzone init needed
-                return;
+    {% if s3_upload %}
+        <script src='{% static "vendor/dropzone/dropzone.min.js" %}'></script>
+        <script src='{% static "js/s3_upload.js" %}'></script>
+        {{ s3_upload.form_values|json_script:"s3-form-values" }}
+        {{ s3_upload.config|json_script:"s3-upload-config" }}
+        <script nonce="{{ CSP_NONCE }}">
+            function _onLoad(target) {
+                if (!$("#report_file_form", target).length) {
+                    // Upload form is not there, no dropzone init needed
+                    return;
+                }
+
+                dropzone = s3UploadInit({
+                    dropzoneSelector: "#report_file_form",
+                    callbackLocationSelector: "#id_report_file_path",
+                    s3FormValuesId: "s3-form-values",
+                    s3UploadConfigId: "s3-upload-config",
+                    sentryInternalUrl: "{% url 'home:sentry_debug' %}",
+                    sentryCsrfToken: "{{ csrf_token }}",
+                    returnPath: true,
+                });
+
+                // Listening on hidden fields change does not work, so:
+                const uploadedFileName = $("#id_uploaded_file_name");
+                const uploadedFileNameDisplay = $("#uploaded_file_name_display");
+                const resetFileName = file => {
+                    uploadedFileName.val("");
+                    uploadedFileNameDisplay.text("Aucun");
+                };
+                dropzone.on("success", file => {
+                    uploadedFileName.val(file.name);
+                    uploadedFileNameDisplay.text(file.name);
+                });
+                dropzone.on("error", resetFileName);
+                dropzone.on("removedfile", resetFileName);
             }
 
-            dropzone = s3UploadInit({
-                dropzoneSelector: "#report_file_form",
-                callbackLocationSelector: "#id_report_file_path",
-                s3FormValuesId: "s3-form-values",
-                s3UploadConfigId: "s3-upload-config",
-                sentryInternalUrl: "{% url 'home:sentry_debug' %}",
-                sentryCsrfToken: "{{ csrf_token }}",
-                returnPath: true,
-            });
-
-            // Listening on hidden fields change does not work, so:
-            const uploadedFileName = $("#id_uploaded_file_name");
-            const uploadedFileNameDisplay = $("#uploaded_file_name_display");
-            const resetFileName = file => {
-                uploadedFileName.val("");
-                uploadedFileNameDisplay.text("Aucun");
-            };
-            dropzone.on("success", file => {
-                uploadedFileName.val(file.name);
-                uploadedFileNameDisplay.text(file.name);
-            });
-            dropzone.on("error", resetFileName);
-            dropzone.on("removedfile", resetFileName);
-        }
-
-        htmx.onLoad(_onLoad);
-        // or, on regular loading:
-        _onLoad()
-    </script>
+            htmx.onLoad(_onLoad);
+            // or, on regular loading:
+            _onLoad()
+        </script>
+    {% endif %}
 {% endblock %}

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -254,10 +254,8 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
         "preview": preview,
         "unfold_details": form.data.get("reason") in PROLONGATION_REPORT_FILE_REASONS,
         "can_upload_prolongation_report": siae.can_upload_prolongation_report,
+        "s3_upload": S3Upload(kind="prolongation_report") if siae.can_upload_prolongation_report else None,
     }
-
-    if siae.can_upload_prolongation_report:
-        context |= {"s3_upload": S3Upload(kind="prolongation_report")}
 
     return render(request, template_name, context)
 
@@ -292,11 +290,8 @@ class DeclareProlongationHTMXFragmentView(TemplateView):
         context |= {
             "approval": self.approval,
             "form": self.form,
+            "s3_upload": S3Upload(kind="prolongation_report") if self.siae.can_upload_prolongation_report else None,
         }
-
-        if self.siae.can_upload_prolongation_report:
-            context |= {"s3_upload": S3Upload(kind="prolongation_report")}
-
         return context
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
### Pourquoi ?

On rajoute toujours `s3_upload` dans le template pour faire plaisir à la future option `FAIL_INVALID_TEMPLATE_VARS` de pytest-django.
Et au passage, on ne rajoute pas tout plein de JS s'il ne va pas servir.

