### PR TITLE
Retirer js-display-if-javascript-enabled

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -215,15 +215,6 @@ _:-ms-fullscreen,
     display: block;
 }
 
-/* JavaScript disabled.
----------------------------------------------------------------------------- */
-
-/* Element is shown with JavaScript. See static > js > utils.js */
-
-.js-display-if-javascript-enabled {
-    display: none;
-}
-
 /* CSS for js-shroud.
 ---------------------------------------------------------------------------- */
 

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -3,8 +3,6 @@ htmx.onLoad((target) => {
         event.preventDefault();
     });
 
-    $(".js-display-if-javascript-enabled", target).css("display", "block");
-
   /**
    * JS to swap elements based on CSS selectors
    */

--- a/itou/templates/apply/submit/application/eligibility.html
+++ b/itou/templates/apply/submit/application/eligibility.html
@@ -24,9 +24,7 @@
                     <p class="mb-2">
                         Tant que l’éligibilité IAE est valide, vous n’avez rien à faire. Si vous souhaitez la mettre à jour, sa validité sera prolongée jusqu'au {{ new_expires_at_if_updated|date:"d/m/Y" }}.
                     </p>
-                    <button class="btn btn-link text-left p-0 js-display-if-javascript-enabled" data-shroud-clear>
-                        Mettre à jour l’éligibilité
-                    </button>
+                    <button class="btn btn-link text-left p-0" data-shroud-clear>Mettre à jour l’éligibilité</button>
                 </div>
             </div>
         </div>

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -41,7 +41,7 @@
                                             <i class="ri-pencil-line mr-2"></i>Modifier
                                         </a>
                                     {% elif can_edit_personal_information %}
-                                        <span class="btn btn-outline-primary btn-ico btn-sm js-display-if-javascript-enabled" data-swap-element="#informations">
+                                        <span class="btn btn-outline-primary btn-ico btn-sm" data-swap-element="#informations">
                                             <i class="ri-pencil-line mr-2"></i>Modifier
                                         </span>
                                     {% endif %}

--- a/itou/templates/apply/submit/application/geiq_eligibility.html
+++ b/itou/templates/apply/submit/application/geiq_eligibility.html
@@ -23,7 +23,7 @@
                     <p class="mb-2">
                         Tant que l’éligibilité à l'aide de l'accompagnement GEIQ est valide, vous n’avez rien à faire. Si vous souhaitez la mettre à jour, sa validité sera prolongée de six mois.
                     </p>
-                    <span class="btn btn-link text-left p-0 js-display-if-javascript-enabled" data-shroud-clear>Mettre à jour l’éligibilité</span>
+                    <span class="btn btn-link text-left p-0" data-shroud-clear>Mettre à jour l’éligibilité</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Pourquoi ?

Le support des fonctionnalités du site sans JavaScript demande beaucoup d’efforts de développement et n’est pas dans les objectifs de l’équipe. De nombreuses fonctionnalités du site nécessitent JavaScript et n’ont pas de mode dégradé. Arrêtons de prétendre que le site pourrait fonctionner sans JavaScript, et simplifions le code.