### PR TITLE
Saisie adresse fiche salarié: utilisation du widget Select2 pour la commune

### DIFF
--- a/itou/asp/models.py
+++ b/itou/asp/models.py
@@ -423,6 +423,9 @@ class Commune(PrettyPrintMixin, AbstractPeriod):
         # But in most of the cases:
         return f"0{self.code[0:2]}"
 
+    def autocomplete_display(self):
+        return f"{self.name} ({self.department_code})"
+
 
 class Department(PrettyPrintMixin, AbstractPeriod):
     """

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -58,10 +58,7 @@
                             {% bootstrap_field form.hexa_additional_address %}
                             <div class="form-row">
                                 <div class="col-12 col-md-3">{% bootstrap_field form.hexa_post_code %}</div>
-                                <div class="col-12 col-md-9">
-                                    {% bootstrap_field form.insee_commune %}
-                                    {% bootstrap_field form.insee_commune_code %}
-                                </div>
+                                <div class="col-12 col-md-9">{% bootstrap_field form.hexa_commune %}</div>
                             </div>
                         </div>
                         <div class="col-12 col-lg-4">

--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -5,6 +5,7 @@ import pytest
 from django.contrib.messages import get_messages
 from django.urls import reverse
 
+from itou.asp.models import Commune
 from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
 from itou.users.enums import LackOfNIRReason
@@ -341,8 +342,7 @@ class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
             "hexa_lane_name": "des colonies",
             "hexa_additional_address": "Bat A",
             "hexa_post_code": "67000",
-            "insee_commune": "STRASBOURG",
-            "insee_commune_code": "67482",
+            "hexa_commune": Commune.objects.by_insee_code("67482").pk,
         }
 
         data = test_data


### PR DESCRIPTION
### Pourquoi ?

Pour pouvoir supprimer jQuery UI.

https://www.notion.so/plateforme-inclusion/C1-Suppression-de-jQuery-UI-680d46411c3f4972ad1c113765924453?pvs=4

