### PR TITLE
Ajout de l'ID 236 de dashboard metabase

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -420,7 +420,7 @@ ASP_ITOU_PREFIX = "99999"
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(
     os.getenv(
         "PILOTAGE_DASHBOARDS_WHITELIST",
-        "[63, 90, 32, 52, 54, 116, 43, 136, 140, 129, 150, 217, 218, 216, 300, 306, 336]",
+        "[90, 32, 52, 54, 116, 43, 136, 140, 129, 150, 217, 218, 216, 236, 300, 306, 336]",
     )
 )
 


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Modifier-le-lien-du-TB-Public-stats-des-emplois-b960f82bc7cf43f4a56a89d4121a9bab?pvs=4

### Pourquoi ?

Pour pouvoir partager un nouveau tableau de bord Metabase en <iframe> sur le site du Pilotage

### Comment

Ajout de l'ID de dashboard metabase 236 à la constante `PILOTAGE_DASHBOARDS_WHITELIST`
Suppression de l'ancien ID 63
