### PR TITLE
Création d'une table structures_v0

### DIFF
--- a/itou/metabase/tables/siaes.py
+++ b/itou/metabase/tables/siaes.py
@@ -13,7 +13,7 @@ def get_field(name):
     return Company._meta.get_field(name)
 
 
-TABLE = MetabaseTable(name="structures")
+TABLE = MetabaseTable(name="structures_v0")
 TABLE.add_columns(
     [
         {"name": "id", "type": "integer", "comment": "ID de la structure", "fn": lambda o: o.id},

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -147,7 +147,7 @@ def get_department_and_region_columns(name_suffix="", comment_suffix="", custom_
 
 
 # FIXME @dejafait drop this as soon as data analysts no longer use
-# structures.code_commune nor organisations.code_commune
+# structures_v0.code_commune nor organisations.code_commune
 # because one post_code can actually have *several* insee_codes (╯°□°)╯︵ ┻━┻
 @functools.cache
 def get_post_code_to_insee_code_map():
@@ -162,7 +162,7 @@ def get_post_code_to_insee_code_map():
 
 
 # FIXME @dejafait drop this as soon as data analysts no longer use
-# structures.code_commune nor organisations.code_commune
+# structures_v0.code_commune nor organisations.code_commune
 # because one post_code can actually have *several* insee_codes (╯°□°)╯︵ ┻━┻
 def convert_post_code_to_insee_code(post_code):
     return get_post_code_to_insee_code_map().get(post_code)
@@ -215,7 +215,7 @@ def get_address_columns(name_suffix="", comment_suffix="", custom_fn=lambda o: o
         + [
             {
                 # FIXME @dejafait drop this as soon as data analysts no longer use
-                # structures.code_commune nor organisations.code_commune
+                # structures_v0.code_commune nor organisations.code_commune
                 # because one post_code can actually have *several* insee_codes (╯°□°)╯︵ ┻━┻
                 "name": f"code_commune{name_suffix}",
                 "type": "varchar",

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -1121,7 +1121,7 @@ def test_populate_siaes():
         management.call_command("populate_metabase_emplois", mode="siaes")
 
     with connection.cursor() as cursor:
-        cursor.execute("SELECT * FROM structures ORDER BY id")
+        cursor.execute("SELECT * FROM structures_v0 ORDER BY id")
         rows = cursor.fetchall()
         assert len(rows) == 1
         assert rows == [


### PR DESCRIPTION
**Carte Notion : **

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Afin de simplifier la vie des data analystos et éviter de casser plusieurs indicateurs metabase on créé une table structures_v0 côté emplois pour créer une table structures sur dbt. 
[PR côté C2](https://github.com/gip-inclusion/pilotage-airflow/pull/189)