### PR TITLE
Fichier de variables d'environnement minimaliste

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,10 @@
 #DJANGO_PORT_ON_DOCKER_HOST=8000
 #POSTGRES_PORT_ON_DOCKER_HOST=5432
 
+PGHOST=localhost
+PGUSER=postgres
+PGPASSWORD=password
+
 # CLEVER_TOKEN and CLEVER_SECRET are to create a machine in
 # ./scripts/create-fast-machine.sh
 # You can find them with "clever login" once you have installed "clever-tools".


### PR DESCRIPTION
### Pourquoi ?

🎯 ajouter les variables d'environment minimum pour faire fonctionner `itou` en local :
* `PGHOST`, `PGUSER`, `PGPASSWORD` pour accéder à la ligne de commande `psql` si `postgres` est hébergé dans un contener `docker`
* `S3_STORAGE_BUCKET_NAME` pour ne pas faire planter `itou` (`s3_upload` not defined) sur les formulaires de téléversement.

### Comment 

* mise à jour de `env.template`