### PR TITLE
Ajout de l'ID 306 de dashboard metabase 

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -419,7 +419,7 @@ ASP_ITOU_PREFIX = "99999"
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(
     os.getenv(
         "PILOTAGE_DASHBOARDS_WHITELIST",
-        "[63, 90, 32, 52, 54, 116, 43, 136, 140, 129, 150, 217, 218, 216, 300, 333, 336]",
+        "[63, 90, 32, 52, 54, 116, 43, 136, 140, 129, 150, 217, 218, 216, 300, 306, 336]",
     )
 )
 


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Ajouter-le-TB-Esat-dans-la-page-public-des-tableaux-de-bord-59579dc5dbc24baf87ff321be7fe2a21?pvs=4

### Pourquoi ?

Pour pouvoir partager un nouveau tableau de bord Metabase en <iframe> sur le site du Pilotage

### Comment

Ajout d'un ID de dashboard metabase à la constante `PILOTAGE_DASHBOARDS_WHITELIST`
Suppression de l'ancien ID 333 qui, finalement, n'était pas le bon ID
