### PR TITLE
Mise en place d'une redirection permanente pour les urls commançant pas SIAE

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.urls import include, path, re_path, register_converter
 from django.views.generic import TemplateView
 
+from itou.utils import redirect_legacy_views
 from itou.utils.urls import SiretConverter
 from itou.www.dashboard import views as dashboard_views
 from itou.www.login import views as login_views
@@ -64,6 +65,7 @@ urlpatterns = [
     path("prescribers/", include("itou.www.prescribers_views.urls")),
     path("search/", include("itou.www.search.urls")),
     path("company/", include("itou.www.companies_views.urls")),
+    re_path(r"^siae/.*$", redirect_legacy_views.redirect_siaes_views),
     path("siae_evaluation/", include("itou.www.siae_evaluations_views.urls")),
     path("login/", include("itou.www.login.urls")),
     path("signup/", include("itou.www.signup.urls")),

--- a/itou/utils/redirect_legacy_views.py
+++ b/itou/utils/redirect_legacy_views.py
@@ -1,0 +1,5 @@
+from django.http import HttpResponsePermanentRedirect
+
+
+def redirect_siaes_views(request, *args, **kwargs):
+    return HttpResponsePermanentRedirect(request.get_full_path().replace("/siae", "/company", 1))

--- a/tests/utils/test_redirect_legacy_views.py
+++ b/tests/utils/test_redirect_legacy_views.py
@@ -1,0 +1,12 @@
+from django.urls import reverse
+from pytest_django.asserts import assertRedirects
+
+from tests.companies.factories import SiaeFactory
+
+
+def test_redirect_siae_views(client):
+    siae = SiaeFactory()
+
+    url = f"/siae/{siae.pk}/card"
+    response = client.get(url)
+    assertRedirects(response, reverse("companies_views:card", kwargs={"siae_id": siae.pk}), status_code=301)


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Renommer-le-mod-le-Siae-b2eae354455a43a9bdef969c4ffa0d73?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Éviter que des urls soient cassés sur les sites des SIAEs