### PR TITLE
settings: suppression de l'intergiciel ErrorLoggingMiddleware

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -128,7 +128,6 @@ MIDDLEWARE = [
     "itou.utils.perms.middleware.ItouCurrentOrganizationMiddleware",
     "itou.www.middleware.never_cache",
     # Final logger
-    "django_datadog_logger.middleware.error_log.ErrorLoggingMiddleware",
     "django_datadog_logger.middleware.request_log.RequestLoggingMiddleware",
 ]
 


### PR DESCRIPTION
### Pourquoi ?

Il logge toutes les exceptions via un logger.exception qui envoie trop de choses à Sentry.

Autant laisser Sentry gérer les exceptions non-gérées.
