### PR TITLE
Détail d'une organisation de prescripteur: correction du titre

### DIFF
--- a/itou/templates/prescribers/card.html
+++ b/itou/templates/prescribers/card.html
@@ -1,7 +1,7 @@
 {% extends "layout/base.html" %}
 {% load format_filters %}
 
-{% block title %}{{ siae.display_name }} {{ block.super }}{% endblock %}
+{% block title %}{{ prescriber_org.display_name }} {{ block.super }}{% endblock %}
 
 {% block content_title %}
     <p>


### PR DESCRIPTION
### Pourquoi ?

Parce que.

cf https://github.com/betagouv/itou/blob/60dbd7ce4210992f2a6a80198f470090da53f38d/itou/www/prescribers_views/views.py#L18-L26