### PR TITLE
Mise à jour Htmx de 1.8.2 à 1.9.6, adaptation gabarit de base

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -17,7 +17,7 @@
         {# https://metatags.io #}
         <meta name="title" content="Les emplois de l'inclusion">
         {# Project uses custom styles for indicators, CSP compatibility #}
-        <meta name="htmx-config" content='{"includeIndicatorStyles": false}'>
+        <meta name="htmx-config" content='{"includeIndicatorStyles": false, "allowScriptTags":false}'>
         {# https://metatags.io Open Graph / Facebook #}
         <meta property="og:type" content="website">
         <meta property="og:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}">
@@ -108,14 +108,6 @@
         <script src="{% static "vendor/jquery-ui/jquery-ui.min.js" %}"></script>
         <script src="{% static "vendor/theme-inclusion/javascripts/app.js" %}"></script>
 
-        <script nonce="{{ CSP_NONCE }}">
-            // Show any toasts that is already present in the DOM
-            $(document).ready(() => {
-                $(".toast-placement-wrapper").children(".toast").each(function() {
-                    $(this).toast("show");
-                });
-            });
-        </script>
 
         <script nonce="{{ CSP_NONCE }}">
             // Tarteaucitron's language is set according to the browser configuration
@@ -225,6 +217,16 @@
             {% if SHOW_DEMO_ACCOUNTS_BANNER %}
                 <script src="{% static 'js/demo_accounts.js'%}"></script>
             {% endif %}
+
+            <script nonce="{{ CSP_NONCE }}">
+                // Show any toasts that is already present in the DOM
+                htmx.onLoad(() => {
+                    $(".toast-placement-wrapper").children(".toast").each(function() {
+                        $(this).toast("show");
+                    });
+                });
+            </script>
+
         {% endblock %}
 
         {% if MATOMO_BASE_URL %}

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -93,8 +93,8 @@ ASSET_INFOS = {
     },
     "htmx.org": {
         "download": {
-            "url": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.8.2.tgz",
-            "sha256": "e0e10e29d3033d98c15ad25d90608685a61b20e1d813f8b9c3c2e00b9055d525",
+            "url": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.9.6.tgz",
+            "sha256": "061fbce477f32ed1141f69fe449c47c7395725d39e739fe27f7fd5a617d5efe8",
         },
         "extract": {
             "origin": "package",


### PR DESCRIPTION
### Pourquoi ?

Les règles CSP empechent l'execution de `htmx`

### Comment 

PR préparant la #3146 

🎃 mise à jour des lib js
🎃 modification de l'import dans `base.html`
🎃 ajout de la règle `"allowScriptTags":false` dans la balise méta `htmx-config` pour limiter l'execution de scripts js non-désirés mais déclenchés par `hx-boost`
🎃 remplacer le `document.ready` par `htmx.onLoad` pour capturer les messages toastés servis via htmx, et le déplacer après le chargement de htmx


### verifications :

- [x] modale apply view _accept
- [x] modale apply process_viem delete_prior_action
- [x] apply include accept_section
- [x] apply include geiq_eligibility_section
- [x] apply include job_application_accept_form
- [x] apply include job_application_prior_action_form
- [x] apply include job_application_prior_action
- [x] apply include siae_hiring_actions ⚠️  `{% if out_of_band_swap %} hx-swap-oob="true"{% endif %}` ⚠️ 
- [x] apply include transition_logs
- [x] apply include geiq_administrative_criteria_form
- [x] apply include geiq progress_bar
- [x] gabarit apply submit application geiq_eligibility 
- [x] approvals include declaration_prescriber_email
- [x] gabarit approvals prolongation_requests list
- [x] include pagination ⚠️ `{% if boost %}hx-boost="true"{% endif %}` ⚠️ 
- [x] gabarit siaes job_description_list
- [x] templatetag job_applications state_badge
- [x] apply AcceptForm
- [x] approvals_views CreateProlongationForm
- [x] approvals_views CreateProlongationRequestForm
- [x] geiq_eligibility_views GEIQAdministrativeCriteriaForm
- [x] geiq_eligibility_views GEIQAdministrativeCriteriaForGEIQForm