### PR TITLE
stats : Ajout du dashboard 310 pour les DREETS IAE

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -175,6 +175,12 @@
                             <span>Voir les données facilitation de l'embauche</span>
                         </a>
                     </li>
+                    <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="{% url 'stats:stats_dreets_iae_state' %}" class="btn-link btn-ico">
+                            <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
+                            <span>Suivre les prescriptions des AHI de ma région</span>
+                        </a>
+                    </li>
                 {% endif %}
                 {% if can_view_stats_dgefp %}
                     <li class="d-flex justify-content-between align-items-center mb-3">

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -142,6 +142,11 @@ METABASE_DASHBOARDS = {
         "tally_popup_form_id": "mVLBXv",
         "tally_embed_form_id": "nPpXpQ",
     },
+    "stats_dreets_iae_state": {
+        "dashboard_id": 310,
+        "tally_popup_form_id": "w2az2j",
+        "tally_embed_form_id": "3Nlvzl",
+    },
     #
     # Institution stats - DGEFP - nation level.
     #

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -69,6 +69,7 @@ urlpatterns = [
     ),
     path("dreets/iae", views.stats_dreets_iae_iae, name="stats_dreets_iae_iae"),
     path("dreets/hiring", views.stats_dreets_iae_hiring, name="stats_dreets_iae_hiring"),
+    path("dreets/state", views.stats_dreets_iae_hiring, name="stats_dreets_iae_state"),
     # Institution stats - DGEFP - nation level.
     path("dgefp/auto_prescription", views.stats_dgefp_auto_prescription, name="stats_dgefp_auto_prescription"),
     path(

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -509,6 +509,14 @@ def stats_dreets_iae_hiring(request):
     )
 
 
+@login_required
+def stats_dreets_iae_state(request):
+    return render_stats_dreets_iae(
+        request=request,
+        page_title="Suivi des prescriptions des AHI de ma région",
+    )
+
+
 def render_stats_dgefp(request, page_title, extra_params=None, extra_context=None):
     if extra_context is None:
         # Do not use mutable default arguments,

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -203,6 +203,7 @@ def test_stats_ddets_iae_log_visit(client, view_name):
         "stats_dreets_iae_follow_prolongation",
         "stats_dreets_iae_iae",
         "stats_dreets_iae_hiring",
+        "stats_dreets_iae_state",
     ],
 )
 def test_stats_dreets_iae_log_visit(client, view_name):


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/Ouvrir-le-TB310-aux-DREETS-IAE-50176fe8dc2148b5b06a783a342e0da4**

### Pourquoi ?
Parce que !!!

### Comment
A la mano comme d'habitude pour que il soit dispo rapidement.

Ce système de permissions + injection de tableaux de bord commence à me gêner un tantinet.
J'ai envie de mettre en place un système revisité de permissions, avec des modèles correspondant aux tableaux de bord managés. 

Chaque tableau de bord pourrait être ouvert à des publics de typologies différentes, directement dans l'admin, et désactivé si besoin, tout en suivant les métadonnées et options (Tally, etc) correctement dans ces modèles.

Cela permettrait d'avoir une seule moulinette d'affichage et de ne plus avoir de temps de dev pour ajouter/supprimer ces tableaux.

### Captures d'écran
![image](https://github.com/betagouv/itou/assets/88618/1173c9d1-c3cd-4fe3-a824-08f5046412d2)
![image](https://github.com/betagouv/itou/assets/88618/b94e1f99-23a5-4463-a620-a63dca886425)


