### PR TITLE
Déplacement de tests

### DIFF
--- a/tests/jobs/tests.py
+++ b/tests/jobs/tests.py
@@ -10,3 +10,24 @@ class FixturesTest(TestCase):
         assert Appellation.objects.count() == 4
         assert Appellation.objects.filter(rome_id="M1805").count() == 2
         assert Appellation.objects.filter(rome_id="N1101").count() == 2
+
+
+def test_appellation_autocomplete():
+    create_test_romes_and_appellations(["N1101", "N4105"])
+
+    [appellation] = Appellation.objects.autocomplete("conducteur lait")
+    assert appellation.code == "12859"
+    assert appellation.name == "Conducteur collecteur / Conductrice collectrice de lait"
+
+    [appellation] = Appellation.objects.autocomplete("chariot armee")
+    assert appellation.code == "12918"
+    assert appellation.name == "Conducteur / Conductrice de chariot élévateur de l'armée"
+
+    # with rome_code
+    appellation = Appellation.objects.autocomplete("conducteur", limit=1, rome_code="N1101")[0]
+    assert appellation.code == "12918"
+    assert appellation.name == "Conducteur / Conductrice de chariot élévateur de l'armée"
+
+    appellation = Appellation.objects.autocomplete("conducteur", limit=1, rome_code="N4105")[0]
+    assert appellation.code == "12859"
+    assert appellation.name == "Conducteur collecteur / Conductrice collectrice de lait"

--- a/tests/www/autocomplete/tests.py
+++ b/tests/www/autocomplete/tests.py
@@ -1,6 +1,5 @@
 from django.urls import reverse
 
-from itou.jobs.models import Appellation
 from tests.cities.factories import create_test_cities
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.siaes.factories import SiaeFactory
@@ -105,15 +104,6 @@ class JobsAutocompleteTest(TestCase):
             }
         ]
         assert response.json() == expected
-
-    def test_search_filter_with_rome_code(self):
-        appellation = Appellation.objects.autocomplete("conducteur", limit=1, rome_code="N1101")[0]
-        assert appellation.code == "12918"
-        assert appellation.name == "Conducteur / Conductrice de chariot élévateur de l'armée"
-
-        appellation = Appellation.objects.autocomplete("conducteur", limit=1, rome_code="N4105")[0]
-        assert appellation.code == "12859"
-        assert appellation.name == "Conducteur collecteur / Conductrice collectrice de lait"
 
 
 class CitiesAutocompleteTest(TestCase):


### PR DESCRIPTION
### Pourquoi ?

Ce sont des tests qui concernent le modèle et non les vues d'autocomple

