### PR TITLE
Création/modification des fiches de postes: possibilité de choisir un poste (code ROME) déjà existant

### DIFF
--- a/itou/jobs/models.py
+++ b/itou/jobs/models.py
@@ -41,7 +41,7 @@ class Rome(models.Model):
 
 
 class AppellationQuerySet(models.QuerySet):
-    def autocomplete(self, search_string, codes_to_exclude=None, limit=10, rome_code=None):
+    def autocomplete(self, search_string, limit=10, rome_code=None):
         """
         A `search_string` equals to `foo bar` will match all results beginning with `foo` and `bar`.
         This is achieved via `to_tsquery` and prefix matching:
@@ -54,10 +54,7 @@ class AppellationQuerySet(models.QuerySet):
         queryset = self.filter(full_text=SearchQuery(tsquery, config="french_unaccent", search_type="raw"))
         if rome_code:
             queryset = queryset.filter(rome__code=rome_code)
-        queryset = queryset.select_related("rome")
-        if codes_to_exclude:
-            queryset = queryset.exclude(code__in=codes_to_exclude)
-        return queryset[:limit]
+        return queryset.select_related("rome")[:limit]
 
 
 class Appellation(models.Model):

--- a/itou/www/autocomplete/views.py
+++ b/itou/www/autocomplete/views.py
@@ -7,7 +7,6 @@ from unidecode import unidecode
 
 from itou.asp.models import Commune
 from itou.cities.models import City
-from itou.companies.models import SiaeJobDescription
 from itou.jobs.models import Appellation
 
 
@@ -67,16 +66,7 @@ def jobs_autocomplete(request):
     """
 
     term = request.GET.get("term", "").strip()
-    siae_id = request.GET.get("siae_id", "").strip()
     appellations = []
-
-    # Fetch excluded codes:
-    # SIAE already have job descriptions with these codes.
-    excluded_codes = (
-        SiaeJobDescription.objects.filter(siae__id=siae_id)
-        .select_related("appellation", "siae")
-        .values_list("appellation__code", flat=True)
-    )
 
     if term:
         appellations = [
@@ -86,7 +76,7 @@ def jobs_autocomplete(request):
                 "rome": appellation.rome.code,
                 "name": appellation.name,
             }
-            for appellation in Appellation.objects.autocomplete(term, codes_to_exclude=excluded_codes, limit=10)
+            for appellation in Appellation.objects.autocomplete(term, limit=10)
         ]
 
     return JsonResponse(appellations, safe=False)

--- a/itou/www/companies_views/forms.py
+++ b/itou/www/companies_views/forms.py
@@ -217,8 +217,6 @@ class FinancialAnnexSelectForm(forms.Form):
 
 
 class EditJobDescriptionForm(forms.ModelForm):
-    JOBS_AUTOCOMPLETE_URL = reverse_lazy("autocomplete:jobs")
-
     # See: itou/static/js/job_autocomplete.js
     job_appellation = forms.CharField(
         label="Poste (code ROME)",
@@ -226,6 +224,7 @@ class EditJobDescriptionForm(forms.ModelForm):
             attrs={
                 "class": "js-job-autocomplete-input form-control",
                 "data-autosubmit-on-enter-pressed": 0,
+                "data-autocomplete-source-url": reverse_lazy("autocomplete:jobs"),
                 "placeholder": "Ex. K2204 ou agent/agente d'entretien en crèche.",
                 "autocomplete": "off",
             }
@@ -295,13 +294,6 @@ class EditJobDescriptionForm(forms.ModelForm):
 
             if self.instance.contract_type != ContractType.OTHER:
                 self.fields["other_contract_type"].widget.attrs.update({"disabled": "disabled"})
-
-        # Pass SIAE id in autocomplete call
-        self.fields["job_appellation"].widget.attrs.update(
-            {
-                "data-autocomplete-source-url": self.JOBS_AUTOCOMPLETE_URL + f"?siae_id={current_siae.pk}",
-            }
-        )
 
         self.fields["custom_name"].widget.attrs.update({"placeholder": ""})
         self.fields["hours_per_week"].widget.attrs.update({"placeholder": ""})


### PR DESCRIPTION
### Pourquoi ?

- La logique d'exclusion posait soucis dans le cas de l'édition où on ne pouvait plus retrouver le poste existant vu qu'il existait en base pour la SIAE
- Mais comme la contrainte n'existe plus depuis #1888 et qu'on souhaite en fait autoriser la création de plusieurs fiches de poste pour le même code ROME (typiquement pour utiliser des offres situées à différents endroits), c'est plus simple de supprimer complètement cette logique et simplifier le code.

