### PR TITLE
Fiches salarié : Permettre de les renvoyer quand le PASS IAE ne correspond plus

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -303,7 +303,6 @@ class JobApplicationQuerySet(models.QuerySet):
             to_siae=siae,
             employee_record__status=employeerecord_enums.Status.NEW,
             employee_record__asp_id=F("to_siae__convention__asp_id"),
-            employee_record__approval_number=F("approval__number"),
         )
 
     def _eligible_job_applications_without_employee_record(self, siae):


### PR DESCRIPTION
### Pourquoi ?

Cas vu au support, suite à un doublon de PASS IAE celui enregistré sur la FS et celui du candidat ne sont plus les mêmes.
