### PR TITLE
static: simplification JS

### DIFF
--- a/itou/static/js/job_autocomplete.js
+++ b/itou/static/js/job_autocomplete.js
@@ -16,11 +16,7 @@ htmx.onLoad((target) => {
     .autocomplete({
       delay: 300,
       minLength: 1,
-      source: function(request, response) {
-        $.getJSON(jobAppellationSearchInput.data('autocomplete-source-url'),
-          {term: request.term, siae_id: request.siae_id,},
-          response)
-      },
+      source: jobAppellationSearchInput.data('autocomplete-source-url'),
       autoFocus: true,
       // Make a selection on focus.
       focus: (event, ui) => {


### PR DESCRIPTION
### Pourquoi ?

`autocomplete-source-url` contient déjà le paramètre siae_id

cf
https://github.com/betagouv/itou/blob/c89b352d88ff5cb8652f81243e7572298baa8438/itou/www/siaes_views/forms.py#L302





