### PR TITLE
Stats : Ajout du département 18 à la liste blanche des CD (Conseils Départementaux)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -419,7 +419,7 @@ ACI_CONVERGENCE_SIRET_WHITELIST = json.loads(os.getenv("ACI_CONVERGENCE_SIRET_WH
 # Kept as a setting to not let User pks or Company asp_ids in clear in the code.
 STATS_SIAE_ASP_ID_WHITELIST = json.loads(os.getenv("STATS_SIAE_ASP_ID_WHITELIST", "[]"))
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_USER_PK_WHITELIST", "[]"))
-STATS_CD_DEPARTMENT_WHITELIST = ["13", "37", "38", "41", "45", "49", "93"]
+STATS_CD_DEPARTMENT_WHITELIST = ["13", "18", "37", "38", "41", "45", "49", "93"]
 
 # Slack notifications sent by Metabase cronjobs.
 SLACK_CRON_WEBHOOK_URL = os.getenv("SLACK_CRON_WEBHOOK_URL")


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Ajouter-CD-18-la-liste-blanche-des-conseils-d-partementaux-pour-acc-der-aux-TB330-et-TB346-24510c2b7c234efe97610e61f7b26e6f**

### Pourquoi ?

Parce que les stats développées pour les CD commencent à avoir du succès.