### PR TITLE
Lister les PASS IAE d'une SIAE sur la page d'admin

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -222,6 +222,12 @@ class ApprovalAdmin(ItouModelAdmin):
         PkSupportRemarkInline,
     )
 
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        if company_id := request.GET.get("assigned_company"):
+            queryset = queryset.is_assigned_to(company_id)
+        return queryset
+
     def get_readonly_fields(self, request, obj=None):
         if obj:
             return ("origin",) + self.readonly_fields

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -209,7 +209,7 @@ class ApprovalQuerySet(CommonApprovalQuerySet):
                 .with_accepted_at()
                 .filter(job_seeker=OuterRef("user"))
                 .order_by("-accepted_at", "-hiring_start_at")
-                .values("to_siae")[:1]
+                .values("to_siae")[:1],
             )
         )
 

--- a/itou/utils/admin.py
+++ b/itou/utils/admin.py
@@ -56,7 +56,7 @@ class ItouStackedInline(StackedInline, ItouTabularInline):
 
 
 class ItouModelAdmin(ModelAdmin):
-    def __get_queryset_with_relations(self, request):
+    def _get_queryset_with_relations(self, request):
         select_related_fields, prefetch_related_fields = set(), set()
         for field in self.model._meta.get_fields():
             if not field.is_relation or field.auto_created:
@@ -76,5 +76,5 @@ class ItouModelAdmin(ModelAdmin):
 
     def get_object(self, request, object_id, from_field=None):
         # Eager-loading all relations, but only when editing one object because `list_select_related` exists
-        with mock.patch.object(self, "get_queryset", self.__get_queryset_with_relations):
+        with mock.patch.object(self, "get_queryset", self._get_queryset_with_relations):
             return super().get_object(request, object_id, from_field)

--- a/tests/approvals/test_admin.py
+++ b/tests/approvals/test_admin.py
@@ -7,6 +7,7 @@ from pytest_django.asserts import assertContains, assertNotContains
 
 from itou.approvals.enums import ProlongationReason
 from itou.files.models import File
+from itou.utils.admin import get_admin_view_link
 from tests.approvals.factories import ApprovalFactory, ProlongationFactory, SuspensionFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.users.factories import ItouStaffFactory
@@ -70,3 +71,10 @@ def test_create_suspensionç_with_no_approval_does_raise_500(admin_client):
         data={},
     )
     assert response.status_code == 200
+
+
+def test_assigned_company(admin_client):
+    approval = ApprovalFactory(with_jobapplication=True)
+    siae = approval.jobapplication_set.get().to_siae
+    response = admin_client.get(reverse("admin:approvals_approval_change", kwargs={"object_id": approval.pk}))
+    assertContains(response, get_admin_view_link(siae, content=siae.display_name), count=2)


### PR DESCRIPTION
demande support : https://itou-inclusion.slack.com/archives/C01181Y04LT/p1698703924145149


J'aimerais bien ajouter le champ en question aussi sur le PASS, mais je n'arrive pas à réutiliser l'annotation `with_assigned_company()` à cause de la surcharge de `get_objet()` mise en place dans `ItouModelAdmin`.

Une idée ?