### PR TITLE
form media: ne pas réinclure de CSS pour les champs Select2 des formulaires

### DIFF
--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -14,8 +14,8 @@
     <script src="{% static "js/city_autocomplete_field_for_jobs.js" %}"></script>
 
     <!-- Needed to use the Datepicker JS widget. -->
-    {{ form_accept.media }}
-    {% if form_personal_data %}{{ form_personal_data.media }}{% endif %}
+    {{ form_accept.media.js }}
+    {% if form_personal_data %}{{ form_personal_data.media.js }}{% endif %}
 
     {# HTMX: dynamic contract type details field, must be reloaded at each DOM swap (otherwise invalidated) #}
     <script nonce="{{ CSP_NONCE }}">

--- a/itou/templates/apply/submit/hire_confirmation.html
+++ b/itou/templates/apply/submit/hire_confirmation.html
@@ -28,8 +28,8 @@
     <script src="{% static "js/city_autocomplete_field_for_jobs.js" %}"></script>
 
     <!-- Needed to use the Datepicker JS widget. -->
-    {{ form_accept.media }}
-    {% if form_personal_data %}{{ form_personal_data.media }}{% endif %}
+    {{ form_accept.media.js }}
+    {% if form_personal_data %}{{ form_personal_data.media.js }}{% endif %}
 
     {# HTMX: dynamic contract type details field, must be reloaded at each DOM swap (otherwise invalidated) #}
     <script nonce="{{ CSP_NONCE }}">


### PR DESCRIPTION
### Pourquoi ?

Le CSS est déjà géré par le thème.

### Commentaire

Et idéalement le CSS devrait de toutes façons être rajoutés dans le `block` "extra_head"