### PR TITLE
metabase - Structures : Ajout des champs adresses renseignées par l'utilisateur

### DIFF
--- a/itou/metabase/tables/siaes.py
+++ b/itou/metabase/tables/siaes.py
@@ -58,6 +58,7 @@ def get_parent_siae(siae):
 
 
 TABLE.add_columns(get_address_columns(comment_suffix=" de la structure mère", custom_fn=get_parent_siae))
+TABLE.add_columns(get_address_columns(name_suffix="_c1", comment_suffix=" de la structure C1"))
 
 TABLE.add_columns(
     [

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -1060,6 +1060,18 @@ def test_populate_siaes():
                 "EI",
                 "17643069438162",
                 "Export ASP",
+                # Address columns " de la structure mère"
+                "112 rue de la Croix-Nivert",
+                "",
+                "75015",
+                None,
+                "Paris",
+                5.43567,
+                12.123876,
+                "75",
+                "75 - Paris",
+                "Île-de-France",
+                # Address columns " de la structure C1"
                 "112 rue de la Croix-Nivert",
                 "",
                 "75015",

--- a/tests/metabase/test_siaes.py
+++ b/tests/metabase/test_siaes.py
@@ -17,3 +17,16 @@ def test_address_fields():
     assert TABLE.get(column_name="code_commune", input=antenna) == vannes.code_insee
     assert TABLE.get(column_name="ville", input=antenna) == parent.city
     assert TABLE.get(column_name="département", input=antenna) == parent.department
+
+
+@pytest.mark.django_db
+def test_address_fields_of_antenna():
+    vannes = create_city_vannes()
+    parent = SiaeFactory(source="ASP")
+    antenna = SiaeFactory(source="USER_CREATED", convention=parent.convention, post_code=vannes.post_codes[0])
+    assert TABLE.get(column_name="adresse_ligne_1_c1", input=antenna) == antenna.address_line_1
+    assert TABLE.get(column_name="adresse_ligne_2_c1", input=antenna) == antenna.address_line_2
+    assert TABLE.get(column_name="code_postal_c1", input=antenna) == antenna.post_code
+    assert TABLE.get(column_name="code_commune_c1", input=antenna) == vannes.code_insee
+    assert TABLE.get(column_name="ville_c1", input=antenna) == antenna.city
+    assert TABLE.get(column_name="département_c1", input=antenna) == antenna.department


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Ajouter-une-colonne-d-partement_c1-la-table-structures-b7c78894ae4b4aa8bdf5aef5c31f2c2b

### Pourquoi ?

Actuellement la table `structures` récupère uniquement le département/région de la structure mère. De ce fait, si une antenne est localisée dans le 28 alors que la structure mère se trouve dans le 27 : c’est le 27 qui sera dans la table au lieu du 28.