### PR TITLE
Correctif de la fixture `_template_string_if_invalid_marker`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,22 @@ def _fail_for_invalid_template_variable_improved(_fail_for_invalid_template_vari
         )
 
 
+@pytest.fixture(autouse=True)
+def _template_string_if_invalid_marker(monkeypatch, request) -> None:
+    # TODO: remove me once https://github.com/pytest-dev/pytest-django/pull/1076 is merged & released
+    marker = request.keywords.get("ignore_template_errors", None)
+    if os.environ.get(INVALID_TEMPLATE_VARS_ENV, "false") == "true":
+        if marker and django_settings_is_configured():
+            from django.conf import settings as dj_settings
+
+            if dj_settings.TEMPLATES:
+                monkeypatch.setattr(
+                    dj_settings.TEMPLATES[0]["OPTIONS"]["string_if_invalid"],
+                    "fail",
+                    False,
+                )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def make_unordered_queries_randomly_ordered():
     """

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -20,6 +20,9 @@ from tests.users.factories import JobSeekerFactory
 from tests.utils.test import parse_response_to_soup
 
 
+pytestmark = pytest.mark.ignore_template_errors
+
+
 class TestApprovalDetailView:
     def test_anonymous_user(self, client):
         approval = ApprovalFactory()

--- a/tests/www/approvals_views/test_display.py
+++ b/tests/www/approvals_views/test_display.py
@@ -1,5 +1,6 @@
 from unittest.mock import PropertyMock, patch
 
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
 from freezegun import freeze_time
@@ -9,6 +10,9 @@ from itou.job_applications.models import JobApplication
 from itou.utils import constants as global_constants
 from tests.job_applications.factories import JobApplicationFactory
 from tests.utils.test import TestCase
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 @patch.object(JobApplication, "can_be_cancelled", new_callable=PropertyMock, return_value=False)

--- a/tests/www/invitations_views/test_prescriber_organization.py
+++ b/tests/www/invitations_views/test_prescriber_organization.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from urllib.parse import urlencode
 
+import pytest
 import respx
 from allauth.account.models import EmailAddress
 from django.conf import settings
@@ -34,6 +35,9 @@ POST_DATA = {
 }
 
 INVITATION_URL = reverse("invitations_views:invite_prescriber_with_org")
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class TestSendPrescriberWithOrgInvitation(TestCase):

--- a/tests/www/invitations_views/test_siae_accept.py
+++ b/tests/www/invitations_views/test_siae_accept.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlencode
 
+import pytest
 import respx
 from django.conf import settings
 from django.contrib import messages
@@ -19,6 +20,9 @@ from tests.openid_connect.inclusion_connect.tests import OIDC_USERINFO, mock_oau
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from tests.users.factories import EmployerFactory
 from tests.utils.test import assertMessages
+
+
+pytestmark = pytest.mark.ignore_template_errors
 
 
 class TestAcceptInvitation(InclusionConnectBaseTestCase):


### PR DESCRIPTION
### Pourquoi ?

Cf https://github.com/pytest-dev/pytest-django/pull/1076