### PR TITLE
Migrer EvaluatedAdministrativeCriteria.proof_url vers proof

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin, messages
+from django.core.files.storage import default_storage
 from django.utils import timezone
 from django.utils.html import format_html
 
@@ -283,11 +284,20 @@ class EvaluatedAdministrativeCriteriaAdmin(ItouModelAdmin):
         "evaluated_job_application",
         "administrative_criteria",
         "uploaded_at",
-        "proof_url",
-        "proof",
+        "proof_link",
         "submitted_at",
         "review_state",
     )
+
+    @admin.display(description="lien du fichier bilan")
+    def proof_link(self, obj):
+        if obj.proof_id:
+            return format_html(
+                "<a href='{}'>{}</a>",
+                default_storage.url(obj.proof_id),
+                obj.proof_id,
+            )
+        return ""
 
 
 @admin.register(models.Sanctions)

--- a/itou/siae_evaluations/migrations/0012_evaluatedadministrativecriteria_proof_url_to_proof.py
+++ b/itou/siae_evaluations/migrations/0012_evaluatedadministrativecriteria_proof_url_to_proof.py
@@ -1,0 +1,48 @@
+import re
+
+from django.conf import settings
+from django.db import migrations, models, transaction
+
+
+def forwards(apps, schema_editor):
+    print()
+    EvaluatedAdministrativeCriteria = apps.get_model("siae_evaluations", "EvaluatedAdministrativeCriteria")
+    EvaluatedAdministrativeCriteria = apps.get_model("siae_evaluations", "EvaluatedAdministrativeCriteria")
+    File = apps.get_model("files", "File")
+    key_re = re.compile(
+        rf"^{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}/(?P<key>evaluations/.*\.[pP][dD][fF])$"
+    )
+    criterias = []
+    with transaction.atomic():
+        for criteria in EvaluatedAdministrativeCriteria.objects.filter(proof=None).exclude(proof_url=""):
+            if match := key_re.match(criteria.proof_url):
+                criteria.proof, _created = File.objects.get_or_create(key=match.group("key"))
+                criterias.append(criteria)
+            else:
+                print(f"Could not migrate proof “{criteria.proof_url}”.")
+        count = EvaluatedAdministrativeCriteria.objects.bulk_update(criterias, fields=["proof"])
+    print(f"Migrated {count} evaluated administrative criteria")
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("siae_evaluations", "0011_evaluatedadministrativecriteria_proof"),
+        ("files", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, migrations.RunPython.noop, elidable=True),
+        migrations.AlterField(
+            model_name="evaluatedadministrativecriteria",
+            name="proof_url",
+            field=models.URLField(blank=True, null=True, max_length=500, verbose_name="lien vers le justificatif"),
+        ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.RemoveField(model_name="evaluatedadministrativecriteria", name="proof_url"),
+            ],
+        ),
+    ]

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -650,7 +650,7 @@ class EvaluatedJobApplication(models.Model):
 
     def compute_state(self):
         def state_from(criteria):
-            if criteria.proof_url == "":
+            if criteria.proof_id is None:
                 return evaluation_enums.EvaluatedJobApplicationsState.PROCESSING
             if criteria.submitted_at is None:
                 return evaluation_enums.EvaluatedJobApplicationsState.UPLOADED
@@ -763,7 +763,6 @@ class EvaluatedAdministrativeCriteria(models.Model):
         related_name="evaluated_administrative_criteria",
     )
 
-    proof_url = models.URLField(max_length=500, verbose_name="lien vers le justificatif", blank=True)
     proof = models.ForeignKey("files.File", on_delete=models.CASCADE, blank=True, null=True)
     uploaded_at = models.DateTimeField(verbose_name="téléversé le", blank=True, null=True)
     submitted_at = models.DateTimeField(verbose_name="transmis le", blank=True, null=True)

--- a/itou/templates/siae_evaluations/includes/criterion_validation.html
+++ b/itou/templates/siae_evaluations/includes/criterion_validation.html
@@ -2,7 +2,10 @@
     <div class="card-body">
         <div class="row align-items-center">
             <div class="col-lg-8 col-md-8 col-12">
-                <a href="{{ evaluated_administrative_criteria.proof_url }}" rel="noopener" target="_blank" aria-label="Vérifier ce justificatif (ouverture dans un nouvel onglet)">
+                <a href="{% url "siae_evaluations_views:view_proof" evaluated_administrative_criteria_id=evaluated_administrative_criteria.pk %}"
+                   rel="noopener"
+                   target="_blank"
+                   aria-label="Vérifier ce justificatif (ouverture dans un nouvel onglet)">
                     <i class="ri-file-copy-2-line ri-lg mr-1"></i>
                     {% if evaluated_siae.state == "SUBMITTED" or evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}
                         Vérifier ce justificatif

--- a/itou/templates/siae_evaluations/includes/list_item.html
+++ b/itou/templates/siae_evaluations/includes/list_item.html
@@ -20,15 +20,15 @@
                     <div class="col-md-12 mt-3">
                         {% if evaluated_administrative_criteria.can_upload %}
                             <a href="{% url 'siae_evaluations_views:siae_upload_doc' evaluated_administrative_criteria.pk %}"
-                               class="btn {% if evaluated_administrative_criteria.proof_url and criteria_review_state == 'PENDING' %}btn-outline-primary {% else %}btn-primary {% endif %}float-right">
-                                {% if evaluated_administrative_criteria.proof_url %}
+                               class="btn {% if evaluated_administrative_criteria.proof_id and criteria_review_state == 'PENDING' %}btn-outline-primary {% else %}btn-primary {% endif %}float-right">
+                                {% if evaluated_administrative_criteria.proof_id %}
                                     Modifier le justificatif
                                 {% else %}
                                     Ajouter un justificatif
                                 {% endif %}
                             </a>
-                        {% elif evaluated_administrative_criteria.proof_url %}
-                            <a href="{{ evaluated_administrative_criteria.proof_url }}" target="_blank" class="btn btn-outline-primary float-right">Visualiser le justificatif soumis</a>
+                        {% elif evaluated_administrative_criteria.proof_id %}
+                            <a href="{% url "siae_evaluations_views:view_proof" evaluated_administrative_criteria_id=evaluated_administrative_criteria.pk %}" target="_blank" class="btn btn-outline-primary float-right">Visualiser le justificatif soumis</a>
                         {% endif %}
                     </div>
                 </div>

--- a/itou/templates/siae_evaluations/institution_evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_job_application.html
@@ -22,7 +22,10 @@
                                     {% for evaluated_administrative_criteria in evaluated_job_application.evaluated_administrative_criteria.all %}
                                         {% include "siae_evaluations/includes/criterion_infos.html" with criteria=evaluated_administrative_criteria.administrative_criteria review_state=evaluated_administrative_criteria.review_state %}
                                         {% if evaluated_siae.evaluation_is_final %}
-                                            <a href="{{ evaluated_administrative_criteria.proof_url }}" rel="noopener" target="_blank" aria-label="Revoir ce justificatif (ouverture dans un nouvel onglet)">
+                                            <a href="{% url "siae_evaluations_views:view_proof" evaluated_administrative_criteria_id=evaluated_administrative_criteria.pk %}"
+                                               rel="noopener"
+                                               target="_blank"
+                                               aria-label="Revoir ce justificatif (ouverture dans un nouvel onglet)">
                                                 Revoir ce justificatif
                                             </a>
                                         {% else %}

--- a/itou/templates/siae_evaluations/siae_upload_doc.html
+++ b/itou/templates/siae_evaluations/siae_upload_doc.html
@@ -29,10 +29,10 @@
                                 </div>
                             </div>
 
-                            {% if evaluated_administrative_criteria.proof_url %}
+                            {% if evaluated_administrative_criteria.proof_id %}
                                 <div class="row mt-3">
                                     <div class="col-md-12">
-                                        <a href="{{ evaluated_administrative_criteria.proof_url }}" target="_blank">Visualiser le justificatif précédemment téléversé</a>
+                                        <a href="{% url "siae_evaluations_views:view_proof" evaluated_administrative_criteria_id=evaluated_administrative_criteria.pk %}" target="_blank">Visualiser le justificatif précédemment téléversé</a>
                                     </div>
                                 </div>
                             {% endif %}
@@ -57,7 +57,7 @@
                                         </div>
 
                                         <button class="btn btn-primary float-right">
-                                            {% if evaluated_administrative_criteria.proof_url %}
+                                            {% if evaluated_administrative_criteria.proof_id %}
                                                 Enregistrer le nouveau justificatif
                                             {% else %}
                                                 Enregistrer le justificatif

--- a/itou/www/siae_evaluations_views/urls.py
+++ b/itou/www/siae_evaluations_views/urls.py
@@ -82,4 +82,5 @@ urlpatterns = [
         name="siae_upload_doc",
     ),
     path("siae_submit_proofs/<int:evaluated_siae_pk>/", views.siae_submit_proofs, name="siae_submit_proofs"),
+    path("view_proof/<int:evaluated_administrative_criteria_id>/", views.view_proof, name="view_proof"),
 ]

--- a/tests/siae_evaluations/factories.py
+++ b/tests/siae_evaluations/factories.py
@@ -98,5 +98,4 @@ class EvaluatedAdministrativeCriteriaFactory(factory.django.DjangoModelFactory):
         model = models.EvaluatedAdministrativeCriteria
 
     administrative_criteria = factory.Iterator(AdministrativeCriteria.objects.all())
-    proof_url = "https://server.com/rocky-balboa.pdf"
     proof = factory.SubFactory(FileFactory)

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -847,17 +847,16 @@ class EvaluatedSiaeModelTest(TestCase):
         del evaluated_siae.state_from_applications
 
         # one evaluated_administrative_criterion
-        # empty : proof_url and submitted_at empty)
+        # empty : proof and submitted_at empty)
         evaluated_administrative_criteria0 = EvaluatedAdministrativeCriteriaFactory(
-            evaluated_job_application=evaluated_job_application, proof_url="", proof=None
+            evaluated_job_application=evaluated_job_application, proof=None
         )
         assert evaluation_enums.EvaluatedSiaeState.PENDING == evaluated_siae.state
         del evaluated_siae.state_from_applications
 
-        # with proof_url
-        evaluated_administrative_criteria0.proof_url = "https://server.com/rocky-balboa.pdf"
+        # with proof
         evaluated_administrative_criteria0.proof = FileFactory()
-        evaluated_administrative_criteria0.save(update_fields=["proof_url", "proof"])
+        evaluated_administrative_criteria0.save(update_fields=["proof"])
         assert evaluation_enums.EvaluatedSiaeState.SUBMITTABLE == evaluated_siae.state
         del evaluated_siae.state_from_applications
 
@@ -1240,13 +1239,12 @@ class EvaluatedJobApplicationModelTest(TestCase):
         assert evaluation_enums.EvaluatedJobApplicationsState.PENDING == evaluated_job_application.compute_state()
 
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteriaFactory(
-            evaluated_job_application=evaluated_job_application, proof_url="", proof=None
+            evaluated_job_application=evaluated_job_application, proof=None
         )
         assert evaluation_enums.EvaluatedJobApplicationsState.PROCESSING == evaluated_job_application.compute_state()
 
-        evaluated_administrative_criteria.proof_url = "https://www.test.com"
         evaluated_administrative_criteria.proof = FileFactory()
-        evaluated_administrative_criteria.save(update_fields=["proof_url", "proof"])
+        evaluated_administrative_criteria.save(update_fields=["proof"])
         assert evaluation_enums.EvaluatedJobApplicationsState.UPLOADED == evaluated_job_application.compute_state()
 
         evaluated_administrative_criteria.submitted_at = timezone.now()
@@ -1396,7 +1394,6 @@ class EvaluatedAdministrativeCriteriaModelTest(TestCase):
 
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteriaFactory(
             evaluated_job_application=EvaluatedJobApplicationFactory(),
-            proof_url="",
             proof=None,
         )
         assert evaluated_administrative_criteria.can_upload()


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Am-liorer-la-compatibilit-de-l-envoi-des-fichiers-c4cfcdb49db64ebca1b80fec141539ba**

# TODO :

- [x] Vérifier la migration (et la timer : 9 s sur ma machine)
- [x] Faire un admin pour `EvaluatedAdministrativeCriteria.proof` (permettre de télécharger le fichier), voir ce qui a été fait par Romain sur ProlongationRequestAdmin.
- [x] Vérifier dans un navigateur
- [x] Ajouter des tests pour siae_evaluations_views:view_proof (voir
  `TestProlongationReportFileView` https://github.com/betagouv/itou/pull/3193)
- [x] Retirer le champ `proof_url` de la DB dans une autre PR
