### PR TITLE
tests: Ordre aléatoire pour les requêtes qui n'en spécifie pas

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -78,7 +78,7 @@ class EvaluatedAdministrativeCriteriaInline(ItouTabularInline):
 
 def _evaluated_siae_serializer(queryset):
     def _get_active_admin(siae):
-        return [p.user.email for p in siae.memberships.all() if p.is_admin and p.user.is_active]
+        return sorted(p.user.email for p in siae.memberships.all() if p.is_admin and p.user.is_active)
 
     def _get_stage(evaluated_siae):
         if evaluated_siae.evaluation_campaign.ended_at:

--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -120,7 +120,7 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, **options):
-        for group, raw_permissions in get_permissions_dict().items():
+        for group, raw_permissions in sorted(get_permissions_dict().items()):
             all_codenames = [
                 perm_code for model, perms in raw_permissions.items() for perm_code in to_perm_codenames(model, perms)
             ]

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -68,7 +68,7 @@ class ItouCurrentOrganizationMiddleware:
                         really_active_memberships.append(membership)
                 # If there is no current siae, we want to default to the first active one
                 # (and preferably not one in grace period)
-                really_active_memberships.sort(key=lambda m: m.siae.has_convention_in_grace_period)
+                really_active_memberships.sort(key=lambda m: (m.siae.has_convention_in_grace_period, m.created_at))
 
                 (
                     request.organizations,

--- a/tests/siae_evaluations/test_emails.py
+++ b/tests/siae_evaluations/test_emails.py
@@ -1,3 +1,5 @@
+import collections
+
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -25,7 +27,7 @@ class TestInstitutionEmailFactory:
 
         email = CampaignEmailFactory(evaluation_campaign).ratio_to_select()
 
-        assert email.to == list(u.email for u in institution.active_members)
+        assert collections.Counter(email.to) == collections.Counter(u.email for u in institution.active_members)
         assert reverse("dashboard:index") in email.body
         assert "Vous disposez de 4 semaines pour choisir votre taux de SIAE à contrôler." in email.body
         assert "Vous disposez de 4 semaines pour sélectionner votre échantillon." in email.subject
@@ -51,7 +53,7 @@ class TestInstitutionEmailFactory:
         evaluation_campaign = EvaluationCampaignFactory(institution=institution, evaluations_asked_at=fake_now)
 
         email = CampaignEmailFactory(evaluation_campaign).selected_siae()
-        assert email.to == list(u.email for u in institution.active_members)
+        assert collections.Counter(email.to) == collections.Counter(u.email for u in institution.active_members)
         assert dateformat.format(evaluation_campaign.evaluated_period_start_at, "d E Y") in email.body
         assert dateformat.format(evaluation_campaign.evaluated_period_end_at, "d E Y") in email.body
 

--- a/tests/siaes/test_import_siae_command.py
+++ b/tests/siaes/test_import_siae_command.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import importlib
 import os
@@ -221,10 +222,10 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         instance = lazy_import_siae_command()
         instance.create_new_siaes()
         assert reverse("signup:siae_select") in mail.outbox[0].body
-        assert [mail.subject for mail in mail.outbox] == [
+        assert collections.Counter(mail.subject for mail in mail.outbox) == collections.Counter(
             f"Activez le compte de votre {kind} {name} sur les emplois de l'inclusion"
             for (kind, name) in Siae.objects.values_list("kind", "name")
-        ]
+        )
 
 
 @override_settings(METABASE_HASH_SALT="foobar2000")

--- a/tests/status/tests.py
+++ b/tests/status/tests.py
@@ -190,9 +190,9 @@ class RunStatusProbesCommandTest(TestCase):
 
         self.cmd._check_and_remove_dangling_probes(non_dangling_probes)
 
-        assert list(models.ProbeStatus.objects.values_list("name", flat=True)) == [
+        assert set(models.ProbeStatus.objects.values_list("name", flat=True)) == {
             probe.name for probe in non_dangling_probes
-        ]
+        }
         assert self.cmd.stdout.getvalue() == "Check dangling probes\nNo dangling probes found\n"
 
     def test_check_and_remove_dangling_probes_when_adding_probes(self):
@@ -201,7 +201,7 @@ class RunStatusProbesCommandTest(TestCase):
 
         self.cmd._check_and_remove_dangling_probes(old_probes + new_probes)
 
-        assert list(models.ProbeStatus.objects.values_list("name", flat=True)) == [probe.name for probe in old_probes]
+        assert set(models.ProbeStatus.objects.values_list("name", flat=True)) == {probe.name for probe in old_probes}
         assert self.cmd.stdout.getvalue() == "Check dangling probes\nNo dangling probes found\n"
 
     def test_check_and_remove_dangling_probes_when_removing_probes(self):
@@ -210,7 +210,7 @@ class RunStatusProbesCommandTest(TestCase):
 
         self.cmd._check_and_remove_dangling_probes(probes_kept)
 
-        assert list(models.ProbeStatus.objects.values_list("name", flat=True)) == [probe.name for probe in probes_kept]
+        assert set(models.ProbeStatus.objects.values_list("name", flat=True)) == {probe.name for probe in probes_kept}
         expected_dangling_names = set(sorted({probe.name for probe in probes_removed}))
         assert (
             self.cmd.stdout.getvalue()

--- a/tests/users/test_admin.py
+++ b/tests/users/test_admin.py
@@ -35,7 +35,7 @@ def test_filter():
         admin.JobSeekerProfileAdmin,
     )
     profiles = filter.queryset(None, JobSeekerProfile.objects.all())
-    assert list(profiles) == list(JobSeekerProfile.objects.all())
+    assert set(profiles) == {js_certified.jobseeker_profile, js_non_certified.jobseeker_profile}
 
 
 def test_get_fields_to_transfer_for_job_seekers():

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -183,8 +183,7 @@ class TestSyncPermsTestCase(TestCase):
             "All done!\n",
         ]
         assert Group.objects.all().count() == 2
-        admin_group = Group.objects.all()[0]
-        assert admin_group.name == "itou-admin"
+        admin_group = Group.objects.get(name="itou-admin")
         assert [perm.codename for perm in admin_group.permissions.all()] == [
             "add_emailaddress",
             "change_emailaddress",
@@ -274,8 +273,7 @@ class TestSyncPermsTestCase(TestCase):
             "change_user",
             "view_user",
         ]
-        support_group = Group.objects.all()[1]
-        assert support_group.name == "itou-support-externe"
+        support_group = Group.objects.get(name="itou-support-externe")
         assert [perm.codename for perm in support_group.permissions.all()] == [
             "view_emailaddress",
             "view_approval",


### PR DESCRIPTION
### Pourquoi ?

- Casser plus vite, qu'une fois de temps en temps, lorsque un de nos test s'attend à un ordre précis et que celui-ci n'est pas spécifié dans le code
- Permet de simuler le cas où l'ordre des lignes physique n'est pas l'ordre des lignes logique.

### Comment <!-- optionnel -->

Ajout d'une _fixture_ `autouse=True` pour patcher la ligne qui va bien dans le code de Django pour que l'ordre par défaut soit `"?"`.

Pour les relecteurs : Je vous ajoute car vous êtes les derniers à être passé sur les bouts de code que je modifie dans `itou` donc vous être normalement bien placés pour voir si un meilleur ordre (ou pas) est possible.