### PR TITLE
Ajout de l'ID 63 de dashboard metabase et tri de la liste

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -410,7 +410,7 @@ ASP_ITOU_PREFIX = "99999"
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(
     os.getenv(
         "PILOTAGE_DASHBOARDS_WHITELIST",
-        "[90, 32, 52, 54, 116, 43, 136, 140, 129, 150, 217, 218, 216, 236, 300, 306, 336]",
+        "[32, 43, 52, 54, 63, 90, 116, 129, 136, 140, 150, 216, 217, 218, 236, 300, 306, 336]",
     )
 )
 

--- a/itou/templates/siaes/show_financial_annexes.html
+++ b/itou/templates/siaes/show_financial_annexes.html
@@ -10,79 +10,83 @@
         <br>
         La gestion de vos annexes financières continue de se faire dans l'extranet 2.0 de l'ASP.
     </p>
+    {% if not siae.is_active %}
+        {% if siae_is_asp %}
+            <div class="alert alert-danger" role="status">
+                <p class="mb-0">
+                    {# Inactive siaes of ASP source cannot be fixed by user. #}
+                    Votre structure est inactive car elle n'est associée à aucune annexe financière valide. Contactez-nous via la rubrique correspondant à votre structure sur
+                    <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" aria-label="{{ ITOU_HELP_CENTER_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_HELP_CENTER_URL }}</a>
+                </p>
+            </div>
+        {% elif siae_is_user_created %}
+            <div class="alert alert-danger" role="status">
+                <p class="mb-0">
+                    {# Inactive user created siaes can be fixed by the user. #}
+                    Votre structure sera prochainement désactivée car elle n'est associée à aucune annexe financière valide. Veuillez dès que possible procéder à la sélection d'une annexe financière valide ci-dessous.
+                </p>
+            </div>
+        {% endif %}
+    {% endif %}
 {% endblock %}
 
 {% block content %}
 
     <section class="s-section">
         <div class="s-section__container container">
-            {% if not siae.is_active %}
-                {% if siae_is_asp %}
-                    <div class="alert alert-danger" role="status">
-                        <p class="mb-0">
-                            {# Inactive siaes of ASP source cannot be fixed by user. #}
-                            Votre structure est inactive car elle n'est associée à aucune annexe financière valide. Contactez-nous via la rubrique correspondant à votre structure sur
-                            <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" aria-label="{{ ITOU_HELP_CENTER_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_HELP_CENTER_URL }}</a>
-                        </p>
-                    </div>
-                {% elif siae_is_user_created %}
-                    <div class="alert alert-danger" role="status">
-                        <p class="mb-0">
-                            {# Inactive user created siaes can be fixed by the user. #}
-                            Votre structure sera prochainement désactivée car elle n'est associée à aucune annexe financière valide. Veuillez dès que possible procéder à la sélection d'une annexe financière valide ci-dessous.
-                        </p>
-                    </div>
-                {% endif %}
-            {% endif %}
-            <h2 class="text-muted">{{ siae.display_name }}</h2>
+            <h2>{{ siae.display_name }}</h2>
             <div class="row">
                 <div class="col-12">
-                    <div class="table-responsive">
-                        <table class="table table-striped table-bordered">
-                            <caption>Liste des annexes financières</caption>
-                            <thead>
-                                <tr>
-                                    <th scope="col">Numéro d'annexe financière</th>
-                                    <th scope="col">Date de début d'effet</th>
-                                    <th scope="col">Date de fin d'effet</th>
-                                    <th scope="col">Validité à ce jour</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% if financial_annexes %}
-                                    {% for financial_annex in financial_annexes %}
-                                        <tr>
-                                            <td>{{ financial_annex.number_with_spaces }}</td>
-                                            <td>{{ financial_annex.start_at|date:"d/m/Y" }}</td>
-                                            <td>{{ financial_annex.end_at|date:"d/m/Y" }}</td>
-                                            {% if financial_annex.is_active %}
-                                                <td>
-                                                    <span class="badge rounded-pill bg-success">Valide</span>
-                                                </td>
-                                            {% else %}
-                                                <td>
-                                                    <span class="badge rounded-pill bg-secondary">Inactive</span>
-                                                </td>
-                                            {% endif %}
-                                        </tr>
-                                    {% endfor %}
-                                {% else %}
+                    <div class="c-box">
+                        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between">
+                            <h3 class="h4 mb-0">Annexes financières</h3>
+                            {% if can_select_af %}
+                                <div class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group" aria-label="Actions sur les annexes financières">
+                                    <a class="btn btn-primary btn-ico justify-content-center mt-3 mt-md-0" href="{% url 'companies_views:select_financial_annex' %}">
+                                        <i class="ri-share-forward-box-line"></i>
+                                        <span>Sélectionner une autre annexe financière</span>
+                                    </a>
+                                </div>
+                            {% endif %}
+                        </div>
+                        <div class="table-responsive-lg mt-3 mt-md-4">
+                            <table class="table">
+                                <caption class="visually-hidden">Liste des annexes financières</caption>
+                                <thead>
                                     <tr>
-                                        <td>Aucune annexe financière associée à cette structure.</td>
-                                        <td></td>
-                                        <td></td>
-                                        <td></td>
+                                        <th scope="col">Numéro d'annexe financière</th>
+                                        <th scope="col">Date de début d'effet</th>
+                                        <th scope="col">Date de fin d'effet</th>
+                                        <th scope="col">Validité à ce jour</th>
                                     </tr>
-                                {% endif %}
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody>
+                                    {% if financial_annexes %}
+                                        {% for financial_annex in financial_annexes %}
+                                            <tr>
+                                                <td>{{ financial_annex.number_with_spaces }}</td>
+                                                <td>{{ financial_annex.start_at|date:"d/m/Y" }}</td>
+                                                <td>{{ financial_annex.end_at|date:"d/m/Y" }}</td>
+                                                {% if financial_annex.is_active %}
+                                                    <td>
+                                                        <span class="badge badge-sm rounded-pill bg-success-lighter text-success">Valide</span>
+                                                    </td>
+                                                {% else %}
+                                                    <td>
+                                                        <span class="badge badge-sm rounded-pill bg-primary">Inactive</span>
+                                                    </td>
+                                                {% endif %}
+                                            </tr>
+                                        {% endfor %}
+                                    {% else %}
+                                        <tr>
+                                            <td colspan="4">Aucune annexe financière associée à cette structure.</td>
+                                        </tr>
+                                    {% endif %}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
-
-                    {% if can_select_af %}
-                        <a href="{% url 'companies_views:select_financial_annex' %}" class="align-self-center">
-                            <span class="btn btn-primary mb-1 w-100 w-sm-auto mt-2">Sélectionner une autre annexe financière</span>
-                        </a>
-                    {% endif %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Modifier-le-TB-vers-lequel-renvoie-le-lien-stat-de-la-page-d-accueil-Pilotage-2a44f7a77de14228911e3bb43904f04a?pvs=4

### Pourquoi ?

Pour pouvoir partager un nouveau tableau de bord Metabase en <iframe> sur le site du Pilotage

### Comment

Ajout de l'ID de dashboard metabase 63 à la constante `PILOTAGE_DASHBOARDS_WHITELIST`
Tri de la liste au passage
