### PR TITLE
Candidature annulée: amélioration de l'email envoyée

### DIFF
--- a/itou/templates/apply/email/cancel_body.txt
+++ b/itou/templates/apply/email/cancel_body.txt
@@ -43,10 +43,10 @@ Le candidat lui même.
 {% endif %}
 
 {% if job_application.sender_kind == SenderKind.PRESCRIBER %}
-
-- {{ job_application.sender.get_full_name }}{% if job_application.sender_prescriber_organization %}
-- {{ job_application.sender_prescriber_organization.display_name }}{% endif %}
-- {{ job_application.sender.email }}{% if job_application.sender.phone %}
+{% if job_application.sender %}
+- {{ job_application.sender.get_full_name }}{% endif %}{% if job_application.sender_prescriber_organization %}
+- {{ job_application.sender_prescriber_organization.display_name }}{% endif %}{% if job_application.sender and job_application.sender.email %}
+- {{ job_application.sender.email }}{% endif %}{% if job_application.sender and job_application.sender.phone %}
 - {{ job_application.sender.phone|format_phone }}{% endif %}
 
 {% endif %}

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -60,9 +60,6 @@ from tests.users.factories import ItouStaffFactory, JobSeekerFactory, Prescriber
 from tests.utils.test import TestCase, get_rows_from_streaming_response
 
 
-pytestmark = pytest.mark.ignore_template_errors
-
-
 @override_settings(
     API_ESD={
         "BASE_URL": "https://base.domain",


### PR DESCRIPTION
### Pourquoi ?

Éviter d'envoyer des éléments de liste vides dans l'email.
