### PR TITLE
Stats : Ajout de stats sur les demandes de prolongations pour la DGEFP

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -196,6 +196,13 @@
                         </a>
                     </li>
                     <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="{% url 'stats:stats_dgefp_follow_prolongation' %}" class="btn-link btn-ico">
+                            <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
+                            <span>Suivre les demandes de prolongation</span>
+                        </a>
+                        <span class="badge badge-pill badge-xs badge-important text-white">Nouveau</span>
+                    </li>
+                    <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_dgefp_iae' %}" class="btn-link btn-ico">
                             <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                             <span>Voir les données IAE France entière</span>

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -160,6 +160,9 @@ METABASE_DASHBOARDS = {
         "tally_popup_form_id": "w2XZxV",
         "tally_embed_form_id": "n9Ba6G",
     },
+    "stats_dgefp_follow_prolongation": {
+        "dashboard_id": 357,
+    },
     "stats_dgefp_iae": {
         "dashboard_id": 117,
     },

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -77,6 +77,11 @@ urlpatterns = [
         views.stats_dgefp_follow_siae_evaluation,
         name="stats_dgefp_follow_siae_evaluation",
     ),
+    path(
+        "dgefp/follow_prolongation",
+        views.stats_dgefp_follow_prolongation,
+        name="stats_dgefp_follow_prolongation",
+    ),
     path("dgefp/iae", views.stats_dgefp_iae, name="stats_dgefp_iae"),
     path("dgefp/siae_evaluation", views.stats_dgefp_siae_evaluation, name="stats_dgefp_siae_evaluation"),
     path("dgefp/af", views.stats_dgefp_af, name="stats_dgefp_af"),

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -545,6 +545,13 @@ def stats_dgefp_follow_siae_evaluation(request):
 
 
 @login_required
+def stats_dgefp_follow_prolongation(request):
+    return render_stats_dgefp(
+        request=request, page_title="Suivi des demandes de prolongation", extra_params=get_params_for_whole_country()
+    )
+
+
+@login_required
 def stats_dgefp_iae(request):
     return render_stats_dgefp(
         request=request, page_title="Données des régions", extra_params=get_params_for_whole_country()

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -239,6 +239,7 @@ def test_stats_dreets_iae_log_visit(client, view_name):
     [
         "stats_dgefp_auto_prescription",
         "stats_dgefp_follow_siae_evaluation",
+        "stats_dgefp_follow_prolongation",
         "stats_dgefp_iae",
         "stats_dgefp_siae_evaluation",
         "stats_dgefp_af",


### PR DESCRIPTION
**Carte Notion : ** : https://www.notion.so/plateforme-inclusion/Suivi-des-cartes-b3082fffe3f34eaea8fff8ba69338005?p=88acffe3b0b34aa6973686c9f64ac5e2&pm=c

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Les DDETS et DREETS avaient accès aux TB privé de suivi de demandes de prolongation mais pas la DGEFP, nous corrigeons ici cet oubli.

[PR DDETS/DREETS](https://github.com/betagouv/itou/pull/3099)

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

