### PR TITLE
Contrôle a posteriori: autoriser les admins à vérifier la vue du calendrier de la campagne

### DIFF
--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -24,7 +24,6 @@ from itou.siae_evaluations.models import (
     EvaluationCampaign,
     Sanctions,
 )
-from itou.siaes.models import Siae
 from itou.utils.emails import send_email_messages
 from itou.utils.perms.institution import get_current_institution_or_404
 from itou.utils.perms.siae import get_current_siae_or_404
@@ -83,7 +82,7 @@ def campaign_calendar(request, evaluation_campaign_pk, template_name="siae_evalu
 
     back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
 
-    if isinstance(request.current_organization, Siae):
+    if request.user.is_employer:
         evaluated_siae = get_object_or_404(
             EvaluatedSiae,
             evaluation_campaign=evaluation_campaign,

--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -502,3 +502,31 @@ class TestViewProof:
         client.force_login(membership.user)
         response = client.get(url)
         assert response.status_code == 404
+
+
+def test_active_campaign_calendar_for_admin_no_crash(admin_client):
+    calendar_html = """
+        <table class="table">
+            <thead class="thead-light">
+                <tr>
+                    <th></th>
+                    <th scope="col">Dates</th>
+                    <th scope="col">Acteurs</th>
+                    <th scope="col">Actions attendues</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th scope="row">Phase 1</th>
+                    <td>Du 15 mai 2023 au 11 juin 2023</td>
+
+                    <td>DDETS</td>
+                    <td>Sélection du taux de SIAE</td>
+                </tr>
+            </tbody>
+        </table>
+    """
+    evaluation_campaign = EvaluationCampaignFactory(calendar__html=calendar_html)
+    calendar_url = reverse("siae_evaluations_views:campaign_calendar", args=[evaluation_campaign.pk])
+    response = admin_client.get(calendar_url)
+    assert response.status_code == 200


### PR DESCRIPTION
### Pourquoi ?

https://itou.sentry.io/issues/4553165118/

Et ça n'est pas très cher. Si cela se complique, on pourra toujours décider de renvoyer une 404.

