### PR TITLE
Fiches salarié : Outrepasser `create_employee_record` si une prolongation existe

### DIFF
--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -516,11 +516,35 @@ class JobApplicationQuerySetTest(TestCase):
             approval=job_app.approval,
         )
         assert job_app in JobApplication.objects.eligible_as_employee_record(job_app.to_siae)
+        # No employee record, but with a suspension, and `create_employee_record` is False
+        job_app = JobApplicationFactory(
+            with_approval=True,
+            hiring_start_at=None,
+            create_employee_record=False,
+        )
+        assert job_app not in JobApplication.objects.eligible_as_employee_record(job_app.to_siae)
+        SuspensionFactory(
+            siae=job_app.to_siae,
+            approval=job_app.approval,
+        )
+        assert job_app not in JobApplication.objects.eligible_as_employee_record(job_app.to_siae)
         # No employee record, but with a prolongation
         job_app = JobApplicationFactory(
             with_approval=True,
             state=JobApplicationWorkflow.STATE_ACCEPTED,
             hiring_start_at=None,
+        )
+        assert job_app not in JobApplication.objects.eligible_as_employee_record(job_app.to_siae)
+        ProlongationFactory(
+            declared_by_siae=job_app.to_siae,
+            approval=job_app.approval,
+        )
+        assert job_app in JobApplication.objects.eligible_as_employee_record(job_app.to_siae)
+        # No employee record, but with a prolongation, and `create_employee_record` is False
+        job_app = JobApplicationFactory(
+            with_approval=True,
+            hiring_start_at=None,
+            create_employee_record=False,
         )
         assert job_app not in JobApplication.objects.eligible_as_employee_record(job_app.to_siae)
         ProlongationFactory(


### PR DESCRIPTION
### Pourquoi ?

Le drapeau `create_employee_record` est levé pour toute les candidatures créées lors de la reprise de stock des AI, mais si une prolongation/suspension est faite alors ce drapeau ne devrait plus être pris en compte car la nouvelle date de fin du PASS IAE **doit** être envoyé à l'ASP sinon les employeurs se retrouve bloqué au moment de la déclaration d'heure.

### Comment <!-- optionnel -->

Pour le moment je limite aux prolongations car ce sont les plus problématiques mais aussi les moins nombreuses, j'espère ne pas avoir à gérer les suspensions (ainsi que d'autre problème de ce type) avec #3218 .

Nombre de nouveaux résultats retournés par la fonction `eligible_as_employee_record` et qui :
- Prolongation uniquement : 6042 pour 430 SIAE impactées
- Prolongation et Suspension : 41535 pour 625 SIAE impactées

