### PR TITLE
Harmonisation de la zone de boutons dans les formulaires

### DIFF
--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -92,14 +92,17 @@
                             {% block form_content %}{% endblock %}
 
                             <hr>
-                            <div class="form-row align-items-center justify-content-end">
+                            <div class="form-row align-items-center gx-3">
                                 {% if back_url %}
-                                    <div class="form-group mb-0 col-6 col-lg-auto">
-                                        <a class="btn btn-link btn-block" href="{{ back_url }}" aria-label="Retourner à l'étape précédente">Retour</a>
+                                    <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                        <a class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="{{ back_url }}" aria-label="Retourner à l'étape précédente">
+                                            <i class="ri-arrow-go-back-line ri-lg"></i>
+                                            <span>Retour</span>
+                                        </a>
                                     </div>
                                 {% endif %}
                                 {% block form_submit_button %}
-                                    <div class="form-group mb-0 col-6 col-lg-auto">
+                                    <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
                                         <button type="submit" class="btn btn-primary btn-block" aria-label="Passer à l'étape suivante">Suivant</button>
                                     </div>
                                 {% endblock %}

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -62,9 +62,13 @@
                                     </p>
                                 </div>
                             </div>
-                            <div class="text-end pt-5">
-                                <a class="btn btn-link me-3" href="{% url "search:siaes_home" %}">Revenir à la recherche</a>
-                                <a class="btn btn-primary" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                            <div class="form-row align-items-center justify-content-end gx-3 mt-3">
+                                <div class="form-group col-6 col-lg-auto">
+                                    <a href="{% url "search:siaes_home" %}" class="btn btn-outline-primary btn-block">Revenir à la recherche</a>
+                                </div>
+                                <div class="form-group col-6 col-lg-auto">
+                                    <a class="btn btn-primary btn-block" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                                </div>
                             </div>
                         </div>
                         {% if not request.user.is_job_seeker %}
@@ -94,9 +98,13 @@
                             </div>
                         {% endif %}
                     {% else %}
-                        <div class="text-end pt-5">
-                            <a class="btn btn-link me-3" href="{% url "search:siaes_home" %}">Revenir à la recherche</a>
-                            <a class="btn btn-primary" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                        <div class="form-row align-items-center justify-content-end gx-3 mt-3">
+                            <div class="form-group col-6 col-lg-auto">
+                                <a href="{% url "search:siaes_home" %}" class="btn btn-outline-primary btn-block">Revenir à la recherche</a>
+                            </div>
+                            <div class="form-group col-6 col-lg-auto">
+                                <a class="btn btn-primary btn-block" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                            </div>
                         </div>
                     {% endif %}
                 </div>

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -214,11 +214,11 @@
 {% endblock %}
 
 {% block form_submit_button %}
-    <div class="form-group mb-0 col-6 col-lg-auto">
+    <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
         {% if request.user.is_employer %}
-            <button class="btn btn-primary">Enregistrer</button>
+            <button class="btn btn-primary btn-block">Enregistrer</button>
         {% else %}
-            <button class="btn btn-primary">Envoyer la candidature</button>
+            <button class="btn btn-primary btn-block">Envoyer la candidature</button>
         {% endif %}
     </div>
 {% endblock %}

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
@@ -65,10 +65,19 @@
 
                             {% block form_content %}{% endblock %}
 
-                            <hr class="my-5">
-                            <div class="form-group text-end">
-                                {% if back_url %}<a class="btn btn-link" href="{{ back_url }}">Retour</a>{% endif %}
-                                {% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary" %}
+                            <hr>
+                            <div class="form-row align-items-center gx-3">
+                                {% if back_url %}
+                                    <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                        <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'étape précédente">
+                                            <i class="ri-arrow-go-back-line ri-lg"></i>
+                                            <span>Retour</span>
+                                        </a>
+                                    </div>
+                                {% endif %}
+                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                    {% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary btn-block" %}
+                                </div>
                             </div>
                         </form>
                     </div>

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html
@@ -41,14 +41,21 @@
 
                             {% include "apply/includes/profile_infos.html" %}
 
-                            <hr class="my-4">
-                            <div class="form-group text-end">
-                                <a class="btn btn-link" href="{{ back_url }}" aria-label="Retourner à l'étape précédente">Retour</a>
-                                {% if update_job_seeker %}
-                                    {% bootstrap_button "Valider les informations" button_type="submit" button_class="btn btn-primary" %}
-                                {% else %}
-                                    {% bootstrap_button "Créer le compte candidat" button_type="submit" button_class="btn btn-primary" %}
-                                {% endif %}
+                            <hr>
+                            <div class="form-row align-items-center gx-3">
+                                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                    <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'étape précédente">
+                                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                                        <span>Retour</span>
+                                    </a>
+                                </div>
+                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                    {% if update_job_seeker %}
+                                        {% bootstrap_button "Valider les informations" button_type="submit" button_class="btn btn-primary btn-block" %}
+                                    {% else %}
+                                        {% bootstrap_button "Créer le compte candidat" button_type="submit" button_class="btn btn-primary btn-block" %}
+                                    {% endif %}
+                                </div>
                             </div>
                         </form>
                     </div>

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -87,11 +87,14 @@
             {% endif %}
             {# Reload this page and show a modal containing more information about the job seeker. #}
             <hr>
-            <div class="form-row align-items-center justify-content-end">
-                <div class="form-group mb-0 col-6 col-lg-auto">
-                    <a class="btn btn-link btn-block" aria-label="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
+            <div class="form-row align-items-center gx-3">
+                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                    <a href="{% url 'dashboard:index' %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner au tableau de bord">
+                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                        <span>Retour</span>
+                    </a>
                 </div>
-                <div class="form-group mb-0 col-6 col-lg-auto">
+                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
                     {% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary btn-block" name="preview" value="1" %}
                 </div>
             </div>

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -39,15 +39,15 @@
             </div>
 
             <hr>
-            <div class="form-row align-items-center justify-content-end">
-                <div class="form-group mb-0 col-6 col-lg-auto">
-                    <a href="{{ back_url }}" class="btn btn-link btn-block" aria-label="Retourner à l'étape précédente">Retour</a>
+            <div class="form-row align-items-center gx-3">
+                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                    <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'étape précédente">
+                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                        <span>Retour</span>
+                    </a>
                 </div>
-                <div class="form-group mb-0 col-6 col-lg-auto">
-                    {# Reload this page and show a modal containing more information about the job seeker. #}
-                    <button type="submit" class="btn btn-primary btn-block" name="preview" value="1" aria-label="Passer à l'étape suivante">
-                        Suivant
-                    </button>
+                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                    {% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary btn-block" name="preview" value="1" %}
                 </div>
             </div>
         </div>

--- a/itou/templates/approvals/pe_approval_search.html
+++ b/itou/templates/approvals/pe_approval_search.html
@@ -28,13 +28,19 @@
 
                     {% endif %}
 
-                    <form method="get" role="form" class="js-prevent-multiple-submit">
+                    <div class="c-form">
+                        <form method="get" role="form" class="js-prevent-multiple-submit">
 
-                        {% bootstrap_form form alert_error_type="all" %}
+                            {% bootstrap_form form alert_error_type="all" %}
 
-                        <div class="form-group">{% bootstrap_button "Rechercher" button_type="submit" button_class="btn btn-primary" %}</div>
-
-                    </form>
+                            <hr>
+                            <div class="form-row align-items-center justify-content-end gx-3">
+                                <div class="form-group col-12 col-lg-auto">
+                                    {% bootstrap_button "Rechercher" button_type="submit" button_class="btn btn-primary w-100 w-lg-auto" %}
+                                </div>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -32,15 +32,30 @@
                             <p>
                                 Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' siae_pk=request.current_organization.pk %}">réaliser une auto-prescription</a>.
                             </p>
-                            <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
+                            <a class="btn btn-link btn-ico ps-lg-0 " href="{{ back_url }}" aria-label="Retourner à l'étape précédente">
+                                <i class="ri-arrow-go-back-line ri-lg"></i>
+                                <span>Retour</span>
+                            </a>
                         {% else %}
-                            <p>
-                                L'agrément <strong>{{ approval.number }}</strong> a été délivré pour <strong>{{ approval.first_name|title }} {{ approval.last_name|upper }}</strong>.
-                            </p>
-                            <p>Nous allons l'importer dans votre compte pour vous permettre de le suspendre ou de le prolonger.</p>
-                            <p>Mais avant, nous avons besoin de connaître l'adresse e-mail de votre salarié(e).</p>
-                            <a class="btn btn-outline-primary" href="{{ back_url }}">Annuler</a>
-                            <a class="btn btn-primary" href="{% url 'approvals:pe_approval_search_user' approval.pk %}">Continuer</a>
+                            <div class="c-form">
+                                <p>
+                                    L'agrément <strong>{{ approval.number }}</strong> a été délivré pour <strong>{{ approval.first_name|title }} {{ approval.last_name|upper }}</strong>.
+                                </p>
+                                <p>Nous allons l'importer dans votre compte pour vous permettre de le suspendre ou de le prolonger.</p>
+                                <p>Mais avant, nous avons besoin de connaître l'adresse e-mail de votre salarié(e).</p>
+                                <hr>
+                                <div class="form-row align-items-center justify-content-end gx-3">
+                                    <div class="form-group col-6 col-lg-auto">
+                                        <a href="{{ back_url }}" class="btn btn-block btn-ico btn-outline-primary">
+                                            <i class="ri-close-fill ri-lg"></i>
+                                            <span>Annuler</span>
+                                        </a>
+                                    </div>
+                                    <div class="form-group col-6 col-lg-auto">
+                                        <a class="btn btn-primary btn-block" href="{% url 'approvals:pe_approval_search_user' approval.pk %}">Continuer</a>
+                                    </div>
+                                </div>
+                            </div>
                         {% endif %}
 
                     {% else %}

--- a/itou/templates/approvals/pe_approval_search_user.html
+++ b/itou/templates/approvals/pe_approval_search_user.html
@@ -14,16 +14,25 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 col-lg-8">
-                    <form method="post" action="{% url 'approvals:pe_approval_create' pe_approval.id %}" class="js-prevent-multiple-submit">
+                    <div class="c-form">
+                        <form method="post" action="{% url 'approvals:pe_approval_create' pe_approval.id %}" class="js-prevent-multiple-submit">
 
-                        {% csrf_token %}
+                            {% csrf_token %}
 
-                        {% bootstrap_form form alert_error_type="all" %}
+                            {% bootstrap_form form alert_error_type="all" %}
 
-                        <div>{% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}</div>
+                            <div class="mb-3">
+                                {% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}
+                            </div>
 
-                        <div class="form-group">{% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary" %}</div>
-                    </form>
+                            <hr>
+                            <div class="form-row align-items-center justify-content-end gx-3">
+                                <div class="form-group col-12 col-lg-auto">
+                                    {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary w-100 w-lg-auto" %}
+                                </div>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -42,8 +42,8 @@
                             <div class="row">
                                 <div class="col-12">
                                     <div class="form-row align-items-center justify-content-end">
-                                        <div class="form-group col-12 col-lg-auto order-2 order-lg-1">
-                                            <a href="{{ back_url }}" class="btn btn-link btn-block btn-ico ps-0 justify-content-center" aria-label="Retour à l'étape précédente">
+                                        <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                            <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retour à l'étape précédente">
                                                 <i class="ri-arrow-go-back-line ri-lg"></i>
                                                 <span>Retour</span>
                                             </a>

--- a/itou/templates/prescribers/edit_organization.html
+++ b/itou/templates/prescribers/edit_organization.html
@@ -23,18 +23,27 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 col-lg-8">
-                    <form method="post" class="js-prevent-multiple-submit">
+                    <div class="c-form">
+                        <form method="post" class="js-prevent-multiple-submit">
 
-                        {% csrf_token %}
+                            {% csrf_token %}
 
-                        {% bootstrap_form form alert_error_type="all" %}
+                            {% bootstrap_form form alert_error_type="all" %}
 
-                        <div class="form-group">
-                            <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
-                            {% bootstrap_button "Enregistrer" button_type="submit" button_class="btn btn-primary" %}
-                        </div>
-
-                    </form>
+                            <hr>
+                            <div class="form-row align-items-center gx-3">
+                                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                    <a href="{% url 'dashboard:index' %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner au tableau de bord">
+                                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                                        <span>Retour</span>
+                                    </a>
+                                </div>
+                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                    <button class="btn btn-primary btn-block" aria-label="Enregistrer la modification">Enregistrer</button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/itou/templates/siaes/create_siae.html
+++ b/itou/templates/siaes/create_siae.html
@@ -5,18 +5,17 @@
 
 {% block content_title %}
     <h1>Créer/rejoindre une nouvelle structure</h1>
-    <div class="alert alert-info">
-        <p>Vous souhaitez rejoindre une structure :</p>
-        <ul>
-            <li>
-                ayant déjà un ou plusieurs membres, <b>demandez à l’un de ces membres de vous inviter depuis son tableau de bord</b>
-            </li>
-            <li>
-                connue des services des emplois de l'inclusion mais n’ayant pas encore de membre : <a href="{% url 'signup:company_select' %}">utilisez ce formulaire</a>
-            </li>
-        </ul>
-        <p class="mb-0">Dans les autres cas, complétez le formulaire ci-dessous.</p>
-    </div>
+    <p>Vous souhaitez rejoindre une structure :</p>
+    <ul>
+        <li>
+            ayant déjà un ou plusieurs membres, <b>demandez à l’un de ces membres de vous inviter depuis son tableau de bord</b>
+        </li>
+        <li>
+            connue des services des emplois de l'inclusion mais n’ayant pas encore de membre : <a href="{% url 'signup:company_select' %}">utilisez ce formulaire</a>
+        </li>
+    </ul>
+    <p class="mb-0">Dans les autres cas, complétez le formulaire ci-dessous.</p>
+
 {% endblock %}
 
 {% block content %}
@@ -44,12 +43,28 @@
                                 {% bootstrap_field field %}
                             {% endfor %}
 
-                            <p>
-                                En cliquant sur le bouton "Enregistrer", vous acceptez que vos informations et coordonnées ci-dessus soient rendues publiques.
-                            </p>
-                            <div class="form-group">
-                                <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
-                                {% bootstrap_button "Enregistrer" button_type="submit" button_class="btn btn-primary" %}
+                            <hr>
+                            <div class="alert alert-warning">
+                                <div class="row">
+                                    <div class="col-auto pe-0">
+                                        <i class="ri-information-line ri-xl"></i>
+                                    </div>
+                                    <div class="col">
+                                        En cliquant sur le bouton <b>« Enregistrer »</b>, vous acceptez que vos informations et coordonnées ci-dessus soient rendues publiques.
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="form-row align-items-center gx-3">
+                                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                    <a href="{% url 'dashboard:index' %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner au tableau de bord">
+                                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                                        <span>Retour</span>
+                                    </a>
+                                </div>
+                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                    <button class="btn btn-primary btn-block" aria-label="Enregister la fiche structure">Enregistrer</button>
+                                </div>
                             </div>
                         </form>
                     </div>

--- a/itou/templates/siaes/edit_job_description.html
+++ b/itou/templates/siaes/edit_job_description.html
@@ -26,11 +26,16 @@
                     </div>
 
                     <div class="c-form">
-                        <div class="text-center mb-3">
-                            <img src="{% static 'img/edit_job_description_header.svg' %}" alt="">
+                        <div class="text-center mb-3 mb-lg-5">
+                            <div class="mb-2">
+                                <img src="{% static 'img/edit_job_description_header.svg' %}" alt="">
+                            </div>
+                            <h1>
+                                Informations générales
+                                <br class="d-none d-lg-inline">
+                                de ma fiche de poste
+                            </h1>
                         </div>
-                        <h1 class="text-center mb-5">Informations générales de ma fiche de poste</h1>
-                        <hr>
 
                         <form method="post" action="?step={{ step }}" class="js-prevent-multiple-submit">
                             {% bootstrap_form_errors form alert_error_type="all" %}
@@ -48,10 +53,17 @@
                             <div id="_other_contract_type_group">{% bootstrap_field form.other_contract_type %}</div>
                             {% bootstrap_field form.hours_per_week %}
                             {% bootstrap_field form.open_positions %}
-
-                            <div class="form-group pt-3 text-end">
-                                <a class="btn btn-outline-primary" href="{% url "companies_views:job_description_list" %}" aria-label="Retour à la liste des métiers">Retour</a>
-                                <button type="submit" class="btn btn-primary" aria-label="Passer à l'étape suivante">Suivant</button>
+                            <hr>
+                            <div class="form-row align-items-center gx-3">
+                                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                    <a href="{% url "companies_views:job_description_list" %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à la liste des métiers">
+                                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                                        <span>Retour</span>
+                                    </a>
+                                </div>
+                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                    <button class="btn btn-primary btn-block" aria-label="Passer à l'étape suivante">Suivant</button>
+                                </div>
                             </div>
                         </form>
                     </div>

--- a/itou/templates/siaes/edit_job_description_details.html
+++ b/itou/templates/siaes/edit_job_description_details.html
@@ -26,14 +26,20 @@
                     </div>
 
                     <div class="c-form">
-                        <div class="text-center mb-3">
-                            <img src="{% static 'img/edit_job_description_header.svg' %}" alt="">
+                        <div class="text-center mb-3 mb-lg-5">
+                            <div class="mb-2">
+                                <img src="{% static 'img/edit_job_description_header.svg' %}" alt="">
+                            </div>
+                            <h1 class="text-center mb-5">
+                                Description
+                                <br class="d-none d-lg-inline">
+                                de ma fiche de poste
+                            </h1>
                         </div>
+
                         <form method="post" class="js-prevent-multiple-submit">
                             {% bootstrap_form_errors form type="all" %}
                             {% csrf_token %}
-                            <h1 class="text-center mb-5">Description de ma fiche de poste</h1>
-                            <hr>
                             {% bootstrap_field form.description %}
                             <div class="alert alert-emploi">
                                 <div class="row">
@@ -79,9 +85,17 @@
                                 {% bootstrap_field form.is_qpv_mandatory %}
                             {% endif %}
 
-                            <div class="form-group pt-3 text-end">
-                                <a class="btn btn-outline-primary" href="{% url "companies_views:edit_job_description" %}" aria-label="Retour à la page précédente">Retour</a>
-                                <button type="submit" class="btn btn-primary" aria-label="Passer à l'étape suivante">Suivant</button>
+                            <hr>
+                            <div class="form-row align-items-center gx-3">
+                                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                    <a href="{% url "companies_views:edit_job_description" %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'étape précédente">
+                                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                                        <span>Retour</span>
+                                    </a>
+                                </div>
+                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                    <button class="btn btn-primary btn-block" aria-label="Passer à l'étape suivante">Suivant</button>
+                                </div>
                             </div>
                         </form>
                     </div>

--- a/itou/templates/siaes/edit_job_description_preview.html
+++ b/itou/templates/siaes/edit_job_description_preview.html
@@ -25,30 +25,45 @@
                     </div>
 
                     <div class="c-form">
-                        <div class="text-center mb-3">
-                            <img src="{% static 'img/edit_job_description_header.svg' %}" alt="">
+                        <div class="text-center mb-3 mb-lg-5">
+                            <div class="mb-2">
+                                <img src="{% static 'img/edit_job_description_header.svg' %}" alt="">
+                            </div>
+                            <h1>
+                                Aperçu
+                                <br class="d-none d-lg-inline">
+                                de ma fiche de poste
+                            </h1>
                         </div>
-                        <h1 class="text-center mb-5">Aperçu de ma fiche de poste</h1>
+
                         {% include "siaes/includes/_job_description_details.html" %}
 
-                        <div class="alert alert-emploi mb-4">
+                        <hr>
+                        <div class="alert alert-warning">
                             <div class="row">
                                 <div class="col-auto pe-0">
                                     <i class="ri-information-line ri-xl"></i>
                                 </div>
                                 <div class="col">
-                                    En cliquant sur le bouton « Publier la fiche de poste », vous acceptez que vos informations et coordonnées soient rendues publiques.
+                                    En cliquant sur le bouton <b>« Publier la fiche de poste »</b>, vous acceptez que vos informations et coordonnées soient rendues publiques.
                                 </div>
                             </div>
                         </div>
 
                         <form method="post" class="js-prevent-multiple-submit">
                             {% csrf_token %}
-                            <div class="form-group text-end">
-                                <a class="btn btn-outline-primary" aria-label="Retour à la page précédente" href="{% url "companies_views:edit_job_description_details" %}">Retour</a>
-                                <button class="btn btn-primary matomo-event" type="submit" data-matomo-category="employeurs" data-matomo-action="submit" data-matomo-option="publier-fiche-poste">
-                                    Publier la fiche de poste
-                                </button>
+                            <div class="form-row align-items-center gx-3">
+                                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                    <a href="{% url "companies_views:edit_job_description_details" %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'étape précédente">
+                                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                                        <span>Retour</span>
+                                    </a>
+                                </div>
+                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                    <button class="btn btn-primary btn-block matomo-event" aria-label="Publier la fiche de poste" data-matomo-category="employeurs" data-matomo-action="submit" data-matomo-option="publier-fiche-poste">
+                                        Publier la fiche de poste
+                                    </button>
+                                </div>
                             </div>
                         </form>
                     </div>

--- a/itou/templates/siaes/edit_siae.html
+++ b/itou/templates/siaes/edit_siae.html
@@ -27,18 +27,18 @@
                     </div>
 
                     <div class="c-form">
-                        <div class="text-center">
-                            <h1 class="h1-hero">
+                        <div class="text-center mb-3 mb-lg-5">
+                            <div class="mb-2">
                                 <img src="{% static 'img/edit_siae_header.svg' %}" alt="En-tête édition SIAE" class="edit-siae-header-image">
-                            </h1>
-                            <h2 class="h1">
+                            </div>
+                            <h1>
                                 Informations générales
                                 <br class="d-none d-lg-inline">
                                 de ma structure
-                            </h2>
+                            </h1>
                         </div>
 
-                        <div class="card c-card c-card--emploi my-3 my-lg-5">
+                        <div class="card c-card c-card--emploi mb-3 mb-lg-5">
                             <div class="card-body">
                                 <p>
                                     <i class="ri-home-7-line ri-xl me-2"></i>{{ siae.kind }} - {{ siae.get_kind_display }}
@@ -66,14 +66,16 @@
                             {% bootstrap_field form.email %}
                             {% bootstrap_field form.website %}
 
-                            <hr class="my-3 my-lg-5">
-
-                            <div class="row mt-3 mt-lg-5 justify-content-end">
-                                <div class="col-6 col-lg-auto">
-                                    <a class="btn btn-link" aria-label="Retourner au tableau de bord" href="{% url 'dashboard:index' %}">Retour</a>
+                            <hr>
+                            <div class="form-row align-items-center gx-3">
+                                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                    <a href="{% url 'dashboard:index' %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner au tableau de bord">
+                                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                                        <span>Retour</span>
+                                    </a>
                                 </div>
-                                <div class="col-6 col-lg-auto">
-                                    <button aria-label="Vers l'étape suivante du formulaire" class="btn float-end btn-primary">Suivant</button>
+                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                    <button class="btn btn-primary btn-block" aria-label="Vers l'étape suivante du formulaire">Suivant</button>
                                 </div>
                             </div>
                         </form>

--- a/itou/templates/siaes/edit_siae_description.html
+++ b/itou/templates/siaes/edit_siae_description.html
@@ -16,7 +16,7 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 col-lg-8">
-                    <div class="c-stepper">
+                    <div class="c-stepper mb-3 mb-lg-5">
                         <div class="progress progress--emploi">
                             <div class="progress-bar progress-bar-66" role="progressbar" aria-valuenow="66" aria-valuemin="0" aria-valuemax="100">
                             </div>
@@ -27,17 +27,16 @@
                     </div>
 
                     <div class="c-form">
-                        <div class="text-center">
-                            <h1 class="h1-hero">
+                        <div class="text-center mb-3 mb-lg-5">
+                            <div class="mb-2">
                                 <img src="{% static 'img/edit_siae_header.svg' %}" alt="En-tête édition SIAE" class="edit-siae-header-image">
-                            </h1>
-                            <h2 class="h1">
+                            </div>
+                            <h1>
                                 Présentation de l'activité
                                 <br class="d-none d-lg-inline">
                                 de ma structure
-                            </h2>
+                            </h1>
                         </div>
-                        <hr class="my-3 my-lg-5">
                         <form method="post" class="js-prevent-multiple-submit">
                             {% csrf_token %}
                             {% bootstrap_form_errors form type="all" %}
@@ -58,7 +57,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <hr class="my-3 my-lg-5">
+                            <hr>
                             {% bootstrap_field form.provided_support %}
                             <div class="alert alert-info">
                                 <div class="row">
@@ -74,17 +73,18 @@
                                 </div>
                             </div>
 
-                            <hr class="my-3 my-lg-5">
-
-                            <div class="row mt-3 mt-lg-5 justify-content-end">
-                                <div class="col-6 col-lg-auto">
-                                    <a class="btn btn-link" aria-label="Retourner à l'édition des coordonnées" href="{{ prev_url }}">Retour</a>
+                            <hr>
+                            <div class="form-row align-items-center gx-3">
+                                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                    <a href="{{ prev_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'édition des coordonnées">
+                                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                                        <span>Retour</span>
+                                    </a>
                                 </div>
-                                <div class="col-6 col-lg-auto">
-                                    <button aria-label="Vers l'étape suivante du formulaire"  class="btn float-end btn-primary">Suivant</button>
+                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                    <button class="btn btn-primary btn-block" aria-label="Vers l'étape suivante du formulaire">Suivant</button>
                                 </div>
                             </div>
-
                         </form>
                     </div>
                 </div>

--- a/itou/templates/siaes/edit_siae_preview.html
+++ b/itou/templates/siaes/edit_siae_preview.html
@@ -28,18 +28,18 @@
                     </div>
 
                     <div class="c-form">
-                        <div class="text-center">
-                            <h1 class="h1-hero">
+                        <div class="text-center mb-3 mb-lg-5">
+                            <div class="mb-2">
                                 <img src="{% static 'img/edit_siae_header.svg' %}" alt="En-tête édition SIAE" class="edit-siae-header-image">
-                            </h1>
-                            <h2 class="h1">
+                            </div>
+                            <h1>
                                 Aperçu de la fiche
                                 <br class="d-none d-lg-inline">
                                 de ma structure
-                            </h2>
+                            </h1>
                         </div>
 
-                        <div class="card c-card c-card--emploi my-3 my-lg-5">
+                        <div class="card c-card c-card--emploi mb-3 mb-lg-5">
                             <div class="card-body">
                                 <p>
                                     <i class="ri-home-7-line ri-xl me-2"></i>{{ siae.kind }} - {{ siae.get_kind_display }}
@@ -69,30 +69,31 @@
 
                             {% if siae.email or siae.phone or siae.website %}
                                 <hr>
+                                <ul class="list-unstyled">
+                                    {% if siae.email %}
+                                        <li>
+                                            <i class="ri-mail-line ri-xl me-2"></i>
+                                            <a aria-label="Contact par mail" href="mailto:{{ siae.email }}" class="font-weight-bold">{{ siae.email }}</a>
+                                        </li>
+                                    {% endif %}
 
-                                {% if siae.email %}
-                                    <p>
-                                        <i class="ri-mail-line ri-xl me-2"></i>
-                                        <a aria-label="Contact par mail" href="mailto:{{ siae.email }}" class="font-weight-bold">{{ siae.email }}</a>
-                                    </p>
-                                {% endif %}
+                                    {% if siae.phone %}
+                                        <li>
+                                            <i class="ri-phone-line ri-xl me-2"></i>
+                                            <a aria-label="Contact téléphonique" href="tel:{{ siae.phone|cut:' ' }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
+                                        </li>
+                                    {% endif %}
 
-                                {% if siae.phone %}
-                                    <p>
-                                        <i class="ri-phone-line ri-xl me-2"></i>
-                                        <a aria-label="Contact téléphonique" href="tel:{{ siae.phone|cut:' ' }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
-                                    </p>
-                                {% endif %}
-
-                                {% if siae.website %}
-                                    <p>
-                                        <i class="ri-global-line ri-xl me-2"></i>
-                                        <a aria-label="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="font-weight-bold">{{ siae.website }}</a>
-                                    </p>
-                                {% endif %}
+                                    {% if siae.website %}
+                                        <li>
+                                            <i class="ri-global-line ri-xl me-2"></i>
+                                            <a aria-label="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="font-weight-bold">{{ siae.website }}</a>
+                                        </li>
+                                    {% endif %}
+                                </ul>
                             {% endif %}
 
-                            <hr class="mb-3 mb-lg-5">
+                            <hr>
 
                             <div class="alert alert-warning">
                                 <div class="row">
@@ -107,14 +108,15 @@
                                 </div>
                             </div>
 
-                            <div class="row mt-3 mt-lg-5 justify-content-end">
-                                <div class="col-6 col-lg-auto">
-                                    <a class="btn btn-link" aria-label="Retourner à l'édition de la description" href="{{ prev_url }}">Retour</a>
+                            <div class="form-row align-items-center gx-3">
+                                <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                    <a href="{{ prev_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'édition de la description">
+                                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                                        <span>Retour</span>
+                                    </a>
                                 </div>
-                                <div class="col-6 col-lg-auto">
-                                    <button aria-label="Publier le formulaire" class="btn btn-primary float-end matomo-event" data-matomo-category="employeurs" data-matomo-action="submit" data-matomo-option="publier-infos-structure">
-                                        Publier
-                                    </button>
+                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                    <button class="btn btn-primary btn-block" aria-label="Publier le formulaire" data-matomo-category="employeurs" data-matomo-action="submit" data-matomo-option="publier-infos-structure">Publier</button>
                                 </div>
                             </div>
                         </form>

--- a/itou/templates/siaes/edit_siae_preview.html
+++ b/itou/templates/siaes/edit_siae_preview.html
@@ -116,7 +116,9 @@
                                     </a>
                                 </div>
                                 <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    <button class="btn btn-primary btn-block" aria-label="Publier le formulaire" data-matomo-category="employeurs" data-matomo-action="submit" data-matomo-option="publier-infos-structure">Publier</button>
+                                    <button class="btn btn-primary btn-block" aria-label="Publier le formulaire" data-matomo-category="employeurs" data-matomo-action="submit" data-matomo-option="publier-infos-structure">
+                                        Publier
+                                    </button>
                                 </div>
                             </div>
                         </form>

--- a/itou/templates/siaes/includes/_siae_details.html
+++ b/itou/templates/siaes/includes/_siae_details.html
@@ -1,24 +1,25 @@
 {% load format_filters %}
 
 <hr>
+<ul class="list-unstyled">
+    {% if siae.email %}
+        <li>
+            <i class="ri-mail-line ri-xl me-2"></i>
+            <a aria-label="Contact par mail" href="mailto:{{ siae.email }}" class="font-weight-bold">{{ siae.email }}</a>
+        </li>
+    {% endif %}
 
-{% if siae.email %}
-    <p>
-        <i class="ri-mail-line ri-xl me-2"></i>
-        <a aria-label="Contact par mail" href="mailto:{{ siae.email }}" class="font-weight-bold">{{ siae.email }}</a>
-    </p>
-{% endif %}
+    {% if siae.phone %}
+        <li>
+            <i class="ri-phone-line ri-xl me-2"></i>
+            <a aria-label="Contact téléphonique" href="tel:{{ siae.phone|cut:" " }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
+        </li>
+    {% endif %}
 
-{% if siae.phone %}
-    <p>
-        <i class="ri-phone-line ri-xl me-2"></i>
-        <a aria-label="Contact téléphonique" href="tel:{{ siae.phone|cut:" " }}" class="font-weight-bold">{{ siae.phone|format_phone }}</a>
-    </p>
-{% endif %}
-
-{% if siae.website %}
-    <p>
-        <i class="ri-global-line ri-xl me-2"></i>
-        <a aria-label="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="font-weight-bold">{{ siae.website }}</a>
-    </p>
-{% endif %}
+    {% if siae.website %}
+        <li>
+            <i class="ri-global-line ri-xl me-2"></i>
+            <a aria-label="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="font-weight-bold">{{ siae.website }}</a>
+        </li>
+    {% endif %}
+</ul>

--- a/itou/templates/siaes/job_description_card.html
+++ b/itou/templates/siaes/job_description_card.html
@@ -22,15 +22,16 @@
                         <hr>
                         <div>
                             {% if can_update_job_description %}
-                                <div class="row mb-4">
-                                    <div class="col">
-                                        <a href="{% url "companies_views:update_job_description" job_description_id=job.pk %}" class="btn btn-sm btn-outline-primary" aria-label="Modifier la fiche de poste">
-                                            Modifier
+                                <div class="form-row align-items-center gx-3 mb-4">
+                                    <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                        <a href="{% url "companies_views:job_description_list" %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retour vers la liste des postes">
+                                            <i class="ri-arrow-go-back-line ri-lg"></i>
+                                            <span>Retour</span>
                                         </a>
                                     </div>
-                                    <div class="col-auto">
-                                        <a href="{% url "companies_views:job_description_list" %}" class="btn btn-sm btn-primary" aria-label="Retour vers la liste des postes">
-                                            Fermer
+                                    <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                        <a href="{% url "companies_views:update_job_description" job_description_id=job.pk %}" class="btn btn-primary btn-block" aria-label="Modifier la fiche de poste">
+                                            Modifier
                                         </a>
                                     </div>
                                 </div>
@@ -55,7 +56,7 @@
 
                                 {% if others_active_jobs and not siae.block_job_applications %}
                                     <hr>
-                                    <h2 class="h2">
+                                    <h2>
                                         Consulter le{{ others_active_jobs|pluralizefr }} recrutement{{ others_active_jobs|pluralizefr }} en cours dans cette structure
                                     </h2>
                                     <ul class="list-group list-group-flush mb-4">

--- a/itou/templates/siaes/select_financial_annex.html
+++ b/itou/templates/siaes/select_financial_annex.html
@@ -13,20 +13,27 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 col-lg-8">
-                    <form method="post" role="form" class="js-prevent-multiple-submit">
+                    <div class="c-form">
+                        <form method="post" role="form" class="js-prevent-multiple-submit">
 
-                        {% csrf_token %}
+                            {% csrf_token %}
 
-                        {% bootstrap_form_errors select_form type="all" %}
+                            {% bootstrap_form_errors select_form type="all" %}
 
-                        {% bootstrap_field select_form.financial_annexes %}
+                            {% bootstrap_field select_form.financial_annexes %}
 
-                        <div class="form-group">{% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary" %}</div>
+                            <hr>
+                            <div class="form-row align-items-center justify-content-end">
+                                <div class="form-group col-12 col-lg-auto">
+                                    {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary w-100 w-lg-auto" %}
+                                </div>
+                            </div>
 
-                    </form>
+                        </form>
+                    </div>
 
-                    <p>
-                        Si votre annexe financière correspond à un SIREN différent de {{ request.current_organization.siren }} ou à un type de structure différent de {{ request.current_organization.kind }}, ou bien si elle n'apparaît pas dans la liste ci-dessus, contactez-nous via la rubrique correspondant à votre structure sur <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" aria-label="{{ ITOU_HELP_CENTER_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_HELP_CENTER_URL }}</a>
+                    <p class="mt-3">
+                        Si votre annexe financière correspond à un SIREN différent de {{ request.current_organization.siren }} ou à un type de structure différent de {{ request.current_organization.kind }}, ou bien si elle n'apparaît pas dans la liste ci-dessus, contactez-nous via la rubrique correspondant à votre structure sur <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" class="has-external-link" aria-label="{{ ITOU_HELP_CENTER_URL }} (ouverture dans un nouvel onglet)">{{ ITOU_HELP_CENTER_URL }}</a>
                     </p>
                 </div>
             </div>

--- a/tests/www/prescribers_views/__snapshots__/test_edit.ambr
+++ b/tests/www/prescribers_views/__snapshots__/test_edit.ambr
@@ -3,9 +3,9 @@
   '''
   <form class="js-prevent-multiple-submit" method="post">
   
-                          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
   
-                          <div class="form-group form-group-required"><label class="form-label" for="id_address_line_1">Adresse</label><input class="form-control" disabled="" id="id_address_line_1" maxlength="255" name="address_line_1" placeholder="Adresse" required="" type="text"/></div><div class="form-group"><label class="form-label" for="id_address_line_2">Complément d'adresse</label><input class="form-control" disabled="" id="id_address_line_2" maxlength="255" name="address_line_2" placeholder="Complément d'adresse" type="text"/><div class="form-text">Appartement, suite, bloc, bâtiment, boite postale, etc.</div>
+                              <div class="form-group form-group-required"><label class="form-label" for="id_address_line_1">Adresse</label><input class="form-control" disabled="" id="id_address_line_1" maxlength="255" name="address_line_1" placeholder="Adresse" required="" type="text"/></div><div class="form-group"><label class="form-label" for="id_address_line_2">Complément d'adresse</label><input class="form-control" disabled="" id="id_address_line_2" maxlength="255" name="address_line_2" placeholder="Complément d'adresse" type="text"/><div class="form-text">Appartement, suite, bloc, bâtiment, boite postale, etc.</div>
   </div><div class="form-group form-group-required"><label class="form-label" for="id_post_code">Code postal</label><input class="form-control" disabled="" id="id_post_code" maxlength="5" name="post_code" placeholder="Code postal" required="" type="text"/></div><div class="form-group form-group-required"><label class="form-label" for="id_city">Ville</label><input class="form-control" disabled="" id="id_city" maxlength="255" name="city" placeholder="Ville" required="" type="text"/></div><div class="form-group form-group-required"><label class="form-label" for="id_department">Département</label><select class="form-select" disabled="" id="id_department" name="department" required="">
     <option value="">---------</option>
   
@@ -227,11 +227,18 @@
   </div><div class="form-group"><label class="form-label" for="id_description">Description</label><textarea class="form-control" cols="40" disabled="" id="id_description" name="description" placeholder="Description" rows="10"></textarea><div class="form-text">Texte de présentation de votre structure.</div>
   </div>
   
-                          <div class="form-group">
-                              <a class="btn btn-outline-primary" href="/dashboard/">Annuler</a>
-                              <button class="btn btn-primary" type="submit">Enregistrer</button>
-                          </div>
-  
-                      </form>
+                              <hr/>
+                              <div class="form-row align-items-center gx-3">
+                                  <div class="form-group col-12 col-lg order-2 order-lg-1">
+                                      <a aria-label="Retourner au tableau de bord" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/dashboard/">
+                                          <i class="ri-arrow-go-back-line ri-lg"></i>
+                                          <span>Retour</span>
+                                      </a>
+                                  </div>
+                                  <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                                      <button aria-label="Enregistrer la modification" class="btn btn-primary btn-block">Enregistrer</button>
+                                  </div>
+                              </div>
+                          </form>
   '''
 # ---


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/ui-harmonisation-de-zone-de-boutons-de-formulaire-80c201142e8b454f975e05855648c858?pvs=4

### Pourquoi ?
Pour harmoniser la mise en forme UI/UX des zones de boutons dans les formulaires

### Comment
Globalement
- respect des dimensions et couleurs
- respect de la mise en forme (surtout pour le bouton "retour")
- respect du positionnement par l'alignement des boutons à droite (sauf pour le bouton "retour")
- respect de la mise en forme responsive (demi-largeur ou full largeur selon les cas)

Exemple de mise en forme recommandée https://betagouv.github.io/itou-theme/layout-itou-form-simple.html

### Remarque
Afin de ne pas faire une trop grosse PR, je referais surement une ou plusieurs PR pour les formulaires restants
En passant, harmonisation de certainn message d'alerte dans les formulaires

### Captures d'écran
Quelques exemples avant/apres

![capture 2023-11-09 à 10 59 15](https://github.com/betagouv/itou/assets/3874024/cd96a71c-f46d-4433-9940-36204f592160)
![capture 2023-11-09 à 10 16 49](https://github.com/betagouv/itou/assets/3874024/56e25247-74a4-4b1d-9c39-4f3d25b66bb4)

---

![capture 2023-11-09 à 10 31 32](https://github.com/betagouv/itou/assets/3874024/3994716e-d7a7-4194-bcd3-7d244f37b268)
![capture 2023-11-09 à 11 00 41](https://github.com/betagouv/itou/assets/3874024/2fafba0c-9cec-4149-87e3-2242da317cd7)

---

![capture 2023-11-09 à 16 52 40](https://github.com/betagouv/itou/assets/3874024/a31060e8-50a9-441c-a9fa-077fa3156399)
![capture 2023-11-09 à 16 54 07](https://github.com/betagouv/itou/assets/3874024/0dd9bcc6-666c-4e14-9f19-a76f5820e78e)


