### PR TITLE
UX: Harmonisation de l'affichage des 0 résultat sur les fiches salarié (ASP) 

### DIFF
--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -120,8 +120,8 @@
                     <div class="c-box p-3 p-md-4">
                         <div class="d-flex align-items-center">
                             <div class="flex-grow-1">
-                                {% with cnt=navigation_pages.paginator.count %}
-                                    <span class="h4 m-0">{{ cnt|default:"Aucun" }} résultat{{ cnt|pluralizefr }}</span>
+                                {% with navigation_pages.paginator.count as counter %}
+                                    <h3 class="h4 m-0">{{ counter }} résultat{{ counter|pluralizefr }}</h3>
                                 {% endwith %}
                             </div>
                             <div>
@@ -155,12 +155,7 @@
                             {% endif %}
                         </div>
 
-                        {% if not navigation_pages %}
-                            <p class="my-3 my-md-4">
-                                <i class="ri-forbid-line ri-lg me-1" aria-hidden="true"></i>
-                                <span>Aucune fiche salarié avec le statut selectionné ...</span>
-                            </p>
-                        {% endif %}
+                        {% if not navigation_pages %}<p class="my-3 my-md-4">Aucune fiche salarié avec le statut selectionné.</p>{% endif %}
                     </div>
 
                     {% include "includes/pagination.html" with page=navigation_pages %}

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -159,7 +159,7 @@ def list_employee_records(request, template_name="employee_record/list.html"):
         "filters_form": filters_form,
         "employee_records_list": employee_records_list,
         "badges": status_badges,
-        "navigation_pages": pager(data, request.GET.get("page", 1), items_per_page=10) if data else None,
+        "navigation_pages": pager(data, request.GET.get("page"), items_per_page=10),
         "feature_availability_date": EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE,
         "need_manual_regularization": need_manual_regularization,
         "ordered_by_label": order_by.label,

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -379,4 +379,4 @@ class ListEmployeeRecordsTest(TestCase):
         self.assertContains(response, "2 résultats")
 
         response = self.client.get(self.url + "?status=READY")
-        self.assertContains(response, "Aucun résultat")
+        self.assertContains(response, "0 résultat")


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/UX-UI-Harmoniser-les-Aucun-0-r-sultat-a7243f4552664bb586dd72d04ed749a5?pvs=4

### Pourquoi ?

Sur la liste des fiches salarié (ASP) quand il n’y a pas de résultats, harmonisation de l'affichage.
Remplacement de "Aucun résultat" par "0 résultat" comme sur les autres listes.

### Captures d'écran
Avant / Apres

![capture 2023-11-13 à 11 35 19](https://github.com/betagouv/itou/assets/3874024/5abff0a6-eb99-401b-ab78-75c36cc0250d)

![capture 2023-11-13 à 11 35 32](https://github.com/betagouv/itou/assets/3874024/eb58c576-8564-4f26-b032-570874f8516a)

