### PR TITLE
Valider les accès aux bilans des demandes de prolongation

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -218,7 +218,10 @@ STATIC_URL = "/static/"
 
 STORAGES = {
     "default": {
-        "BACKEND": "itou.utils.storage.s3.S3Storage",
+        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+    },
+    "public": {
+        "BACKEND": "itou.utils.storage.s3.PublicStorage",
     },
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin, messages
+from django.core.files.storage import default_storage
 from django.urls import path
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -418,7 +419,7 @@ class ProlongationCommonAdmin(ItouModelAdmin):
     def report_file_link(self, obj):
         return format_html(
             "<a href='{}'>{}</a>",
-            obj.report_file.link,
+            default_storage.url(obj.report_file.key),
             obj.report_file.key,
         )
 

--- a/itou/approvals/notifications.py
+++ b/itou/approvals/notifications.py
@@ -1,8 +1,10 @@
 from django.db.models import F
+from django.urls import reverse
 
 from itou.common_apps.notifications.base_class import BaseNotification
 from itou.prescribers.models import PrescriberMembership
 from itou.utils.emails import get_email_message
+from itou.utils.urls import get_absolute_url
 
 
 class ProlongationRequestCreated(BaseNotification):
@@ -16,7 +18,15 @@ class ProlongationRequestCreated(BaseNotification):
     @property
     def email(self):
         to = [self.prolongation_request.validated_by.email]
-        context = {"prolongation_request": self.prolongation_request}
+        context = {
+            "prolongation_request": self.prolongation_request,
+            "report_file_url": get_absolute_url(
+                reverse(
+                    "approvals:prolongation_request_report_file",
+                    kwargs={"prolongation_request_id": self.prolongation_request.pk},
+                )
+            ),
+        }
         subject = "approvals/email/prolongation_request/created_subject.txt"
         body = "approvals/email/prolongation_request/created_body.txt"
         return get_email_message(to, context, subject, body)
@@ -41,6 +51,12 @@ class ProlongationRequestCreatedReminder(BaseNotification):
         )
         context = {
             "prolongation_request": self.prolongation_request,
+            "report_file_url": get_absolute_url(
+                reverse(
+                    "approvals:prolongation_request_report_file",
+                    kwargs={"prolongation_request_id": self.prolongation_request.pk},
+                )
+            ),
         }
         subject = "approvals/email/prolongation_request/created_reminder_subject.txt"
         body = "approvals/email/prolongation_request/created_reminder_body.txt"

--- a/itou/files/models.py
+++ b/itou/files/models.py
@@ -1,4 +1,3 @@
-from django.core.files.storage import default_storage
 from django.db import models
 from django.utils import timezone
 
@@ -13,7 +12,3 @@ class File(models.Model):
 
     class Meta:
         verbose_name = "fichier"
-
-    @property
-    def link(self):
-        return default_storage.url(self.key)

--- a/itou/templates/approvals/email/prolongation_request/created_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/created_body.txt
@@ -23,7 +23,7 @@ L'employeur souhaite vous apporter des explications supplémentaires par télép
 - Début de la prolongation : {{ prolongation_request.start_at|date:"d/m/Y" }}
 - Fin de la prolongation : {{ prolongation_request.end_at|date:"d/m/Y" }}
 - Motif de prolongation : {{ prolongation_request.get_reason_display }}
-{% if prolongation_request.report_file %}- Fiche bilan : {{ prolongation_request.report_file.link }}{% endif %}
+{% if prolongation_request.report_file %}- Fiche bilan : {{ report_file_url }}{% endif %}
 
 Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur {{ prolongation_request.prescriber_organization.display_name }} sur les emplois de l'inclusion, à la rubrique "Gérer mes prolongations de PASS IAE".
 

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -42,7 +42,7 @@
                             </p>
                             <p>
                                 <a class="btn btn-secondary btn-ico"
-                                   href="{{ prolongation_request.report_file.link }}"
+                                   href="{% url "approvals:prolongation_request_report_file" prolongation_request_id=prolongation_request.pk %}"
                                    download="Bilan prolongation PASS IAE {{ prolongation_request.approval.number }} {{ prolongation_request.approval.user.get_full_name }}.xlsx">
                                     <i class="ri-download-line ri-lg font-weight-normal"></i>
                                     <span>Télécharger le bilan</span>

--- a/itou/utils/storage/s3.py
+++ b/itou/utils/storage/s3.py
@@ -18,6 +18,7 @@ def s3_client():
     )
 
 
-class S3Storage(S3Boto3Storage):
-    # Don’t expose S3 credentials through the default_storage.url().
+class PublicStorage(S3Boto3Storage):
+    # Not using the S3StaticStorage backend to ensure the listdir() operation remains forbidden.
+    # Don’t sign URLs, objects are public.
     querystring_auth = False

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -6,7 +6,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
-from django.core.files.storage import default_storage
+from django.core.files.storage import storages
 from django.db import transaction
 from django.forms import ValidationError
 from django.http import Http404, HttpResponseRedirect
@@ -1052,8 +1052,9 @@ class ApplicationResumeView(ApplicationBaseView):
             if resume := self.form.cleaned_data.get("resume"):
                 key = f"resume/{uuid.uuid4()}.pdf"
                 File.objects.create(key=key)
-                name = default_storage.save(key, resume)
-                job_application.resume_link = default_storage.url(name)
+                public_storage = storages["public"]
+                name = public_storage.save(key, resume)
+                job_application.resume_link = public_storage.url(name)
 
             # Save the job application
             with transaction.atomic():

--- a/itou/www/approvals_views/urls.py
+++ b/itou/www/approvals_views/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
         name="prolongation_request_show",
     ),
     path(
+        "prolongation/request/<int:prolongation_request_id>/report-file/",
+        views.prolongation_request_report_file,
+        name="prolongation_request_report_file",
+    ),
+    path(
         "prolongation/request/<int:prolongation_request_id>/grant",
         views.ProlongationRequestGrantView.as_view(),
         name="prolongation_request_grant",

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -11,6 +11,7 @@ from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.views import View
+from django.views.decorators.http import require_safe
 from django.views.generic import DetailView, ListView, TemplateView
 from formtools.wizard.views import NamedUrlSessionWizardView
 
@@ -389,6 +390,19 @@ def prolongation_requests_list(request, template_name="approvals/prolongation_re
         "pager": pager(queryset, request.GET.get("page"), items_per_page=10),
     }
     return render(request, template_name, context)
+
+
+@require_safe
+@login_required
+def prolongation_request_report_file(request, prolongation_request_id):
+    prolongation_request = get_object_or_404(
+        ProlongationRequest,
+        pk=prolongation_request_id,
+        report_file__isnull=False,
+    )
+    if prolongation_request.prescriber_organization_id not in [org.pk for org in request.organizations]:
+        raise Http404
+    return HttpResponseRedirect(default_storage.url(prolongation_request.report_file_id))
 
 
 class ProlongationRequestViewMixin(LoginRequiredMixin):

--- a/tests/approvals/__snapshots__/test_notifications.ambr
+++ b/tests/approvals/__snapshots__/test_notifications.ambr
@@ -22,7 +22,7 @@
   - Début de la prolongation : 01/01/2000
   - Fin de la prolongation : 31/01/2000
   - Motif de prolongation : 50 ans et plus
-  - Fiche bilan : http://localhost:9000/tests/snapshot/f0r_5n4p5h07
+  - Fiche bilan : http://localhost:8000/approvals/prolongation/request/666/report-file/
   
   Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur Pres. org. sur les emplois de l'inclusion, à la rubrique "Gérer mes prolongations de PASS IAE".
   
@@ -81,7 +81,7 @@
   - Début de la prolongation : 01/01/2000
   - Fin de la prolongation : 31/01/2000
   - Motif de prolongation : 50 ans et plus
-  - Fiche bilan : http://localhost:9000/tests/snapshot/f0r_5n4p5h07
+  - Fiche bilan : http://localhost:8000/approvals/prolongation/request/666/report-file/
   
   Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur Pres. org. sur les emplois de l'inclusion, à la rubrique "Gérer mes prolongations de PASS IAE".
   

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.gis.db.models.fields import get_srid_info
 from django.core import management
 from django.core.cache import cache
-from django.core.files.storage import default_storage
+from django.core.files.storage import default_storage, storages
 from django.core.management import call_command
 from django.db import connection
 from django.template import base as base_template
@@ -93,10 +93,15 @@ def test_settings():
 
 @pytest.fixture(autouse=True)
 def storage_prefix_per_test(test_settings):
-    original_location = default_storage.location
-    default_storage.location = f"{uuid.uuid4()}"
+    public_storage = storages["public"]
+    original_default_location = default_storage.location
+    original_public_location = public_storage.location
+    namespace = f"{uuid.uuid4()}"
+    default_storage.location = namespace
+    public_storage.location = namespace
     yield
-    default_storage.location = original_location
+    default_storage.location = original_default_location
+    public_storage.location = original_public_location
 
 
 @pytest.fixture

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -4,31 +4,10 @@ import httpx
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.core.management import call_command
-from django.utils import timezone
 from pytest_django.asserts import assertQuerySetEqual
 
-from itou.approvals.enums import ProlongationReason
 from itou.files.models import File
 from itou.utils.storage.s3 import s3_client
-from tests.approvals.factories import ProlongationFactory
-
-
-def test_report_file_link():
-    prolongation = ProlongationFactory(reason=ProlongationReason.RQTH)
-
-    assert prolongation.report_file is None
-
-    file_path = "prolongation_report/test.xslx"
-    report_file = File(file_path, timezone.now())
-    report_file.save()
-
-    prolongation.report_file = report_file
-    prolongation.save()
-
-    assert (
-        prolongation.report_file.link
-        == f"{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}/{default_storage.location}/{file_path}"
-    )
 
 
 def test_sync_files_ignores_temporary_storage(temporary_bucket):

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -7,7 +7,7 @@ import pytest
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib import messages
-from django.core.files.storage import default_storage
+from django.core.files.storage import storages
 from django.urls import resolve, reverse
 from django.utils import timezone
 from pytest_django.asserts import assertContains, assertRedirects
@@ -421,7 +421,7 @@ class ApplyAsJobSeekerTest(TestCase):
         assert job_application.message == "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         assert list(job_application.selected_jobs.all()) == [siae.job_description_through.first()]
         assert job_application.resume_link == (
-            f"http://localhost:9000/tests/{default_storage.location}"
+            f"http://localhost:9000/tests/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
@@ -834,7 +834,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         ]
         assert (
             job_application.resume_link == f"{settings.AWS_S3_ENDPOINT_URL}"
-            f"tests/{default_storage.location}/resume/11111111-1111-1111-1111-111111111111.pdf"
+            f"tests/{storages['public'].location}/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
         assert f"job_application-{siae.pk}" not in self.client.session
@@ -1079,7 +1079,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
             siae.job_description_through.last(),
         ]
         assert job_application.resume_link == (
-            f"http://localhost:9000/tests/{default_storage.location}"
+            f"http://localhost:9000/tests/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
@@ -1358,7 +1358,7 @@ class ApplyAsPrescriberTest(TestCase):
             siae.job_description_through.last(),
         ]
         assert job_application.resume_link == (
-            f"http://localhost:9000/tests/{default_storage.location}"
+            f"http://localhost:9000/tests/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
@@ -1786,7 +1786,7 @@ class ApplyAsSiaeTest(TestCase):
             siae.job_description_through.last(),
         ]
         assert job_application.resume_link == (
-            f"http://localhost:9000/tests/{default_storage.location}"
+            f"http://localhost:9000/tests/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -637,7 +637,7 @@
                                   Le bilan des actions réalisées et actions prévues avec le salarié, rempli par l’employeur est présent sur le document excel téléchargeable ci-dessous.
                               </p>
                               <p>
-                                  <a class="btn btn-secondary btn-ico" download="Bilan prolongation PASS IAE 999999999999 John DOE.xlsx" href="http://localhost:9000/tests/snapshot/f0r_5n4p5h07">
+                                  <a class="btn btn-secondary btn-ico" download="Bilan prolongation PASS IAE 999999999999 John DOE.xlsx" href="/approvals/prolongation/request/666/report-file/">
                                       <i class="ri-download-line ri-lg font-weight-normal"></i>
                                       <span>Télécharger le bilan</span>
                                   </a>


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Am-liorer-la-compatibilit-de-l-envoi-des-fichiers-c4cfcdb49db64ebca1b80fec141539ba**

### Pourquoi ?

Sécurité.