### PR TITLE
Harmonisation/simplification des redirections

### DIFF
--- a/itou/templates/account/account_type_selection.html
+++ b/itou/templates/account/account_type_selection.html
@@ -17,7 +17,7 @@
                                 <h3 class="h4 card-title font-weight-light">Vous êtes candidat en recherche d'emploi</h3>
                             </div>
                             <div class="card-footer">
-                                <a class="btn btn-primary stretched-link" href="{% url 'login:job_seeker' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                                <a class="btn btn-primary stretched-link" href="{% url 'login:job_seeker' %}{% redirection_url value=redirect_field_value %}">
                                     Se connecter
                                 </a>
                             </div>
@@ -27,7 +27,7 @@
                                 <h3 class="h4 card-title font-weight-light">Vous êtes prescripteur ou orienteur</h3>
                             </div>
                             <div class="card-footer">
-                                <a class="btn btn-primary stretched-link" href="{% url 'login:prescriber' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                                <a class="btn btn-primary stretched-link" href="{% url 'login:prescriber' %}{% redirection_url value=redirect_field_value %}">
                                     Se connecter
                                 </a>
                             </div>
@@ -39,7 +39,7 @@
                                 </h3>
                             </div>
                             <div class="card-footer">
-                                <a class="btn btn-primary stretched-link" href="{% url 'login:siae_staff' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                                <a class="btn btn-primary stretched-link" href="{% url 'login:siae_staff' %}{% redirection_url value=redirect_field_value %}">
                                     Se connecter
                                 </a>
                             </div>
@@ -49,7 +49,7 @@
                                 <h3 class="h4 card-title font-weight-light">Vous êtes membre d’une institution partenaire</h3>
                             </div>
                             <div class="card-footer">
-                                <a class="btn btn-primary stretched-link" href="{% url 'login:labor_inspector' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                                <a class="btn btn-primary stretched-link" href="{% url 'login:labor_inspector' %}{% redirection_url value=redirect_field_value %}">
                                     Se connecter
                                 </a>
                             </div>

--- a/itou/templates/account/includes/login_form.html
+++ b/itou/templates/account/includes/login_form.html
@@ -8,7 +8,7 @@
             <div class="col-12">
                 <p class="h4">Se connecter avec vos identifiants</p>
                 {% bootstrap_form_errors form type="all" %}
-                {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
+                {% redirection_input_field value=redirect_field_value %}
                 {% bootstrap_field form.login %}
                 {% bootstrap_field form.password form_group_class="form-group mb-2" %}
                 <div class="form-group">

--- a/itou/templates/account/logout.html
+++ b/itou/templates/account/logout.html
@@ -19,7 +19,7 @@
 
                             {% csrf_token %}
 
-                            {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
+                            {% redirection_input_field value=redirect_field_value %}
 
                             {% buttons %}
                                 <button class="btn btn-primary">Se déconnecter</button>

--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -128,22 +128,22 @@
             <div class="dropdown-menu" id="loginUserDropdown{% if is_mobile %}Mobile{% endif %}">
                 <ul class="list-unstyled">
                     <li>
-                        <a class="dropdown-item" href="{% url 'login:job_seeker' %}{% redirection_url value=redirect_field_value %}">
+                        <a class="dropdown-item" href="{% url 'login:job_seeker' %}{% redirection_url value=redirect_field_value|default:"" %}">
                             Candidat
                         </a>
                     </li>
                     <li>
-                        <a class="dropdown-item" href="{% url 'login:prescriber' %}{% redirection_url value=redirect_field_value %}">
+                        <a class="dropdown-item" href="{% url 'login:prescriber' %}{% redirection_url value=redirect_field_value|default:"" %}">
                             Prescripteur
                         </a>
                     </li>
                     <li>
-                        <a class="dropdown-item" href="{% url 'login:siae_staff' %}{% redirection_url value=redirect_field_value %}">
+                        <a class="dropdown-item" href="{% url 'login:siae_staff' %}{% redirection_url value=redirect_field_value|default:"" %}">
                             Employeur solidaire
                         </a>
                     </li>
                     <li>
-                        <a class="dropdown-item" href="{% url 'login:labor_inspector' %}{% redirection_url value=redirect_field_value %}">
+                        <a class="dropdown-item" href="{% url 'login:labor_inspector' %}{% redirection_url value=redirect_field_value|default:"" %}">
                             Institution partenaire
                         </a>
                     </li>

--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -128,22 +128,22 @@
             <div class="dropdown-menu" id="loginUserDropdown{% if is_mobile %}Mobile{% endif %}">
                 <ul class="list-unstyled">
                     <li>
-                        <a class="dropdown-item" href="{% url 'login:job_seeker' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                        <a class="dropdown-item" href="{% url 'login:job_seeker' %}{% redirection_url value=redirect_field_value %}">
                             Candidat
                         </a>
                     </li>
                     <li>
-                        <a class="dropdown-item" href="{% url 'login:prescriber' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                        <a class="dropdown-item" href="{% url 'login:prescriber' %}{% redirection_url value=redirect_field_value %}">
                             Prescripteur
                         </a>
                     </li>
                     <li>
-                        <a class="dropdown-item" href="{% url 'login:siae_staff' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                        <a class="dropdown-item" href="{% url 'login:siae_staff' %}{% redirection_url value=redirect_field_value %}">
                             Employeur solidaire
                         </a>
                     </li>
                     <li>
-                        <a class="dropdown-item" href="{% url 'login:labor_inspector' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                        <a class="dropdown-item" href="{% url 'login:labor_inspector' %}{% redirection_url value=redirect_field_value %}">
                             Institution partenaire
                         </a>
                     </li>

--- a/itou/templates/search/siaes_search_home.html
+++ b/itou/templates/search/siaes_search_home.html
@@ -26,7 +26,7 @@
                             <h3 class="h4 card-title font-weight-light">Inscrivez-vous pour commencer à utiliser la plateforme</h3>
                         </div>
                         <div class="card-footer">
-                            <a class="btn btn-primary stretched-link" href="{% url 'account_signup' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                            <a class="btn btn-primary stretched-link" href="{% url 'account_signup' %}{% redirection_url value=redirect_field_value %}">
                                 Créer un compte
                             </a>
                         </div>

--- a/itou/templates/signup/job_seeker_nir.html
+++ b/itou/templates/signup/job_seeker_nir.html
@@ -24,7 +24,7 @@
 
                             {% bootstrap_form form %}
 
-                            {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
+                            {% redirection_input_field value=redirect_field_value %}
 
                             {% if form.errors %}
                                 <div class="alert alert-info">

--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -47,7 +47,7 @@
 
                             {% csrf_token %}
 
-                            {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
+                            {% redirection_input_field value=redirect_field_value %}
 
                             {# bootstrap_form_errors form alert_error_type="all" #}
 

--- a/itou/templates/signup/job_seeker_situation.html
+++ b/itou/templates/signup/job_seeker_situation.html
@@ -20,7 +20,7 @@
 
                             {% csrf_token %}
 
-                            {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
+                            {% redirection_input_field value=redirect_field_value %}
 
                             {% bootstrap_form form alert_error_type="all" %}
 

--- a/itou/templates/signup/signup.html
+++ b/itou/templates/signup/signup.html
@@ -20,7 +20,7 @@
                                 </h3>
                             </div>
                             <div class="card-footer">
-                                <a class="btn btn-primary stretched-link" href="{% url 'signup:siae_select' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                                <a class="btn btn-primary stretched-link" href="{% url 'signup:siae_select' %}{% redirection_url value=redirect_field_value %}">
                                     Créer un compte
                                 </a>
                             </div>
@@ -30,7 +30,7 @@
                                 <h3 class="h4 card-title font-weight-light">Vous êtes prescripteur ou orienteur</h3>
                             </div>
                             <div class="card-footer">
-                                <a class="btn btn-primary stretched-link" href="{% url 'signup:prescriber_check_already_exists' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                                <a class="btn btn-primary stretched-link" href="{% url 'signup:prescriber_check_already_exists' %}{% redirection_url value=redirect_field_value %}">
                                     Créer un compte
                                 </a>
                             </div>
@@ -40,7 +40,7 @@
                                 <h3 class="h4 card-title font-weight-light">Vous êtes en recherche d'un emploi et souhaitez postuler</h3>
                             </div>
                             <div class="card-footer">
-                                <a class="btn btn-primary stretched-link" href="{% url 'signup:job_seeker_situation' %}{% redirection_url name=redirect_field_name value=redirect_field_value %}">
+                                <a class="btn btn-primary stretched-link" href="{% url 'signup:job_seeker_situation' %}{% redirection_url value=redirect_field_value %}">
                                     Créer un compte
                                 </a>
                             </div>

--- a/itou/utils/templatetags/redirection_fields.py
+++ b/itou/utils/templatetags/redirection_fields.py
@@ -2,6 +2,7 @@
 https://docs.djangoproject.com/en/dev/howto/custom-template-tags/
 """
 from django import template
+from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.utils.safestring import mark_safe
 
 
@@ -9,28 +10,28 @@ register = template.Library()
 
 
 @register.simple_tag
-def redirection_url(name, value):
+def redirection_url(value):
     """
     Append a URL to be followed if needed.
 
     Usage:
         {% load redirection_fields %}
-        '/my_url{% redirection_url name=redirect_field_name value=redirect_field_value %}''
+        '/my_url{% redirection_url value=redirect_field_value %}''
     """
     if value:
-        return f"?{name}={value}"
+        return f"?{REDIRECT_FIELD_NAME}={value}"
     return ""
 
 
 @register.simple_tag
-def redirection_input_field(name, value):
+def redirection_input_field(value):
     """
     Return a form input field with a redirection URL if needed.
 
     Usage:
         {% load redirection_fields %}
-        {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
+        {% redirection_input_field value=redirect_field_value %}
     """
     if value:
-        return mark_safe(f'<input type="hidden" name="{name}" value="{value}">')
+        return mark_safe(f'<input type="hidden" name="{REDIRECT_FIELD_NAME}" value="{value}">')
     return ""

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -46,7 +46,6 @@ class ItouLoginView(LoginView):
             "login_url": login_url,
             "signup_url": signup_url,
             "signup_allowed": True,
-            "redirect_field_name": REDIRECT_FIELD_NAME,
             "redirect_field_value": get_safe_url(self.request, REDIRECT_FIELD_NAME),
             "inclusion_connect_url": self._get_inclusion_connect_url(context),
         }

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -58,14 +58,13 @@ class ItouPasswordResetView(PasswordResetView):
 
 
 @require_GET
-def signup(request, template_name="signup/signup.html", redirect_field_name=REDIRECT_FIELD_NAME):
+def signup(request, template_name="signup/signup.html"):
     """
     Override allauth `account_signup` URL
     (the route is defined in config.urls).
     """
     context = {
-        "redirect_field_name": redirect_field_name,
-        "redirect_field_value": get_safe_url(request, redirect_field_name),
+        "redirect_field_value": get_safe_url(request, REDIRECT_FIELD_NAME),
     }
     return render(request, template_name, context)
 
@@ -99,9 +98,7 @@ class JobSeekerSignupView(SignupView):
         return kwargs
 
 
-def job_seeker_situation(
-    request, template_name="signup/job_seeker_situation.html", redirect_field_name=REDIRECT_FIELD_NAME
-):
+def job_seeker_situation(request, template_name="signup/job_seeker_situation.html"):
     """
     Second step of the signup process for jobseeker.
 
@@ -118,20 +115,19 @@ def job_seeker_situation(
             next_url = reverse("signup:job_seeker_nir")
 
         # forward next page
-        if redirect_field_name in form.data:
-            next_url = f"{next_url}?{redirect_field_name}={form.data[redirect_field_name]}"
+        if REDIRECT_FIELD_NAME in form.data:
+            next_url = f"{next_url}?{REDIRECT_FIELD_NAME}={form.data[REDIRECT_FIELD_NAME]}"
 
         return HttpResponseRedirect(next_url)
 
     context = {
         "form": form,
-        "redirect_field_name": redirect_field_name,
-        "redirect_field_value": get_safe_url(request, redirect_field_name),
+        "redirect_field_value": get_safe_url(request, REDIRECT_FIELD_NAME),
     }
     return render(request, template_name, context)
 
 
-def job_seeker_nir(request, template_name="signup/job_seeker_nir.html", redirect_field_name=REDIRECT_FIELD_NAME):
+def job_seeker_nir(request, template_name="signup/job_seeker_nir.html"):
     form = forms.JobSeekerNirForm(data=request.POST or None)
 
     if request.method == "POST":
@@ -140,8 +136,8 @@ def job_seeker_nir(request, template_name="signup/job_seeker_nir.html", redirect
             request.session[global_constants.ITOU_SESSION_NIR_KEY] = form.cleaned_data["nir"]
 
             # forward next page
-            if redirect_field_name in form.data:
-                next_url = f"{next_url}?{redirect_field_name}={form.data[redirect_field_name]}"
+            if REDIRECT_FIELD_NAME in form.data:
+                next_url = f"{next_url}?{REDIRECT_FIELD_NAME}={form.data[REDIRECT_FIELD_NAME]}"
 
             return HttpResponseRedirect(next_url)
 
@@ -150,8 +146,7 @@ def job_seeker_nir(request, template_name="signup/job_seeker_nir.html", redirect
 
     context = {
         "form": form,
-        "redirect_field_name": redirect_field_name,
-        "redirect_field_value": get_safe_url(request, redirect_field_name),
+        "redirect_field_value": get_safe_url(request, REDIRECT_FIELD_NAME),
     }
     return render(request, template_name, context)
 

--- a/tests/status/tests.py
+++ b/tests/status/tests.py
@@ -3,7 +3,6 @@ import textwrap
 from unittest import mock
 
 import factory
-import pytest
 from django import urls
 from django.core import management
 from django.utils import timezone
@@ -14,8 +13,6 @@ from itou.status.management.commands import run_status_probes
 from tests.status import factories
 from tests.utils.test import TestCase
 
-
-pytestmark = pytest.mark.ignore_template_errors
 
 fake = Faker()
 

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -663,11 +663,11 @@ class UtilsTemplateTagsTestCase(TestCase):
         redirect_field_value = reverse("search:siaes_home")
 
         # Redirection value.
-        context = {"redirect_field_name": "next", "redirect_field_value": redirect_field_value}
+        context = {"redirect_field_value": redirect_field_value}
         template = Template(
             """
             {% load redirection_fields %}
-            {% url "dashboard:index" %}{% redirection_url name=redirect_field_name value=redirect_field_value %}
+            {% url "dashboard:index" %}{% redirection_url value=redirect_field_value %}
         """
         )
         out = template.render(Context(context)).strip()
@@ -678,7 +678,7 @@ class UtilsTemplateTagsTestCase(TestCase):
         template = Template(
             """
             {% load redirection_fields %}
-            {% url "dashboard:index" %}{% redirection_url name=redirect_field_name value=redirect_field_value %}
+            {% url "dashboard:index" %}{% redirection_url value=redirect_field_value %}
         """
         )
         out = template.render(Context()).strip()
@@ -690,11 +690,11 @@ class UtilsTemplateTagsTestCase(TestCase):
         value = reverse("search:siaes_home")
 
         # Redirection value.
-        context = {"redirect_field_name": name, "redirect_field_value": value}
+        context = {"redirect_field_value": value}
         template = Template(
             """
             {% load redirection_fields %}
-            {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
+            {% redirection_input_field value=redirect_field_value %}
         """
         )
         out = template.render(Context(context)).strip()
@@ -705,7 +705,7 @@ class UtilsTemplateTagsTestCase(TestCase):
         template = Template(
             """
             {% load redirection_fields %}
-            {% redirection_input_field name=redirect_field_name value=redirect_field_value %}
+            {% redirection_input_field value=redirect_field_value %}
         """
         )
         out = template.render(Context()).strip()

--- a/tests/www/api/tests.py
+++ b/tests/www/api/tests.py
@@ -1,10 +1,6 @@
-import pytest
 from django.conf import settings
 from django.urls import reverse
 from pytest_django.asserts import assertContains
-
-
-pytestmark = pytest.mark.ignore_template_errors
 
 
 def test_index(client):

--- a/tests/www/invitations_views/test_new_user.py
+++ b/tests/www/invitations_views/test_new_user.py
@@ -1,10 +1,6 @@
 import uuid
 
-import pytest
 from django.shortcuts import reverse
-
-
-pytestmark = pytest.mark.ignore_template_errors
 
 
 class TestNewUser:

--- a/tests/www/login/tests.py
+++ b/tests/www/login/tests.py
@@ -1,6 +1,5 @@
 from urllib.parse import urlencode
 
-import pytest
 import respx
 from django.contrib import messages
 from django.test import override_settings
@@ -25,9 +24,6 @@ from tests.users.factories import (
     SiaeStaffFactory,
 )
 from tests.utils.test import TestCase, assertMessages, reload_module
-
-
-pytestmark = pytest.mark.ignore_template_errors
 
 
 class ItouLoginTest(TestCase):

--- a/tests/www/prescribers_views/test_edit.py
+++ b/tests/www/prescribers_views/test_edit.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-import pytest
 from django.urls import reverse
 from pytest_django.asserts import assertContains
 
@@ -9,9 +8,6 @@ from itou.prescribers.models import PrescriberOrganization
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
 from tests.prescribers.factories import PrescriberOrganizationFactory, PrescriberOrganizationWithMembershipFactory
 from tests.utils.test import TestCase, parse_response_to_soup
-
-
-pytestmark = pytest.mark.ignore_template_errors
 
 
 class CardViewTest(TestCase):

--- a/tests/www/releases/tests.py
+++ b/tests/www/releases/tests.py
@@ -1,10 +1,6 @@
-import pytest
 from django.urls import reverse
 
 from tests.utils.test import TestCase
-
-
-pytestmark = pytest.mark.ignore_template_errors
 
 
 class ReleaseTest(TestCase):

--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -1,6 +1,5 @@
 import datetime
 
-import pytest
 from django.urls import reverse
 from django.utils import timezone
 
@@ -11,9 +10,6 @@ from tests.institutions.factories import InstitutionMembershipFactory
 from tests.siae_evaluations.factories import EvaluatedSiaeFactory
 from tests.siaes.factories import SiaeMembershipFactory
 from tests.utils.test import TestCase
-
-
-pytestmark = pytest.mark.ignore_template_errors
 
 
 class EvaluatedSiaeSanctionViewTest(TestCase):

--- a/tests/www/signup/test_job_seeker.py
+++ b/tests/www/signup/test_job_seeker.py
@@ -1,6 +1,5 @@
 import uuid
 
-import pytest
 import respx
 from allauth.account.models import EmailConfirmationHMAC
 from django.conf import settings
@@ -17,9 +16,6 @@ from tests.cities.factories import create_test_cities
 from tests.openid_connect.france_connect.tests import FC_USERINFO, mock_oauth_dance
 from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
 from tests.utils.test import TestCase, reload_module
-
-
-pytestmark = pytest.mark.ignore_template_errors
 
 
 class JobSeekerSignupTest(TestCase):

--- a/tests/www/signup/test_password.py
+++ b/tests/www/signup/test_password.py
@@ -1,4 +1,3 @@
-import pytest
 from allauth.account.forms import default_token_generator
 from allauth.account.utils import user_pk_to_url_str
 from django.conf import settings
@@ -8,9 +7,6 @@ from django.utils.http import urlencode
 
 from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
 from tests.utils.test import TestCase
-
-
-pytestmark = pytest.mark.ignore_template_errors
 
 
 class PasswordResetTest(TestCase):


### PR DESCRIPTION
### Pourquoi ?

On utilise partout `django.contrib.auth.REDIRECT_FIELD_NAME` (et il vaut mieux utiliser partout le même champ).
Autant directement utiliser la constante de Django plutôt que laisser croire qu'on pourrait utiliser autre chose.

Cela facilite ensuite l'utilisation d'un filtre `default` pour pouvoir enlever la `pytest.mark.ignore_template_errors` de certains tests.
