### PR TITLE
Templates : Correction de variables manquantes

### DIFF
--- a/itou/templates/approvals/printable_approval.html
+++ b/itou/templates/approvals/printable_approval.html
@@ -11,10 +11,10 @@
     <div class="container py-4 px-5">
         <div class="row">
             <div class="col-sm-3 offset-sm-3 text-end">
-                <img src="{{ base_url }}{% static 'img/pdf/logoMinTravail.png' %}" class="w-75" alt="Logo du Ministère du travail, de l'emploi et de l'insertion">
+                <img src="{% static 'img/pdf/logoMinTravail.png' %}" class="w-75" alt="Logo du Ministère du travail, de l'emploi et de l'insertion">
             </div>
             <div class="col-sm-3">
-                <img src="{{ base_url }}{% static 'img/pdf/logoPE.png' %}" class="w-75" alt="Logo de Pôle emploi">
+                <img src="{% static 'img/pdf/logoPE.png' %}" class="w-75" alt="Logo de Pôle emploi">
             </div>
         </div>
 

--- a/itou/templates/layout/base_printable.html
+++ b/itou/templates/layout/base_printable.html
@@ -12,7 +12,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         {% block meta_description %}{% endblock %}
         <link rel="stylesheet" href="{% static "vendor/theme-inclusion/stylesheets/app.css" %}" type="text/css">
-        <link rel="stylesheet" href="{{ base_url }}{% static 'css/itou.css' %}" type="text/css">
+        <link rel="stylesheet" href="{% static 'css/itou.css' %}" type="text/css">
         <style type="text/css">
             html {
                 background: transparent !important;

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -20,9 +20,6 @@ from tests.users.factories import JobSeekerFactory
 from tests.utils.test import parse_response_to_soup
 
 
-pytestmark = pytest.mark.ignore_template_errors
-
-
 class TestApprovalDetailView:
     def test_anonymous_user(self, client):
         approval = ApprovalFactory()
@@ -73,6 +70,7 @@ class TestApprovalDetailView:
         assertContains(response, '<i class="ri-group-line me-2" aria-hidden="true"></i>Prescripteur habilité', count=1)
         assertContains(response, '<i class="ri-group-line me-2" aria-hidden="true"></i>Orienteur', count=1)
 
+    @pytest.mark.ignore_template_errors
     def test_detail_view_no_job_application(self, client):
         siae = SiaeFactory(with_membership=True)
         siae_member = siae.members.first()
@@ -89,6 +87,7 @@ class TestApprovalDetailView:
         assertContains(response, "Informations du salarié")
         assertContains(response, "Candidatures de ce salarié")
 
+    @pytest.mark.ignore_template_errors
     @freeze_time("2023-04-26")
     def test_approval_status_includes(self, client, snapshot):
         """

--- a/tests/www/approvals_views/test_display.py
+++ b/tests/www/approvals_views/test_display.py
@@ -1,6 +1,5 @@
 from unittest.mock import PropertyMock, patch
 
-import pytest
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
 from freezegun import freeze_time
@@ -10,9 +9,6 @@ from itou.job_applications.models import JobApplication
 from itou.utils import constants as global_constants
 from tests.job_applications.factories import JobApplicationFactory
 from tests.utils.test import TestCase
-
-
-pytestmark = pytest.mark.ignore_template_errors
 
 
 @patch.object(JobApplication, "can_be_cancelled", new_callable=PropertyMock, return_value=False)


### PR DESCRIPTION
### Pourquoi ?

Car personne ne semble vouloir les corriger.
Lancer `pytest -v tests/www/approvals_views/test_detail.py` résulte en erreur car des variables ne sont pas définies, je ne sais pas pourquoi elle ne sont pas sur la CI mais c'est peut-être dû au fait que ça soit des `TestCase` :shrug:.