### PR TITLE
Correction du script d'affichage des toasts via htmx

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -221,9 +221,12 @@
             <script nonce="{{ CSP_NONCE }}">
                 // Show any toasts that is already present in the DOM
                 htmx.onLoad(() => {
-                    $(".toast-placement-wrapper").children(".toast").each(function() {
-                        $(this).toast("show");
+                    const toastContainer = document.querySelector('.toast-container');
+                    const toastElList = [].slice.call(toastContainer.querySelectorAll('.toast'));
+                    let toastList = toastElList.map(function(toastEl) {
+                        return new bootstrap.Toast(toastEl);
                     });
+                    toastList.forEach(toast => toast.show());
                 });
             </script>
 


### PR DESCRIPTION
### Pourquoi ?

Correction du js éxécuté au chargement de `htmx.onload()`

### Comment <!-- optionnel -->

Remplacement du js d'affichage des `toast` par la nouvelle méthode de bootstrap 5 en vanilla js
