### PR TITLE
Modification de la logique d'envoi des Pass IAE à PE

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -2,7 +2,7 @@
   "*/5 * * * * $ROOT/clevercloud/status-probes.sh",
   "*/5 * * * * $ROOT/clevercloud/run_management_command.sh scan_s3_files",
 
-  "0 * * * * $ROOT/clevercloud/send_approvals_to_pe.sh",
+  "*/5 * * * * $ROOT/clevercloud/send_approvals_to_pe.sh",
   "5 * * * * $ROOT/clevercloud/run_management_command.sh sync_pec_offers --wet-run",
   "5 * * * * $ROOT/clevercloud/run_management_command.sh update_siaes_job_app_score",
   "10 * * * * $ROOT/clevercloud/run_management_command.sh pe_certify_users --wet-run",

--- a/itou/approvals/management/commands/send_approvals_to_pe.py
+++ b/itou/approvals/management/commands/send_approvals_to_pe.py
@@ -10,9 +10,8 @@ from itou.utils.apis import enums as api_enums
 
 
 # arbitrary value, set so that we don't run the cron for too long.
-# if the delay is set to 1 second, then this would take approximately 200 seconds,
-# or 3 minutes.
-MAX_APPROVALS_PER_RUN = 100
+# if the delay is set to 1 second, then this would take approximately 20 seconds
+MAX_APPROVALS_PER_RUN = 10
 
 
 class Command(BaseCommand):

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -30,7 +30,6 @@ from itou.job_applications.enums import (
     RefusalReason,
     SenderKind,
 )
-from itou.job_applications.tasks import huey_notify_pole_emploi
 from itou.users.enums import LackOfPoleEmploiId, UserKind
 from itou.utils.emails import get_email_message, send_email_messages
 from itou.utils.models import InclusiveDateRangeField
@@ -988,12 +987,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             self.approval_number_sent_at = timezone.now()
             self.approval_delivery_mode = self.APPROVAL_DELIVERY_MODE_AUTOMATIC
             self.approval.unsuspend(self.hiring_start_at)
-            # FIXME(vperron): This is an unelegant method to avoid using huey
-            # in local development, thus needing Redis. Maybe some development
-            # settings involving a local, in-memory huey in immediate mode would
-            # be better, but this is a fast fix.
-            if settings.API_ESD["BASE_URL"]:
-                huey_notify_pole_emploi(self)
 
     @xwf_models.transition()
     def refuse(self, *args, **kwargs):

--- a/itou/job_applications/tasks.py
+++ b/itou/job_applications/tasks.py
@@ -1,6 +1,0 @@
-from huey.contrib.djhuey import db_task
-
-
-@db_task()
-def huey_notify_pole_emploi(job_application):
-    return job_application.approval.notify_pole_emploi()

--- a/tests/approvals/test_notify_pole_emploi.py
+++ b/tests/approvals/test_notify_pole_emploi.py
@@ -328,7 +328,7 @@ class ApprovalsSendToPeManagementTestCase(TestCase):
             stdout=stdout,
         )
         assert stdout.getvalue().split("\n") == [
-            "approvals needing to be sent count=2, batch count=100",
+            "approvals needing to be sent count=2, batch count=10",
             f"approvals={pending_approval} start_at={pending_approval.start_at.isoformat()} "
             "pe_state=notification_pending",
             f"approvals={retry_approval} start_at={retry_approval.start_at.isoformat()} "

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -1,5 +1,4 @@
 from itertools import product
-from unittest.mock import patch
 
 import pytest
 from dateutil.relativedelta import relativedelta
@@ -42,8 +41,6 @@ DISABLED_NIR = 'disabled id="id_nir"'
 PRIOR_ACTION_SECTION_TITLE = "Action préalable à l'embauche"
 
 
-# patch the one used in the `models` module, not the original one in tasks
-@patch("itou.job_applications.models.huey_notify_pole_emploi", return_value=False)
 class ProcessViewsTest(TestCase):
     def accept_job_application(self, job_application, post_data=None, city=None, assert_successful=True):
         """


### PR DESCRIPTION
### Pourquoi ?

Pour:
- simplifier la logique de notification à PE
- arrêter d'envoyer des Pass dans le futur (avec le risque qu'ils soient annulés)