### PR TITLE
Ajout de la colonne type de contrat à la table fiches de poste

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -33,6 +33,7 @@ from itou.analytics.models import Datum, StatsDashboardVisit
 from itou.approvals.models import Approval, PoleEmploiApproval, Prolongation, ProlongationRequest
 from itou.cities.models import City
 from itou.common_apps.address.departments import DEPARTMENT_TO_REGION, DEPARTMENTS
+from itou.companies.enums import ContractType
 from itou.companies.models import Company, CompanyMembership, JobDescription
 from itou.eligibility.enums import AdministrativeCriteriaLevel
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
@@ -470,11 +471,17 @@ class Command(BaseCommand):
         # TODO(vperron,dejafait): This works as long as we don't have several table creations in the same call.
         # If we someday want to create several tables, we will probably need to disable autocommit in our helper
         # functions and make it manually at the end.
-        table_name = "c1_ref_origine_candidature"
-        self.stdout.write(f"Preparing content for {table_name} table...")
-        rows = [OrderedDict(code=str(item), label=item.label) for item in Origin]
-        df = get_df_from_rows(rows)
-        store_df(df=df, table_name=table_name)
+        enum_data = [
+            {"table_name": "c1_ref_origine_candidature", "enum": Origin},
+            {"table_name": "c1_ref_type_contrat", "enum": ContractType},
+        ]
+        for item in enum_data:
+            table_name = item["table_name"]
+            enum = item["enum"]
+            self.stdout.write(f"Preparing content for {table_name} table...")
+            rows = [OrderedDict(code=str(item), label=item.label) for item in enum]
+            df = get_df_from_rows(rows)
+            store_df(df=df, table_name=table_name)
 
     @timeit
     def report_data_inconsistencies(self):

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -471,13 +471,11 @@ class Command(BaseCommand):
         # TODO(vperron,dejafait): This works as long as we don't have several table creations in the same call.
         # If we someday want to create several tables, we will probably need to disable autocommit in our helper
         # functions and make it manually at the end.
-        enum_data = [
-            {"table_name": "c1_ref_origine_candidature", "enum": Origin},
-            {"table_name": "c1_ref_type_contrat", "enum": ContractType},
-        ]
-        for item in enum_data:
-            table_name = item["table_name"]
-            enum = item["enum"]
+        enum_to_table = {
+            Origin: "c1_ref_origine_candidature",
+            ContractType: "c1_ref_type_contrat",
+        }
+        for enum, table_name in enum_to_table.items():
             self.stdout.write(f"Preparing content for {table_name} table...")
             rows = [OrderedDict(code=str(item), label=item.label) for item in enum]
             df = get_df_from_rows(rows)

--- a/itou/metabase/tables/job_descriptions.py
+++ b/itou/metabase/tables/job_descriptions.py
@@ -29,6 +29,12 @@ TABLE.add_columns(
             "comment": "Recrutement ouvert à ce jour",
             "fn": lambda o: o.is_active,
         },
+        {
+            "name": "type_contrat",
+            "type": "varchar",
+            "comment": "Type de contrat proposé",
+            "fn": lambda o: o.contract_type,
+        },
         {"name": "id_employeur", "type": "integer", "comment": "ID employeur", "fn": lambda o: o.company.id},
         {"name": "type_employeur", "type": "varchar", "comment": "Type employeur", "fn": lambda o: o.company.kind},
         {"name": "siret_employeur", "type": "varchar", "comment": "SIRET employeur", "fn": lambda o: o.company.siret},

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -970,6 +970,7 @@ def test_populate_enums():
     num_queries += 1  # COMMIT (rename_table_atomically DROP TABLE)
     num_queries += 1  # COMMIT (rename_table_atomically RENAME TABLE)
     num_queries += 1  # COMMIT (rename_table_atomically DROP TABLE)
+    num_queries *= 2  # We inject thus many enums so far.
     with assertNumQueries(num_queries):
         management.call_command("populate_metabase_emplois", mode="enums")
 
@@ -982,6 +983,11 @@ def test_populate_enums():
             ("default", "Créée normalement via les emplois"),
             ("pe_approval", "Créée lors d'un import d'Agrément Pole Emploi"),
         ]
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT * FROM c1_ref_type_contrat ORDER BY code")
+        rows = cursor.fetchall()
+        assert rows[0] == ("APPRENTICESHIP", "Contrat d'apprentissage")
 
 
 def test_data_inconsistencies(capsys):
@@ -1011,7 +1017,7 @@ def test_data_inconsistencies(capsys):
 @freeze_time("2023-02-02")
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.usefixtures("metabase")
-def test_populate_fiches_de_poste():
+def test_populate_job_descriptions():
     create_test_romes_and_appellations(["M1805"], appellations_per_rome=1)
     company = CompanyFactory(
         for_snapshot=True,
@@ -1066,6 +1072,7 @@ def test_populate_fiches_de_poste():
                 "M1805",
                 "Études et développement informatique",
                 1,
+                job.contract_type,
                 company.pk,
                 "GEIQ",
                 "12989128580059",


### PR DESCRIPTION
Fil Slack : https://itou-inclusion.slack.com/archives/CQ6D0QPPZ/p1694162133414989

### Pourquoi ?

Pour permettre d'identifier les fiches de poste CVG et PHC dans le cadre des travaux avec convergence.


