### PR TITLE
Renommage de `asp.models.SiaeKind()` en `asp.models.SiaeMeasure()`

### DIFF
--- a/itou/asp/models.py
+++ b/itou/asp/models.py
@@ -508,14 +508,6 @@ class Country(PrettyPrintMixin, models.Model):
         verbose_name_plural = "pays"
         ordering = ["name"]
 
-    @property
-    def is_france(self):
-        """
-        Check if provided country is France
-        Polynesian islands are considered as a distinct country but are french in-fine
-        """
-        return self.group == self.Group.FRANCE
-
 
 class SiaeMeasure(models.TextChoices):
     """
@@ -537,14 +529,6 @@ class SiaeMeasure(models.TextChoices):
     FDI = "FDI_DC", "Droit Commun -  Fonds Départemental pour l'Insertion"
     EI_MP = "EI_MP", "Milieu Pénitentiaire - Entreprise d'Insertion"
     ACI_MP = "ACI_MP", "Milieu Pénitentiaire - Atelier et Chantier d'Insertion"
-
-    @property
-    def valid_kind_for_employee_record(self):
-        """
-        The ASP SIAE kind ("Mesure") must be one of the following
-        to be eligible for ASP employee record processing
-        """
-        return self.value in ["AI_DC", "ACI_DC", "ETTI_DC", "EI_DC"]
 
     @classmethod
     def from_siae_kind(cls, kind):

--- a/itou/asp/models.py
+++ b/itou/asp/models.py
@@ -517,7 +517,7 @@ class Country(PrettyPrintMixin, models.Model):
         return self.group == self.Group.FRANCE
 
 
-class SiaeKind(models.TextChoices):
+class SiaeMeasure(models.TextChoices):
     """
     ASP SIAE kind (mesure)
 

--- a/itou/employee_record/migrations/0010_add_asp_measure_to_unique_constraint.py
+++ b/itou/employee_record/migrations/0010_add_asp_measure_to_unique_constraint.py
@@ -1,6 +1,6 @@
 from django.db import migrations, models
 
-from itou.asp.models import SiaeKind
+from itou.asp.models import SiaeMeasure
 
 
 def _fill_asp_measure(apps, schema_editor):
@@ -13,7 +13,7 @@ def _fill_asp_measure(apps, schema_editor):
 
     batch = []
     for er in objects_to_migrate:
-        er.asp_measure = SiaeKind.from_siae_kind(er.job_application.to_siae.kind)
+        er.asp_measure = SiaeMeasure.from_siae_kind(er.job_application.to_siae.kind)
         batch.append(er)
     EmployeeRecord.objects.bulk_update(batch, fields=["asp_measure"])
 

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from rest_framework.authtoken.admin import User
 
 from itou.approvals.models import Approval
-from itou.asp.models import EmployerType, PrescriberType, SiaeKind
+from itou.asp.models import EmployerType, PrescriberType, SiaeMeasure
 from itou.job_applications.enums import SenderKind
 from itou.siaes.models import Siae, SiaeFinancialAnnex
 from itou.users.models import JobSeekerProfile
@@ -201,7 +201,7 @@ class EmployeeRecord(ASPExchangeInformation):
     # These fields are duplicated to act as constraint fields on DB level
     approval_number = models.CharField(max_length=12, verbose_name="numéro d'agrément")
     asp_id = models.PositiveIntegerField(verbose_name="identifiant ASP de la SIAE")
-    asp_measure = models.CharField(verbose_name="mesure ASP de la SIAE", choices=SiaeKind.choices)
+    asp_measure = models.CharField(verbose_name="mesure ASP de la SIAE", choices=SiaeMeasure.choices)
 
     # If the SIAE is an "antenna",
     # we MUST provide the SIRET of the SIAE linked to the financial annex on ASP side (i.e. "parent/mother" SIAE)
@@ -276,7 +276,7 @@ class EmployeeRecord(ASPExchangeInformation):
         # If the SIAE is an antenna, the SIRET will be rejected by the ASP so we have to use the mother's one
         self.siret = self.siret_from_asp_source(self.job_application.to_siae)
         self.asp_id = self.job_application.to_siae.convention.asp_id
-        self.asp_measure = SiaeKind.from_siae_kind(self.job_application.to_siae.kind)
+        self.asp_measure = SiaeMeasure.from_siae_kind(self.job_application.to_siae.kind)
         self.approval_number = self.job_application.approval.number
 
     # Business methods
@@ -526,7 +526,7 @@ class EmployeeRecord(ASPExchangeInformation):
         """
         Mapping between ASP and itou models for SIAE kind ("Mesure")
         """
-        return SiaeKind.from_siae_kind(self.job_application.to_siae.kind)
+        return SiaeMeasure.from_siae_kind(self.job_application.to_siae.kind)
 
     @property
     def is_orphan(self):

--- a/tests/employee_record/factories.py
+++ b/tests/employee_record/factories.py
@@ -31,7 +31,7 @@ class EmployeeRecordFactory(BareEmployeeRecordFactory):
     )
     asp_id = factory.SelfAttribute(".job_application.to_siae.convention.asp_id")
     asp_measure = factory.LazyAttribute(
-        lambda obj: asp_models.SiaeKind.from_siae_kind(obj.job_application.to_siae.kind)
+        lambda obj: asp_models.SiaeMeasure.from_siae_kind(obj.job_application.to_siae.kind)
     )
     approval_number = factory.SelfAttribute(".job_application.approval.number")
     siret = factory.SelfAttribute(".job_application.to_siae.siret")


### PR DESCRIPTION
### Pourquoi ?

Pour ne plus les confondre avec `siaes.enums.SiaeKind()`