### PR TITLE
Refonte carte candidature vue prescripteur

### DIFF
--- a/itou/templates/apply/includes/list_card_body_siae.html
+++ b/itou/templates/apply/includes/list_card_body_siae.html
@@ -6,7 +6,7 @@
 
     <hr />
     <div class="row">
-        <div class="col-12 col-lg-5 mb-3 mb-lg-0">
+        <div class="col-12 {% if job_application.preloaded_administrative_criteria %}col-lg-5 mb-3 mb-lg-0{% endif %}">
             <h3 class="h3 mb-1">
                 {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}
             </h3>

--- a/itou/templates/apply/includes/list_card_body_siae.html
+++ b/itou/templates/apply/includes/list_card_body_siae.html
@@ -17,7 +17,7 @@
                 </span>
             {% endif %}
 
-            {% if siae.is_subject_to_eligibility_rules %}
+            {% if job_application.to_siae.is_subject_to_eligibility_rules %}
                 {% with approval=job_application.job_seeker.latest_common_approval %}
                     {% if approval %}
                         <span class="badge badge-xs rounded-pill {% if approval.state == 'EXPIRED' %} bg-emploi-light text-primary{% else %} bg-success-lighter text-success{% endif %}">

--- a/itou/templates/apply/list_for_prescriber.html
+++ b/itou/templates/apply/list_for_prescriber.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load django_bootstrap5 %}
 {% load static %}
 {% load str_filters %}
 
@@ -7,9 +8,9 @@
 {% block content_title %}<h1>Candidatures</h1>{% endblock %}
 
 {% block content %}
-    <section class="s-section">
-        <div class="s-section__container container">
-            <div class="row">
+    <section class="s-box">
+        <div class="s-box__container container">
+            <div class="s-box__row row">
                 <div class="col-12 col-md-4 mb-3 mb-md-5">
                     <aside class="c-aside-filters">
                         <button class="c-aside-filters__btn__collapse" data-bs-toggle="collapse" data-bs-target="#asideFiltersCollapse" aria-expanded="true" aria-controls="asideFiltersCollapse">
@@ -49,17 +50,17 @@
 
                 <div class="col-12 col-md-8">
                     <section aria-labelledby="results">
-                        <div class="d-flex flex-column flex-sm-row align-items-sm-center">
-                            <h2 id="results" class="mb-0 flex-grow-1">
+                        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                            <h3 class="h4 mb-0" id="results">
                                 {% with job_applications_page.paginator.count as counter %}
                                     {{ counter }} <strong>résultat{{ counter|pluralizefr }}</strong>
                                 {% endwith %}
-                            </h2>
-                            <div>
+                            </h3>
+                            <div class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group" aria-label="Actions sur les candidatures">
                                 {% include "apply/includes/job_applications_export_button.html" %}
                                 {% if filters_counter > 0 %}
-                                    <a href="{% url 'apply:list_for_prescriber' %}" class="btn btn-link btn-ico ps-0">
-                                        <i class="ri-close-fill"></i>
+                                    <a href="{% url 'apply:list_for_prescriber' %}" class="btn btn-secondary btn-ico mt-3 mt-md-0">
+                                        <i class="ri-arrow-go-back-line" aria-hidden="true"></i>
                                         <span>Réinitialiser les filtres ({{ filters_counter }})</span>
                                     </a>
                                 {% endif %}
@@ -86,15 +87,19 @@
                             </div>
                         {% else %}
                             {% for job_application in job_applications_page %}
-                                <div class="c-card card my-4 has-links-inside">
-                                    {# TODO: when working on this template in the near future, try to refactor with list_card_body_siae.html #}
-                                    {% include "apply/includes/list_card_header.html" with job_application=job_application %}
-                                    {% include "apply/includes/list_card_body.html" with job_application=job_application %}
-                                    <div class="card-footer text-end">
-                                        <a href="{% url 'apply:details_for_prescriber' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
-                                           class="btn btn-sm btn-outline-primary"
-                                           aria-label="Plus d’informations sur la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}">
-                                            Plus d’informations
+                                <div class="c-card card my-3 my-md-4 has-links-inside">
+                                    {% include "apply/includes/list_card_body_siae.html" %}
+                                    <div class="card-footer text-end bg-light">
+                                        {% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %}
+                                            <span class="d-inline-flex align-items-center text-warning fs-sm">
+                                                <i class="ri-time-line ri-lg me-1"></i>
+                                                En attente de réponse depuis {{ job_application.pending_for_weeks }} semaines.
+                                            </span>
+                                        {% endif %}
+                                        <a class="btn btn-sm btn-outline-primary bg-white"
+                                           href="{% url 'apply:details_for_prescriber' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
+                                           aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
+                                           Voir sa candidature
                                         </a>
                                     </div>
                                 </div>

--- a/itou/templates/apply/list_for_prescriber.html
+++ b/itou/templates/apply/list_for_prescriber.html
@@ -99,8 +99,9 @@
                                         <a class="btn btn-sm btn-outline-primary bg-white"
                                            href="{% url 'apply:details_for_prescriber' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
                                            aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
-                                           Voir sa candidature
-                                        </a>
+                                           data-matomo-category="candidature"
+                                           data-matomo-action="clic"
+                                           data-matomo-option="voir_candidature_prescripteur">Voir sa candidature</a>
                                     </div>
                                 </div>
                             {% endfor %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -105,9 +105,10 @@
                                         {% endif %}
                                         <a class="btn btn-sm btn-outline-primary bg-white"
                                            href="{% url 'apply:details_for_siae' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
-                                           aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}">
-                                            Voir sa candidature
-                                        </a>
+                                           aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
+                                           data-matomo-category="candidature"
+                                           data-matomo-action="clic"
+                                           data-matomo-option="voir_candidature_employeur">Voir sa candidature</a>
                                     </div>
                                 </div>
 

--- a/itou/templates/approvals/includes/job_description_list.html
+++ b/itou/templates/approvals/includes/job_description_list.html
@@ -28,6 +28,9 @@
                 <i class="ri-group-line me-2" aria-hidden="true"></i>Orienteur
             {% endif %}
         {% endif %}
+        {% if request.user.is_prescriber %}
+            chez <a href="{% url 'companies_views:card' siae_id=job_application.to_siae.id %}"><strong>{{ job_application.to_siae.display_name }}</strong></a>
+        {% endif %}
 
     </span>
     {# élément à passer au dessus du précédent en vue mobile #}

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -271,13 +271,13 @@
 # name: TestListForSiae.test_warns_about_long_awaiting_applications[PRESCRIBER - warnings for 2222 and 3333]
   '''
   <section aria-labelledby="results">
-                          <div class="d-flex flex-column flex-sm-row align-items-sm-center">
-                              <h2 class="mb-0 flex-grow-1" id="results">
+                          <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                              <h3 class="h4 mb-0" id="results">
                                   
                                       3 <strong>résultats</strong>
                                   
-                              </h2>
-                              <div>
+                              </h3>
+                              <div aria-label="Actions sur les candidatures" class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group">
                                   
       
           <a aria-label="Exporter la liste de candidatures" class="btn btn-ico btn-secondary mt-3 mt-md-0" href="/apply/prescriber/list/exports">
@@ -293,208 +293,205 @@
   
                           
                               
-                                  <div class="c-card card my-4 has-links-inside">
-                                      
-                                      
-  
-  <div class="card-header">
-      <p class="mb-0">
-          <b>J… H…</b>
-          chez
-          <b>
-              <a href="/company/42/card?back_url=/apply/prescriber/list">
-                  Hit pit
-              </a>
-          </b>
-          
-      </p>
-      <p class="mb-0">
-          <span class="text-secondary fs-sm">30 mars 2023 à 02:00</span>
-          
-      </p>
-      <hr class="mb-0"/>
-  </div>
-  
+                                  <div class="c-card card my-3 my-md-4 has-links-inside">
                                       
   
   <div class="card-body">
-      <div class="row">
-          <div class="col-12 col-md-6 col-lg-4 mb-3 mb-lg-0">
-              
-                  <p class="font-weight-bold mb-1">Métier recherché :</p>
-                  
-                      <p class="fs-sm card-text">Candidature spontanée</p>
-                  
-              
-          </div>
-          <div class="col-12 col-md-6 col-lg-4 mb-3 mb-lg-0">
-              <p class="font-weight-bold mb-1">Envoyée par :</p>
-              <p class="fs-sm card-text">
-                  
-                      Vous
-                  
   
+      
+  <div class="fs-sm d-flex flex-column flex-md-row align-items-center mb-3">
+      <span class="text-secondary order-2 order-md-1 me-auto">
+          Émise le 30 mars 2023 par
+  
+          
+              <strong>Vous</strong>
+          
+          
+              chez <a href="/company/42/card"><strong>Hit pit</strong></a>
+          
+  
+      </span>
+      
+      <span class="order-1 order-md-2 ms-auto"><span class="badge badge-sm rounded-pill text-wrap mb-1 bg-info" id="state_11111111-1111-1111-1111-111111111111">Nouvelle candidature</span></span>
+  </div>
+  <hr class="my-3"/>
+  
+      <div>
+          
+              <i class="ri-briefcase-line ri-xl me-1"></i><span class="font-weight-bold me-1 me-md-2">Candidature spontanée</span>
+          
+      </div>
+  
+  
+  
+      <hr/>
+      <div class="row">
+          <div class="col-12">
+              <h3 class="h3 mb-1">
+                  J… H…
+              </h3>
+              
+  
+              
                   
                       
-                  
+                          
+                              <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line"></i>
+                                  Éligible à l’IAE
+                              </span>
+                          
+                      
   
                   
-              </p>
+              
           </div>
-          <div class="col-12 col-md-12 col-lg-4 ps-lg-0">
-              <p class="font-weight-bold mb-1">Statut :</p>
-              <p class="fs-sm card-text">
-                  <span class="badge badge-sm rounded-pill text-wrap mb-1 bg-info" id="state_11111111-1111-1111-1111-111111111111">Nouvelle candidature</span>
-                  
-              </p>
-          </div>
+          
       </div>
+  
   </div>
   
-                                      <div class="card-footer text-end">
-                                          <a aria-label="Plus d’informations sur la candidature de J… H…" class="btn btn-sm btn-outline-primary" href="/apply/11111111-1111-1111-1111-111111111111/prescriber/details?back_url=/apply/prescriber/list">
-                                              Plus d’informations
-                                          </a>
+                                      <div class="card-footer text-end bg-light">
+                                          
+                                          <a aria-label="Gérer la candidature de J… H…" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_prescripteur" href="/apply/11111111-1111-1111-1111-111111111111/prescriber/details?back_url=/apply/prescriber/list">Voir sa candidature</a>
                                       </div>
                                   </div>
                               
-                                  <div class="c-card card my-4 has-links-inside">
-                                      
-                                      
-  
-  <div class="card-header">
-      <p class="mb-0">
-          <b>J… H…</b>
-          chez
-          <b>
-              <a href="/company/42/card?back_url=/apply/prescriber/list">
-                  Hit pit
-              </a>
-          </b>
-          
-      </p>
-      <p class="mb-0">
-          <span class="text-secondary fs-sm">18 mars 2023 à 01:00</span>
-          
-              <br/>
-              <span class="text-danger fs-sm font-weight-bold">
-                  En attente de réponse depuis 3 semaines.
-              </span>
-          
-      </p>
-      <hr class="mb-0"/>
-  </div>
-  
+                                  <div class="c-card card my-3 my-md-4 has-links-inside">
                                       
   
   <div class="card-body">
-      <div class="row">
-          <div class="col-12 col-md-6 col-lg-4 mb-3 mb-lg-0">
-              
-                  <p class="font-weight-bold mb-1">Métier recherché :</p>
-                  
-                      <p class="fs-sm card-text">Candidature spontanée</p>
-                  
-              
-          </div>
-          <div class="col-12 col-md-6 col-lg-4 mb-3 mb-lg-0">
-              <p class="font-weight-bold mb-1">Envoyée par :</p>
-              <p class="fs-sm card-text">
-                  
-                      Vous
-                  
   
+      
+  <div class="fs-sm d-flex flex-column flex-md-row align-items-center mb-3">
+      <span class="text-secondary order-2 order-md-1 me-auto">
+          Émise le 18 mars 2023 par
+  
+          
+              <strong>Vous</strong>
+          
+          
+              chez <a href="/company/42/card"><strong>Hit pit</strong></a>
+          
+  
+      </span>
+      
+      <span class="order-1 order-md-2 ms-auto"><span class="badge badge-sm rounded-pill text-wrap mb-1 bg-info" id="state_22222222-2222-2222-2222-222222222222">Nouvelle candidature</span></span>
+  </div>
+  <hr class="my-3"/>
+  
+      <div>
+          
+              <i class="ri-briefcase-line ri-xl me-1"></i><span class="font-weight-bold me-1 me-md-2">Candidature spontanée</span>
+          
+      </div>
+  
+  
+  
+      <hr/>
+      <div class="row">
+          <div class="col-12">
+              <h3 class="h3 mb-1">
+                  J… H…
+              </h3>
+              
+  
+              
                   
                       
-                  
+                          
+                              <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line"></i>
+                                  Éligible à l’IAE
+                              </span>
+                          
+                      
   
                   
-              </p>
+              
           </div>
-          <div class="col-12 col-md-12 col-lg-4 ps-lg-0">
-              <p class="font-weight-bold mb-1">Statut :</p>
-              <p class="fs-sm card-text">
-                  <span class="badge badge-sm rounded-pill text-wrap mb-1 bg-info" id="state_22222222-2222-2222-2222-222222222222">Nouvelle candidature</span>
-                  
-              </p>
-          </div>
+          
       </div>
+  
   </div>
   
-                                      <div class="card-footer text-end">
-                                          <a aria-label="Plus d’informations sur la candidature de J… H…" class="btn btn-sm btn-outline-primary" href="/apply/22222222-2222-2222-2222-222222222222/prescriber/details?back_url=/apply/prescriber/list">
-                                              Plus d’informations
-                                          </a>
+                                      <div class="card-footer text-end bg-light">
+                                          
+                                              <span class="d-inline-flex align-items-center text-warning fs-sm">
+                                                  <i class="ri-time-line ri-lg me-1"></i>
+                                                  En attente de réponse depuis 3 semaines.
+                                              </span>
+                                          
+                                          <a aria-label="Gérer la candidature de J… H…" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_prescripteur" href="/apply/22222222-2222-2222-2222-222222222222/prescriber/details?back_url=/apply/prescriber/list">Voir sa candidature</a>
                                       </div>
                                   </div>
                               
-                                  <div class="c-card card my-4 has-links-inside">
-                                      
-                                      
-  
-  <div class="card-header">
-      <p class="mb-0">
-          <b>J… H…</b>
-          chez
-          <b>
-              <a href="/company/42/card?back_url=/apply/prescriber/list">
-                  Hit pit
-              </a>
-          </b>
-          
-      </p>
-      <p class="mb-0">
-          <span class="text-secondary fs-sm">16 février 2023 à 01:00</span>
-          
-              <br/>
-              <span class="text-danger fs-sm font-weight-bold">
-                  En attente de réponse depuis 8 semaines.
-              </span>
-          
-      </p>
-      <hr class="mb-0"/>
-  </div>
-  
+                                  <div class="c-card card my-3 my-md-4 has-links-inside">
                                       
   
   <div class="card-body">
-      <div class="row">
-          <div class="col-12 col-md-6 col-lg-4 mb-3 mb-lg-0">
-              
-                  <p class="font-weight-bold mb-1">Métier recherché :</p>
-                  
-                      <p class="fs-sm card-text">Candidature spontanée</p>
-                  
-              
-          </div>
-          <div class="col-12 col-md-6 col-lg-4 mb-3 mb-lg-0">
-              <p class="font-weight-bold mb-1">Envoyée par :</p>
-              <p class="fs-sm card-text">
-                  
-                      Vous
-                  
   
+      
+  <div class="fs-sm d-flex flex-column flex-md-row align-items-center mb-3">
+      <span class="text-secondary order-2 order-md-1 me-auto">
+          Émise le 16 février 2023 par
+  
+          
+              <strong>Vous</strong>
+          
+          
+              chez <a href="/company/42/card"><strong>Hit pit</strong></a>
+          
+  
+      </span>
+      
+      <span class="order-1 order-md-2 ms-auto"><span class="badge badge-sm rounded-pill text-wrap mb-1 bg-info" id="state_33333333-3333-3333-3333-333333333333">Nouvelle candidature</span></span>
+  </div>
+  <hr class="my-3"/>
+  
+      <div>
+          
+              <i class="ri-briefcase-line ri-xl me-1"></i><span class="font-weight-bold me-1 me-md-2">Candidature spontanée</span>
+          
+      </div>
+  
+  
+  
+      <hr/>
+      <div class="row">
+          <div class="col-12">
+              <h3 class="h3 mb-1">
+                  J… H…
+              </h3>
+              
+  
+              
                   
                       
-                  
+                          
+                              <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line"></i>
+                                  Éligible à l’IAE
+                              </span>
+                          
+                      
   
                   
-              </p>
+              
           </div>
-          <div class="col-12 col-md-12 col-lg-4 ps-lg-0">
-              <p class="font-weight-bold mb-1">Statut :</p>
-              <p class="fs-sm card-text">
-                  <span class="badge badge-sm rounded-pill text-wrap mb-1 bg-info" id="state_33333333-3333-3333-3333-333333333333">Nouvelle candidature</span>
-                  
-              </p>
-          </div>
+          
       </div>
+  
   </div>
   
-                                      <div class="card-footer text-end">
-                                          <a aria-label="Plus d’informations sur la candidature de J… H…" class="btn btn-sm btn-outline-primary" href="/apply/33333333-3333-3333-3333-333333333333/prescriber/details?back_url=/apply/prescriber/list">
-                                              Plus d’informations
-                                          </a>
+                                      <div class="card-footer text-end bg-light">
+                                          
+                                              <span class="d-inline-flex align-items-center text-warning fs-sm">
+                                                  <i class="ri-time-line ri-lg me-1"></i>
+                                                  En attente de réponse depuis 8 semaines.
+                                              </span>
+                                          
+                                          <a aria-label="Gérer la candidature de J… H…" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_prescripteur" href="/apply/33333333-3333-3333-3333-333333333333/prescriber/details?back_url=/apply/prescriber/list">Voir sa candidature</a>
                                       </div>
                                   </div>
                               
@@ -550,6 +547,7 @@
                   <i aria-hidden="true" class="ri-group-line me-2"></i>Orienteur
               
           
+          
   
       </span>
       
@@ -567,7 +565,7 @@
   
       <hr/>
       <div class="row">
-          <div class="col-12 col-lg-5 mb-3 mb-lg-0">
+          <div class="col-12">
               <h3 class="h3 mb-1">
                   Jacques HENRY
               </h3>
@@ -594,9 +592,7 @@
   
                                       <div class="card-footer text-end bg-light">
                                           
-                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" href="/apply/11111111-1111-1111-1111-111111111111/siae/details?back_url=/apply/siae/list">
-                                              Voir sa candidature
-                                          </a>
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_employeur" href="/apply/11111111-1111-1111-1111-111111111111/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
                                       </div>
                                   </div>
   
@@ -651,6 +647,7 @@
                   <i aria-hidden="true" class="ri-group-line me-2"></i>Orienteur
               
           
+          
   
       </span>
       
@@ -668,7 +665,7 @@
   
       <hr/>
       <div class="row">
-          <div class="col-12 col-lg-5 mb-3 mb-lg-0">
+          <div class="col-12">
               <h3 class="h3 mb-1">
                   Jacques HENRY
               </h3>
@@ -700,9 +697,7 @@
                                                   En attente de réponse depuis 3 semaines.
                                               </span>
                                           
-                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" href="/apply/22222222-2222-2222-2222-222222222222/siae/details?back_url=/apply/siae/list">
-                                              Voir sa candidature
-                                          </a>
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_employeur" href="/apply/22222222-2222-2222-2222-222222222222/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
                                       </div>
                                   </div>
   
@@ -727,6 +722,7 @@
                   <i aria-hidden="true" class="ri-group-line me-2"></i>Orienteur
               
           
+          
   
       </span>
       
@@ -744,7 +740,7 @@
   
       <hr/>
       <div class="row">
-          <div class="col-12 col-lg-5 mb-3 mb-lg-0">
+          <div class="col-12">
               <h3 class="h3 mb-1">
                   Jacques HENRY
               </h3>
@@ -776,9 +772,7 @@
                                                   En attente de réponse depuis 8 semaines.
                                               </span>
                                           
-                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" href="/apply/33333333-3333-3333-3333-333333333333/siae/details?back_url=/apply/siae/list">
-                                              Voir sa candidature
-                                          </a>
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_employeur" href="/apply/33333333-3333-3333-3333-333333333333/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
                                       </div>
                                   </div>
   

--- a/tests/www/apply/test_list.py
+++ b/tests/www/apply/test_list.py
@@ -874,6 +874,7 @@ def test_list_for_unauthorized_prescriber_view(client):
         + 3  # count, list & prefetch of job application
         + 1  # get job seekers approvals
         + 1  # check user authorized membership (can_edit_personal_information)
+        + 3  # get job seekers administrative criteria
         + 3  # update session
     ):
         response = client.get(url)

--- a/tests/www/apply/test_list.py
+++ b/tests/www/apply/test_list.py
@@ -879,7 +879,7 @@ def test_list_for_unauthorized_prescriber_view(client):
     ):
         response = client.get(url)
 
-    assertContains(response, "<b>S… U…</b>", html=True)
+    assertContains(response, '<h3 class="h3 mb-1">S… U…</h3>', html=True)
     # Unfortunately, the job seeker's name is available in the filters
     # assertNotContains(response, "Supersecretname")
 


### PR DESCRIPTION
**Carte Notion : **

[<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->](https://www.notion.so/plateforme-inclusion/Refonte-carte-candidature-prescripteur-En-tant-que-prescripteur-je-veux-visualiser-les-infos-cl-s-0935119b28b04121a626476ff0e46a91?pvs=4)

### Pourquoi ?

améliorer la lisibilité des informations

### Comment <!-- optionnel -->

* duplication des templates de `apply.views.list_views.list_for_siae`
* enrichissement du template `approvals/includes/job_description_list.html`
* enrichissement de la vue `apply.views.list_views.list_for_prescriber`, ajout des critères administratifs

### Captures d'écran 

vue prescripteur habilité

![image](https://github.com/betagouv/itou/assets/11419273/b181f976-bf7c-4a30-96e1-593b74a4be01)

vue orienteur

![image](https://github.com/betagouv/itou/assets/11419273/bbbeb1a2-9005-4f0b-85a6-ac1e27cd0f00)


### TODO

- [x] mise à jour des tests
- [x] balises evenement Matomo sur "voir candidature" et "lien SIAE"
