### PR TITLE
Création d'un `TextChoices` `LackOfPoleEmploiId`

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -31,7 +31,7 @@ from itou.job_applications.enums import (
 from itou.job_applications.tasks import huey_notify_pole_emploi
 from itou.siaes.enums import SIAE_WITH_CONVENTION_KINDS, ContractType, SiaeKind
 from itou.siaes.models import Siae
-from itou.users.enums import UserKind
+from itou.users.enums import LackOfPoleEmploiId, UserKind
 from itou.utils.emails import get_email_message, send_email_messages
 from itou.utils.models import InclusiveDateRangeField
 from itou.utils.urls import get_absolute_url
@@ -953,7 +953,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
                 self.job_seeker.has_no_common_approval and (self.job_seeker.nir or self.job_seeker.pole_emploi_id)
             ) or (
                 self.job_seeker.pole_emploi_id
-                or self.job_seeker.lack_of_pole_emploi_id_reason == self.job_seeker.REASON_NOT_REGISTERED
+                or self.job_seeker.lack_of_pole_emploi_id_reason == LackOfPoleEmploiId.REASON_NOT_REGISTERED
             ):
                 # Security check: it's supposed to be blocked upstream.
                 if self.eligibility_diagnosis is None:
@@ -970,7 +970,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
                 emails.append(self.email_deliver_approval(accepted_by))
             elif not self.job_seeker.nir or (
                 not self.job_seeker.pole_emploi_id
-                and self.job_seeker.lack_of_pole_emploi_id_reason == self.job_seeker.REASON_FORGOTTEN
+                and self.job_seeker.lack_of_pole_emploi_id_reason == LackOfPoleEmploiId.REASON_FORGOTTEN
             ):
                 # Trigger a manual approval creation.
                 self.approval_delivery_mode = self.APPROVAL_DELIVERY_MODE_MANUAL

--- a/itou/users/enums.py
+++ b/itou/users/enums.py
@@ -39,3 +39,8 @@ class LackOfNIRReason(models.TextChoices):
         "NIR_ASSOCIATED_TO_OTHER",
         "Le numéro de sécurité sociale est associé à quelqu'un d'autre",
     )
+
+
+class LackOfPoleEmploiId(models.TextChoices):
+    REASON_FORGOTTEN = "FORGOTTEN", "Identifiant Pôle emploi oublié"
+    REASON_NOT_REGISTERED = "NOT_REGISTERED", "Non inscrit auprès de Pôle emploi"

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -37,7 +37,7 @@ from itou.utils.apis.exceptions import AddressLookupError
 from itou.utils.models import UniqueConstraintWithErrorCode
 from itou.utils.validators import validate_birthdate, validate_nir, validate_pole_emploi_id
 
-from .enums import IdentityProvider, LackOfNIRReason, Title, UserKind
+from .enums import IdentityProvider, LackOfNIRReason, LackOfPoleEmploiId, Title, UserKind
 
 
 class ApprovalAlreadyExistsError(Exception):
@@ -155,13 +155,6 @@ class User(AbstractUser, AddressMixin):
     More details in `itou.external_data.models` module
     """
 
-    REASON_FORGOTTEN = "FORGOTTEN"
-    REASON_NOT_REGISTERED = "NOT_REGISTERED"
-    REASON_CHOICES = (
-        (REASON_FORGOTTEN, "Identifiant Pôle emploi oublié"),
-        (REASON_NOT_REGISTERED, "Non inscrit auprès de Pôle emploi"),
-    )
-
     ERROR_EMAIL_ALREADY_EXISTS = "Cet e-mail existe déjà."
 
     title = models.CharField(
@@ -240,7 +233,7 @@ class User(AbstractUser, AddressMixin):
             "pour effectuer manuellement les vérifications d’usage."
         ),
         max_length=30,
-        choices=REASON_CHOICES,
+        choices=LackOfPoleEmploiId.choices,
         blank=True,
     )
     resume_link = models.URLField(max_length=500, verbose_name="lien vers un CV", blank=True)

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -23,7 +23,7 @@ from itou.files.forms import ItouFileField
 from itou.job_applications import enums as job_applications_enums
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow, PriorAction
 from itou.siaes.enums import SIAE_WITH_CONVENTION_KINDS, ContractType, SiaeKind
-from itou.users.enums import UserKind
+from itou.users.enums import LackOfPoleEmploiId, UserKind
 from itou.users.models import JobSeekerProfile, User
 from itou.utils import constants as global_constants
 from itou.utils.emails import redact_email_address
@@ -295,7 +295,7 @@ class CreateOrUpdateJobSeekerStep3Form(forms.ModelForm):
         # Handle Pole Emploi extra fields
         if self.cleaned_data["pole_emploi"]:
             if self.cleaned_data["pole_emploi_id_forgotten"]:
-                self.cleaned_data["lack_of_pole_emploi_id_reason"] = User.REASON_FORGOTTEN
+                self.cleaned_data["lack_of_pole_emploi_id_reason"] = LackOfPoleEmploiId.REASON_FORGOTTEN
                 self.cleaned_data["pole_emploi_id"] = ""
             elif self.cleaned_data.get("pole_emploi_id"):
                 self.cleaned_data["lack_of_pole_emploi_id_reason"] = ""
@@ -309,7 +309,7 @@ class CreateOrUpdateJobSeekerStep3Form(forms.ModelForm):
         else:
             self.cleaned_data["pole_emploi_id_forgotten"] = ""
             self.cleaned_data["pole_emploi_id"] = ""
-            self.cleaned_data["lack_of_pole_emploi_id_reason"] = User.REASON_NOT_REGISTERED
+            self.cleaned_data["lack_of_pole_emploi_id_reason"] = LackOfPoleEmploiId.REASON_NOT_REGISTERED
 
         # Handle RSA extra fields
         if self.cleaned_data["rsa_allocation"]:

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -29,6 +29,7 @@ from itou.employee_record.enums import Status
 from itou.files.models import File
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siaes.enums import SiaeKind
+from itou.users.enums import LackOfPoleEmploiId
 from tests.approvals.factories import (
     ApprovalFactory,
     PoleEmploiApprovalFactory,
@@ -901,7 +902,7 @@ class CustomApprovalAdminViewsTest(TestCase):
         job_seeker = JobSeekerFactory(
             nir="",
             pole_emploi_id="",
-            lack_of_pole_emploi_id_reason=JobSeekerFactory._meta.model.REASON_FORGOTTEN,
+            lack_of_pole_emploi_id_reason=LackOfPoleEmploiId.REASON_FORGOTTEN,
         )
         job_application = JobApplicationSentByJobSeekerFactory(
             job_seeker=job_seeker,

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -33,7 +33,7 @@ from itou.job_applications.models import JobApplication, JobApplicationTransitio
 from itou.job_applications.notifications import NewQualifiedJobAppEmployersNotification
 from itou.jobs.models import Appellation
 from itou.siaes.enums import ContractType, SiaeKind
-from itou.users.enums import Title
+from itou.users.enums import LackOfPoleEmploiId, Title
 from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.templatetags import format_filters
@@ -942,7 +942,7 @@ class JobApplicationNotificationsTest(TestCase):
     def test_manually_deliver_approval(self, *args, **kwargs):
         staff_member = ItouStaffFactory()
         job_seeker = JobSeekerFactory(
-            nir="", pole_emploi_id="", lack_of_pole_emploi_id_reason=JobSeekerFactory._meta.model.REASON_FORGOTTEN
+            nir="", pole_emploi_id="", lack_of_pole_emploi_id_reason=LackOfPoleEmploiId.REASON_FORGOTTEN
         )
         approval = ApprovalFactory(user=job_seeker)
         job_application = JobApplicationFactory(
@@ -965,7 +965,7 @@ class JobApplicationNotificationsTest(TestCase):
     def test_manually_refuse_approval(self):
         staff_member = ItouStaffFactory()
         job_seeker = JobSeekerFactory(
-            nir="", pole_emploi_id="", lack_of_pole_emploi_id_reason=JobSeekerFactory._meta.model.REASON_FORGOTTEN
+            nir="", pole_emploi_id="", lack_of_pole_emploi_id_reason=LackOfPoleEmploiId.REASON_FORGOTTEN
         )
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
@@ -1261,7 +1261,7 @@ class JobApplicationWorkflowTest(TestCase):
         When a Pôle emploi ID is forgotten, a manual approval delivery is triggered.
         """
         job_seeker = JobSeekerFactory(
-            nir="", pole_emploi_id="", lack_of_pole_emploi_id_reason=JobSeekerFactory._meta.model.REASON_FORGOTTEN
+            nir="", pole_emploi_id="", lack_of_pole_emploi_id_reason=LackOfPoleEmploiId.REASON_FORGOTTEN
         )
         job_application = JobApplicationSentByJobSeekerFactory(
             job_seeker=job_seeker, state=JobApplicationWorkflow.STATE_PROCESSING
@@ -1314,7 +1314,7 @@ class JobApplicationWorkflowTest(TestCase):
 
     def test_accept_job_application_sent_by_job_seeker_unregistered_no_pe_approval(self, notify_mock):
         job_seeker = JobSeekerFactory(
-            nir="", pole_emploi_id="", lack_of_pole_emploi_id_reason=JobSeekerFactory._meta.model.REASON_NOT_REGISTERED
+            nir="", pole_emploi_id="", lack_of_pole_emploi_id_reason=LackOfPoleEmploiId.REASON_NOT_REGISTERED
         )
         job_application = JobApplicationSentByJobSeekerFactory(
             job_seeker=job_seeker,

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -20,7 +20,7 @@ from itou.asp.models import AllocationDuration, EducationLevel, EmployerType
 from itou.job_applications.enums import Origin
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.siaes.enums import SiaeKind
-from itou.users.enums import IdentityProvider, LackOfNIRReason, Title, UserKind
+from itou.users.enums import IdentityProvider, LackOfNIRReason, LackOfPoleEmploiId, Title, UserKind
 from itou.users.models import JobSeekerProfile, User
 from itou.utils.mocks.address_format import BAN_GEOCODING_API_RESULTS_MOCK, RESULTS_BY_ADDRESS
 from tests.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
@@ -166,7 +166,7 @@ class ModelTest(TestCase):
         # If both fields are present at the same time, `pole_emploi_id` takes precedence.
         job_seeker = JobSeekerFactory(
             pole_emploi_id="69970749",
-            lack_of_pole_emploi_id_reason=User.REASON_FORGOTTEN,
+            lack_of_pole_emploi_id_reason=LackOfPoleEmploiId.REASON_FORGOTTEN,
         )
         cleaned_data = {
             "pole_emploi_id": job_seeker.pole_emploi_id,
@@ -185,7 +185,9 @@ class ModelTest(TestCase):
         }
         User.clean_pole_emploi_fields(cleaned_data)
 
-        job_seeker = JobSeekerFactory(pole_emploi_id="", lack_of_pole_emploi_id_reason=User.REASON_FORGOTTEN)
+        job_seeker = JobSeekerFactory(
+            pole_emploi_id="", lack_of_pole_emploi_id_reason=LackOfPoleEmploiId.REASON_FORGOTTEN
+        )
         cleaned_data = {
             "pole_emploi_id": job_seeker.pole_emploi_id,
             "lack_of_pole_emploi_id_reason": job_seeker.lack_of_pole_emploi_id_reason,

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -17,8 +17,7 @@ from itou.job_applications import enums as job_applications_enums
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.siae_evaluations.models import Sanctions
 from itou.siaes.enums import ContractType, SiaeKind
-from itou.users.enums import LackOfNIRReason, UserKind
-from itou.users.models import User
+from itou.users.enums import LackOfNIRReason, LackOfPoleEmploiId, UserKind
 from itou.utils.models import InclusiveDateRange
 from itou.utils.templatetags.format_filters import format_nir
 from itou.utils.widgets import DuetDatePickerWidget
@@ -555,7 +554,7 @@ class ProcessViewsTest(TestCase):
             # The state of the 3 `pole_emploi_*` fields will trigger a manual delivery.
             job_seeker__nir="",
             job_seeker__pole_emploi_id="",
-            job_seeker__lack_of_pole_emploi_id_reason=User.REASON_FORGOTTEN,
+            job_seeker__lack_of_pole_emploi_id_reason=LackOfPoleEmploiId.REASON_FORGOTTEN,
         )
 
         siae_user = job_application.to_siae.members.first()

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -23,7 +23,7 @@ from itou.job_applications.enums import QualificationLevel, QualificationType, S
 from itou.job_applications.models import JobApplication
 from itou.siae_evaluations.models import Sanctions
 from itou.siaes.enums import ContractType, SiaeKind
-from itou.users.enums import LackOfNIRReason
+from itou.users.enums import LackOfNIRReason, LackOfPoleEmploiId
 from itou.users.models import User
 from itou.utils.models import InclusiveDateRange
 from itou.utils.session import SessionNamespace
@@ -754,7 +754,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
         }
         assert self.client.session[job_seeker_session_name] == expected_job_seeker_session
 
@@ -994,7 +994,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
         }
         assert self.client.session[job_seeker_session_name] == expected_job_seeker_session
 
@@ -1265,7 +1265,7 @@ class ApplyAsPrescriberTest(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
         }
         assert self.client.session[job_seeker_session_name] == expected_job_seeker_session
 
@@ -1706,7 +1706,7 @@ class ApplyAsSiaeTest(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
         }
         assert self.client.session[job_seeker_session_name] == expected_job_seeker_session
 
@@ -1968,7 +1968,7 @@ class DirectHireFullProcessTest(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
         }
         assert self.client.session[job_seeker_session_name] == expected_job_seeker_session
 
@@ -2599,7 +2599,7 @@ class UpdateJobSeekerBaseTestCase(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
         }
         assert self.client.session[self.job_seeker_session_key] == expected_job_seeker_session
         self.job_seeker.refresh_from_db()
@@ -2692,7 +2692,7 @@ class UpdateJobSeekerBaseTestCase(TestCase):
         }
         expected_job_seeker_session["user"] |= {
             "pole_emploi_id": "",
-            "lack_of_pole_emploi_id_reason": User.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
         }
         assert self.client.session[self.job_seeker_session_key] == expected_job_seeker_session
         self.job_seeker.refresh_from_db()

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -28,7 +28,7 @@ from itou.siae_evaluations import enums as evaluation_enums
 from itou.siae_evaluations.constants import CAMPAIGN_VIEWABLE_DURATION
 from itou.siae_evaluations.models import Sanctions
 from itou.siaes.enums import SiaeKind
-from itou.users.enums import IdentityProvider, LackOfNIRReason, UserKind
+from itou.users.enums import IdentityProvider, LackOfNIRReason, LackOfPoleEmploiId, UserKind
 from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.models import InclusiveDateRange
@@ -751,7 +751,7 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
             "phone": "0610203050",
-            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
             "address_line_1": "10, rue du Gué",
             "address_line_2": "Sous l'escalier",
             "post_code": "35400",
@@ -790,7 +790,7 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
             "phone": "0610203050",
-            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
             "address_line_1": "10, rue du Gué",
             "address_line_2": "Sous l'escalier",
             "post_code": "35400",
@@ -821,7 +821,7 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
             "phone": "0610203050",
-            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
             "address_line_1": "10, rue du Gué",
             "address_line_2": "Sous l'escalier",
             "post_code": "35400",
@@ -854,7 +854,7 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
             "phone": "0610203050",
-            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
             "address_line_1": "10, rue du Gué",
             "address_line_2": "Sous l'escalier",
             "post_code": "35400",
@@ -978,7 +978,7 @@ class EditJobSeekerInfo(TestCase):
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
-            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
             "address_line_1": "10, rue du Gué",
             "post_code": "35400",
             "city": "Saint-Malo",
@@ -1038,7 +1038,7 @@ class EditJobSeekerInfo(TestCase):
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
-            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
             "address_line_1": "10, rue du Gué",
             "post_code": "35400",
             "city": "Saint-Malo",
@@ -1082,7 +1082,7 @@ class EditJobSeekerInfo(TestCase):
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
-            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
             "address_line_1": "10, rue du Gué",
             "post_code": "35400",
             "city": "Saint-Malo",
@@ -1222,7 +1222,7 @@ class EditJobSeekerInfo(TestCase):
         post_data = {
             "email": new_email,
             "birthdate": "20/12/1978",
-            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
             "address_line_1": "10, rue du Gué",
             "post_code": "35400",
             "city": "Saint-Malo",
@@ -1272,7 +1272,7 @@ class EditJobSeekerInfo(TestCase):
         post_data = {
             "email": new_email,
             "birthdate": "20/12/1978",
-            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
             "address_line_1": "10, rue du Gué",
             "post_code": "35400",
             "city": "Saint-Malo",
@@ -1314,7 +1314,7 @@ class EditJobSeekerInfo(TestCase):
         post_data = {
             "email": user.email,
             "birthdate": "20/12/1978",
-            "lack_of_pole_emploi_id_reason": user.REASON_NOT_REGISTERED,
+            "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
             "address_line_1": "",
             "post_code": "35400",
             "city": "Saint-Malo",


### PR DESCRIPTION
### Pourquoi ?

Cela facilitera le déplacement des champs `pole_emploi_id` & `lack_of_pole_emploi_id_reason` vers le modèle `JobSeekerProfile`

