### PR TITLE
Metabase : Ajout de trois nouveaux champs (code NAF, email public et email d'authentication) à la table `structures`

### DIFF
--- a/itou/metabase/tables/siaes.py
+++ b/itou/metabase/tables/siaes.py
@@ -3,9 +3,14 @@ from itou.metabase.tables.utils import (
     MetabaseTable,
     get_address_columns,
     get_choice,
+    get_column_from_field,
     get_establishment_is_active_column,
     get_establishment_last_login_date_column,
 )
+
+
+def get_field(name):
+    return Siae._meta.get_field(name)
 
 
 TABLE = MetabaseTable(name="structures")
@@ -44,6 +49,9 @@ TABLE.add_columns(
             "comment": "Source des données de la structure",
             "fn": lambda o: get_choice(choices=Siae.SOURCE_CHOICES, key=o.source),
         },
+        get_column_from_field(get_field("naf"), name="code_naf"),
+        get_column_from_field(get_field("email"), name="email_public"),
+        get_column_from_field(get_field("auth_email"), name="email_authentification"),
     ]
 )
 

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -1095,6 +1095,9 @@ def test_populate_siaes():
     siae = SiaeFactory(
         for_snapshot=True,
         siret="17643069438162",
+        naf="1071A",
+        email="contact@garaje_el_martinet.es",
+        auth_email="secret.ceo@garaje_el_martinet.es",
         with_membership=True,
         with_jobs=True,
         coords="POINT (5.43567 12.123876)",
@@ -1131,6 +1134,9 @@ def test_populate_siaes():
                 "EI",
                 "17643069438162",
                 "Export ASP",
+                "1071A",
+                "contact@garaje_el_martinet.es",
+                "secret.ceo@garaje_el_martinet.es",
                 # Address columns " de la structure mère"
                 "112 rue de la Croix-Nivert",
                 "",


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Ajouter-dans-la-table-structure-c2-les-mails-d-authentifications-code-NAF-des-SIAE-dans-c2-53e3df5ade37425bae73edc60868d85f**

### Pourquoi ?

Pour que nos Bizdev aient une source supplémentaire d'emails pros pertinents pour mieux cibler les responsables de chaque SIAE. Avant cette PR ils pouvaient uniquement cibler les membres admin d'une SIAE donnée, qui en pratique ne correspondent pas vraiment aux responsables de la SIAE. L'email d'authentification fourni par l'ASP devrait permettre un meilleur ciblage.
