### PR TITLE
[RENOUVELLEMENT DES PASS REPRISE DE STOCK AI] ETQ employeur en AI je suis invité à réaliser mes démarches de demande de prolongation avant que les PASS n’expirent

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -102,6 +102,23 @@
         </div>
     {% endif %}
 
+    {% if user.is_employer and request.current_organization.kind == CompanyKind.AI %}
+        <div id="AIStockProlongationAlert" class="alert alert-info">
+            <p>
+                Si votre structure est concernée par la délivrance automatique de PASS IAE qui a eu lieu le 01/12/2021, nous vous invitons à <a href="{% url "approvals:list" %}">vérifier que leur durée de validité couvre bien la période de travail prévue</a>.
+                <br>
+                Si des prolongations de parcours sont nécessaires, nous vous invitons à réaliser vos demandes de prolongation tant que les PASS IAE sont valides.
+            </p>
+            <p class="mb-0">
+                <i>
+                    Attention : une demande de prolongation n’est plus possible si le PASS IAE est expiré.
+                    <br>
+                    Prévoir un délai de traitement par le prescripteur habilité d’environ 7 jours.
+                </i>
+            </p>
+        </div>
+    {% endif %}
+
     {# welcoming_tour desactivé spécifiquement pour les institutions partenaires #}
     {# en attendant une carte plus globale sur le sujet #}
     {% if user.joined_recently and not user.is_labor_inspector %}

--- a/tests/www/dashboard/__snapshots__/tests.ambr
+++ b/tests/www/dashboard/__snapshots__/tests.ambr
@@ -1,4 +1,22 @@
 # serializer version: 1
+# name: test_alert_message_for_ai_stock_prolongation[AI]
+  '''
+  <div class="alert alert-info" id="AIStockProlongationAlert">
+              <p>
+                  Si votre structure est concernée par la délivrance automatique de PASS IAE qui a eu lieu le 01/12/2021, nous vous invitons à <a href="/approvals/list">vérifier que leur durée de validité couvre bien la période de travail prévue</a>.
+                  <br/>
+                  Si des prolongations de parcours sont nécessaires, nous vous invitons à réaliser vos demandes de prolongation tant que les PASS IAE sont valides.
+              </p>
+              <p class="mb-0">
+                  <i>
+                      Attention : une demande de prolongation n’est plus possible si le PASS IAE est expiré.
+                      <br/>
+                      Prévoir un délai de traitement par le prescripteur habilité d’environ 7 jours.
+                  </i>
+              </p>
+          </div>
+  '''
+# ---
 # name: test_maze_survey
   '''
   <div class="maze-survey bg-white shadow fixed-sm-bottom m-3 py-3 alert alert-dismissible alert-dismissible-once d-none" id="alertMazeSurvey">

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -1885,3 +1885,15 @@ def test_maze_survey(client, snapshot):
     client.session.clear()
     response = client.get(reverse("dashboard:index"))
     assert str(parse_response_to_soup(response, ".maze-survey")) == snapshot
+
+
+@pytest.mark.parametrize("kind", CompanyKind)
+def test_alert_message_for_ai_stock_prolongation(client, snapshot, kind):
+    employer = CompanyMembershipFactory(siae__kind=kind).user
+    client.force_login(employer)
+
+    response = client.get(reverse("dashboard:index"))
+    if kind is CompanyKind.AI:
+        assert str(parse_response_to_soup(response, "#AIStockProlongationAlert")) == snapshot
+    else:
+        assertNotContains(response, "AIStockProlongationAlert")


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/RENOUVELLEMENT-DES-PASS-REPRISE-DE-STOCK-AI-ETQ-employeur-en-AI-je-suis-invit-r-aliser-mes-d-mar-554d9d9310cd4c318534a5b4c9c4ece1

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Plus de 25 000 PASS issus de la reprise de stock AI expireront la semaine 27/11/2023 
nous souhaitons alerter les employeurs en AI afin qu’ils effectuent les démarches de demande de prolongation dans les temps.

### Comment <!-- optionnel -->

Message d’information dans le tableau de bord des AI

### Captures d'écran <!-- optionnel -->

![image](https://github.com/betagouv/itou/assets/20045330/e0df58ed-5f2a-49cb-90a0-28f1885d8e14)
