### PR TITLE
Fiches Salarié : Ne plus casser au moment de la sérialisation pour le pays de naissance et la commune

### DIFF
--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -51,8 +51,8 @@ class _PersonSerializer(serializers.Serializer):
     dateNaissance = serializers.DateField(format="%d/%m/%Y", source="job_seeker.birthdate")
 
     codeDpt = serializers.CharField(source="job_seeker.birth_place.department_code", required=False)
-    codeInseePays = serializers.CharField(source="job_seeker.jobseeker_profile.birth_country.code")
-    codeGroupePays = serializers.CharField(source="job_seeker.jobseeker_profile.birth_country.group")
+    codeInseePays = serializers.CharField(source="job_seeker.jobseeker_profile.birth_country.code", allow_null=True)
+    codeGroupePays = serializers.CharField(source="job_seeker.jobseeker_profile.birth_country.group", allow_null=True)
 
     # codeComInsee is only mandatory if birth country is France
     codeComInsee = serializers.SerializerMethodField(required=False)
@@ -96,7 +96,7 @@ class _AddressSerializer(serializers.Serializer):
     adrLibelleVoie = serializers.SerializerMethodField()
     adrCpltDistribution = serializers.SerializerMethodField()
 
-    codeinseecom = serializers.CharField(source="jobseeker_profile.hexa_commune.code")
+    codeinseecom = serializers.CharField(source="jobseeker_profile.hexa_commune.code", allow_null=True)
     codepostalcedex = serializers.CharField(source="jobseeker_profile.hexa_post_code")
 
     def get_adrCpltDistribution(self, obj: User) -> str | None:

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
@@ -43,10 +43,10 @@
   Preflight activated, checking for possible serialization errors...
   Found 1 object(s) to check, split in chunks of 700 objects.
   Checking file #1 (chunk of 1 objects)
-  ERROR: serialization of PK:42 PASS:XXXXX3724456 SIRET:17483349486512 JA:49536a29-88b5-49c3-8c46-333bbbc36308 JOBSEEKER:Jonathan MARTINEZ — email@example.com STATUS:READY ASP_ID:21 failed!
-  > Got AttributeError when attempting to get a value for field `codeinseecom` on serializer `_AddressSerializer`.
-  > The serializer field might be named incorrectly and not match any attribute or key on the `User` instance.
-  > Original exception text was: 'NoneType' object has no attribute 'code'.
+  ERROR: serialization of PK:42 PASS: SIRET:17483349486512 JA:49536a29-88b5-49c3-8c46-333bbbc36308 JOBSEEKER:Jonathan MARTINEZ — email@example.com STATUS:READY ASP_ID:21 failed!
+  > Got AttributeError when attempting to get a value for field `passDateDeb` on serializer `_PersonSerializer`.
+  > The serializer field might be named incorrectly and not match any attribute or key on the `EmployeeRecord` instance.
+  > Original exception text was: 'NoneType' object has no attribute 'start_at'.
   
   '''
 # ---

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records_updates.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records_updates.ambr
@@ -44,9 +44,9 @@
   Found 1 object(s) to check, split in chunks of 700 objects.
   Checking file #1 (chunk of 1 objects)
   ERROR: serialization of EmployeeRecordUpdateNotification object (42) failed!
-  > Got AttributeError when attempting to get a value for field `codeinseecom` on serializer `_AddressSerializer`.
-  > The serializer field might be named incorrectly and not match any attribute or key on the `User` instance.
-  > Original exception text was: 'NoneType' object has no attribute 'code'.
+  > Got AttributeError when attempting to get a value for field `passDateDeb` on serializer `_PersonSerializer`.
+  > The serializer field might be named incorrectly and not match any attribute or key on the `EmployeeRecord` instance.
+  > Original exception text was: 'NoneType' object has no attribute 'start_at'.
   
   '''
 # ---

--- a/tests/employee_record/test_serializers.py
+++ b/tests/employee_record/test_serializers.py
@@ -8,8 +8,10 @@ from itou.employee_record.serializers import (
     EmployeeRecordUpdateNotificationBatchSerializer,
     EmployeeRecordUpdateNotificationSerializer,
     _AddressSerializer,
+    _PersonSerializer,
 )
-from tests.employee_record.factories import EmployeeRecordWithProfileFactory
+from tests.employee_record.factories import EmployeeRecordFactory, EmployeeRecordWithProfileFactory
+from tests.users.factories import JobSeekerFactory
 from tests.utils.test import TestCase
 
 
@@ -67,6 +69,30 @@ class EmployeeRecordAddressSerializerTest(TestCase):
 
         assert data is not None
         assert good_lane_name == data["adrLibelleVoie"]
+
+    def test_with_empty_fields(self):
+        serializer = _AddressSerializer(JobSeekerFactory())
+
+        assert serializer.data == {
+            "adrTelephone": None,
+            "adrMail": None,
+            "adrNumeroVoie": "",
+            "codeextensionvoie": None,
+            "codetypevoie": "",
+            "adrLibelleVoie": None,
+            "adrCpltDistribution": None,
+            "codeinseecom": None,
+            "codepostalcedex": "",
+        }
+
+
+def test_person_serializer_with_empty_birth_country():
+    serializer = _PersonSerializer(
+        EmployeeRecordFactory(job_application__job_seeker__jobseeker_profile__birth_country=None)
+    )
+
+    assert serializer.data["codeInseePays"] is None
+    assert serializer.data["codeGroupePays"] is None
 
 
 class EmployeeRecordUpdateNotificationSerializerTest(TestCase):

--- a/tests/employee_record/test_transfer_employee_records.py
+++ b/tests/employee_record/test_transfer_employee_records.py
@@ -77,8 +77,10 @@ def test_preflight_without_object(snapshot, command):
 
 
 def test_preflight_with_error(snapshot, command):
-    employee_record = EmployeeRecordFactory(
+    EmployeeRecordFactory(
         ready_for_transfer=True,
+        approval_number="",
+        job_application__approval=None,
         # Data used by the snapshot
         pk=42,
         job_application__pk="49536a29-88b5-49c3-8c46-333bbbc36308",
@@ -89,8 +91,6 @@ def test_preflight_with_error(snapshot, command):
         job_application__job_seeker__last_name="Martinez",
         job_application__job_seeker__email="email@example.com",
     )
-    employee_record.job_application.job_seeker.jobseeker_profile.hexa_commune = None
-    employee_record.job_application.job_seeker.jobseeker_profile.save(update_fields=["hexa_commune"])
 
     command.handle(preflight=True, upload=False, download=False, wet_run=False)
     assert command.stdout.getvalue() == snapshot

--- a/tests/employee_record/test_transfer_employee_records_updates.py
+++ b/tests/employee_record/test_transfer_employee_records_updates.py
@@ -76,13 +76,13 @@ def test_preflight_without_object(snapshot, command):
 
 
 def test_preflight_with_error(snapshot, command):
-    notification = EmployeeRecordUpdateNotificationFactory(
+    EmployeeRecordUpdateNotificationFactory(
         ready_for_transfer=True,
+        employee_record__approval_number="",
+        employee_record__job_application__approval=None,
         # Data used by the snapshot
         pk=42,
     )
-    notification.employee_record.job_application.job_seeker.jobseeker_profile.hexa_commune = None
-    notification.employee_record.job_application.job_seeker.jobseeker_profile.save(update_fields=["hexa_commune"])
 
     command.handle(preflight=True, upload=False, download=False, wet_run=False)
     assert command.stdout.getvalue() == snapshot


### PR DESCRIPTION
### Pourquoi ?

[LES-EMPLOIS-PROD-109](https://itou.sentry.io/issues/4458291355/)
[LES-EMPLOIS-PROD-17N](https://itou.sentry.io/issues/4573311262/)
