### PR TITLE
Ajout des dates du PASS IAE sur les cartes « profil salariés »

### DIFF
--- a/itou/templates/approvals/includes/list_card.html
+++ b/itou/templates/approvals/includes/list_card.html
@@ -1,4 +1,5 @@
 {% load format_filters %}
+{% load str_filters %}
 
 <div class="c-card card my-4 has-links-inside">
     <div class="card-header pb-3">
@@ -13,6 +14,18 @@
                     PASS IAE {{ approval.get_state_display|lower }}
                 </span>
             </div>
+        </div>
+
+        <div class="fs-sm">
+            Nombre de jours restants sur le PASS IAE :
+            {% if approval.is_valid %}
+                {{ approval.remainder.days }} jour{{ approval.remainder.days|pluralizefr }}
+            {% else %}
+                0 jour
+            {% endif %}
+            <i class="ri-information-line ri-xl text-info"
+               data-bs-toggle="tooltip"
+               title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
         </div>
     </div>
 

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -190,6 +190,7 @@ class TestApprovalsListView:
             </span>""",
             html=True,
         )
+
         assertContains(
             response,
             """<span class="badge badge-sm rounded-pill text-wrap bg-success-lighter text-success">
@@ -214,3 +215,12 @@ class TestApprovalsListView:
             </span>""",
             html=True,
         )
+
+        # Check IAE pass remainder days
+        assertContains(response, "365 jours")
+
+        assertContains(response, "366 jours")
+
+        assertContains(response, "730 jours")
+
+        assertContains(response, "0 jour")


### PR DESCRIPTION
### Carte Notion

https://www.notion.so/plateforme-inclusion/En-tant-que-SIAE-je-visualise-les-dates-du-PASS-IAE-sur-les-cartes-profil-salari-s-8a6d3df8d9e84397a89508dea03d5678

### Pourquoi ?

Nous souhaitons afficher les dates du PASS IAE sur les cartes “profil salarié”

